### PR TITLE
remove OptSearchInvalid global

### DIFF
--- a/globals.c
+++ b/globals.c
@@ -80,7 +80,6 @@ bool OptNewsSend;           ///< (pseudo) used to change behavior when posting
 bool OptNoCurses;           ///< (pseudo) when sending in batch mode
 bool OptPgpCheckTrust;      ///< (pseudo) used by dlg_pgp()
 bool OptResortInit;         ///< (pseudo) used to force the next resort to be from scratch
-bool OptSearchInvalid;      ///< (pseudo) used to invalidate the search pattern
 bool OptSortSubthreads;     ///< (pseudo) used when $sort_aux changes
 // clang-format on
 

--- a/globals.h
+++ b/globals.h
@@ -75,7 +75,6 @@ extern bool OptNewsSend;            ///< (pseudo) used to change behavior when p
 extern bool OptNoCurses;            ///< (pseudo) when sending in batch mode
 extern bool OptPgpCheckTrust;       ///< (pseudo) used by dlg_pgp()
 extern bool OptResortInit;          ///< (pseudo) used to force the next resort to be from scratch
-extern bool OptSearchInvalid;       ///< (pseudo) used to invalidate the search pattern
 extern bool OptSortSubthreads;      ///< (pseudo) used when $sort_aux changes
 
 extern char **EnvList;              ///< Private copy of the environment variables

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -656,7 +656,7 @@ void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *oldcount,
         update_index(menu, shared->mailbox_view, check, *oldcount, shared);
 
       FREE(&new_last_folder);
-      OptSearchInvalid = true;
+      mutt_pattern_free(&shared->search_state->pattern);
       menu_queue_redraw(menu, MENU_REDRAW_INDEX);
       return;
     }
@@ -719,7 +719,7 @@ void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *oldcount,
   struct EventMailbox ev_m = { shared->mailbox };
   mutt_mailbox_check(ev_m.mailbox, MUTT_MAILBOX_CHECK_FORCE);
   menu_queue_redraw(menu, MENU_REDRAW_FULL);
-  OptSearchInvalid = true;
+  mutt_pattern_free(&shared->search_state->pattern);
 }
 
 #ifdef USE_NOTMUCH
@@ -1151,7 +1151,7 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
           menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
         }
 
-        OptSearchInvalid = true;
+        mutt_pattern_free(&shared->search_state->pattern);
       }
       else if ((check == MX_STATUS_NEW_MAIL) || (check == MX_STATUS_REOPENED) ||
                (check == MX_STATUS_FLAGS))
@@ -1199,7 +1199,7 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
         shared->mailbox->verbose = verbose;
         priv->menu->max = shared->mailbox->vcount;
         menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
-        OptSearchInvalid = true;
+        mutt_pattern_free(&shared->search_state->pattern);
       }
 
       index_shared_data_set_email(shared, mutt_get_virt_email(shared->mailbox,

--- a/index/functions.c
+++ b/index/functions.c
@@ -1653,7 +1653,7 @@ static int op_main_sync_folder(struct IndexSharedData *shared,
         }
       }
     }
-    OptSearchInvalid = true;
+    mutt_pattern_free(&shared->search_state->pattern);
   }
   else if ((check == MX_STATUS_NEW_MAIL) || (check == MX_STATUS_REOPENED))
   {
@@ -1899,7 +1899,7 @@ static int op_quit(struct IndexSharedData *shared, struct IndexPrivateData *priv
     }
 
     menu_queue_redraw(priv->menu, MENU_REDRAW_FULL); /* new mail arrived? */
-    OptSearchInvalid = true;
+    mutt_pattern_free(&shared->search_state->pattern);
   }
 
   return FR_NO_ACTION;
@@ -2070,7 +2070,7 @@ static int op_sort(struct IndexSharedData *shared, struct IndexPrivateData *priv
   if (shared->mailbox && (shared->mailbox->msg_count != 0))
   {
     resort_index(shared->mailbox_view, priv->menu);
-    OptSearchInvalid = true;
+    mutt_pattern_free(&shared->search_state->pattern);
   }
 
   return FR_SUCCESS;
@@ -2318,14 +2318,14 @@ static int op_main_imap_logout_all(struct IndexSharedData *shared,
       {
         update_index(priv->menu, shared->mailbox_view, check, priv->oldcount, shared);
       }
-      OptSearchInvalid = true;
+      mutt_pattern_free(&shared->search_state->pattern);
       menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
       return FR_ERROR;
     }
   }
   imap_logout_all();
   mutt_message(_("Logged out of IMAP servers"));
-  OptSearchInvalid = true;
+  mutt_pattern_free(&shared->search_state->pattern);
   menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
 
   return FR_SUCCESS;

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -59,6 +59,7 @@
 #include "mview.h"
 #include "mx.h"
 #include "opcodes.h"
+#include "pattern/lib.h"
 #include "private_data.h"
 #include "protos.h"
 #include "status.h"
@@ -442,7 +443,7 @@ int dlg_pager(struct PagerView *pview)
         if ((check == MX_STATUS_NEW_MAIL) || (check == MX_STATUS_REOPENED))
         {
           pager_queue_redraw(priv, PAGER_REDRAW_PAGER);
-          OptSearchInvalid = true;
+          mutt_pattern_free(&shared->search_state->pattern);
         }
       }
 

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -447,6 +447,7 @@ int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
   struct Mailbox *m = mv ? mv->mailbox : NULL;
   if (!m)
     return -1;
+  bool pattern_changed = false;
 
   if (buf_is_empty(state->string) || (flags & SEARCH_PROMPT))
   {
@@ -464,32 +465,35 @@ int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
     buf_copy(tmp, state->string);
     const char *const c_simple_search = cs_subset_string(NeoMutt->sub, "simple_search");
     mutt_check_simple(tmp, NONULL(c_simple_search));
-
-    if (!state->pattern || !buf_str_equal(tmp, state->string_expn))
+    if (!buf_str_equal(tmp, state->string_expn))
     {
-      OptSearchInvalid = true;
-      buf_copy(state->string_expn, tmp);
-      mutt_message(_("Compiling search pattern..."));
       mutt_pattern_free(&state->pattern);
-      struct Buffer *err = buf_pool_get();
-      state->pattern = mutt_pattern_comp(mv, menu, tmp->data, MUTT_PC_FULL_MSG, err);
-      if (!state->pattern)
-      {
-        buf_pool_release(&tmp);
-        mutt_error("%s", buf_string(err));
-        buf_free(&err);
-        buf_reset(state->string);
-        buf_reset(state->string_expn);
-        return -1;
-      }
-      buf_free(&err);
-      mutt_clear_error();
+      buf_copy(state->string_expn, tmp);
+      buf_pool_release(&tmp);
     }
-
-    buf_pool_release(&tmp);
   }
 
-  if (OptSearchInvalid)
+  if (!state->pattern)
+  {
+    mutt_message(_("Compiling search pattern..."));
+    mutt_pattern_free(&state->pattern);
+    struct Buffer *err = buf_pool_get();
+    state->pattern = mutt_pattern_comp(mv, menu, state->string_expn->data,
+                                       MUTT_PC_FULL_MSG, err);
+    pattern_changed = true;
+    if (!state->pattern)
+    {
+      mutt_error("%s", buf_string(err));
+      buf_free(&err);
+      buf_reset(state->string);
+      buf_reset(state->string_expn);
+      return -1;
+    }
+    buf_free(&err);
+    mutt_clear_error();
+  }
+
+  if (pattern_changed)
   {
     for (int i = 0; i < m->msg_count; i++)
       m->emails[i]->searched = false;
@@ -497,7 +501,6 @@ int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
     if ((m->type == MUTT_IMAP) && (!imap_search(m, state->pattern)))
       return -1;
 #endif
-    OptSearchInvalid = false;
   }
 
   int incr = state->reverse ? -1 : 1;
@@ -602,6 +605,7 @@ int mutt_search_alias_command(struct Menu *menu, int cur,
   const struct AliasMenuData *mdata = menu->mdata;
   const struct AliasViewArray *ava = &mdata->ava;
   int rc = -1;
+  bool pattern_changed = false;
 
   if (buf_is_empty(state->string) || flags & SEARCH_PROMPT)
   {
@@ -618,40 +622,40 @@ int mutt_search_alias_command(struct Menu *menu, int cur,
     struct Buffer *tmp = buf_pool_get();
     buf_copy(tmp, state->string);
     mutt_check_simple(tmp, MUTT_ALIAS_SIMPLESEARCH);
-
-    if (!state->pattern || !buf_str_equal(tmp, state->string_expn))
+    if (!buf_str_equal(tmp, state->string_expn))
     {
-      OptSearchInvalid = true;
-      buf_copy(state->string_expn, tmp);
-      mutt_message(_("Compiling search pattern..."));
       mutt_pattern_free(&state->pattern);
-      struct Buffer *err = buf_pool_get();
-      state->pattern = mutt_pattern_comp(NULL, menu, tmp->data, MUTT_PC_FULL_MSG, err);
-      if (!state->pattern)
-      {
-        buf_pool_release(&tmp);
-        mutt_error("%s", buf_string(err));
-        buf_free(&err);
-        buf_reset(state->string);
-        buf_reset(state->string_expn);
-        return -1;
-      }
-      buf_free(&err);
-      mutt_clear_error();
+      buf_copy(state->string_expn, tmp);
+      buf_pool_release(&tmp);
     }
-
-    buf_pool_release(&tmp);
   }
 
-  if (OptSearchInvalid)
+  if (!state->pattern)
+  {
+    mutt_message(_("Compiling search pattern..."));
+    struct Buffer *err = buf_pool_get();
+    state->pattern = mutt_pattern_comp(NULL, menu, state->string_expn->data,
+                                       MUTT_PC_FULL_MSG, err);
+    pattern_changed = true;
+    if (!state->pattern)
+    {
+      mutt_error("%s", buf_string(err));
+      buf_free(&err);
+      buf_reset(state->string);
+      buf_reset(state->string_expn);
+      return -1;
+    }
+    buf_free(&err);
+    mutt_clear_error();
+  }
+
+  if (pattern_changed)
   {
     struct AliasView *av = NULL;
     ARRAY_FOREACH(av, ava)
     {
       av->is_searched = false;
     }
-
-    OptSearchInvalid = false;
   }
 
   int incr = state->reverse ? -1 : 1;

--- a/test/pattern/dummy.c
+++ b/test/pattern/dummy.c
@@ -90,7 +90,6 @@ short AbortKey;
 bool OptForceRefresh;
 bool OptKeepQuiet;
 bool OptNoCurses;
-bool OptSearchInvalid;
 
 typedef uint8_t MuttFormatFlags;
 typedef uint16_t CompletionFlags;


### PR DESCRIPTION
Instead of setting `OptSearchInvalid = true` when an action (switch mailbox, new mail, sort, ...) "invalidates" the current search, we free the current search pattern. This triggers a recompile in the search methods.

This means the search methods behavior changes a bit: before we only "forgot" which mails we already searched and if they matched. Now we recompile the search pattern on invalidation.

I actually like this change because it makes the search methods `mutt_search_command()` and `mutt_search_alias_command()` a bit clearer. But if we decide that this is too expensive we could simply move the `invalid` bool to the `SearchState` and keep the current logic.