### PR TITLE
remove search globals

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -694,7 +694,7 @@ $(PWD)/parse:
 LIBPATTERN=	libpattern.a
 LIBPATTERNOBJS=	pattern/compile.o pattern/config.o pattern/dlg_pattern.o \
 		pattern/exec.o pattern/flags.o pattern/functions.o \
-		pattern/message.o pattern/pattern.o
+		pattern/message.o pattern/pattern.o pattern/search_state.o
 CLEANFILES+=	$(LIBPATTERN) $(LIBPATTERNOBJS)
 ALLOBJS+=	$(LIBPATTERNOBJS)
 

--- a/alias/dlg_alias.c
+++ b/alias/dlg_alias.c
@@ -388,6 +388,7 @@ int alias_complete(struct Buffer *buf, struct ConfigSubset *sub)
 
   struct AliasMenuData mdata = { ARRAY_HEAD_INITIALIZER, NULL, sub };
   mdata.limit = buf_strdup(buf);
+  mdata.search_state = search_state_new();
 
   if (buf_at(buf, 0) != '\0')
   {
@@ -493,6 +494,7 @@ done:
   ARRAY_FREE(&mdata.ava);
   FREE(&mdata.limit);
   FREE(&mdata.title);
+  search_state_free(&mdata.search_state);
 
   return 0;
 }
@@ -507,6 +509,7 @@ void alias_dialog(struct Mailbox *m, struct ConfigSubset *sub)
   struct Alias *np = NULL;
 
   struct AliasMenuData mdata = { ARRAY_HEAD_INITIALIZER, NULL, sub };
+  mdata.search_state = search_state_new();
 
   // Create a View Array of all the Aliases
   TAILQ_FOREACH(np, &Aliases, entries)
@@ -551,4 +554,5 @@ done:
   ARRAY_FREE(&mdata.ava);
   FREE(&mdata.limit);
   FREE(&mdata.title);
+  search_state_free(&mdata.search_state);
 }

--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -80,6 +80,7 @@
 #include "email/lib.h"
 #include "core/lib.h"
 #include "gui/lib.h"
+#include "pattern/lib.h"
 #include "mutt.h"
 #include "lib.h"
 #include "enter/lib.h"
@@ -452,6 +453,7 @@ static bool dlg_query(struct Buffer *buf, struct AliasMenuData *mdata)
 int query_complete(struct Buffer *buf, struct ConfigSubset *sub)
 {
   struct AliasMenuData mdata = { ARRAY_HEAD_INITIALIZER, NULL, sub };
+  mdata.search_state = search_state_new();
 
   struct AliasList al = TAILQ_HEAD_INITIALIZER(al);
   const char *const c_query_command = cs_subset_string(sub, "query_command");
@@ -520,6 +522,7 @@ done:
   ARRAY_FREE(&mdata.ava);
   FREE(&mdata.title);
   FREE(&mdata.limit);
+  search_state_free(&mdata.search_state);
   aliaslist_free(&al);
   return 0;
 }

--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -544,6 +544,7 @@ void query_index(struct Mailbox *m, struct ConfigSubset *sub)
   struct AliasList al = TAILQ_HEAD_INITIALIZER(al);
   struct AliasMenuData mdata = { ARRAY_HEAD_INITIALIZER, NULL, sub };
   mdata.al = &al;
+  mdata.search_state = search_state_new();
 
   struct Buffer *buf = buf_pool_get();
   if ((mw_get_field(_("Query: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0) ||
@@ -589,6 +590,7 @@ done:
   ARRAY_FREE(&mdata.ava);
   FREE(&mdata.title);
   FREE(&mdata.limit);
+  search_state_free(&mdata.search_state);
   aliaslist_free(&al);
   buf_pool_release(&buf);
 }

--- a/alias/functions.c
+++ b/alias/functions.c
@@ -242,8 +242,27 @@ static int op_query(struct AliasMenuData *mdata, int op)
  */
 static int op_search(struct AliasMenuData *mdata, int op)
 {
+  SearchFlags flags = SEARCH_NO_FLAGS;
+  switch (op)
+  {
+    case OP_SEARCH:
+      flags |= SEARCH_PROMPT;
+      mdata->search_state->reverse = false;
+      break;
+    case OP_SEARCH_REVERSE:
+      flags |= SEARCH_PROMPT;
+      mdata->search_state->reverse = true;
+      break;
+    case OP_SEARCH_NEXT:
+      break;
+    case OP_SEARCH_OPPOSITE:
+      flags |= SEARCH_OPPOSITE;
+      break;
+  }
+
   struct Menu *menu = mdata->menu;
-  int index = mutt_search_alias_command(menu, menu_get_index(menu), op);
+  int index = mutt_search_alias_command(menu, mdata->search_state,
+                                        menu_get_index(menu), flags);
   if (index == -1)
     return FR_NO_ACTION;
 

--- a/alias/functions.c
+++ b/alias/functions.c
@@ -261,8 +261,8 @@ static int op_search(struct AliasMenuData *mdata, int op)
   }
 
   struct Menu *menu = mdata->menu;
-  int index = mutt_search_alias_command(menu, mdata->search_state,
-                                        menu_get_index(menu), flags);
+  int index = menu_get_index(menu);
+  index = mutt_search_alias_command(menu, index, mdata->search_state, flags);
   if (index == -1)
     return FR_NO_ACTION;
 

--- a/alias/gui.h
+++ b/alias/gui.h
@@ -50,14 +50,15 @@ ARRAY_HEAD(AliasViewArray, struct AliasView);
  */
 struct AliasMenuData
 {
-  struct AliasViewArray ava;    ///< All Aliases/Queries
-  struct AliasList *al;         ///< Alias data
-  struct ConfigSubset *sub;     ///< Config items
-  struct Menu *menu;            ///< Menu
-  struct Buffer *query;         ///< Query string
-  char *limit;                  ///< Limit being used
-  struct MuttWindow *sbar;      ///< Status Bar
-  char *title;                  ///< Title for the status bar
+  struct AliasViewArray  ava;           ///< All Aliases/Queries
+  struct AliasList      *al;            ///< Alias data
+  struct ConfigSubset   *sub;           ///< Config items
+  struct Menu           *menu;          ///< Menu
+  struct Buffer         *query;         ///< Query string
+  char                  *limit;         ///< Limit being used
+  struct MuttWindow     *sbar;          ///< Status Bar
+  char                  *title;         ///< Title for the status bar
+  struct SearchState    *search_state;  ///< State of the current search
 };
 
 int alias_config_observer(struct NotifyCallback *nc);

--- a/globals.h
+++ b/globals.h
@@ -76,7 +76,6 @@ extern bool OptNoCurses;            ///< (pseudo) when sending in batch mode
 extern bool OptPgpCheckTrust;       ///< (pseudo) used by dlg_pgp()
 extern bool OptResortInit;          ///< (pseudo) used to force the next resort to be from scratch
 extern bool OptSearchInvalid;       ///< (pseudo) used to invalidate the search pattern
-extern bool OptSearchReverse;       ///< (pseudo) used by ci_search_command
 extern bool OptSortSubthreads;      ///< (pseudo) used when $sort_aux changes
 
 extern char **EnvList;              ///< Private copy of the environment variables

--- a/index/functions.c
+++ b/index/functions.c
@@ -2030,11 +2030,11 @@ static int op_search(struct IndexSharedData *shared, struct IndexPrivateData *pr
   {
     case OP_SEARCH:
       flags |= SEARCH_PROMPT;
-      shared->search->reverse = false;
+      shared->search_state->reverse = false;
       break;
     case OP_SEARCH_REVERSE:
       flags |= SEARCH_PROMPT;
-      shared->search->reverse = true;
+      shared->search_state->reverse = true;
       break;
     case OP_SEARCH_NEXT:
       break;
@@ -2047,7 +2047,8 @@ static int op_search(struct IndexSharedData *shared, struct IndexPrivateData *pr
   // searching for next/previous/... needs to be on a message and
   // thus a non-empty mailbox
   int index = menu_get_index(priv->menu);
-  index = mutt_search_command(shared->mailbox_view, priv->menu, shared->search, index, flags);
+  index = mutt_search_command(shared->mailbox_view, priv->menu,
+                              shared->search_state, index, flags);
   if (index != -1)
     menu_set_index(priv->menu, index);
 

--- a/index/functions.c
+++ b/index/functions.c
@@ -2025,9 +2025,6 @@ static int op_save(struct IndexSharedData *shared, struct IndexPrivateData *priv
  */
 static int op_search(struct IndexSharedData *shared, struct IndexPrivateData *priv, int op)
 {
-  if (!shared->search)
-    shared->search = mutt_search_new();
-
   SearchFlags flags = SEARCH_NO_FLAGS;
   switch (op)
   {

--- a/index/functions.c
+++ b/index/functions.c
@@ -2047,8 +2047,8 @@ static int op_search(struct IndexSharedData *shared, struct IndexPrivateData *pr
   // searching for next/previous/... needs to be on a message and
   // thus a non-empty mailbox
   int index = menu_get_index(priv->menu);
-  index = mutt_search_command(shared->mailbox_view, priv->menu,
-                              shared->search_state, index, flags);
+  index = mutt_search_command(shared->mailbox_view, priv->menu, index,
+                              shared->search_state, flags);
   if (index != -1)
     menu_set_index(priv->menu, index);
 

--- a/index/shared_data.c
+++ b/index/shared_data.c
@@ -31,6 +31,7 @@
 #include "mutt/lib.h"
 #include "email/lib.h"
 #include "core/lib.h"
+#include "pattern/lib.h"
 #include "shared_data.h"
 #include "lib.h"
 #include "mview.h"
@@ -292,6 +293,8 @@ void index_shared_data_free(struct MuttWindow *win, void **ptr)
     notify_observer_remove(shared->mailbox->notify, index_shared_mailbox_observer, shared);
   if (shared->email)
     notify_observer_remove(shared->email->notify, index_shared_email_observer, shared);
+
+  mutt_search_free(&shared->search);
 
   FREE(ptr);
 }

--- a/index/shared_data.c
+++ b/index/shared_data.c
@@ -294,7 +294,7 @@ void index_shared_data_free(struct MuttWindow *win, void **ptr)
   if (shared->email)
     notify_observer_remove(shared->email->notify, index_shared_email_observer, shared);
 
-  search_state_free(&shared->search);
+  search_state_free(&shared->search_state);
 
   FREE(ptr);
 }
@@ -309,7 +309,7 @@ struct IndexSharedData *index_shared_data_new(void)
 
   shared->notify = notify_new();
   shared->sub = NeoMutt->sub;
-  shared->search = search_state_new();
+  shared->search_state = search_state_new();
 
   mutt_debug(LL_NOTIFY, "NT_INDEX_ADD: %p\n", (void *) shared);
   notify_send(shared->notify, NT_INDEX, NT_INDEX_ADD, shared);

--- a/index/shared_data.c
+++ b/index/shared_data.c
@@ -31,9 +31,9 @@
 #include "mutt/lib.h"
 #include "email/lib.h"
 #include "core/lib.h"
-#include "pattern/lib.h"
 #include "shared_data.h"
 #include "lib.h"
+#include "pattern/lib.h"
 #include "mview.h"
 
 /**
@@ -294,7 +294,7 @@ void index_shared_data_free(struct MuttWindow *win, void **ptr)
   if (shared->email)
     notify_observer_remove(shared->email->notify, index_shared_email_observer, shared);
 
-  mutt_search_free(&shared->search);
+  search_state_free(&shared->search);
 
   FREE(ptr);
 }
@@ -309,7 +309,7 @@ struct IndexSharedData *index_shared_data_new(void)
 
   shared->notify = notify_new();
   shared->sub = NeoMutt->sub;
-  shared->search = mutt_search_new();
+  shared->search = search_state_new();
 
   mutt_debug(LL_NOTIFY, "NT_INDEX_ADD: %p\n", (void *) shared);
   notify_send(shared->notify, NT_INDEX, NT_INDEX_ADD, shared);

--- a/index/shared_data.c
+++ b/index/shared_data.c
@@ -309,6 +309,7 @@ struct IndexSharedData *index_shared_data_new(void)
 
   shared->notify = notify_new();
   shared->sub = NeoMutt->sub;
+  shared->search = mutt_search_new();
 
   mutt_debug(LL_NOTIFY, "NT_INDEX_ADD: %p\n", (void *) shared);
   notify_send(shared->notify, NT_INDEX, NT_INDEX_ADD, shared);

--- a/index/shared_data.h
+++ b/index/shared_data.h
@@ -42,6 +42,7 @@ struct IndexSharedData
   struct Email        *email;          ///< Currently selected Email
   size_t               email_seq;      ///< Sequence number of the current email
   struct Notify       *notify;         ///< Notifications: #NotifyIndex, #IndexSharedData
+  struct Search       *search;         ///< State of the current index search
 };
 
 void                    index_shared_data_free(struct MuttWindow *win, void **ptr);

--- a/index/shared_data.h
+++ b/index/shared_data.h
@@ -42,7 +42,7 @@ struct IndexSharedData
   struct Email        *email;          ///< Currently selected Email
   size_t               email_seq;      ///< Sequence number of the current email
   struct Notify       *notify;         ///< Notifications: #NotifyIndex, #IndexSharedData
-  struct Search       *search;         ///< State of the current index search
+  struct SearchState  *search;         ///< State of the current index search
 };
 
 void                    index_shared_data_free(struct MuttWindow *win, void **ptr);

--- a/index/shared_data.h
+++ b/index/shared_data.h
@@ -42,7 +42,7 @@ struct IndexSharedData
   struct Email        *email;          ///< Currently selected Email
   size_t               email_seq;      ///< Sequence number of the current email
   struct Notify       *notify;         ///< Notifications: #NotifyIndex, #IndexSharedData
-  struct SearchState  *search_state;   ///< State of the current index search
+  struct SearchState  *search_state;   ///< State of the current search
 };
 
 void                    index_shared_data_free(struct MuttWindow *win, void **ptr);

--- a/index/shared_data.h
+++ b/index/shared_data.h
@@ -42,7 +42,7 @@ struct IndexSharedData
   struct Email        *email;          ///< Currently selected Email
   size_t               email_seq;      ///< Sequence number of the current email
   struct Notify       *notify;         ///< Notifications: #NotifyIndex, #IndexSharedData
-  struct SearchState  *search;         ///< State of the current index search
+  struct SearchState  *search_state;   ///< State of the current index search
 };
 
 void                    index_shared_data_free(struct MuttWindow *win, void **ptr);

--- a/pattern/lib.h
+++ b/pattern/lib.h
@@ -176,18 +176,13 @@ enum PatternType
   MUTT_PAT_MAX,
 };
 
-typedef uint8_t SearchFlags;       ///< Flags for searches; e.g. #SEARCH_REVERSE
-#define SEARCH_NO_FLAGS        0   ///< No flags are set
-#define SEARCH_REVERSE   (1 << 0)  ///< Search backwards
-#define SEARCH_OPPOSITE  (1 << 1)  ///< Search in the opposite direction, yes both can be set (OP_SEARCH_OPPOSITE)
-#define SEARCH_PROMPT    (1 << 2)  ///< Ask for search input
-
 struct Search {
   int                 cur;         ///< index number of current email
-  struct PatternList *pattern;     ///< current search pattern
-  struct Buffer      *input;       ///< last pattern searched for
-  struct Buffer      *input_expn;  ///< expanded version of LastSearch
-  SearchFlags         flags;       ///< flags for search, e.g. #SEARCH_REVERSE
+  struct PatternList *pattern;     ///< compiled search pattern
+  struct Buffer      *string;      ///< search string
+  struct Buffer      *string_expn; ///< expanded search string
+  bool                reverse;     ///< search backwards
+  bool                prompt;      ///< ask for search input
 };
 
 bool mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags, struct Mailbox *m,

--- a/pattern/lib.h
+++ b/pattern/lib.h
@@ -193,9 +193,9 @@ bool mutt_is_list_recipient(bool all_addr, struct Envelope *env);
 bool mutt_is_subscribed_list_recipient(bool all_addr, struct Envelope *env);
 int mutt_pattern_func(struct MailboxView *mv, int op, char *prompt);
 int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata, struct Menu *menu);
-int mutt_search_command(struct MailboxView *mv, struct Menu *menu,
-                        struct SearchState *state, int cur, SearchFlags flags);
-int mutt_search_alias_command(struct Menu *menu, struct SearchState *state,
-                              int cur, SearchFlags flags);
+int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
+                        struct SearchState *state, SearchFlags flags);
+int mutt_search_alias_command(struct Menu *menu, int cur,
+                              struct SearchState *state, SearchFlags flags);
 
 #endif /* MUTT_PATTERN_LIB_H */

--- a/pattern/lib.h
+++ b/pattern/lib.h
@@ -26,16 +26,17 @@
  *
  * Match patterns to emails
  *
- * | File                  | Description                  |
- * | :-------------------- | :--------------------------- |
- * | pattern/compile.c     | @subpage pattern_compile     |
- * | pattern/config.c      | @subpage pattern_config      |
- * | pattern/dlg_pattern.c | @subpage pattern_dlg_pattern |
- * | pattern/exec.c        | @subpage pattern_exec        |
- * | pattern/flags.c       | @subpage pattern_flags       |
- * | pattern/functions.c   | @subpage pattern_functions   |
- * | pattern/message.c     | @subpage pattern_message     |
- * | pattern/pattern.c     | @subpage pattern_pattern     |
+ * | File                   | Description                   |
+ * | :--------------------- | :---------------------------- |
+ * | pattern/compile.c      | @subpage pattern_compile      |
+ * | pattern/config.c       | @subpage pattern_config       |
+ * | pattern/dlg_pattern.c  | @subpage pattern_dlg_pattern  |
+ * | pattern/exec.c         | @subpage pattern_exec         |
+ * | pattern/flags.c        | @subpage pattern_flags        |
+ * | pattern/functions.c    | @subpage pattern_functions    |
+ * | pattern/message.c      | @subpage pattern_message      |
+ * | pattern/pattern.c      | @subpage pattern_pattern      |
+ * | pattern/search_state.c | @subpage pattern_search_state |
  */
 
 #ifndef MUTT_PATTERN_LIB_H
@@ -47,6 +48,7 @@
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "mutt.h"
+#include "search_state.h" // IWYU pragma: keep
 
 struct AliasMenuData;
 struct AliasView;
@@ -176,23 +178,6 @@ enum PatternType
   MUTT_PAT_MAX,
 };
 
-/**
- * struct Search - State of a search
- *
- * This data is kept across operations to allow operations like OP_SEARCH_NEXT.
- */
-struct Search {
-  struct PatternList *pattern;     ///< compiled search pattern
-  struct Buffer      *string;      ///< search string
-  struct Buffer      *string_expn; ///< expanded search string
-  bool                reverse;     ///< search backwards
-};
-
-typedef uint8_t SearchFlags;       ///< Flags for a specific search, e.g. #SEARCH_PROMPT
-#define SEARCH_NO_FLAGS        0   ///< No flags are set
-#define SEARCH_PROMPT    (1 << 0)  ///< Ask for search input
-#define SEARCH_OPPOSITE  (1 << 1)  ///< Search in the opposite direction
-
 bool mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags, struct Mailbox *m,
                        struct Email *e, struct PatternCache *cache);
 bool mutt_pattern_alias_exec(struct Pattern *pat, PatternExecFlags flags,
@@ -208,10 +193,7 @@ bool mutt_is_list_recipient(bool all_addr, struct Envelope *env);
 bool mutt_is_subscribed_list_recipient(bool all_addr, struct Envelope *env);
 int mutt_pattern_func(struct MailboxView *mv, int op, char *prompt);
 int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata, struct Menu *menu);
-int mutt_search_command(struct MailboxView *mv, struct Menu *menu, struct Search *state, int cur, SearchFlags flags);
+int mutt_search_command(struct MailboxView *mv, struct Menu *menu, struct SearchState *state, int cur, SearchFlags flags);
 int mutt_search_alias_command(struct Menu *menu, int cur, int op);
-
-struct Search *mutt_search_new();
-void mutt_search_free(struct Search **search);
 
 #endif /* MUTT_PATTERN_LIB_H */

--- a/pattern/lib.h
+++ b/pattern/lib.h
@@ -193,7 +193,9 @@ bool mutt_is_list_recipient(bool all_addr, struct Envelope *env);
 bool mutt_is_subscribed_list_recipient(bool all_addr, struct Envelope *env);
 int mutt_pattern_func(struct MailboxView *mv, int op, char *prompt);
 int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata, struct Menu *menu);
-int mutt_search_command(struct MailboxView *mv, struct Menu *menu, struct SearchState *state, int cur, SearchFlags flags);
-int mutt_search_alias_command(struct Menu *menu, int cur, int op);
+int mutt_search_command(struct MailboxView *mv, struct Menu *menu,
+                        struct SearchState *state, int cur, SearchFlags flags);
+int mutt_search_alias_command(struct Menu *menu, struct SearchState *state,
+                              int cur, SearchFlags flags);
 
 #endif /* MUTT_PATTERN_LIB_H */

--- a/pattern/lib.h
+++ b/pattern/lib.h
@@ -176,14 +176,22 @@ enum PatternType
   MUTT_PAT_MAX,
 };
 
+/**
+ * struct Search - State of a search
+ *
+ * This data is kept across operations to allow operations like OP_SEARCH_NEXT.
+ */
 struct Search {
-  int                 cur;         ///< index number of current email
   struct PatternList *pattern;     ///< compiled search pattern
   struct Buffer      *string;      ///< search string
   struct Buffer      *string_expn; ///< expanded search string
   bool                reverse;     ///< search backwards
-  bool                prompt;      ///< ask for search input
 };
+
+typedef uint8_t SearchFlags;       ///< Flags for a specific search, e.g. #SEARCH_PROMPT
+#define SEARCH_NO_FLAGS        0   ///< No flags are set
+#define SEARCH_PROMPT    (1 << 0)  ///< Ask for search input
+#define SEARCH_OPPOSITE  (1 << 1)  ///< Search in the opposite direction
 
 bool mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags, struct Mailbox *m,
                        struct Email *e, struct PatternCache *cache);
@@ -200,7 +208,10 @@ bool mutt_is_list_recipient(bool all_addr, struct Envelope *env);
 bool mutt_is_subscribed_list_recipient(bool all_addr, struct Envelope *env);
 int mutt_pattern_func(struct MailboxView *mv, int op, char *prompt);
 int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata, struct Menu *menu);
-int mutt_search_command(struct MailboxView *mv, struct Menu *menu, struct Search *state);
+int mutt_search_command(struct MailboxView *mv, struct Menu *menu, struct Search *state, int cur, SearchFlags flags);
 int mutt_search_alias_command(struct Menu *menu, int cur, int op);
+
+struct Search *mutt_search_new();
+void mutt_search_free(struct Search **search);
 
 #endif /* MUTT_PATTERN_LIB_H */

--- a/pattern/lib.h
+++ b/pattern/lib.h
@@ -176,6 +176,20 @@ enum PatternType
   MUTT_PAT_MAX,
 };
 
+typedef uint8_t SearchFlags;       ///< Flags for searches; e.g. #SEARCH_REVERSE
+#define SEARCH_NO_FLAGS        0   ///< No flags are set
+#define SEARCH_REVERSE   (1 << 0)  ///< Search backwards
+#define SEARCH_OPPOSITE  (1 << 1)  ///< Search in the opposite direction, yes both can be set (OP_SEARCH_OPPOSITE)
+#define SEARCH_PROMPT    (1 << 2)  ///< Ask for search input
+
+struct Search {
+  int                 cur;         ///< index number of current email
+  struct PatternList *pattern;     ///< current search pattern
+  struct Buffer      *input;       ///< last pattern searched for
+  struct Buffer      *input_expn;  ///< expanded version of LastSearch
+  SearchFlags         flags;       ///< flags for search, e.g. #SEARCH_REVERSE
+};
+
 bool mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags, struct Mailbox *m,
                        struct Email *e, struct PatternCache *cache);
 bool mutt_pattern_alias_exec(struct Pattern *pat, PatternExecFlags flags,
@@ -191,7 +205,7 @@ bool mutt_is_list_recipient(bool all_addr, struct Envelope *env);
 bool mutt_is_subscribed_list_recipient(bool all_addr, struct Envelope *env);
 int mutt_pattern_func(struct MailboxView *mv, int op, char *prompt);
 int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata, struct Menu *menu);
-int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur, int op);
+int mutt_search_command(struct MailboxView *mv, struct Menu *menu, struct Search *state);
 int mutt_search_alias_command(struct Menu *menu, int cur, int op);
 
 #endif /* MUTT_PATTERN_LIB_H */

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -484,6 +484,8 @@ int mutt_search_command(struct MailboxView *mv, struct Menu *menu,
         buf_pool_release(&tmp);
         mutt_error("%s", err.data);
         FREE(&err.data);
+        buf_reset(state->string);
+        buf_reset(state->string_expn);
         return -1;
       }
       FREE(&err.data);

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -466,25 +466,22 @@ int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
 
     if (!state->pattern || !buf_str_equal(tmp, state->string_expn))
     {
-      struct Buffer err;
-      buf_init(&err);
       OptSearchInvalid = true;
       buf_copy(state->string_expn, tmp);
       mutt_message(_("Compiling search pattern..."));
       mutt_pattern_free(&state->pattern);
-      err.dsize = 256;
-      err.data = mutt_mem_malloc(err.dsize);
-      state->pattern = mutt_pattern_comp(mv, menu, tmp->data, MUTT_PC_FULL_MSG, &err);
+      struct Buffer *err = buf_pool_get();
+      state->pattern = mutt_pattern_comp(mv, menu, tmp->data, MUTT_PC_FULL_MSG, err);
       if (!state->pattern)
       {
         buf_pool_release(&tmp);
-        mutt_error("%s", err.data);
-        FREE(&err.data);
+        mutt_error("%s", buf_string(err));
+        buf_free(&err);
         buf_reset(state->string);
         buf_reset(state->string_expn);
         return -1;
       }
-      FREE(&err.data);
+      buf_free(&err);
       mutt_clear_error();
     }
 
@@ -623,25 +620,22 @@ int mutt_search_alias_command(struct Menu *menu, int cur,
 
     if (!state->pattern || !buf_str_equal(tmp, state->string_expn))
     {
-      struct Buffer err;
-      buf_init(&err);
       OptSearchInvalid = true;
       buf_copy(state->string_expn, tmp);
       mutt_message(_("Compiling search pattern..."));
       mutt_pattern_free(&state->pattern);
-      err.dsize = 256;
-      err.data = mutt_mem_malloc(err.dsize);
-      state->pattern = mutt_pattern_comp(NULL, menu, tmp->data, MUTT_PC_FULL_MSG, &err);
+      struct Buffer *err = buf_pool_get();
+      state->pattern = mutt_pattern_comp(NULL, menu, tmp->data, MUTT_PC_FULL_MSG, err);
       if (!state->pattern)
       {
         buf_pool_release(&tmp);
-        mutt_error("%s", err.data);
-        FREE(&err.data);
+        mutt_error("%s", buf_string(err));
+        buf_free(&err);
         buf_reset(state->string);
         buf_reset(state->string_expn);
         return -1;
       }
-      FREE(&err.data);
+      buf_free(&err);
       mutt_clear_error();
     }
 

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -443,7 +443,7 @@ bail:
  * @retval -1    No match, or error
  */
 int mutt_search_command(struct MailboxView *mv, struct Menu *menu,
-                        struct Search *search, int cur, SearchFlags flags)
+                        struct SearchState *search, int cur, SearchFlags flags)
 {
   struct Progress *progress = NULL;
   int rc = -1;
@@ -749,25 +749,4 @@ done:
   progress_free(&progress);
   buf_pool_release(&buf);
   return rc;
-}
-
-struct Search *mutt_search_new()
-{
-  struct Search *search = mutt_mem_calloc(1, sizeof(struct Search));
-  search->string = buf_pool_get();
-  search->string_expn = buf_pool_get();
-  return search;
-}
-
-void mutt_search_free(struct Search **ptr)
-{
-  if (!ptr || !*ptr)
-    return;
-
-  struct Search *search = *ptr;
-  mutt_pattern_free(&search->pattern);
-  buf_pool_release(&search->string);
-  buf_pool_release(&search->string_expn);
-
-  FREE(ptr);
 }

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -432,14 +432,14 @@ bail:
  * mutt_search_command - Perform a search
  * @param mv    Mailbox view to search through
  * @param menu  Current Menu
- * @param state Current search state
  * @param cur   Index number of current email
+ * @param state Current search state
  * @param flags Search flags, e.g. SEARCH_PROMPT
  * @retval >=0  Index of matching email
  * @retval -1   No match, or error
  */
-int mutt_search_command(struct MailboxView *mv, struct Menu *menu,
-                        struct SearchState *state, int cur, SearchFlags flags)
+int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
+                        struct SearchState *state, SearchFlags flags)
 {
   struct Progress *progress = NULL;
   int rc = -1;
@@ -591,14 +591,14 @@ done:
 /**
  * mutt_search_alias_command - Perform a search
  * @param menu  Menu to search through
- * @param state Current search state
  * @param cur   Index number of current email
+ * @param state Current search state
  * @param flags Search flags, e.g. SEARCH_PROMPT
  * @retval >=0  Index of matching alias
  * @retval -1   No match, or error
  */
-int mutt_search_alias_command(struct Menu *menu, struct SearchState *state,
-                              int cur, SearchFlags flags)
+int mutt_search_alias_command(struct Menu *menu, int cur,
+                              struct SearchState *state, SearchFlags flags)
 {
   struct Progress *progress = NULL;
   const struct AliasMenuData *mdata = menu->mdata;

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -33,7 +33,6 @@
 #include <stdbool.h>
 #include "private.h"
 #include "mutt/lib.h"
-#include "mutt/pool.h"
 #include "config/lib.h"
 #include "email/lib.h"
 #include "core/lib.h"

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -85,10 +85,6 @@ struct RangeRegex RangeRegexes[] = {
 typedef bool (*eat_arg_t)(struct Pattern *pat, PatternCompFlags flags,
                           struct Buffer *s, struct Buffer *err);
 
-static struct PatternList *SearchPattern = NULL; ///< current search pattern
-static char LastSearch[256] = { 0 };             ///< last pattern searched for
-static char LastSearchExpn[1024] = { 0 }; ///< expanded version of LastSearch
-
 /**
  * quote_simple - Apply simple quoting to a string
  * @param str    String to quote
@@ -594,61 +590,55 @@ done:
 
 /**
  * mutt_search_alias_command - Perform a search
- * @param menu Menu to search through
- * @param cur  Index number of current alias
- * @param op   Operation to perform, e.g. OP_SEARCH_NEXT
- * @retval >=0 Index of matching alias
- * @retval -1 No match, or error
+ * @param menu  Menu to search through
+ * @param state Current search state
+ * @param cur   Index number of current email
+ * @param flags Search flags, e.g. SEARCH_PROMPT
+ * @retval >=0  Index of matching alias
+ * @retval -1   No match, or error
  */
-int mutt_search_alias_command(struct Menu *menu, int cur, int op)
+int mutt_search_alias_command(struct Menu *menu, struct SearchState *state,
+                              int cur, SearchFlags flags)
 {
   struct Progress *progress = NULL;
   const struct AliasMenuData *mdata = menu->mdata;
   const struct AliasViewArray *ava = &mdata->ava;
-  struct Buffer *buf = NULL;
   int rc = -1;
 
-  if ((*LastSearch == '\0') || ((op != OP_SEARCH_NEXT) && (op != OP_SEARCH_OPPOSITE)))
+  if (buf_is_empty(state->string) || flags & SEARCH_PROMPT)
   {
-    buf = buf_pool_get();
-    buf_strcpy(buf, (LastSearch[0] != '\0') ? LastSearch : "");
-    if ((mw_get_field(((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ? _("Search for: ") : _("Reverse search for: "),
-                      buf, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, false, NULL, NULL, NULL) != 0) ||
-        buf_is_empty(buf))
+    if ((mw_get_field((flags & OP_SEARCH_REVERSE) ? _("Reverse search for: ") : _("Search for: "),
+                      state->string, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, false,
+                      NULL, NULL, NULL) != 0) ||
+        buf_is_empty(state->string))
     {
       goto done;
     }
 
-    if ((op == OP_SEARCH) || (op == OP_SEARCH_NEXT))
-      OptSearchReverse = false;
-    else
-      OptSearchReverse = true;
-
     /* compare the *expanded* version of the search pattern in case
      * $simple_search has changed while we were searching */
     struct Buffer *tmp = buf_pool_get();
-    buf_copy(tmp, buf);
+    buf_copy(tmp, state->string);
     mutt_check_simple(tmp, MUTT_ALIAS_SIMPLESEARCH);
 
-    if (!SearchPattern || !mutt_str_equal(buf_string(tmp), LastSearchExpn))
+    if (!state->pattern || !buf_str_equal(tmp, state->string_expn))
     {
       struct Buffer err;
       buf_init(&err);
       OptSearchInvalid = true;
-      mutt_str_copy(LastSearch, buf_string(buf), sizeof(LastSearch));
-      mutt_str_copy(LastSearchExpn, buf_string(tmp), sizeof(LastSearchExpn));
+      buf_copy(state->string_expn, tmp);
       mutt_message(_("Compiling search pattern..."));
-      mutt_pattern_free(&SearchPattern);
+      mutt_pattern_free(&state->pattern);
       err.dsize = 256;
       err.data = mutt_mem_malloc(err.dsize);
-      SearchPattern = mutt_pattern_comp(NULL, menu, tmp->data, MUTT_PC_FULL_MSG, &err);
-      if (!SearchPattern)
+      state->pattern = mutt_pattern_comp(NULL, menu, tmp->data, MUTT_PC_FULL_MSG, &err);
+      if (!state->pattern)
       {
         buf_pool_release(&tmp);
         mutt_error("%s", err.data);
         FREE(&err.data);
-        LastSearch[0] = '\0';
-        LastSearchExpn[0] = '\0';
+        buf_reset(state->string);
+        buf_reset(state->string_expn);
         return -1;
       }
       FREE(&err.data);
@@ -669,8 +659,8 @@ int mutt_search_alias_command(struct Menu *menu, int cur, int op)
     OptSearchInvalid = false;
   }
 
-  int incr = OptSearchReverse ? -1 : 1;
-  if (op == OP_SEARCH_OPPOSITE)
+  int incr = state->reverse ? -1 : 1;
+  if (flags & SEARCH_OPPOSITE)
     incr = -incr;
 
   progress = progress_new(_("Searching..."), MUTT_PROGRESS_READ, ARRAY_SIZE(ava));
@@ -724,7 +714,7 @@ int mutt_search_alias_command(struct Menu *menu, int cur, int op)
     {
       /* remember that we've already searched this message */
       av->is_searched = true;
-      av->is_matched = mutt_pattern_alias_exec(SLIST_FIRST(SearchPattern),
+      av->is_matched = mutt_pattern_alias_exec(SLIST_FIRST(state->pattern),
                                                MUTT_MATCH_FULL_ADDRESS, av, NULL);
       if (av->is_matched)
       {
@@ -749,6 +739,5 @@ int mutt_search_alias_command(struct Menu *menu, int cur, int op)
   mutt_error(_("Not found"));
 done:
   progress_free(&progress);
-  buf_pool_release(&buf);
   return rc;
 }

--- a/pattern/search_state.c
+++ b/pattern/search_state.c
@@ -1,0 +1,51 @@
+/**
+ * @file
+ * Holds state of a search
+ *
+ * @authors
+ * Copyright (C) 2023 Dennis Schön <mail@dennis-schoen.de>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page pattern_search_state Holds state of a search
+ *
+ * Holds state of a search
+ */
+
+#include "mutt/lib.h"
+#include "lib.h"
+
+struct SearchState *search_state_new()
+{
+  struct SearchState *s = mutt_mem_calloc(1, sizeof(struct SearchState));
+  s->string = buf_pool_get();
+  s->string_expn = buf_pool_get();
+  return s;
+}
+
+void search_state_free(struct SearchState **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct SearchState *s = *ptr;
+  mutt_pattern_free(&s->pattern);
+  buf_pool_release(&s->string);
+  buf_pool_release(&s->string_expn);
+
+  FREE(ptr);
+}

--- a/pattern/search_state.c
+++ b/pattern/search_state.c
@@ -29,6 +29,10 @@
 #include "mutt/lib.h"
 #include "lib.h"
 
+/**
+ * search_state_new - Create a new SearchState
+ * @retval ptr New SearchState
+ */
 struct SearchState *search_state_new()
 {
   struct SearchState *s = mutt_mem_calloc(1, sizeof(struct SearchState));
@@ -37,6 +41,10 @@ struct SearchState *search_state_new()
   return s;
 }
 
+/**
+ * search_state_free - Free a SearchState
+ * @param ptr SearchState to free
+ */
 void search_state_free(struct SearchState **ptr)
 {
   if (!ptr || !*ptr)

--- a/pattern/search_state.h
+++ b/pattern/search_state.h
@@ -1,0 +1,44 @@
+/**
+ * @file
+ * Holds state of a search
+ *
+ * @authors
+ * Copyright (C) 2023 Dennis Schön <mail@dennis-schoen.de>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * struct SearchState - Holds state of a search
+ *
+ * This data is kept to allow operations like OP_SEARCH_NEXT.
+ */
+struct SearchState {
+  struct PatternList *pattern;     ///< compiled search pattern
+  struct Buffer      *string;      ///< search string
+  struct Buffer      *string_expn; ///< expanded search string
+  bool                reverse;     ///< search backwards
+};
+
+typedef uint8_t SearchFlags;       ///< Flags for a specific search, e.g. #SEARCH_PROMPT
+#define SEARCH_NO_FLAGS        0   ///< No flags are set
+#define SEARCH_PROMPT    (1 << 0)  ///< Ask for search input
+#define SEARCH_OPPOSITE  (1 << 1)  ///< Search in the opposite direction
+
+struct SearchState *search_state_new();
+void search_state_free(struct SearchState **search);

--- a/pattern/search_state.h
+++ b/pattern/search_state.h
@@ -40,5 +40,5 @@ typedef uint8_t SearchFlags;       ///< Flags for a specific search, e.g. #SEARC
 #define SEARCH_PROMPT    (1 << 0)  ///< Ask for search input
 #define SEARCH_OPPOSITE  (1 << 1)  ///< Search in the opposite direction
 
-struct SearchState *search_state_new();
+struct SearchState *search_state_new(void);
 void search_state_free(struct SearchState **search);

--- a/postpone/dlg_postpone.c
+++ b/postpone/dlg_postpone.c
@@ -257,6 +257,7 @@ struct Email *dlg_postponed(struct Mailbox *m)
 
   mview_free(&mv);
   cs_subset_str_native_set(NeoMutt->sub, "sort", c_sort, NULL);
+  search_state_free(&pd.search_state);
   simple_dialog_free(&dlg);
 
   return pd.email;

--- a/postpone/dlg_postpone.c
+++ b/postpone/dlg_postpone.c
@@ -77,6 +77,7 @@
 #include "gui/lib.h"
 #include "index/lib.h"
 #include "menu/lib.h"
+#include "pattern/lib.h"
 #include "format_flags.h"
 #include "functions.h"
 #include "hdrline.h"
@@ -210,7 +211,7 @@ struct Email *dlg_postponed(struct Mailbox *m)
   menu->mdata = mv;
   menu->mdata_free = NULL; // Menu doesn't own the data
 
-  struct PostponeData pd = { mv, menu, NULL, false };
+  struct PostponeData pd = { mv, menu, NULL, false, search_state_new() };
   dlg->wdata = &pd;
 
   // NT_COLOR is handled by the SimpleDialog

--- a/postpone/functions.c
+++ b/postpone/functions.c
@@ -118,7 +118,7 @@ static int op_search(struct PostponeData *pd, int op)
 
   int index = menu_get_index(pd->menu);
   struct MailboxView *mv = pd->mailbox_view;
-  index = mutt_search_command(mv, pd->menu, pd->search_state, index, flags);
+  index = mutt_search_command(mv, pd->menu, index, pd->search_state, flags);
   if (index != -1)
     menu_set_index(pd->menu, index);
 

--- a/postpone/functions.c
+++ b/postpone/functions.c
@@ -98,9 +98,10 @@ static int op_generic_select_entry(struct PostponeData *pd, int op)
  */
 static int op_search(struct PostponeData *pd, int op)
 {
-  struct Search *st = {0};
+  int index = menu_get_index(pd->menu);
+  struct Search *st = { 0 };
   struct MailboxView *mv = pd->mailbox_view;
-  int index = mutt_search_command(mv, pd->menu, st);
+  index = mutt_search_command(mv, pd->menu, st, index, 0);
   if (index != -1)
     menu_set_index(pd->menu, index);
 

--- a/postpone/functions.c
+++ b/postpone/functions.c
@@ -98,9 +98,9 @@ static int op_generic_select_entry(struct PostponeData *pd, int op)
  */
 static int op_search(struct PostponeData *pd, int op)
 {
-  int index = menu_get_index(pd->menu);
+  struct Search *st = {0};
   struct MailboxView *mv = pd->mailbox_view;
-  index = mutt_search_command(mv, pd->menu, index, op);
+  int index = mutt_search_command(mv, pd->menu, st);
   if (index != -1)
     menu_set_index(pd->menu, index);
 

--- a/postpone/functions.c
+++ b/postpone/functions.c
@@ -98,10 +98,27 @@ static int op_generic_select_entry(struct PostponeData *pd, int op)
  */
 static int op_search(struct PostponeData *pd, int op)
 {
+  SearchFlags flags = SEARCH_NO_FLAGS;
+  switch (op)
+  {
+    case OP_SEARCH:
+      flags |= SEARCH_PROMPT;
+      pd->search_state->reverse = false;
+      break;
+    case OP_SEARCH_REVERSE:
+      flags |= SEARCH_PROMPT;
+      pd->search_state->reverse = true;
+      break;
+    case OP_SEARCH_NEXT:
+      break;
+    case OP_SEARCH_OPPOSITE:
+      flags |= SEARCH_OPPOSITE;
+      break;
+  }
+
   int index = menu_get_index(pd->menu);
-  struct Search *st = { 0 };
   struct MailboxView *mv = pd->mailbox_view;
-  index = mutt_search_command(mv, pd->menu, st, index, 0);
+  index = mutt_search_command(mv, pd->menu, pd->search_state, index, flags);
   if (index != -1)
     menu_set_index(pd->menu, index);
 

--- a/postpone/functions.h
+++ b/postpone/functions.h
@@ -36,6 +36,7 @@ struct PostponeData
   struct Menu        *menu;          ///< Postponed Menu
   struct Email       *email;         ///< Selected Email
   bool                done;          ///< Should we close the Dialog?
+  struct SearchState *search_state;  ///< State of the current search
 };
 
 /**


### PR DESCRIPTION
**Goals**

* get rid of `OptSearchReverse` from `globals.c`
* don't use op codes (`OP_SEARCH_BACKWARDS`, ...) in `mutt_search_command()` and `mutt_search_alias_command()`
* remove `SearchPattern`, `LastSearch` and `LastSearchExpn` globals from `pattern/pattern.c`

**Idea**

I split the required search data into two parts:
1. State that needs to be kept across operations. This is what the globals `OptSearchReverse` and `SearchPattern`, `LastSearch`, `LastSearchExpn` currrently hold.
2. "one-time" search flags:
  a. `OP_SEARCH` and `OP_SEARCH_BACKWARDS` trigger the search functions to prompt the user for input.
  b. `OP_SEARCH_OPPOSITE` tells the search function to search in the opposite direction of what is currently the global state. 

For the state data I've added a new struct `SearchState` that holds the data previously in the globals. That struct itself is kept on `IndexSharedData`, `AliasMenuData` and `PostponeData`.

For the flags I added `SearchFlags` (`SEARCH_PROMPT`, `SEARCH_OPPOSITE`) that get computed in `op_search()` based on the operation.

-> Related discussion: https://github.com/neomutt/neomutt/discussions/3997