### PR TITLE
editor: move completion functions

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -106,9 +106,9 @@ $(PWD)/address:
 ###############################################################################
 # libalias
 LIBALIAS=	libalias.a
-LIBALIASOBJS=	alias/alias.o alias/array.o alias/commands.o alias/config.o \
-		alias/dlg_alias.o alias/dlg_query.o alias/functions.o \
-		alias/gui.o alias/reverse.o alias/sort.o
+LIBALIASOBJS=	alias/alias.o alias/array.o alias/commands.o alias/complete.o \
+		alias/config.o alias/dlg_alias.o alias/dlg_query.o \
+		alias/functions.o alias/gui.o alias/reverse.o alias/sort.o
 CLEANFILES+=	$(LIBALIAS) $(LIBALIASOBJS)
 ALLOBJS+=	$(LIBALIASOBJS)
 
@@ -166,8 +166,8 @@ $(PWD)/bcache:
 ###############################################################################
 # libbrowser
 LIBBROWSER=	libbrowser.a
-LIBBROWSEROBJS=	browser/config.o browser/dlg_browser.o browser/functions.o \
-		browser/private_data.o browser/sort.o
+LIBBROWSEROBJS=	browser/complete.o browser/config.o browser/dlg_browser.o \
+		browser/functions.o browser/private_data.o browser/sort.o
 CLEANFILES+=	$(LIBBROWSER) $(LIBBROWSEROBJS)
 ALLOBJS+=	$(LIBBROWSEROBJS)
 
@@ -648,9 +648,9 @@ $(PWD)/nntp:
 # libnotmuch
 @if USE_NOTMUCH
 LIBNOTMUCH=	libnotmuch.a
-LIBNOTMUCHOBJS=	notmuch/config.o notmuch/db.o notmuch/notmuch.o \
-		notmuch/adata.o notmuch/edata.o notmuch/mdata.o \
-		notmuch/query.o notmuch/tag.o
+LIBNOTMUCHOBJS=	notmuch/complete.o notmuch/config.o notmuch/db.o \
+		notmuch/notmuch.o notmuch/adata.o notmuch/edata.o \
+		notmuch/mdata.o notmuch/query.o notmuch/tag.o
 CLEANFILES+=	$(LIBNOTMUCH) $(LIBNOTMUCHOBJS)
 ALLOBJS+=	$(LIBNOTMUCHOBJS)
 
@@ -692,9 +692,10 @@ $(PWD)/parse:
 ###############################################################################
 # libpattern
 LIBPATTERN=	libpattern.a
-LIBPATTERNOBJS=	pattern/compile.o pattern/config.o pattern/dlg_pattern.o \
-		pattern/exec.o pattern/flags.o pattern/functions.o \
-		pattern/message.o pattern/pattern.o pattern/search_state.o
+LIBPATTERNOBJS=	pattern/complete.o pattern/compile.o pattern/config.o \
+		pattern/dlg_pattern.o pattern/exec.o pattern/flags.o \
+		pattern/functions.o pattern/message.o pattern/pattern.o \
+		pattern/search_state.o
 CLEANFILES+=	$(LIBPATTERN) $(LIBPATTERNOBJS)
 ALLOBJS+=	$(LIBPATTERNOBJS)
 
@@ -852,11 +853,11 @@ $(ALLOBJS):
 # The order of these libraries depends on their dependencies.
 # The libraries with the most dependencies will come first.
 MUTTLIBS+=	$(LIBINDEX) $(LIBPAGER) $(LIBINDEX) $(LIBPAGER) $(LIBAUTOCRYPT) $(LIBPOP) \
-		$(LIBBROWSER) $(LIBCOMPMBOX) $(LIBSTORE) \
+		$(LIBENTER) $(LIBCOMPLETE) $(LIBBROWSER) $(LIBCOMPMBOX) $(LIBSTORE) \
 		$(LIBPROGRESS) $(LIBQUESTION) $(LIBPOSTPONE) $(LIBALIAS) $(LIBSEND) \
-		$(LIBCONVERT) $(LIBCOMPOSE) $(LIBATTACH) $(LIBGUI) $(LIBENTER) $(LIBCOMPLETE) $(LIBNNTP) \
+		$(LIBCONVERT) $(LIBCOMPOSE) $(LIBATTACH) $(LIBGUI) $(LIBNNTP) \
 		$(LIBPATTERN) $(LIBMENU) $(LIBCOLOR) $(LIBENVELOPE) $(LIBMIXMASTER) \
-		$(LIBHELPBAR) $(LIBMBOX) $(LIBNOTMUCH) $(LIBMAILDIR) \
+		$(LIBHELPBAR) $(LIBMBOX) $(LIBNOTMUCH) $(LIBMAILDIR) $(LIBENTER) $(LIBCOMPLETE) $(LIBNNTP) \
 		$(LIBNCRYPT) $(LIBIMAP) $(LIBCONN) $(LIBHCACHE) \
 		$(LIBCOMPRESS) $(LIBSIDEBAR) $(LIBBCACHE) $(LIBHISTORY) \
 		$(LIBCORE) $(LIBPARSE) $(LIBCONFIG) $(LIBEMAIL) $(LIBADDRESS) \

--- a/alias/alias.c
+++ b/alias/alias.c
@@ -499,8 +499,9 @@ retry_name:
   const char *const c_alias_file = cs_subset_path(sub, "alias_file");
   buf_strcpy(buf, c_alias_file);
 
+  struct FileCompletionData cdata = { false, NULL, NULL, NULL };
   if (mw_get_field(_("Save to file: "), buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                   false, NULL, NULL, NULL, &CompleteMailboxOps, NULL) != 0)
+                   false, NULL, NULL, NULL, &CompleteMailboxOps, &cdata) != 0)
   {
     goto done;
   }

--- a/alias/alias.c
+++ b/alias/alias.c
@@ -394,7 +394,8 @@ void alias_create(struct AddressList *al, const struct ConfigSubset *sub)
 
 retry_name:
   /* L10N: prompt to add a new alias */
-  if ((mw_get_field(_("Alias as: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field(_("Alias as: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
+                    NULL, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;
@@ -434,7 +435,8 @@ retry_name:
 
   do
   {
-    if ((mw_get_field(_("Address: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0) ||
+    if ((mw_get_field(_("Address: "), buf, MUTT_COMP_NO_FLAGS, false, NULL,
+                      NULL, NULL, NULL, NULL) != 0) ||
         buf_is_empty(buf))
     {
       alias_free(&alias);
@@ -457,7 +459,8 @@ retry_name:
   else
     buf_reset(buf);
 
-  if (mw_get_field(_("Personal name: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0)
+  if (mw_get_field(_("Personal name: "), buf, MUTT_COMP_NO_FLAGS, false, NULL,
+                   NULL, NULL, NULL, NULL) != 0)
   {
     alias_free(&alias);
     goto done;
@@ -465,7 +468,8 @@ retry_name:
   buf_copy(TAILQ_FIRST(&alias->addr)->personal, buf);
 
   buf_reset(buf);
-  if (mw_get_field(_("Comment: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) == 0)
+  if (mw_get_field(_("Comment: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
+                   NULL, NULL, NULL) == 0)
   {
     mutt_str_replace(&alias->comment, buf_string(buf));
   }
@@ -495,7 +499,7 @@ retry_name:
   buf_strcpy(buf, c_alias_file);
 
   if (mw_get_field(_("Save to file: "), buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                   false, NULL, NULL, NULL) != 0)
+                   false, NULL, NULL, NULL, NULL, NULL) != 0)
   {
     goto done;
   }

--- a/alias/alias.c
+++ b/alias/alias.c
@@ -497,8 +497,8 @@ retry_name:
   buf_strcpy(buf, c_alias_file);
 
   struct FileCompletionData cdata = { false, NULL, NULL, NULL };
-  if (mw_get_field(_("Save to file: "), buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                   HC_FILE, &CompleteMailboxOps, &cdata) != 0)
+  if (mw_get_field(_("Save to file: "), buf, MUTT_COMP_CLEAR, HC_FILE,
+                   &CompleteMailboxOps, &cdata) != 0)
   {
     goto done;
   }

--- a/alias/alias.c
+++ b/alias/alias.c
@@ -48,6 +48,7 @@
 #include "lib.h"
 #include "browser/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "question/lib.h"
 #include "send/lib.h"
 #include "alternates.h"
@@ -395,7 +396,7 @@ void alias_create(struct AddressList *al, const struct ConfigSubset *sub)
 
 retry_name:
   /* L10N: prompt to add a new alias */
-  if ((mw_get_field(_("Alias as: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
+  if ((mw_get_field(_("Alias as: "), buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;
@@ -435,7 +436,7 @@ retry_name:
 
   do
   {
-    if ((mw_get_field(_("Address: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
+    if ((mw_get_field(_("Address: "), buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0) ||
         buf_is_empty(buf))
     {
       alias_free(&alias);
@@ -458,7 +459,7 @@ retry_name:
   else
     buf_reset(buf);
 
-  if (mw_get_field(_("Personal name: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
+  if (mw_get_field(_("Personal name: "), buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0)
   {
     alias_free(&alias);
     goto done;
@@ -466,7 +467,7 @@ retry_name:
   buf_copy(TAILQ_FIRST(&alias->addr)->personal, buf);
 
   buf_reset(buf);
-  if (mw_get_field(_("Comment: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0)
+  if (mw_get_field(_("Comment: "), buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) == 0)
   {
     mutt_str_replace(&alias->comment, buf_string(buf));
   }
@@ -497,7 +498,7 @@ retry_name:
 
   struct FileCompletionData cdata = { false, NULL, NULL, NULL };
   if (mw_get_field(_("Save to file: "), buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                   &CompleteMailboxOps, &cdata) != 0)
+                   HC_FILE, &CompleteMailboxOps, &cdata) != 0)
   {
     goto done;
   }

--- a/alias/alias.c
+++ b/alias/alias.c
@@ -395,8 +395,7 @@ void alias_create(struct AddressList *al, const struct ConfigSubset *sub)
 
 retry_name:
   /* L10N: prompt to add a new alias */
-  if ((mw_get_field(_("Alias as: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
-                    NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field(_("Alias as: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;
@@ -436,8 +435,7 @@ retry_name:
 
   do
   {
-    if ((mw_get_field(_("Address: "), buf, MUTT_COMP_NO_FLAGS, false, NULL,
-                      NULL, NULL, NULL, NULL) != 0) ||
+    if ((mw_get_field(_("Address: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
         buf_is_empty(buf))
     {
       alias_free(&alias);
@@ -460,8 +458,7 @@ retry_name:
   else
     buf_reset(buf);
 
-  if (mw_get_field(_("Personal name: "), buf, MUTT_COMP_NO_FLAGS, false, NULL,
-                   NULL, NULL, NULL, NULL) != 0)
+  if (mw_get_field(_("Personal name: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
   {
     alias_free(&alias);
     goto done;
@@ -469,8 +466,7 @@ retry_name:
   buf_copy(TAILQ_FIRST(&alias->addr)->personal, buf);
 
   buf_reset(buf);
-  if (mw_get_field(_("Comment: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
-                   NULL, NULL, NULL) == 0)
+  if (mw_get_field(_("Comment: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0)
   {
     mutt_str_replace(&alias->comment, buf_string(buf));
   }
@@ -501,7 +497,7 @@ retry_name:
 
   struct FileCompletionData cdata = { false, NULL, NULL, NULL };
   if (mw_get_field(_("Save to file: "), buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                   false, NULL, NULL, NULL, &CompleteMailboxOps, &cdata) != 0)
+                   &CompleteMailboxOps, &cdata) != 0)
   {
     goto done;
   }

--- a/alias/alias.c
+++ b/alias/alias.c
@@ -46,6 +46,7 @@
 #include "mutt.h"
 #include "alias.h"
 #include "lib.h"
+#include "browser/lib.h"
 #include "enter/lib.h"
 #include "question/lib.h"
 #include "send/lib.h"
@@ -499,7 +500,7 @@ retry_name:
   buf_strcpy(buf, c_alias_file);
 
   if (mw_get_field(_("Save to file: "), buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                   false, NULL, NULL, NULL, NULL, NULL) != 0)
+                   false, NULL, NULL, NULL, &CompleteMailboxOps, NULL) != 0)
   {
     goto done;
   }

--- a/alias/complete.c
+++ b/alias/complete.c
@@ -32,14 +32,16 @@
 #include "core/lib.h"
 #include "lib.h"
 #include "enter/lib.h"
+#include "opcodes.h"
 
 /**
- * complete_alias_complete - Complete an Alias
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ * complete_alias_complete - Complete an Alias - Implements ::complete_function_t -- @ingroup complete_api
  */
-int complete_alias_complete(struct EnterWindowData *wdata)
+int complete_alias_complete(struct EnterWindowData *wdata, int op)
 {
+  if (!wdata || (op != OP_EDITOR_COMPLETE))
+    return FR_NO_ACTION;
+
   /* invoke the alias-menu to get more addresses */
   size_t i;
   for (i = wdata->state->curpos; (i > 0) && (wdata->state->wbuf[i - 1] != ',') &&
@@ -62,12 +64,13 @@ int complete_alias_complete(struct EnterWindowData *wdata)
 }
 
 /**
- * complete_alias_query - Complete an Alias Query
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ * complete_alias_query - Complete an Alias Query - Implements ::complete_function_t -- @ingroup complete_api
  */
-int complete_alias_query(struct EnterWindowData *wdata)
+int complete_alias_query(struct EnterWindowData *wdata, int op)
 {
+  if (!wdata || (op != OP_EDITOR_COMPLETE))
+    return FR_NO_ACTION;
+
   size_t i = wdata->state->curpos;
   if (i != 0)
   {

--- a/alias/complete.c
+++ b/alias/complete.c
@@ -31,6 +31,7 @@
 #include "mutt/lib.h"
 #include "core/lib.h"
 #include "lib.h"
+#include "complete/lib.h"
 #include "enter/lib.h"
 #include "opcodes.h"
 
@@ -87,3 +88,23 @@ int complete_alias_query(struct EnterWindowData *wdata, int op)
 
   return FR_CONTINUE;
 }
+
+/**
+ * complete_alias - Alias completion wrapper - Implements ::complete_function_t -- @ingroup complete_api
+ */
+int complete_alias(struct EnterWindowData *wdata, int op)
+{
+  if (op == OP_EDITOR_COMPLETE)
+    return complete_alias_complete(wdata, op);
+  if (op == OP_EDITOR_COMPLETE_QUERY)
+    return complete_alias_query(wdata, op);
+
+  return FR_NO_ACTION;
+}
+
+/**
+ * CompleteAliasOps - Auto-Completion of Aliases
+ */
+const struct CompleteOps CompleteAliasOps = {
+  .complete = complete_alias,
+};

--- a/alias/complete.c
+++ b/alias/complete.c
@@ -1,0 +1,86 @@
+/**
+ * @file
+ * Alias Auto-Completion
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page alias_complete Alias Auto-Completion
+ *
+ * Alias Auto-Completion
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "lib.h"
+#include "enter/lib.h"
+
+/**
+ * complete_alias_complete - Complete an Alias
+ * @param wdata Enter window data
+ * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ */
+int complete_alias_complete(struct EnterWindowData *wdata)
+{
+  /* invoke the alias-menu to get more addresses */
+  size_t i;
+  for (i = wdata->state->curpos; (i > 0) && (wdata->state->wbuf[i - 1] != ',') &&
+                                 (wdata->state->wbuf[i - 1] != ':');
+       i--)
+  {
+  }
+  for (; (i < wdata->state->lastchar) && (wdata->state->wbuf[i] == ' '); i++)
+    ; // do nothing
+
+  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf + i, wdata->state->curpos - i);
+  int rc = alias_complete(wdata->buffer, NeoMutt->sub);
+  replace_part(wdata->state, i, buf_string(wdata->buffer));
+  if (rc != 1)
+  {
+    return FR_CONTINUE;
+  }
+
+  return FR_SUCCESS;
+}
+
+/**
+ * complete_alias_query - Complete an Alias Query
+ * @param wdata Enter window data
+ * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ */
+int complete_alias_query(struct EnterWindowData *wdata)
+{
+  size_t i = wdata->state->curpos;
+  if (i != 0)
+  {
+    for (; (i > 0) && (wdata->state->wbuf[i - 1] != ','); i--)
+      ; // do nothing
+
+    for (; (i < wdata->state->curpos) && (wdata->state->wbuf[i] == ' '); i++)
+      ; // do nothing
+  }
+
+  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf + i, wdata->state->curpos - i);
+  query_complete(wdata->buffer, NeoMutt->sub);
+  replace_part(wdata->state, i, buf_string(wdata->buffer));
+
+  return FR_CONTINUE;
+}

--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -83,6 +83,7 @@
 #include "mutt.h"
 #include "lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "menu/lib.h"
 #include "pattern/lib.h"
 #include "send/lib.h"
@@ -547,7 +548,7 @@ void query_index(struct Mailbox *m, struct ConfigSubset *sub)
   mdata.search_state = search_state_new();
 
   struct Buffer *buf = buf_pool_get();
-  if ((mw_get_field(_("Query: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
+  if ((mw_get_field(_("Query: "), buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;

--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -547,8 +547,7 @@ void query_index(struct Mailbox *m, struct ConfigSubset *sub)
   mdata.search_state = search_state_new();
 
   struct Buffer *buf = buf_pool_get();
-  if ((mw_get_field(_("Query: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
-                    NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field(_("Query: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;

--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -547,7 +547,8 @@ void query_index(struct Mailbox *m, struct ConfigSubset *sub)
   mdata.search_state = search_state_new();
 
   struct Buffer *buf = buf_pool_get();
-  if ((mw_get_field(_("Query: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field(_("Query: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
+                    NULL, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;

--- a/alias/functions.c
+++ b/alias/functions.c
@@ -190,8 +190,7 @@ static int op_main_limit(struct AliasMenuData *mdata, int op)
 static int op_query(struct AliasMenuData *mdata, int op)
 {
   struct Buffer *buf = mdata->query;
-  if ((mw_get_field(_("Query: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
-                    NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field(_("Query: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     return FR_NO_ACTION;

--- a/alias/functions.c
+++ b/alias/functions.c
@@ -39,6 +39,7 @@
 #include "functions.h"
 #include "lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "menu/lib.h"
 #include "pattern/lib.h"
 #include "question/lib.h"
@@ -190,7 +191,7 @@ static int op_main_limit(struct AliasMenuData *mdata, int op)
 static int op_query(struct AliasMenuData *mdata, int op)
 {
   struct Buffer *buf = mdata->query;
-  if ((mw_get_field(_("Query: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
+  if ((mw_get_field(_("Query: "), buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     return FR_NO_ACTION;

--- a/alias/functions.c
+++ b/alias/functions.c
@@ -190,7 +190,8 @@ static int op_main_limit(struct AliasMenuData *mdata, int op)
 static int op_query(struct AliasMenuData *mdata, int op)
 {
   struct Buffer *buf = mdata->query;
-  if ((mw_get_field(_("Query: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field(_("Query: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
+                    NULL, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     return FR_NO_ACTION;

--- a/alias/lib.h
+++ b/alias/lib.h
@@ -47,12 +47,16 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include "core/lib.h"
+#include "complete/lib.h"
 
 struct Address;
 struct AddressList;
 struct Buffer;
 struct ConfigSubset;
+struct EnterWindowData;
 struct Envelope;
+
+extern const struct CompleteOps CompleteAliasOps;
 
 void alias_init   (void);
 void alias_cleanup(void);
@@ -73,6 +77,8 @@ void alias_dialog  (struct Mailbox *m, struct ConfigSubset *sub);
 
 int  query_complete(struct Buffer *buf, struct ConfigSubset *sub);
 void query_index   (struct Mailbox *m, struct ConfigSubset *sub);
+
+int complete_alias(struct EnterWindowData *wdata, int op);
 
 struct Address *alias_reverse_lookup(const struct Address *addr);
 

--- a/alias/lib.h
+++ b/alias/lib.h
@@ -30,6 +30,7 @@
  * | alias/alias.c       | @subpage alias_alias       |
  * | alias/array.c       | @subpage alias_array       |
  * | alias/commands.c    | @subpage alias_commands    |
+ * | alias/complete.c    | @subpage alias_complete    |
  * | alias/config.c      | @subpage alias_config      |
  * | alias/dlg_alias.c   | @subpage alias_dlg_alias   |
  * | alias/dlg_query.c   | @subpage alias_dlg_query   |

--- a/attach/recvattach.c
+++ b/attach/recvattach.c
@@ -301,7 +301,7 @@ static int query_save_attachment(FILE *fp, struct Body *body, struct Email *e, c
   while (prompt)
   {
     if ((mw_get_field(prompt, buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR, false,
-                      NULL, NULL, NULL) != 0) ||
+                      NULL, NULL, NULL, NULL, NULL) != 0) ||
         buf_is_empty(buf))
     {
       goto cleanup;
@@ -482,7 +482,7 @@ void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
           prepend_savedir(buf);
 
           if ((mw_get_field(_("Save to file: "), buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                            false, NULL, NULL, NULL) != 0) ||
+                            false, NULL, NULL, NULL, NULL, NULL) != 0) ||
               buf_is_empty(buf))
           {
             goto cleanup;
@@ -729,7 +729,7 @@ void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
   state.flags = STATE_CHARCONV;
 
   if (mw_get_field((filter ? _("Filter through: ") : _("Pipe to: ")), buf,
-                   MUTT_COMP_FILE_SIMPLE, false, NULL, NULL, NULL) != 0)
+                   MUTT_COMP_FILE_SIMPLE, false, NULL, NULL, NULL, NULL, NULL) != 0)
   {
     goto cleanup;
   }

--- a/attach/recvattach.c
+++ b/attach/recvattach.c
@@ -302,8 +302,8 @@ static int query_save_attachment(FILE *fp, struct Body *body, struct Email *e, c
   while (prompt)
   {
     struct FileCompletionData cdata = { false, NULL, NULL, NULL };
-    if ((mw_get_field(prompt, buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR, false,
-                      NULL, NULL, NULL, &CompleteMailboxOps, &cdata) != 0) ||
+    if ((mw_get_field(prompt, buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
+                      &CompleteMailboxOps, &cdata) != 0) ||
         buf_is_empty(buf))
     {
       goto cleanup;
@@ -485,7 +485,7 @@ void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
 
           struct FileCompletionData cdata = { false, NULL, NULL, NULL };
           if ((mw_get_field(_("Save to file: "), buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                            false, NULL, NULL, NULL, &CompleteMailboxOps, &cdata) != 0) ||
+                            &CompleteMailboxOps, &cdata) != 0) ||
               buf_is_empty(buf))
           {
             goto cleanup;
@@ -731,8 +731,8 @@ void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
   /* perform charset conversion on text attachments when piping */
   state.flags = STATE_CHARCONV;
 
-  if (mw_get_field((filter ? _("Filter through: ") : _("Pipe to: ")), buf, MUTT_COMP_FILE_SIMPLE,
-                   false, NULL, NULL, NULL, &CompleteFileOps, NULL) != 0)
+  if (mw_get_field((filter ? _("Filter through: ") : _("Pipe to: ")), buf,
+                   MUTT_COMP_FILE_SIMPLE, &CompleteFileOps, NULL) != 0)
   {
     goto cleanup;
   }

--- a/attach/recvattach.c
+++ b/attach/recvattach.c
@@ -43,6 +43,7 @@
 #include "recvattach.h"
 #include "browser/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "menu/lib.h"
 #include "ncrypt/lib.h"
 #include "question/lib.h"
@@ -302,7 +303,7 @@ static int query_save_attachment(FILE *fp, struct Body *body, struct Email *e, c
   while (prompt)
   {
     struct FileCompletionData cdata = { false, NULL, NULL, NULL };
-    if ((mw_get_field(prompt, buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
+    if ((mw_get_field(prompt, buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR, HC_FILE,
                       &CompleteMailboxOps, &cdata) != 0) ||
         buf_is_empty(buf))
     {
@@ -485,7 +486,7 @@ void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
 
           struct FileCompletionData cdata = { false, NULL, NULL, NULL };
           if ((mw_get_field(_("Save to file: "), buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                            &CompleteMailboxOps, &cdata) != 0) ||
+                            HC_FILE, &CompleteMailboxOps, &cdata) != 0) ||
               buf_is_empty(buf))
           {
             goto cleanup;
@@ -732,7 +733,7 @@ void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
   state.flags = STATE_CHARCONV;
 
   if (mw_get_field((filter ? _("Filter through: ") : _("Pipe to: ")), buf,
-                   MUTT_COMP_FILE_SIMPLE, &CompleteFileOps, NULL) != 0)
+                   MUTT_COMP_FILE_SIMPLE, HC_COMMAND, &CompleteFileOps, NULL) != 0)
   {
     goto cleanup;
   }

--- a/attach/recvattach.c
+++ b/attach/recvattach.c
@@ -41,6 +41,7 @@
 #include "gui/lib.h"
 #include "mutt.h"
 #include "recvattach.h"
+#include "browser/lib.h"
 #include "enter/lib.h"
 #include "menu/lib.h"
 #include "ncrypt/lib.h"
@@ -301,7 +302,7 @@ static int query_save_attachment(FILE *fp, struct Body *body, struct Email *e, c
   while (prompt)
   {
     if ((mw_get_field(prompt, buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR, false,
-                      NULL, NULL, NULL, NULL, NULL) != 0) ||
+                      NULL, NULL, NULL, &CompleteMailboxOps, NULL) != 0) ||
         buf_is_empty(buf))
     {
       goto cleanup;
@@ -482,7 +483,7 @@ void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
           prepend_savedir(buf);
 
           if ((mw_get_field(_("Save to file: "), buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                            false, NULL, NULL, NULL, NULL, NULL) != 0) ||
+                            false, NULL, NULL, NULL, &CompleteMailboxOps, NULL) != 0) ||
               buf_is_empty(buf))
           {
             goto cleanup;
@@ -728,8 +729,8 @@ void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
   /* perform charset conversion on text attachments when piping */
   state.flags = STATE_CHARCONV;
 
-  if (mw_get_field((filter ? _("Filter through: ") : _("Pipe to: ")), buf,
-                   MUTT_COMP_FILE_SIMPLE, false, NULL, NULL, NULL, NULL, NULL) != 0)
+  if (mw_get_field((filter ? _("Filter through: ") : _("Pipe to: ")), buf, MUTT_COMP_FILE_SIMPLE,
+                   false, NULL, NULL, NULL, &CompleteFileOps, NULL) != 0)
   {
     goto cleanup;
   }

--- a/attach/recvattach.c
+++ b/attach/recvattach.c
@@ -301,8 +301,9 @@ static int query_save_attachment(FILE *fp, struct Body *body, struct Email *e, c
   prompt = _("Save to file: ");
   while (prompt)
   {
+    struct FileCompletionData cdata = { false, NULL, NULL, NULL };
     if ((mw_get_field(prompt, buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR, false,
-                      NULL, NULL, NULL, &CompleteMailboxOps, NULL) != 0) ||
+                      NULL, NULL, NULL, &CompleteMailboxOps, &cdata) != 0) ||
         buf_is_empty(buf))
     {
       goto cleanup;
@@ -482,8 +483,9 @@ void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
           buf_strcpy(buf, mutt_path_basename(NONULL(top->filename)));
           prepend_savedir(buf);
 
+          struct FileCompletionData cdata = { false, NULL, NULL, NULL };
           if ((mw_get_field(_("Save to file: "), buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                            false, NULL, NULL, NULL, &CompleteMailboxOps, NULL) != 0) ||
+                            false, NULL, NULL, NULL, &CompleteMailboxOps, &cdata) != 0) ||
               buf_is_empty(buf))
           {
             goto cleanup;

--- a/attach/recvattach.c
+++ b/attach/recvattach.c
@@ -303,8 +303,7 @@ static int query_save_attachment(FILE *fp, struct Body *body, struct Email *e, c
   while (prompt)
   {
     struct FileCompletionData cdata = { false, NULL, NULL, NULL };
-    if ((mw_get_field(prompt, buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR, HC_FILE,
-                      &CompleteMailboxOps, &cdata) != 0) ||
+    if ((mw_get_field(prompt, buf, MUTT_COMP_CLEAR, HC_FILE, &CompleteMailboxOps, &cdata) != 0) ||
         buf_is_empty(buf))
     {
       goto cleanup;
@@ -485,8 +484,8 @@ void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
           prepend_savedir(buf);
 
           struct FileCompletionData cdata = { false, NULL, NULL, NULL };
-          if ((mw_get_field(_("Save to file: "), buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                            HC_FILE, &CompleteMailboxOps, &cdata) != 0) ||
+          if ((mw_get_field(_("Save to file: "), buf, MUTT_COMP_CLEAR, HC_FILE,
+                            &CompleteMailboxOps, &cdata) != 0) ||
               buf_is_empty(buf))
           {
             goto cleanup;
@@ -733,7 +732,7 @@ void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
   state.flags = STATE_CHARCONV;
 
   if (mw_get_field((filter ? _("Filter through: ") : _("Pipe to: ")), buf,
-                   MUTT_COMP_FILE_SIMPLE, HC_COMMAND, &CompleteFileOps, NULL) != 0)
+                   MUTT_COMP_NO_FLAGS, HC_COMMAND, &CompleteFileOps, NULL) != 0)
   {
     goto cleanup;
   }

--- a/browser/complete.c
+++ b/browser/complete.c
@@ -33,7 +33,6 @@
 #include "mutt/lib.h"
 #include "core/lib.h"
 #include "gui/lib.h"
-#include "mutt.h"
 #include "lib.h"
 #include "complete/lib.h"
 #include "enter/lib.h"
@@ -75,10 +74,13 @@ int complete_file_mbox(struct EnterWindowData *wdata, int op)
        (memcmp(wdata->tempbuf, wdata->state->wbuf,
                wdata->state->lastchar * sizeof(wchar_t)) == 0)))
   {
-    dlg_browser(wdata->buffer,
-                ((wdata->flags & MUTT_COMP_FILE_MBOX) ? MUTT_SEL_FOLDER : MUTT_SEL_NO_FLAGS) |
-                    (cdata->multiple ? MUTT_SEL_MULTI : MUTT_SEL_NO_FLAGS),
-                cdata->mailbox, cdata->files, cdata->numfiles);
+    SelectFileFlags flags = MUTT_SEL_NO_FLAGS;
+    if (wdata->hclass == HC_MBOX)
+      flags |= MUTT_SEL_FOLDER;
+    if (cdata->multiple)
+      flags |= MUTT_SEL_MULTI;
+
+    dlg_browser(wdata->buffer, flags, cdata->mailbox, cdata->files, cdata->numfiles);
     if (!buf_is_empty(wdata->buffer))
     {
       buf_pretty_mailbox(wdata->buffer);

--- a/browser/complete.c
+++ b/browser/complete.c
@@ -127,3 +127,17 @@ int complete_file_simple(struct EnterWindowData *wdata, int op)
   replace_part(wdata->state, i, buf_string(wdata->buffer));
   return rc;
 }
+
+/**
+ * CompleteFileOps - Auto-Completion of Files
+ */
+const struct CompleteOps CompleteFileOps = {
+  .complete = complete_file_simple,
+};
+
+/**
+ * CompleteMailboxOps - Auto-Completion of Files / Mailboxes
+ */
+const struct CompleteOps CompleteMailboxOps = {
+  .complete = complete_file_mbox,
+};

--- a/browser/complete.c
+++ b/browser/complete.c
@@ -32,6 +32,7 @@
 #include <string.h>
 #include "mutt/lib.h"
 #include "core/lib.h"
+#include "gui/lib.h"
 #include "mutt.h"
 #include "lib.h"
 #include "complete/lib.h"
@@ -49,11 +50,13 @@ int complete_file_mbox(struct EnterWindowData *wdata, int op)
   if (!wdata)
     return FR_NO_ACTION;
 
+  struct FileCompletionData *cdata = wdata->cdata;
+
   if (op == OP_EDITOR_MAILBOX_CYCLE)
   {
     wdata->first = true; /* clear input if user types a real key later */
     buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
-    mutt_mailbox_next(wdata->m, wdata->buffer);
+    mutt_mailbox_next(cdata->mailbox, wdata->buffer);
 
     wdata->state->curpos = wdata->state->lastchar = mutt_mb_mbstowcs(
         &wdata->state->wbuf, &wdata->state->wbuflen, 0, buf_string(wdata->buffer));
@@ -74,8 +77,8 @@ int complete_file_mbox(struct EnterWindowData *wdata, int op)
   {
     dlg_browser(wdata->buffer,
                 ((wdata->flags & MUTT_COMP_FILE_MBOX) ? MUTT_SEL_FOLDER : MUTT_SEL_NO_FLAGS) |
-                    (wdata->multiple ? MUTT_SEL_MULTI : MUTT_SEL_NO_FLAGS),
-                wdata->m, wdata->files, wdata->numfiles);
+                    (cdata->multiple ? MUTT_SEL_MULTI : MUTT_SEL_NO_FLAGS),
+                cdata->mailbox, cdata->files, cdata->numfiles);
     if (!buf_is_empty(wdata->buffer))
     {
       buf_pretty_mailbox(wdata->buffer);
@@ -122,7 +125,7 @@ int complete_file_simple(struct EnterWindowData *wdata, int op)
       (memcmp(wdata->tempbuf, wdata->state->wbuf + i,
               (wdata->state->lastchar - i) * sizeof(wchar_t)) == 0))
   {
-    dlg_browser(wdata->buffer, MUTT_SEL_NO_FLAGS, wdata->m, NULL, NULL);
+    dlg_browser(wdata->buffer, MUTT_SEL_NO_FLAGS, NULL, NULL, NULL);
     if (buf_is_empty(wdata->buffer))
       replace_part(wdata->state, i, buf_string(wdata->buffer));
     return FR_CONTINUE;

--- a/browser/complete.c
+++ b/browser/complete.c
@@ -38,14 +38,16 @@
 #include "enter/lib.h"
 #include "history/lib.h"
 #include "muttlib.h"
+#include "opcodes.h"
 
 /**
- * complete_file_mbox - Complete a Mailbox
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ * complete_file_mbox - Complete a Mailbox - Implements ::complete_function_t -- @ingroup complete_api
  */
-int complete_file_mbox(struct EnterWindowData *wdata)
+int complete_file_mbox(struct EnterWindowData *wdata, int op)
 {
+  if (!wdata || (op != OP_EDITOR_COMPLETE))
+    return FR_NO_ACTION;
+
   int rc = FR_SUCCESS;
   buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
 
@@ -87,12 +89,13 @@ int complete_file_mbox(struct EnterWindowData *wdata)
 }
 
 /**
- * complete_file_simple - Complete a filename
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ * complete_file_simple - Complete a filename - Implements ::complete_function_t -- @ingroup complete_api
  */
-int complete_file_simple(struct EnterWindowData *wdata)
+int complete_file_simple(struct EnterWindowData *wdata, int op)
 {
+  if (!wdata || (op != OP_EDITOR_COMPLETE))
+    return FR_NO_ACTION;
+
   int rc = FR_SUCCESS;
   size_t i;
   for (i = wdata->state->curpos;

--- a/browser/complete.c
+++ b/browser/complete.c
@@ -1,0 +1,126 @@
+/**
+ * @file
+ * Browser Auto-Completion
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page browser_complete Browser Auto-Completion
+ *
+ * Browser Auto-Completion
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include <string.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "mutt.h"
+#include "lib.h"
+#include "complete/lib.h"
+#include "enter/lib.h"
+#include "history/lib.h"
+#include "muttlib.h"
+
+/**
+ * complete_file_mbox - Complete a Mailbox
+ * @param wdata Enter window data
+ * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ */
+int complete_file_mbox(struct EnterWindowData *wdata)
+{
+  int rc = FR_SUCCESS;
+  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
+
+  /* see if the path has changed from the last time */
+  if ((!wdata->tempbuf && !wdata->state->lastchar) ||
+      (wdata->tempbuf && (wdata->templen == wdata->state->lastchar) &&
+       (memcmp(wdata->tempbuf, wdata->state->wbuf,
+               wdata->state->lastchar * sizeof(wchar_t)) == 0)))
+  {
+    dlg_browser(wdata->buffer,
+                ((wdata->flags & MUTT_COMP_FILE_MBOX) ? MUTT_SEL_FOLDER : MUTT_SEL_NO_FLAGS) |
+                    (wdata->multiple ? MUTT_SEL_MULTI : MUTT_SEL_NO_FLAGS),
+                wdata->m, wdata->files, wdata->numfiles);
+    if (!buf_is_empty(wdata->buffer))
+    {
+      buf_pretty_mailbox(wdata->buffer);
+      if (!wdata->pass)
+        mutt_hist_add(wdata->hclass, buf_string(wdata->buffer), true);
+      wdata->done = true;
+      return FR_SUCCESS;
+    }
+
+    /* file selection cancelled */
+    return FR_CONTINUE;
+  }
+
+  if (mutt_complete(wdata->cd, wdata->buffer) == 0)
+  {
+    wdata->templen = wdata->state->lastchar;
+    mutt_mem_realloc(&wdata->tempbuf, wdata->templen * sizeof(wchar_t));
+    memcpy(wdata->tempbuf, wdata->state->wbuf, wdata->templen * sizeof(wchar_t));
+  }
+  else
+  {
+    return FR_ERROR; // let the user know that nothing matched
+  }
+  replace_part(wdata->state, 0, buf_string(wdata->buffer));
+  return rc;
+}
+
+/**
+ * complete_file_simple - Complete a filename
+ * @param wdata Enter window data
+ * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ */
+int complete_file_simple(struct EnterWindowData *wdata)
+{
+  int rc = FR_SUCCESS;
+  size_t i;
+  for (i = wdata->state->curpos;
+       (i > 0) && !mutt_mb_is_shell_char(wdata->state->wbuf[i - 1]); i--)
+  {
+  }
+  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf + i, wdata->state->curpos - i);
+  if (wdata->tempbuf && (wdata->templen == (wdata->state->lastchar - i)) &&
+      (memcmp(wdata->tempbuf, wdata->state->wbuf + i,
+              (wdata->state->lastchar - i) * sizeof(wchar_t)) == 0))
+  {
+    dlg_browser(wdata->buffer, MUTT_SEL_NO_FLAGS, wdata->m, NULL, NULL);
+    if (buf_is_empty(wdata->buffer))
+      replace_part(wdata->state, i, buf_string(wdata->buffer));
+    return FR_CONTINUE;
+  }
+
+  if (mutt_complete(wdata->cd, wdata->buffer) == 0)
+  {
+    wdata->templen = wdata->state->lastchar - i;
+    mutt_mem_realloc(&wdata->tempbuf, wdata->templen * sizeof(wchar_t));
+    memcpy(wdata->tempbuf, wdata->state->wbuf + i, wdata->templen * sizeof(wchar_t));
+  }
+  else
+  {
+    rc = FR_ERROR;
+  }
+
+  replace_part(wdata->state, i, buf_string(wdata->buffer));
+  return rc;
+}

--- a/browser/complete.c
+++ b/browser/complete.c
@@ -37,6 +37,7 @@
 #include "complete/lib.h"
 #include "enter/lib.h"
 #include "history/lib.h"
+#include "mutt_mailbox.h"
 #include "muttlib.h"
 #include "opcodes.h"
 
@@ -45,7 +46,21 @@
  */
 int complete_file_mbox(struct EnterWindowData *wdata, int op)
 {
-  if (!wdata || (op != OP_EDITOR_COMPLETE))
+  if (!wdata)
+    return FR_NO_ACTION;
+
+  if (op == OP_EDITOR_MAILBOX_CYCLE)
+  {
+    wdata->first = true; /* clear input if user types a real key later */
+    buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
+    mutt_mailbox_next(wdata->m, wdata->buffer);
+
+    wdata->state->curpos = wdata->state->lastchar = mutt_mb_mbstowcs(
+        &wdata->state->wbuf, &wdata->state->wbuflen, 0, buf_string(wdata->buffer));
+    return FR_SUCCESS;
+  }
+
+  if (op != OP_EDITOR_COMPLETE)
     return FR_NO_ACTION;
 
   int rc = FR_SUCCESS;

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -97,8 +97,9 @@ static int op_browser_new_file(struct BrowserPrivateData *priv, int op)
   struct Buffer *buf = buf_pool_get();
   buf_printf(buf, "%s/", buf_string(&LastDir));
 
+  struct FileCompletionData cdata = { false, priv->mailbox, NULL, NULL };
   const int rc = mw_get_field(_("New file name: "), buf, MUTT_COMP_FILE, false,
-                              NULL, NULL, NULL, &CompleteMailboxOps, NULL);
+                              NULL, NULL, NULL, &CompleteMailboxOps, &cdata);
   if (rc != 0)
   {
     buf_pool_release(&buf);
@@ -311,8 +312,9 @@ static int op_change_directory(struct BrowserPrivateData *priv, int op)
 
   if (op == OP_CHANGE_DIRECTORY)
   {
+    struct FileCompletionData cdata = { false, priv->mailbox, NULL, NULL };
     int rc = mw_get_field(_("Chdir to: "), buf, MUTT_COMP_FILE, false, NULL,
-                          NULL, NULL, &CompleteMailboxOps, NULL);
+                          NULL, NULL, &CompleteMailboxOps, &cdata);
     if ((rc != 0) && buf_is_empty(buf))
     {
       buf_pool_release(&buf);

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -43,6 +43,7 @@
 #include "attach/lib.h"
 #include "enter/lib.h"
 #include "menu/lib.h"
+#include "pattern/lib.h"
 #include "question/lib.h"
 #include "send/lib.h"
 #include "globals.h" // IWYU pragma: keep
@@ -97,7 +98,7 @@ static int op_browser_new_file(struct BrowserPrivateData *priv, int op)
   buf_printf(buf, "%s/", buf_string(&LastDir));
 
   const int rc = mw_get_field(_("New file name: "), buf, MUTT_COMP_FILE, false,
-                              NULL, NULL, NULL, NULL, NULL);
+                              NULL, NULL, NULL, &CompleteMailboxOps, NULL);
   if (rc != 0)
   {
     buf_pool_release(&buf);
@@ -311,7 +312,7 @@ static int op_change_directory(struct BrowserPrivateData *priv, int op)
   if (op == OP_CHANGE_DIRECTORY)
   {
     int rc = mw_get_field(_("Chdir to: "), buf, MUTT_COMP_FILE, false, NULL,
-                          NULL, NULL, NULL, NULL);
+                          NULL, NULL, &CompleteMailboxOps, NULL);
     if ((rc != 0) && buf_is_empty(buf))
     {
       buf_pool_release(&buf);
@@ -939,7 +940,8 @@ static int op_subscribe_pattern(struct BrowserPrivateData *priv, int op)
   else
     snprintf(tmp2, sizeof(tmp2), _("Unsubscribe pattern: "));
   /* buf comes from the buffer pool, so defaults to size 1024 */
-  if ((mw_get_field(tmp2, buf, MUTT_COMP_PATTERN, false, NULL, NULL, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field(tmp2, buf, MUTT_COMP_PATTERN, false, NULL, NULL, NULL,
+                    &CompletePatternOps, NULL) != 0) ||
       buf_is_empty(buf))
   {
     buf_pool_release(&buf);

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -99,7 +99,7 @@ static int op_browser_new_file(struct BrowserPrivateData *priv, int op)
   buf_printf(buf, "%s/", buf_string(&LastDir));
 
   struct FileCompletionData cdata = { false, priv->mailbox, NULL, NULL };
-  const int rc = mw_get_field(_("New file name: "), buf, MUTT_COMP_FILE,
+  const int rc = mw_get_field(_("New file name: "), buf, MUTT_COMP_NO_FLAGS,
                               HC_FILE, &CompleteMailboxOps, &cdata);
   if (rc != 0)
   {
@@ -314,7 +314,7 @@ static int op_change_directory(struct BrowserPrivateData *priv, int op)
   if (op == OP_CHANGE_DIRECTORY)
   {
     struct FileCompletionData cdata = { false, priv->mailbox, NULL, NULL };
-    int rc = mw_get_field(_("Chdir to: "), buf, MUTT_COMP_FILE, HC_FILE,
+    int rc = mw_get_field(_("Chdir to: "), buf, MUTT_COMP_NO_FLAGS, HC_FILE,
                           &CompleteMailboxOps, &cdata);
     if ((rc != 0) && buf_is_empty(buf))
     {
@@ -942,7 +942,7 @@ static int op_subscribe_pattern(struct BrowserPrivateData *priv, int op)
   else
     snprintf(tmp2, sizeof(tmp2), _("Unsubscribe pattern: "));
   /* buf comes from the buffer pool, so defaults to size 1024 */
-  if ((mw_get_field(tmp2, buf, MUTT_COMP_PATTERN, HC_PATTERN, &CompletePatternOps, NULL) != 0) ||
+  if ((mw_get_field(tmp2, buf, MUTT_COMP_NO_FLAGS, HC_PATTERN, &CompletePatternOps, NULL) != 0) ||
       buf_is_empty(buf))
   {
     buf_pool_release(&buf);

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -97,7 +97,7 @@ static int op_browser_new_file(struct BrowserPrivateData *priv, int op)
   buf_printf(buf, "%s/", buf_string(&LastDir));
 
   const int rc = mw_get_field(_("New file name: "), buf, MUTT_COMP_FILE, false,
-                              NULL, NULL, NULL);
+                              NULL, NULL, NULL, NULL, NULL);
   if (rc != 0)
   {
     buf_pool_release(&buf);
@@ -310,7 +310,8 @@ static int op_change_directory(struct BrowserPrivateData *priv, int op)
 
   if (op == OP_CHANGE_DIRECTORY)
   {
-    int rc = mw_get_field(_("Chdir to: "), buf, MUTT_COMP_FILE, false, NULL, NULL, NULL);
+    int rc = mw_get_field(_("Chdir to: "), buf, MUTT_COMP_FILE, false, NULL,
+                          NULL, NULL, NULL, NULL);
     if ((rc != 0) && buf_is_empty(buf))
     {
       buf_pool_release(&buf);
@@ -489,7 +490,8 @@ static int op_enter_mask(struct BrowserPrivateData *priv, int op)
   const struct Regex *c_mask = cs_subset_regex(NeoMutt->sub, "mask");
   struct Buffer *buf = buf_pool_get();
   buf_strcpy(buf, c_mask ? c_mask->pattern : NULL);
-  if (mw_get_field(_("File Mask: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0)
+  if (mw_get_field(_("File Mask: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
+                   NULL, NULL, NULL) != 0)
   {
     buf_pool_release(&buf);
     return FR_NO_ACTION;
@@ -937,7 +939,7 @@ static int op_subscribe_pattern(struct BrowserPrivateData *priv, int op)
   else
     snprintf(tmp2, sizeof(tmp2), _("Unsubscribe pattern: "));
   /* buf comes from the buffer pool, so defaults to size 1024 */
-  if ((mw_get_field(tmp2, buf, MUTT_COMP_PATTERN, false, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field(tmp2, buf, MUTT_COMP_PATTERN, false, NULL, NULL, NULL, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     buf_pool_release(&buf);

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -42,6 +42,7 @@
 #include "lib.h"
 #include "attach/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "menu/lib.h"
 #include "pattern/lib.h"
 #include "question/lib.h"
@@ -99,7 +100,7 @@ static int op_browser_new_file(struct BrowserPrivateData *priv, int op)
 
   struct FileCompletionData cdata = { false, priv->mailbox, NULL, NULL };
   const int rc = mw_get_field(_("New file name: "), buf, MUTT_COMP_FILE,
-                              &CompleteMailboxOps, &cdata);
+                              HC_FILE, &CompleteMailboxOps, &cdata);
   if (rc != 0)
   {
     buf_pool_release(&buf);
@@ -313,7 +314,8 @@ static int op_change_directory(struct BrowserPrivateData *priv, int op)
   if (op == OP_CHANGE_DIRECTORY)
   {
     struct FileCompletionData cdata = { false, priv->mailbox, NULL, NULL };
-    int rc = mw_get_field(_("Chdir to: "), buf, MUTT_COMP_FILE, &CompleteMailboxOps, &cdata);
+    int rc = mw_get_field(_("Chdir to: "), buf, MUTT_COMP_FILE, HC_FILE,
+                          &CompleteMailboxOps, &cdata);
     if ((rc != 0) && buf_is_empty(buf))
     {
       buf_pool_release(&buf);
@@ -492,7 +494,7 @@ static int op_enter_mask(struct BrowserPrivateData *priv, int op)
   const struct Regex *c_mask = cs_subset_regex(NeoMutt->sub, "mask");
   struct Buffer *buf = buf_pool_get();
   buf_strcpy(buf, c_mask ? c_mask->pattern : NULL);
-  if (mw_get_field(_("File Mask: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
+  if (mw_get_field(_("File Mask: "), buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0)
   {
     buf_pool_release(&buf);
     return FR_NO_ACTION;
@@ -940,7 +942,7 @@ static int op_subscribe_pattern(struct BrowserPrivateData *priv, int op)
   else
     snprintf(tmp2, sizeof(tmp2), _("Unsubscribe pattern: "));
   /* buf comes from the buffer pool, so defaults to size 1024 */
-  if ((mw_get_field(tmp2, buf, MUTT_COMP_PATTERN, &CompletePatternOps, NULL) != 0) ||
+  if ((mw_get_field(tmp2, buf, MUTT_COMP_PATTERN, HC_PATTERN, &CompletePatternOps, NULL) != 0) ||
       buf_is_empty(buf))
   {
     buf_pool_release(&buf);

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -98,8 +98,8 @@ static int op_browser_new_file(struct BrowserPrivateData *priv, int op)
   buf_printf(buf, "%s/", buf_string(&LastDir));
 
   struct FileCompletionData cdata = { false, priv->mailbox, NULL, NULL };
-  const int rc = mw_get_field(_("New file name: "), buf, MUTT_COMP_FILE, false,
-                              NULL, NULL, NULL, &CompleteMailboxOps, &cdata);
+  const int rc = mw_get_field(_("New file name: "), buf, MUTT_COMP_FILE,
+                              &CompleteMailboxOps, &cdata);
   if (rc != 0)
   {
     buf_pool_release(&buf);
@@ -313,8 +313,7 @@ static int op_change_directory(struct BrowserPrivateData *priv, int op)
   if (op == OP_CHANGE_DIRECTORY)
   {
     struct FileCompletionData cdata = { false, priv->mailbox, NULL, NULL };
-    int rc = mw_get_field(_("Chdir to: "), buf, MUTT_COMP_FILE, false, NULL,
-                          NULL, NULL, &CompleteMailboxOps, &cdata);
+    int rc = mw_get_field(_("Chdir to: "), buf, MUTT_COMP_FILE, &CompleteMailboxOps, &cdata);
     if ((rc != 0) && buf_is_empty(buf))
     {
       buf_pool_release(&buf);
@@ -493,8 +492,7 @@ static int op_enter_mask(struct BrowserPrivateData *priv, int op)
   const struct Regex *c_mask = cs_subset_regex(NeoMutt->sub, "mask");
   struct Buffer *buf = buf_pool_get();
   buf_strcpy(buf, c_mask ? c_mask->pattern : NULL);
-  if (mw_get_field(_("File Mask: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
-                   NULL, NULL, NULL) != 0)
+  if (mw_get_field(_("File Mask: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
   {
     buf_pool_release(&buf);
     return FR_NO_ACTION;
@@ -942,8 +940,7 @@ static int op_subscribe_pattern(struct BrowserPrivateData *priv, int op)
   else
     snprintf(tmp2, sizeof(tmp2), _("Unsubscribe pattern: "));
   /* buf comes from the buffer pool, so defaults to size 1024 */
-  if ((mw_get_field(tmp2, buf, MUTT_COMP_PATTERN, false, NULL, NULL, NULL,
-                    &CompletePatternOps, NULL) != 0) ||
+  if ((mw_get_field(tmp2, buf, MUTT_COMP_PATTERN, &CompletePatternOps, NULL) != 0) ||
       buf_is_empty(buf))
   {
     buf_pool_release(&buf);

--- a/browser/lib.h
+++ b/browser/lib.h
@@ -43,6 +43,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include "mutt/lib.h"
+#include "complete/lib.h"
 
 struct Mailbox;
 struct Menu;
@@ -57,6 +58,9 @@ typedef uint8_t SelectFileFlags;  ///< Flags for mutt_select_file(), e.g. #MUTT_
 #define MUTT_SEL_MAILBOX (1 << 0) ///< Select a mailbox
 #define MUTT_SEL_MULTI   (1 << 1) ///< Multi-selection is enabled
 #define MUTT_SEL_FOLDER  (1 << 2) ///< Select a local directory
+
+extern const struct CompleteOps CompleteFileOps;
+extern const struct CompleteOps CompleteMailboxOps;
 
 /**
  * struct Folder - A folder/dir in the browser

--- a/browser/lib.h
+++ b/browser/lib.h
@@ -27,6 +27,7 @@
  *
  * | File                   | Description                   |
  * | :--------------------- | :---------------------------- |
+ * | browser/complete.c     | @subpage browser_complete     |
  * | browser/config.c       | @subpage browser_config       |
  * | browser/dlg_browser.c  | @subpage browser_dlg_browser  |
  * | browser/functions.c    | @subpage browser_functions    |

--- a/complete/compapi.h
+++ b/complete/compapi.h
@@ -1,0 +1,49 @@
+/**
+ * @file
+ * API Auto-Completion
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_COMPLETE_COMPAPI_H
+#define MUTT_COMPLETE_COMPAPI_H
+
+#include "core/lib.h"
+
+struct EnterWindowData;
+
+/**
+ * @defgroup complete_api Auto-Completion API
+ *
+ * Auto-Completion API
+ */
+struct CompleteOps
+{
+  /**
+   * @defgroup compapi_complete complete()
+   * @ingroup complete_api
+   *
+   * complete - Perform Auto-Completion
+   * @param wdata  Enter Window data
+   * @param op     Operation to perform, e.g. OP_COMPLETE
+   * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+   */
+  enum FunctionRetval (*complete)(struct EnterWindowData *wdata, int op);
+};
+
+#endif /* MUTT_COMPLETE_COMPAPI_H */

--- a/complete/helpers.c
+++ b/complete/helpers.c
@@ -38,6 +38,7 @@
 #include "enter/lib.h"
 #include "index/lib.h"
 #include "menu/lib.h"
+#include "compapi.h"
 #include "data.h"
 #include "functions.h"
 #include "keymap.h"
@@ -467,3 +468,17 @@ int complete_label(struct EnterWindowData *wdata, int op)
 
   return FR_SUCCESS;
 }
+
+/**
+ * CompleteCommandOps - Auto-Completion of Commands
+ */
+const struct CompleteOps CompleteCommandOps = {
+  .complete = complete_command,
+};
+
+/**
+ * CompleteLabelOps - Auto-Completion of Labels
+ */
+const struct CompleteOps CompleteLabelOps = {
+  .complete = complete_label,
+};

--- a/complete/helpers.c
+++ b/complete/helpers.c
@@ -41,6 +41,7 @@
 #include "data.h"
 #include "functions.h"
 #include "keymap.h"
+#include "opcodes.h"
 
 /**
  * matches_ensure_morespace - Allocate more space for auto-completion
@@ -417,12 +418,13 @@ int mutt_var_value_complete(struct CompletionData *cd, struct Buffer *buf, int p
 }
 
 /**
- * complete_command - Complete a NeoMutt Command
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ * complete_command - Complete a NeoMutt Command - Implements ::complete_function_t -- @ingroup complete_api
  */
-int complete_command(struct EnterWindowData *wdata)
+int complete_command(struct EnterWindowData *wdata, int op)
 {
+  if (!wdata || (op != OP_EDITOR_COMPLETE))
+    return FR_NO_ACTION;
+
   int rc = FR_SUCCESS;
   buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
   size_t i = buf_len(wdata->buffer);
@@ -441,12 +443,13 @@ int complete_command(struct EnterWindowData *wdata)
 }
 
 /**
- * complete_label - Complete a label
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ * complete_label - Complete a label - Implements ::complete_function_t -- @ingroup complete_api
  */
-int complete_label(struct EnterWindowData *wdata)
+int complete_label(struct EnterWindowData *wdata, int op)
 {
+  if (!wdata || (op != OP_EDITOR_COMPLETE))
+    return FR_NO_ACTION;
+
   size_t i;
   for (i = wdata->state->curpos; (i > 0) && (wdata->state->wbuf[i - 1] != ',') &&
                                  (wdata->state->wbuf[i - 1] != ':');

--- a/complete/helpers.c
+++ b/complete/helpers.c
@@ -35,9 +35,9 @@
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"
+#include "enter/lib.h"
 #include "index/lib.h"
 #include "menu/lib.h"
-#include "notmuch/lib.h"
 #include "data.h"
 #include "functions.h"
 #include "keymap.h"
@@ -47,7 +47,7 @@
  * @param cd       Completion Data
  * @param new_size Space required
  */
-static void matches_ensure_morespace(struct CompletionData *cd, int new_size)
+void matches_ensure_morespace(struct CompletionData *cd, int new_size)
 {
   if (new_size <= (cd->match_list_len - 2))
     return;
@@ -71,8 +71,7 @@ static void matches_ensure_morespace(struct CompletionData *cd, int new_size)
  *
  * Changes the dest buffer if necessary/possible to aid completion.
  */
-static bool candidate(struct CompletionData *cd, char *user, const char *src,
-                      char *dest, size_t dlen)
+bool candidate(struct CompletionData *cd, char *user, const char *src, char *dest, size_t dlen)
 {
   if (!dest || !user || !src)
     return false;
@@ -96,58 +95,6 @@ static bool candidate(struct CompletionData *cd, char *user, const char *src,
   }
   return true;
 }
-
-#ifdef USE_NOTMUCH
-/**
- * complete_all_nm_tags - Pass a list of Notmuch tags to the completion code
- * @param cd Completion Data
- * @param pt List of all Notmuch tags
- * @retval  0 Success
- * @retval -1 Error
- */
-static int complete_all_nm_tags(struct CompletionData *cd, const char *pt)
-{
-  struct Mailbox *m_cur = get_current_mailbox();
-  int tag_count_1 = 0;
-  int tag_count_2 = 0;
-  int rc = -1;
-
-  mutt_str_copy(cd->user_typed, pt, sizeof(cd->user_typed));
-  memset(cd->match_list, 0, cd->match_list_len);
-  memset(cd->completed, 0, sizeof(cd->completed));
-  cd->free_match_strings = true;
-
-  nm_db_longrun_init(m_cur, false);
-
-  /* Work out how many tags there are. */
-  if ((nm_get_all_tags(m_cur, NULL, &tag_count_1) != 0) || (tag_count_1 == 0))
-    goto done;
-
-  /* Get all the tags. */
-  const char **nm_tags = mutt_mem_calloc(tag_count_1, sizeof(char *));
-  if ((nm_get_all_tags(m_cur, nm_tags, &tag_count_2) != 0) || (tag_count_1 != tag_count_2))
-  {
-    completion_data_free_match_strings(cd);
-    goto done;
-  }
-
-  /* Put them into the completion machinery. */
-  for (int i = 0; i < tag_count_1; i++)
-  {
-    if (!candidate(cd, cd->user_typed, nm_tags[i], cd->completed, sizeof(cd->completed)))
-      FREE(&nm_tags[i]);
-  }
-
-  matches_ensure_morespace(cd, cd->num_matched);
-  cd->match_list[cd->num_matched++] = mutt_str_dup(cd->user_typed);
-  rc = 0;
-
-done:
-  FREE(&nm_tags);
-  nm_db_longrun_done(m_cur);
-  return rc;
-}
-#endif
 
 /**
  * mutt_command_complete - Complete a command name
@@ -411,130 +358,6 @@ int mutt_label_complete(struct CompletionData *cd, struct Buffer *buf, int numta
   return 1;
 }
 
-#ifdef USE_NOTMUCH
-/**
- * mutt_nm_query_complete - Complete to the nearest notmuch tag
- * @param cd      Completion Data
- * @param buf     Buffer for the result
- * @param pos     Cursor position in the buffer
- * @param numtabs Number of times the user has hit 'tab'
- * @retval true  Success, a match
- * @retval false Error, no match
- *
- * Complete the nearest "tag:"-prefixed string previous to pos.
- */
-bool mutt_nm_query_complete(struct CompletionData *cd, struct Buffer *buf, int pos, int numtabs)
-{
-  char *pt = buf->data;
-  int spaces;
-
-  SKIPWS(pt);
-  spaces = pt - buf->data;
-
-  pt = (char *) mutt_strn_rfind((char *) buf, pos, "tag:");
-  if (pt)
-  {
-    pt += 4;
-    if (numtabs == 1)
-    {
-      /* First TAB. Collect all the matches */
-      complete_all_nm_tags(cd, pt);
-
-      /* All matches are stored. Longest non-ambiguous string is ""
-       * i.e. don't change 'buf'. Fake successful return this time.  */
-      if (cd->user_typed[0] == '\0')
-        return true;
-    }
-
-    if ((cd->completed[0] == '\0') && (cd->user_typed[0] != '\0'))
-      return false;
-
-    /* cd->num_matched will _always_ be at least 1 since the initial
-     * user-typed string is always stored */
-    if ((numtabs == 1) && (cd->num_matched == 2))
-    {
-      snprintf(cd->completed, sizeof(cd->completed), "%s", cd->match_list[0]);
-    }
-    else if ((numtabs > 1) && (cd->num_matched > 2))
-    {
-      /* cycle through all the matches */
-      snprintf(cd->completed, sizeof(cd->completed), "%s",
-               cd->match_list[(numtabs - 2) % cd->num_matched]);
-    }
-
-    /* return the completed query */
-    strncpy(pt, cd->completed, buf->data + buf->dsize - pt - spaces);
-  }
-  else
-  {
-    return false;
-  }
-
-  return true;
-}
-#endif
-
-#ifdef USE_NOTMUCH
-/**
- * mutt_nm_tag_complete - Complete to the nearest notmuch tag
- * @param cd      Completion Data
- * @param buf     Buffer for the result
- * @param numtabs Number of times the user has hit 'tab'
- * @retval true  Success, a match
- * @retval false Error, no match
- *
- * Complete the nearest "+" or "-" -prefixed string previous to pos.
- */
-bool mutt_nm_tag_complete(struct CompletionData *cd, struct Buffer *buf, int numtabs)
-{
-  if (!buf)
-    return false;
-
-  char *pt = buf->data;
-
-  /* Only examine the last token */
-  char *last_space = strrchr(buf->data, ' ');
-  if (last_space)
-    pt = (last_space + 1);
-
-  /* Skip the +/- */
-  if ((pt[0] == '+') || (pt[0] == '-'))
-    pt++;
-
-  if (numtabs == 1)
-  {
-    /* First TAB. Collect all the matches */
-    complete_all_nm_tags(cd, pt);
-
-    /* All matches are stored. Longest non-ambiguous string is ""
-     * i.e. don't change 'buf'. Fake successful return this time.  */
-    if (cd->user_typed[0] == '\0')
-      return true;
-  }
-
-  if ((cd->completed[0] == '\0') && (cd->user_typed[0] != '\0'))
-    return false;
-
-  /* cd->num_matched will _always_ be at least 1 since the initial
-   * user-typed string is always stored */
-  if ((numtabs == 1) && (cd->num_matched == 2))
-  {
-    snprintf(cd->completed, sizeof(cd->completed), "%s", cd->match_list[0]);
-  }
-  else if ((numtabs > 1) && (cd->num_matched > 2))
-  {
-    /* cycle through all the matches */
-    snprintf(cd->completed, sizeof(cd->completed), "%s",
-             cd->match_list[(numtabs - 2) % cd->num_matched]);
-  }
-
-  /* return the completed query */
-  strncpy(pt, cd->completed, buf->data + buf->dsize - pt);
-
-  return true;
-}
-#endif
-
 /**
  * mutt_var_value_complete - Complete a variable/value
  * @param cd  Completion Data
@@ -591,4 +414,53 @@ int mutt_var_value_complete(struct CompletionData *cd, struct Buffer *buf, int p
     return 1;
   }
   return 0;
+}
+
+/**
+ * complete_command - Complete a NeoMutt Command
+ * @param wdata Enter window data
+ * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ */
+int complete_command(struct EnterWindowData *wdata)
+{
+  int rc = FR_SUCCESS;
+  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
+  size_t i = buf_len(wdata->buffer);
+  if ((i != 0) && (buf_at(wdata->buffer, i - 1) == '=') &&
+      (mutt_var_value_complete(wdata->cd, wdata->buffer, i) != 0))
+  {
+    wdata->tabs = 0;
+  }
+  else if (mutt_command_complete(wdata->cd, wdata->buffer, i, wdata->tabs) == 0)
+  {
+    rc = FR_ERROR;
+  }
+
+  replace_part(wdata->state, 0, buf_string(wdata->buffer));
+  return rc;
+}
+
+/**
+ * complete_label - Complete a label
+ * @param wdata Enter window data
+ * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ */
+int complete_label(struct EnterWindowData *wdata)
+{
+  size_t i;
+  for (i = wdata->state->curpos; (i > 0) && (wdata->state->wbuf[i - 1] != ',') &&
+                                 (wdata->state->wbuf[i - 1] != ':');
+       i--)
+  {
+  }
+  for (; (i < wdata->state->lastchar) && (wdata->state->wbuf[i] == ' '); i++)
+    ; // do nothing
+
+  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf + i, wdata->state->curpos - i);
+  int rc = mutt_label_complete(wdata->cd, wdata->buffer, wdata->tabs);
+  replace_part(wdata->state, i, buf_string(wdata->buffer));
+  if (rc != 1)
+    return FR_CONTINUE;
+
+  return FR_SUCCESS;
 }

--- a/complete/lib.h
+++ b/complete/lib.h
@@ -35,6 +35,7 @@
 #ifndef MUTT_COMPLETE_LIB_H
 #define MUTT_COMPLETE_LIB_H
 
+#include <stddef.h>
 #include <stdbool.h>
 // IWYU pragma: begin_keep
 #include "data.h"
@@ -48,5 +49,7 @@ int  mutt_label_complete    (struct CompletionData *cd, struct Buffer *buf, int 
 bool mutt_nm_query_complete (struct CompletionData *cd, struct Buffer *buf, int pos, int numtabs);
 bool mutt_nm_tag_complete   (struct CompletionData *cd, struct Buffer *buf, int numtabs);
 int  mutt_var_value_complete(struct CompletionData *cd, struct Buffer *buf, int pos);
+void matches_ensure_morespace(struct CompletionData *cd, int new_size);
+bool candidate               (struct CompletionData *cd, char *user, const char *src, char *dest, size_t dlen);
 
 #endif /* MUTT_COMPLETE_LIB_H */

--- a/complete/lib.h
+++ b/complete/lib.h
@@ -38,10 +38,14 @@
 #include <stddef.h>
 #include <stdbool.h>
 // IWYU pragma: begin_keep
+#include "compapi.h"
 #include "data.h"
 // IWYU pragma: end_keep
 
 struct Buffer;
+
+extern const struct CompleteOps CompleteCommandOps;
+extern const struct CompleteOps CompleteLabelOps;
 
 int  mutt_command_complete  (struct CompletionData *cd, struct Buffer *buf, int pos, int numtabs);
 int  mutt_complete          (struct CompletionData *cd, struct Buffer *buf);

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1310,8 +1310,9 @@ static int op_attachment_new_mime(struct ComposeSharedData *shared, int op)
   struct Buffer *type = NULL;
   struct AttachPtr *ap = NULL;
 
+  struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
   if ((mw_get_field(_("New file: "), fname, MUTT_COMP_FILE, false, NULL, NULL,
-                    NULL, &CompleteMailboxOps, NULL) != 0) ||
+                    NULL, &CompleteMailboxOps, &cdata) != 0) ||
       buf_is_empty(fname))
   {
     goto done;
@@ -1422,8 +1423,9 @@ static int op_attachment_rename_attachment(struct ComposeSharedData *shared, int
     src = cur_att->body->filename;
   struct Buffer *fname = buf_pool_get();
   buf_strcpy(fname, mutt_path_basename(NONULL(src)));
+  struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
   int rc = mw_get_field(_("Send attachment with name: "), fname, MUTT_COMP_FILE,
-                        false, NULL, NULL, NULL, &CompleteMailboxOps, NULL);
+                        false, NULL, NULL, NULL, &CompleteMailboxOps, &cdata);
   if (rc == 0)
   {
     // It's valid to set an empty string here, to erase what was set
@@ -1754,8 +1756,9 @@ static int op_compose_rename_file(struct ComposeSharedData *shared, int op)
   struct Buffer *fname = buf_pool_get();
   buf_strcpy(fname, cur_att->body->filename);
   buf_pretty_mailbox(fname);
+  struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
   if ((mw_get_field(_("Rename to: "), fname, MUTT_COMP_FILE, false, NULL, NULL,
-                    NULL, &CompleteMailboxOps, NULL) == 0) &&
+                    NULL, &CompleteMailboxOps, &cdata) == 0) &&
       !buf_is_empty(fname))
   {
     struct stat st = { 0 };

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1309,7 +1309,7 @@ static int op_attachment_new_mime(struct ComposeSharedData *shared, int op)
   struct AttachPtr *ap = NULL;
 
   struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
-  if ((mw_get_field(_("New file: "), fname, MUTT_COMP_FILE, HC_FILE,
+  if ((mw_get_field(_("New file: "), fname, MUTT_COMP_NO_FLAGS, HC_FILE,
                     &CompleteMailboxOps, &cdata) != 0) ||
       buf_is_empty(fname))
   {
@@ -1421,8 +1421,8 @@ static int op_attachment_rename_attachment(struct ComposeSharedData *shared, int
   struct Buffer *fname = buf_pool_get();
   buf_strcpy(fname, mutt_path_basename(NONULL(src)));
   struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
-  int rc = mw_get_field(_("Send attachment with name: "), fname, MUTT_COMP_FILE,
-                        HC_FILE, &CompleteMailboxOps, &cdata);
+  int rc = mw_get_field(_("Send attachment with name: "), fname,
+                        MUTT_COMP_NO_FLAGS, HC_FILE, &CompleteMailboxOps, &cdata);
   if (rc == 0)
   {
     // It's valid to set an empty string here, to erase what was set
@@ -1754,7 +1754,7 @@ static int op_compose_rename_file(struct ComposeSharedData *shared, int op)
   buf_strcpy(fname, cur_att->body->filename);
   buf_pretty_mailbox(fname);
   struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
-  if ((mw_get_field(_("Rename to: "), fname, MUTT_COMP_FILE, HC_FILE,
+  if ((mw_get_field(_("Rename to: "), fname, MUTT_COMP_NO_FLAGS, HC_FILE,
                     &CompleteMailboxOps, &cdata) == 0) &&
       !buf_is_empty(fname))
   {

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -890,7 +890,8 @@ static int op_attachment_edit_content_id(struct ComposeSharedData *shared, int o
     FREE(&id);
   }
 
-  if (mw_get_field("Content-ID: ", buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) == 0)
+  if (mw_get_field("Content-ID: ", buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
+                   NULL, NULL, NULL) == 0)
   {
     if (!mutt_str_equal(id, buf_string(buf)))
     {
@@ -934,7 +935,8 @@ static int op_attachment_edit_description(struct ComposeSharedData *shared, int 
   buf_strcpy(buf, cur_att->body->description);
 
   /* header names should not be translated */
-  if (mw_get_field("Description: ", buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) == 0)
+  if (mw_get_field("Description: ", buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
+                   NULL, NULL, NULL) == 0)
   {
     if (!mutt_str_equal(cur_att->body->description, buf_string(buf)))
     {
@@ -965,7 +967,7 @@ static int op_attachment_edit_encoding(struct ComposeSharedData *shared, int op)
   buf_strcpy(buf, ENCODING(cur_att->body->encoding));
 
   if ((mw_get_field("Content-Transfer-Encoding: ", buf, MUTT_COMP_NO_FLAGS,
-                    false, NULL, NULL, NULL) == 0) &&
+                    false, NULL, NULL, NULL, NULL, NULL) == 0) &&
       !buf_is_empty(buf))
   {
     int enc = mutt_check_encoding(buf_string(buf));
@@ -1006,7 +1008,8 @@ static int op_attachment_edit_language(struct ComposeSharedData *shared, int op)
                                                  shared->adata->menu);
 
   buf_strcpy(buf, cur_att->body->language);
-  if (mw_get_field("Content-Language: ", buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) == 0)
+  if (mw_get_field("Content-Language: ", buf, MUTT_COMP_NO_FLAGS, false, NULL,
+                   NULL, NULL, NULL, NULL) == 0)
   {
     if (!mutt_str_equal(cur_att->body->language, buf_string(buf)))
     {
@@ -1307,7 +1310,8 @@ static int op_attachment_new_mime(struct ComposeSharedData *shared, int op)
   struct Buffer *type = NULL;
   struct AttachPtr *ap = NULL;
 
-  if ((mw_get_field(_("New file: "), fname, MUTT_COMP_FILE, false, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field(_("New file: "), fname, MUTT_COMP_FILE, false, NULL, NULL,
+                    NULL, NULL, NULL) != 0) ||
       buf_is_empty(fname))
   {
     goto done;
@@ -1316,7 +1320,8 @@ static int op_attachment_new_mime(struct ComposeSharedData *shared, int op)
 
   /* Call to lookup_mime_type () ?  maybe later */
   type = buf_pool_get();
-  if ((mw_get_field("Content-Type: ", type, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field("Content-Type: ", type, MUTT_COMP_NO_FLAGS, false, NULL,
+                    NULL, NULL, NULL, NULL) != 0) ||
       buf_is_empty(type))
   {
     goto done;
@@ -1418,7 +1423,7 @@ static int op_attachment_rename_attachment(struct ComposeSharedData *shared, int
   struct Buffer *fname = buf_pool_get();
   buf_strcpy(fname, mutt_path_basename(NONULL(src)));
   int rc = mw_get_field(_("Send attachment with name: "), fname, MUTT_COMP_FILE,
-                        false, NULL, NULL, NULL);
+                        false, NULL, NULL, NULL, NULL, NULL);
   if (rc == 0)
   {
     // It's valid to set an empty string here, to erase what was set
@@ -1749,7 +1754,8 @@ static int op_compose_rename_file(struct ComposeSharedData *shared, int op)
   struct Buffer *fname = buf_pool_get();
   buf_strcpy(fname, cur_att->body->filename);
   buf_pretty_mailbox(fname);
-  if ((mw_get_field(_("Rename to: "), fname, MUTT_COMP_FILE, false, NULL, NULL, NULL) == 0) &&
+  if ((mw_get_field(_("Rename to: "), fname, MUTT_COMP_FILE, false, NULL, NULL,
+                    NULL, NULL, NULL) == 0) &&
       !buf_is_empty(fname))
   {
     struct stat st = { 0 };

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -890,8 +890,7 @@ static int op_attachment_edit_content_id(struct ComposeSharedData *shared, int o
     FREE(&id);
   }
 
-  if (mw_get_field("Content-ID: ", buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
-                   NULL, NULL, NULL) == 0)
+  if (mw_get_field("Content-ID: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0)
   {
     if (!mutt_str_equal(id, buf_string(buf)))
     {
@@ -935,8 +934,7 @@ static int op_attachment_edit_description(struct ComposeSharedData *shared, int 
   buf_strcpy(buf, cur_att->body->description);
 
   /* header names should not be translated */
-  if (mw_get_field("Description: ", buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
-                   NULL, NULL, NULL) == 0)
+  if (mw_get_field("Description: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0)
   {
     if (!mutt_str_equal(cur_att->body->description, buf_string(buf)))
     {
@@ -966,8 +964,7 @@ static int op_attachment_edit_encoding(struct ComposeSharedData *shared, int op)
                                                  shared->adata->menu);
   buf_strcpy(buf, ENCODING(cur_att->body->encoding));
 
-  if ((mw_get_field("Content-Transfer-Encoding: ", buf, MUTT_COMP_NO_FLAGS,
-                    false, NULL, NULL, NULL, NULL, NULL) == 0) &&
+  if ((mw_get_field("Content-Transfer-Encoding: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0) &&
       !buf_is_empty(buf))
   {
     int enc = mutt_check_encoding(buf_string(buf));
@@ -1008,8 +1005,7 @@ static int op_attachment_edit_language(struct ComposeSharedData *shared, int op)
                                                  shared->adata->menu);
 
   buf_strcpy(buf, cur_att->body->language);
-  if (mw_get_field("Content-Language: ", buf, MUTT_COMP_NO_FLAGS, false, NULL,
-                   NULL, NULL, NULL, NULL) == 0)
+  if (mw_get_field("Content-Language: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0)
   {
     if (!mutt_str_equal(cur_att->body->language, buf_string(buf)))
     {
@@ -1311,8 +1307,7 @@ static int op_attachment_new_mime(struct ComposeSharedData *shared, int op)
   struct AttachPtr *ap = NULL;
 
   struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
-  if ((mw_get_field(_("New file: "), fname, MUTT_COMP_FILE, false, NULL, NULL,
-                    NULL, &CompleteMailboxOps, &cdata) != 0) ||
+  if ((mw_get_field(_("New file: "), fname, MUTT_COMP_FILE, &CompleteMailboxOps, &cdata) != 0) ||
       buf_is_empty(fname))
   {
     goto done;
@@ -1321,8 +1316,7 @@ static int op_attachment_new_mime(struct ComposeSharedData *shared, int op)
 
   /* Call to lookup_mime_type () ?  maybe later */
   type = buf_pool_get();
-  if ((mw_get_field("Content-Type: ", type, MUTT_COMP_NO_FLAGS, false, NULL,
-                    NULL, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field("Content-Type: ", type, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
       buf_is_empty(type))
   {
     goto done;
@@ -1425,7 +1419,7 @@ static int op_attachment_rename_attachment(struct ComposeSharedData *shared, int
   buf_strcpy(fname, mutt_path_basename(NONULL(src)));
   struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
   int rc = mw_get_field(_("Send attachment with name: "), fname, MUTT_COMP_FILE,
-                        false, NULL, NULL, NULL, &CompleteMailboxOps, &cdata);
+                        &CompleteMailboxOps, &cdata);
   if (rc == 0)
   {
     // It's valid to set an empty string here, to erase what was set
@@ -1757,8 +1751,7 @@ static int op_compose_rename_file(struct ComposeSharedData *shared, int op)
   buf_strcpy(fname, cur_att->body->filename);
   buf_pretty_mailbox(fname);
   struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
-  if ((mw_get_field(_("Rename to: "), fname, MUTT_COMP_FILE, false, NULL, NULL,
-                    NULL, &CompleteMailboxOps, &cdata) == 0) &&
+  if ((mw_get_field(_("Rename to: "), fname, MUTT_COMP_FILE, &CompleteMailboxOps, &cdata) == 0) &&
       !buf_is_empty(fname))
   {
     struct stat st = { 0 };

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1311,7 +1311,7 @@ static int op_attachment_new_mime(struct ComposeSharedData *shared, int op)
   struct AttachPtr *ap = NULL;
 
   if ((mw_get_field(_("New file: "), fname, MUTT_COMP_FILE, false, NULL, NULL,
-                    NULL, NULL, NULL) != 0) ||
+                    NULL, &CompleteMailboxOps, NULL) != 0) ||
       buf_is_empty(fname))
   {
     goto done;
@@ -1423,7 +1423,7 @@ static int op_attachment_rename_attachment(struct ComposeSharedData *shared, int
   struct Buffer *fname = buf_pool_get();
   buf_strcpy(fname, mutt_path_basename(NONULL(src)));
   int rc = mw_get_field(_("Send attachment with name: "), fname, MUTT_COMP_FILE,
-                        false, NULL, NULL, NULL, NULL, NULL);
+                        false, NULL, NULL, NULL, &CompleteMailboxOps, NULL);
   if (rc == 0)
   {
     // It's valid to set an empty string here, to erase what was set
@@ -1755,7 +1755,7 @@ static int op_compose_rename_file(struct ComposeSharedData *shared, int op)
   buf_strcpy(fname, cur_att->body->filename);
   buf_pretty_mailbox(fname);
   if ((mw_get_field(_("Rename to: "), fname, MUTT_COMP_FILE, false, NULL, NULL,
-                    NULL, NULL, NULL) == 0) &&
+                    NULL, &CompleteMailboxOps, NULL) == 0) &&
       !buf_is_empty(fname))
   {
     struct stat st = { 0 };

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -47,6 +47,7 @@
 #include "attach/lib.h"
 #include "browser/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "index/lib.h"
 #include "menu/lib.h"
 #include "ncrypt/lib.h"
@@ -890,7 +891,7 @@ static int op_attachment_edit_content_id(struct ComposeSharedData *shared, int o
     FREE(&id);
   }
 
-  if (mw_get_field("Content-ID: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0)
+  if (mw_get_field("Content-ID: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) == 0)
   {
     if (!mutt_str_equal(id, buf_string(buf)))
     {
@@ -934,7 +935,7 @@ static int op_attachment_edit_description(struct ComposeSharedData *shared, int 
   buf_strcpy(buf, cur_att->body->description);
 
   /* header names should not be translated */
-  if (mw_get_field("Description: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0)
+  if (mw_get_field("Description: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) == 0)
   {
     if (!mutt_str_equal(cur_att->body->description, buf_string(buf)))
     {
@@ -964,7 +965,8 @@ static int op_attachment_edit_encoding(struct ComposeSharedData *shared, int op)
                                                  shared->adata->menu);
   buf_strcpy(buf, ENCODING(cur_att->body->encoding));
 
-  if ((mw_get_field("Content-Transfer-Encoding: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0) &&
+  if ((mw_get_field("Content-Transfer-Encoding: ", buf, MUTT_COMP_NO_FLAGS,
+                    HC_OTHER, NULL, NULL) == 0) &&
       !buf_is_empty(buf))
   {
     int enc = mutt_check_encoding(buf_string(buf));
@@ -1005,7 +1007,7 @@ static int op_attachment_edit_language(struct ComposeSharedData *shared, int op)
                                                  shared->adata->menu);
 
   buf_strcpy(buf, cur_att->body->language);
-  if (mw_get_field("Content-Language: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0)
+  if (mw_get_field("Content-Language: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) == 0)
   {
     if (!mutt_str_equal(cur_att->body->language, buf_string(buf)))
     {
@@ -1307,7 +1309,8 @@ static int op_attachment_new_mime(struct ComposeSharedData *shared, int op)
   struct AttachPtr *ap = NULL;
 
   struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
-  if ((mw_get_field(_("New file: "), fname, MUTT_COMP_FILE, &CompleteMailboxOps, &cdata) != 0) ||
+  if ((mw_get_field(_("New file: "), fname, MUTT_COMP_FILE, HC_FILE,
+                    &CompleteMailboxOps, &cdata) != 0) ||
       buf_is_empty(fname))
   {
     goto done;
@@ -1316,7 +1319,7 @@ static int op_attachment_new_mime(struct ComposeSharedData *shared, int op)
 
   /* Call to lookup_mime_type () ?  maybe later */
   type = buf_pool_get();
-  if ((mw_get_field("Content-Type: ", type, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
+  if ((mw_get_field("Content-Type: ", type, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0) ||
       buf_is_empty(type))
   {
     goto done;
@@ -1419,7 +1422,7 @@ static int op_attachment_rename_attachment(struct ComposeSharedData *shared, int
   buf_strcpy(fname, mutt_path_basename(NONULL(src)));
   struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
   int rc = mw_get_field(_("Send attachment with name: "), fname, MUTT_COMP_FILE,
-                        &CompleteMailboxOps, &cdata);
+                        HC_FILE, &CompleteMailboxOps, &cdata);
   if (rc == 0)
   {
     // It's valid to set an empty string here, to erase what was set
@@ -1751,7 +1754,8 @@ static int op_compose_rename_file(struct ComposeSharedData *shared, int op)
   buf_strcpy(fname, cur_att->body->filename);
   buf_pretty_mailbox(fname);
   struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
-  if ((mw_get_field(_("Rename to: "), fname, MUTT_COMP_FILE, &CompleteMailboxOps, &cdata) == 0) &&
+  if ((mw_get_field(_("Rename to: "), fname, MUTT_COMP_FILE, HC_FILE,
+                    &CompleteMailboxOps, &cdata) == 0) &&
       !buf_is_empty(fname))
   {
     struct stat st = { 0 };

--- a/conn/connaccount.c
+++ b/conn/connaccount.c
@@ -78,8 +78,7 @@ int mutt_account_getuser(struct ConnAccount *cac)
     mutt_str_copy(cac->user, Username, sizeof(cac->user));
 
     struct Buffer *buf = buf_pool_get();
-    const int rc = mw_get_field(prompt, buf, MUTT_COMP_UNBUFFERED, false, NULL,
-                                NULL, NULL, NULL, NULL);
+    const int rc = mw_get_field(prompt, buf, MUTT_COMP_UNBUFFERED, NULL, NULL);
     mutt_str_copy(cac->user, buf_string(buf), sizeof(cac->user));
     buf_pool_release(&buf);
     if (rc != 0)
@@ -158,7 +157,7 @@ int mutt_account_getpass(struct ConnAccount *cac)
 
     struct Buffer *buf = buf_pool_get();
     const int rc = mw_get_field(prompt, buf, MUTT_COMP_PASS | MUTT_COMP_UNBUFFERED,
-                                false, NULL, NULL, NULL, NULL, NULL);
+                                NULL, NULL);
     mutt_str_copy(cac->pass, buf_string(buf), sizeof(cac->pass));
     buf_pool_release(&buf);
     if (rc != 0)

--- a/conn/connaccount.c
+++ b/conn/connaccount.c
@@ -37,6 +37,7 @@
 #include "mutt.h"
 #include "connaccount.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "accountcmd.h"
 #include "globals.h"
 
@@ -78,7 +79,7 @@ int mutt_account_getuser(struct ConnAccount *cac)
     mutt_str_copy(cac->user, Username, sizeof(cac->user));
 
     struct Buffer *buf = buf_pool_get();
-    const int rc = mw_get_field(prompt, buf, MUTT_COMP_UNBUFFERED, NULL, NULL);
+    const int rc = mw_get_field(prompt, buf, MUTT_COMP_UNBUFFERED, HC_OTHER, NULL, NULL);
     mutt_str_copy(cac->user, buf_string(buf), sizeof(cac->user));
     buf_pool_release(&buf);
     if (rc != 0)
@@ -157,7 +158,7 @@ int mutt_account_getpass(struct ConnAccount *cac)
 
     struct Buffer *buf = buf_pool_get();
     const int rc = mw_get_field(prompt, buf, MUTT_COMP_PASS | MUTT_COMP_UNBUFFERED,
-                                NULL, NULL);
+                                HC_OTHER, NULL, NULL);
     mutt_str_copy(cac->pass, buf_string(buf), sizeof(cac->pass));
     buf_pool_release(&buf);
     if (rc != 0)

--- a/conn/connaccount.c
+++ b/conn/connaccount.c
@@ -78,7 +78,8 @@ int mutt_account_getuser(struct ConnAccount *cac)
     mutt_str_copy(cac->user, Username, sizeof(cac->user));
 
     struct Buffer *buf = buf_pool_get();
-    const int rc = mw_get_field(prompt, buf, MUTT_COMP_UNBUFFERED, false, NULL, NULL, NULL);
+    const int rc = mw_get_field(prompt, buf, MUTT_COMP_UNBUFFERED, false, NULL,
+                                NULL, NULL, NULL, NULL);
     mutt_str_copy(cac->user, buf_string(buf), sizeof(cac->user));
     buf_pool_release(&buf);
     if (rc != 0)
@@ -157,7 +158,7 @@ int mutt_account_getpass(struct ConnAccount *cac)
 
     struct Buffer *buf = buf_pool_get();
     const int rc = mw_get_field(prompt, buf, MUTT_COMP_PASS | MUTT_COMP_UNBUFFERED,
-                                false, NULL, NULL, NULL);
+                                false, NULL, NULL, NULL, NULL, NULL);
     mutt_str_copy(cac->pass, buf_string(buf), sizeof(cac->pass));
     buf_pool_release(&buf);
     if (rc != 0)

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -712,8 +712,8 @@ int mutt_sasl_interact(sasl_interact_t *interaction)
     snprintf(prompt, sizeof(prompt), "%s: ", interaction->prompt);
     buf_reset(resp);
 
-    if (OptNoCurses ||
-        (mw_get_field(prompt, resp, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0))
+    if (OptNoCurses || (mw_get_field(prompt, resp, MUTT_COMP_NO_FLAGS, false,
+                                     NULL, NULL, NULL, NULL, NULL) != 0))
     {
       rc = SASL_FAIL;
       break;

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -52,6 +52,7 @@
 #include "mutt.h"
 #include "sasl.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "connaccount.h"
 #include "connection.h"
 #include "globals.h"
@@ -712,7 +713,8 @@ int mutt_sasl_interact(sasl_interact_t *interaction)
     snprintf(prompt, sizeof(prompt), "%s: ", interaction->prompt);
     buf_reset(resp);
 
-    if (OptNoCurses || (mw_get_field(prompt, resp, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0))
+    if (OptNoCurses ||
+        (mw_get_field(prompt, resp, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0))
     {
       rc = SASL_FAIL;
       break;

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -712,8 +712,7 @@ int mutt_sasl_interact(sasl_interact_t *interaction)
     snprintf(prompt, sizeof(prompt), "%s: ", interaction->prompt);
     buf_reset(resp);
 
-    if (OptNoCurses || (mw_get_field(prompt, resp, MUTT_COMP_NO_FLAGS, false,
-                                     NULL, NULL, NULL, NULL, NULL) != 0))
+    if (OptNoCurses || (mw_get_field(prompt, resp, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0))
     {
       rc = SASL_FAIL;
       break;

--- a/enter/functions.c
+++ b/enter/functions.c
@@ -32,14 +32,12 @@
 #include "config/lib.h"
 #include "core/lib.h"
 #include "gui/lib.h"
-#include "mutt.h"
 #include "functions.h"
 #include "complete/lib.h"
 #include "history/lib.h"
 #include "menu/lib.h"
 #include "enter.h"
 #include "keymap.h"
-#include "mutt_mailbox.h"
 #include "opcodes.h"
 #include "protos.h"
 #include "state.h" // IWYU pragma: keep
@@ -155,25 +153,6 @@ static int op_editor_history_up(struct EnterWindowData *wdata, int op)
   replace_part(wdata->state, 0, mutt_hist_prev(wdata->hclass));
   wdata->redraw = ENTER_REDRAW_INIT;
   return FR_SUCCESS;
-}
-
-/**
- * op_editor_mailbox_cycle - Cycle among incoming mailboxes - Implements ::enter_function_t - @ingroup enter_function_api
- */
-static int op_editor_mailbox_cycle(struct EnterWindowData *wdata, int op)
-{
-  if (wdata->flags & MUTT_COMP_FILE_MBOX)
-  {
-    wdata->first = true; /* clear input if user types a real key later */
-    buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
-    mutt_mailbox_next(wdata->m, wdata->buffer);
-
-    wdata->state->curpos = wdata->state->lastchar = mutt_mb_mbstowcs(
-        &wdata->state->wbuf, &wdata->state->wbuflen, 0, buf_string(wdata->buffer));
-    return FR_SUCCESS;
-  }
-
-  return FR_NO_ACTION;
 }
 
 // -----------------------------------------------------------------------------
@@ -407,7 +386,7 @@ static const struct EnterFunction EnterFunctions[] = {
   { OP_EDITOR_KILL_LINE,          op_editor_kill_line },
   { OP_EDITOR_KILL_WHOLE_LINE,    op_editor_kill_whole_line },
   { OP_EDITOR_KILL_WORD,          op_editor_kill_word },
-  { OP_EDITOR_MAILBOX_CYCLE,      op_editor_mailbox_cycle },
+  { OP_EDITOR_MAILBOX_CYCLE,      op_editor_complete },
   { OP_EDITOR_QUOTE_CHAR,         op_editor_quote_char },
   { OP_EDITOR_TRANSPOSE_CHARS,    op_editor_transpose_chars },
   { OP_EDITOR_UPCASE_WORD,        op_editor_capitalize_word },

--- a/enter/functions.c
+++ b/enter/functions.c
@@ -28,27 +28,32 @@
 
 #include "config.h"
 #include <string.h>
-#include <wchar.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"
-#include "alias/lib.h"
 #include "gui/lib.h"
 #include "mutt.h"
 #include "functions.h"
-#include "browser/lib.h"
 #include "complete/lib.h"
 #include "history/lib.h"
 #include "menu/lib.h"
-#include "pattern/lib.h"
 #include "enter.h"
 #include "keymap.h"
 #include "mutt_mailbox.h"
-#include "muttlib.h"
 #include "opcodes.h"
 #include "protos.h"
 #include "state.h" // IWYU pragma: keep
 #include "wdata.h"
+
+int complete_alias_complete(struct EnterWindowData *wdata);
+int complete_alias_query(struct EnterWindowData *wdata);
+int complete_command(struct EnterWindowData *wdata);
+int complete_file_mbox(struct EnterWindowData *wdata);
+int complete_file_simple(struct EnterWindowData *wdata);
+int complete_label(struct EnterWindowData *wdata);
+int complete_nm_query(struct EnterWindowData *wdata);
+int complete_nm_tag(struct EnterWindowData *wdata);
+int complete_pattern(struct EnterWindowData *wdata);
 
 /**
  * replace_part - Search and replace on a buffer
@@ -56,7 +61,7 @@
  * @param from  Starting point for the replacement
  * @param buf   Replacement string
  */
-static void replace_part(struct EnterState *es, size_t from, const char *buf)
+void replace_part(struct EnterState *es, size_t from, const char *buf)
 {
   /* Save the suffix */
   size_t savelen = es->lastchar - es->curpos;
@@ -89,268 +94,6 @@ static void replace_part(struct EnterState *es, size_t from, const char *buf)
 }
 
 // -----------------------------------------------------------------------------
-
-/**
- * complete_file_simple - Complete a filename
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
- */
-static int complete_file_simple(struct EnterWindowData *wdata)
-{
-  int rc = FR_SUCCESS;
-  size_t i;
-  for (i = wdata->state->curpos;
-       (i > 0) && !mutt_mb_is_shell_char(wdata->state->wbuf[i - 1]); i--)
-  {
-  }
-  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf + i, wdata->state->curpos - i);
-  if (wdata->tempbuf && (wdata->templen == (wdata->state->lastchar - i)) &&
-      (memcmp(wdata->tempbuf, wdata->state->wbuf + i,
-              (wdata->state->lastchar - i) * sizeof(wchar_t)) == 0))
-  {
-    dlg_browser(wdata->buffer, MUTT_SEL_NO_FLAGS, wdata->m, NULL, NULL);
-    if (buf_is_empty(wdata->buffer))
-      replace_part(wdata->state, i, buf_string(wdata->buffer));
-    return FR_CONTINUE;
-  }
-
-  if (mutt_complete(wdata->cd, wdata->buffer) == 0)
-  {
-    wdata->templen = wdata->state->lastchar - i;
-    mutt_mem_realloc(&wdata->tempbuf, wdata->templen * sizeof(wchar_t));
-    memcpy(wdata->tempbuf, wdata->state->wbuf + i, wdata->templen * sizeof(wchar_t));
-  }
-  else
-  {
-    rc = FR_ERROR;
-  }
-
-  replace_part(wdata->state, i, buf_string(wdata->buffer));
-  return rc;
-}
-
-/**
- * complete_alias_complete - Complete an Alias
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
- */
-static int complete_alias_complete(struct EnterWindowData *wdata)
-{
-  /* invoke the alias-menu to get more addresses */
-  size_t i;
-  for (i = wdata->state->curpos; (i > 0) && (wdata->state->wbuf[i - 1] != ',') &&
-                                 (wdata->state->wbuf[i - 1] != ':');
-       i--)
-  {
-  }
-  for (; (i < wdata->state->lastchar) && (wdata->state->wbuf[i] == ' '); i++)
-    ; // do nothing
-
-  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf + i, wdata->state->curpos - i);
-  int rc = alias_complete(wdata->buffer, NeoMutt->sub);
-  replace_part(wdata->state, i, buf_string(wdata->buffer));
-  if (rc != 1)
-  {
-    return FR_CONTINUE;
-  }
-
-  return FR_SUCCESS;
-}
-
-/**
- * complete_label - Complete a label
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
- */
-static int complete_label(struct EnterWindowData *wdata)
-{
-  size_t i;
-  for (i = wdata->state->curpos; (i > 0) && (wdata->state->wbuf[i - 1] != ',') &&
-                                 (wdata->state->wbuf[i - 1] != ':');
-       i--)
-  {
-  }
-  for (; (i < wdata->state->lastchar) && (wdata->state->wbuf[i] == ' '); i++)
-    ; // do nothing
-
-  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf + i, wdata->state->curpos - i);
-  int rc = mutt_label_complete(wdata->cd, wdata->buffer, wdata->tabs);
-  replace_part(wdata->state, i, buf_string(wdata->buffer));
-  if (rc != 1)
-    return FR_CONTINUE;
-
-  return FR_SUCCESS;
-}
-
-/**
- * complete_pattern - Complete a NeoMutt Pattern
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
- */
-static int complete_pattern(struct EnterWindowData *wdata)
-{
-  size_t i = wdata->state->curpos;
-  if (i && (wdata->state->wbuf[i - 1] == '~'))
-  {
-    if (dlg_pattern(wdata->buffer->data, wdata->buffer->dsize))
-      replace_part(wdata->state, i - 1, wdata->buffer->data);
-    buf_fix_dptr(wdata->buffer);
-    return FR_CONTINUE;
-  }
-
-  for (; (i > 0) && (wdata->state->wbuf[i - 1] != '~'); i--)
-    ; // do nothing
-
-  if ((i > 0) && (i < wdata->state->curpos) &&
-      (wdata->state->wbuf[i - 1] == '~') && (wdata->state->wbuf[i] == 'y'))
-  {
-    i++;
-    buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf + i, wdata->state->curpos - i);
-    int rc = mutt_label_complete(wdata->cd, wdata->buffer, wdata->tabs);
-    replace_part(wdata->state, i, wdata->buffer->data);
-    buf_fix_dptr(wdata->buffer);
-    if (rc != 1)
-    {
-      return FR_CONTINUE;
-    }
-  }
-  else
-  {
-    return FR_NO_ACTION;
-  }
-
-  return FR_SUCCESS;
-}
-
-/**
- * complete_alias_query - Complete an Alias Query
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
- */
-static int complete_alias_query(struct EnterWindowData *wdata)
-{
-  size_t i = wdata->state->curpos;
-  if (i != 0)
-  {
-    for (; (i > 0) && (wdata->state->wbuf[i - 1] != ','); i--)
-      ; // do nothing
-
-    for (; (i < wdata->state->curpos) && (wdata->state->wbuf[i] == ' '); i++)
-      ; // do nothing
-  }
-
-  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf + i, wdata->state->curpos - i);
-  query_complete(wdata->buffer, NeoMutt->sub);
-  replace_part(wdata->state, i, buf_string(wdata->buffer));
-
-  return FR_CONTINUE;
-}
-
-/**
- * complete_command - Complete a NeoMutt Command
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
- */
-static int complete_command(struct EnterWindowData *wdata)
-{
-  int rc = FR_SUCCESS;
-  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
-  size_t i = buf_len(wdata->buffer);
-  if ((i != 0) && (buf_at(wdata->buffer, i - 1) == '=') &&
-      (mutt_var_value_complete(wdata->cd, wdata->buffer, i) != 0))
-  {
-    wdata->tabs = 0;
-  }
-  else if (mutt_command_complete(wdata->cd, wdata->buffer, i, wdata->tabs) == 0)
-  {
-    rc = FR_ERROR;
-  }
-
-  replace_part(wdata->state, 0, buf_string(wdata->buffer));
-  return rc;
-}
-
-/**
- * complete_file_mbox - Complete a Mailbox
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
- */
-static int complete_file_mbox(struct EnterWindowData *wdata)
-{
-  int rc = FR_SUCCESS;
-  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
-
-  /* see if the path has changed from the last time */
-  if ((!wdata->tempbuf && !wdata->state->lastchar) ||
-      (wdata->tempbuf && (wdata->templen == wdata->state->lastchar) &&
-       (memcmp(wdata->tempbuf, wdata->state->wbuf,
-               wdata->state->lastchar * sizeof(wchar_t)) == 0)))
-  {
-    dlg_browser(wdata->buffer,
-                ((wdata->flags & MUTT_COMP_FILE_MBOX) ? MUTT_SEL_FOLDER : MUTT_SEL_NO_FLAGS) |
-                    (wdata->multiple ? MUTT_SEL_MULTI : MUTT_SEL_NO_FLAGS),
-                wdata->m, wdata->files, wdata->numfiles);
-    if (!buf_is_empty(wdata->buffer))
-    {
-      buf_pretty_mailbox(wdata->buffer);
-      if (!wdata->pass)
-        mutt_hist_add(wdata->hclass, buf_string(wdata->buffer), true);
-      wdata->done = true;
-      return FR_SUCCESS;
-    }
-
-    /* file selection cancelled */
-    return FR_CONTINUE;
-  }
-
-  if (mutt_complete(wdata->cd, wdata->buffer) == 0)
-  {
-    wdata->templen = wdata->state->lastchar;
-    mutt_mem_realloc(&wdata->tempbuf, wdata->templen * sizeof(wchar_t));
-    memcpy(wdata->tempbuf, wdata->state->wbuf, wdata->templen * sizeof(wchar_t));
-  }
-  else
-  {
-    return FR_ERROR; // let the user know that nothing matched
-  }
-  replace_part(wdata->state, 0, buf_string(wdata->buffer));
-  return rc;
-}
-
-#ifdef USE_NOTMUCH
-/**
- * complete_nm_query - Complete a Notmuch Query
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
- */
-static int complete_nm_query(struct EnterWindowData *wdata)
-{
-  int rc = FR_SUCCESS;
-  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
-  size_t len = buf_len(wdata->buffer);
-  if (!mutt_nm_query_complete(wdata->cd, wdata->buffer, len, wdata->tabs))
-    rc = FR_ERROR;
-
-  replace_part(wdata->state, 0, buf_string(wdata->buffer));
-  return rc;
-}
-
-/**
- * complete_nm_tag - Complete a Notmuch Tag
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
- */
-static int complete_nm_tag(struct EnterWindowData *wdata)
-{
-  int rc = FR_SUCCESS;
-  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
-  if (!mutt_nm_tag_complete(wdata->cd, wdata->buffer, wdata->tabs))
-    rc = FR_ERROR;
-
-  replace_part(wdata->state, 0, buf_string(wdata->buffer));
-  return rc;
-}
-#endif
 
 /**
  * op_editor_complete - Complete filename or alias - Implements ::enter_function_t - @ingroup enter_function_api

--- a/enter/functions.c
+++ b/enter/functions.c
@@ -45,15 +45,15 @@
 #include "state.h" // IWYU pragma: keep
 #include "wdata.h"
 
-int complete_alias_complete(struct EnterWindowData *wdata);
-int complete_alias_query(struct EnterWindowData *wdata);
-int complete_command(struct EnterWindowData *wdata);
-int complete_file_mbox(struct EnterWindowData *wdata);
-int complete_file_simple(struct EnterWindowData *wdata);
-int complete_label(struct EnterWindowData *wdata);
-int complete_nm_query(struct EnterWindowData *wdata);
-int complete_nm_tag(struct EnterWindowData *wdata);
-int complete_pattern(struct EnterWindowData *wdata);
+int complete_alias_complete(struct EnterWindowData *wdata, int op);
+int complete_alias_query(struct EnterWindowData *wdata, int op);
+int complete_command(struct EnterWindowData *wdata, int op);
+int complete_file_mbox(struct EnterWindowData *wdata, int op);
+int complete_file_simple(struct EnterWindowData *wdata, int op);
+int complete_label(struct EnterWindowData *wdata, int op);
+int complete_nm_query(struct EnterWindowData *wdata, int op);
+int complete_nm_tag(struct EnterWindowData *wdata, int op);
+int complete_pattern(struct EnterWindowData *wdata, int op);
 
 /**
  * replace_part - Search and replace on a buffer
@@ -115,39 +115,39 @@ static int op_editor_complete(struct EnterWindowData *wdata, int op)
   wdata->tabs++;
   wdata->redraw = ENTER_REDRAW_LINE;
   if (wdata->flags & MUTT_COMP_FILE_SIMPLE)
-    return complete_file_simple(wdata);
+    return complete_file_simple(wdata, op);
 
   if (wdata->flags & (MUTT_COMP_FILE | MUTT_COMP_FILE_MBOX))
-    return complete_file_mbox(wdata);
+    return complete_file_mbox(wdata, op);
 
   if (wdata->flags & MUTT_COMP_ALIAS)
   {
     switch (op)
     {
       case OP_EDITOR_COMPLETE:
-        return complete_alias_complete(wdata);
+        return complete_alias_complete(wdata, op);
       case OP_EDITOR_COMPLETE_QUERY:
-        return complete_alias_query(wdata);
+        return complete_alias_query(wdata, op);
       default:
         return FR_NO_ACTION;
     }
   }
 
   if ((wdata->flags & MUTT_COMP_LABEL))
-    return complete_label(wdata);
+    return complete_label(wdata, op);
 
   if ((wdata->flags & MUTT_COMP_PATTERN))
-    return complete_pattern(wdata);
+    return complete_pattern(wdata, op);
 
   if (wdata->flags & MUTT_COMP_COMMAND)
-    return complete_command(wdata);
+    return complete_command(wdata, op);
 
 #ifdef USE_NOTMUCH
   if (wdata->flags & MUTT_COMP_NM_QUERY)
-    return complete_nm_query(wdata);
+    return complete_nm_query(wdata, op);
 
   if (wdata->flags & MUTT_COMP_NM_TAG)
-    return complete_nm_tag(wdata);
+    return complete_nm_tag(wdata, op);
 #endif
 
   return FR_NO_ACTION;

--- a/enter/functions.h
+++ b/enter/functions.h
@@ -42,6 +42,17 @@ struct MuttWindow;
 typedef int (*enter_function_t)(struct EnterWindowData *wdata, int op);
 
 /**
+ * @defgroup complete_api Auto-Completion API
+ *
+ * Prototype for an Auto-Completion Function
+ *
+ * @param wdata  Enter Window data
+ * @param op     Operation to perform, e.g. OP_EDITOR_COMPLETE
+ * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ */
+typedef int (*complete_function_t)(struct EnterWindowData *wdata, int op);
+
+/**
  * struct EnterFunction - A NeoMutt function
  */
 struct EnterFunction

--- a/enter/functions.h
+++ b/enter/functions.h
@@ -24,7 +24,9 @@
 #define MUTT_ENTER_FUNCTIONS_H
 
 #include <stdbool.h>
+#include <stddef.h>
 
+struct EnterState;
 struct EnterWindowData;
 struct MuttWindow;
 
@@ -50,5 +52,6 @@ struct EnterFunction
 
 int enter_function_dispatcher(struct MuttWindow *win, int op);
 bool self_insert(struct EnterWindowData *wdata, int ch);
+void replace_part(struct EnterState *es, size_t from, const char *buf);
 
 #endif /* MUTT_ENTER_FUNCTIONS_H */

--- a/enter/lib.h
+++ b/enter/lib.h
@@ -49,7 +49,7 @@ struct Buffer;
 struct CompleteOps;
 struct Mailbox;
 
-int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete, bool multiple, struct Mailbox *m, char ***files, int *numfiles, struct CompleteOps *comp_api, void *cdata);
+int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete, bool multiple, struct Mailbox *m, char ***files, int *numfiles, const struct CompleteOps *comp_api, void *cdata);
 void replace_part(struct EnterState *es, size_t from, const char *buf);
 
 #endif /* MUTT_ENTER_LIB_H */

--- a/enter/lib.h
+++ b/enter/lib.h
@@ -42,11 +42,13 @@
 // IWYU pragma: begin_keep
 #include "enter.h"
 #include "state.h"
+#include "wdata.h"
 // IWYU pragma: end_keep
 
 struct Buffer;
 struct Mailbox;
 
 int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete, bool multiple, struct Mailbox *m, char ***files, int *numfiles);
+void replace_part(struct EnterState *es, size_t from, const char *buf);
 
 #endif /* MUTT_ENTER_LIB_H */

--- a/enter/lib.h
+++ b/enter/lib.h
@@ -37,7 +37,6 @@
 #define MUTT_ENTER_LIB_H
 
 #include <stddef.h>
-#include <stdbool.h>
 #include "mutt.h"
 // IWYU pragma: begin_keep
 #include "enter.h"
@@ -47,9 +46,8 @@
 
 struct Buffer;
 struct CompleteOps;
-struct Mailbox;
 
-int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete, bool multiple, struct Mailbox *m, char ***files, int *numfiles, const struct CompleteOps *comp_api, void *cdata);
+int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete, const struct CompleteOps *comp_api, void *cdata);
 void replace_part(struct EnterState *es, size_t from, const char *buf);
 
 #endif /* MUTT_ENTER_LIB_H */

--- a/enter/lib.h
+++ b/enter/lib.h
@@ -46,9 +46,10 @@
 // IWYU pragma: end_keep
 
 struct Buffer;
+struct CompleteOps;
 struct Mailbox;
 
-int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete, bool multiple, struct Mailbox *m, char ***files, int *numfiles);
+int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete, bool multiple, struct Mailbox *m, char ***files, int *numfiles, struct CompleteOps *comp_api, void *cdata);
 void replace_part(struct EnterState *es, size_t from, const char *buf);
 
 #endif /* MUTT_ENTER_LIB_H */

--- a/enter/lib.h
+++ b/enter/lib.h
@@ -43,11 +43,12 @@
 #include "state.h"
 #include "wdata.h"
 // IWYU pragma: end_keep
+#include "history/lib.h"
 
 struct Buffer;
 struct CompleteOps;
 
-int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete, const struct CompleteOps *comp_api, void *cdata);
+int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete, enum HistoryClass hclass, const struct CompleteOps *comp_api, void *cdata);
 void replace_part(struct EnterState *es, size_t from, const char *buf);
 
 #endif /* MUTT_ENTER_LIB_H */

--- a/enter/wdata.h
+++ b/enter/wdata.h
@@ -49,6 +49,7 @@ struct EnterWindowData
   int col;                        ///< Initial cursor positions
   CompletionFlags flags;          ///< Flags, see #CompletionFlags
   struct EnterState *state;       ///< Current state of text entry
+  enum HistoryClass hclass;       ///< History to use, e.g. #HC_COMMAND
   const struct CompleteOps *comp_api; ///< Auto-Completion API
   void *cdata;                    ///< Auto-Completion private data
 
@@ -56,7 +57,6 @@ struct EnterWindowData
   enum EnterRedrawFlags redraw;   ///< What needs redrawing? See #EnterRedrawFlags
   bool pass;                      ///< Password mode, conceal characters
   bool first;                     ///< First time through, no input yet
-  enum HistoryClass hclass;       ///< History to use, e.g. #HC_COMMAND
   wchar_t *tempbuf;               ///< Buffer used by completion
   size_t templen;                 ///< Length of complete buffer
   mbstate_t *mbstate;             ///< Multi-byte state

--- a/enter/wdata.h
+++ b/enter/wdata.h
@@ -48,10 +48,6 @@ struct EnterWindowData
   struct Buffer *buffer;          ///< struct Buffer for the result
   int col;                        ///< Initial cursor positions
   CompletionFlags flags;          ///< Flags, see #CompletionFlags
-  bool multiple;                  ///< Allow multiple matches
-  struct Mailbox *m;              ///< Mailbox
-  char ***files;                  ///< List of files selected
-  int *numfiles;                  ///< Number of files selected
   struct EnterState *state;       ///< Current state of text entry
   const struct CompleteOps *comp_api; ///< Auto-Completion API
   void *cdata;                    ///< Auto-Completion private data

--- a/enter/wdata.h
+++ b/enter/wdata.h
@@ -53,6 +53,8 @@ struct EnterWindowData
   char ***files;                  ///< List of files selected
   int *numfiles;                  ///< Number of files selected
   struct EnterState *state;       ///< Current state of text entry
+  struct CompleteOps *comp_api;   ///< Auto-Completion API
+  void *cdata;                    ///< Auto-Completion private data
 
   // Local variables
   enum EnterRedrawFlags redraw;   ///< What needs redrawing? See #EnterRedrawFlags

--- a/enter/wdata.h
+++ b/enter/wdata.h
@@ -53,7 +53,7 @@ struct EnterWindowData
   char ***files;                  ///< List of files selected
   int *numfiles;                  ///< Number of files selected
   struct EnterState *state;       ///< Current state of text entry
-  struct CompleteOps *comp_api;   ///< Auto-Completion API
+  const struct CompleteOps *comp_api; ///< Auto-Completion API
   void *cdata;                    ///< Auto-Completion private data
 
   // Local variables

--- a/enter/window.c
+++ b/enter/window.c
@@ -173,10 +173,6 @@ bool self_insert(struct EnterWindowData *wdata, int ch)
  * @param[in]  field    Prompt
  * @param[in]  buf      Buffer for the result
  * @param[in]  complete Flags, see #CompletionFlags
- * @param[in]  multiple Allow multiple selections
- * @param[in]  m        Mailbox
- * @param[out] files    List of files selected
- * @param[out] numfiles Number of files selected
  * @param[in]  comp_api Auto-completion API
  * @param[in]  cdata    Auto-completion private data
  * @retval 0  Selection made
@@ -191,7 +187,6 @@ bool self_insert(struct EnterWindowData *wdata, int ch)
  * See #OpEditor for a list of functions.
  */
 int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete,
-                 bool multiple, struct Mailbox *m, char ***files, int *numfiles,
                  const struct CompleteOps *comp_api, void *cdata)
 {
   struct MuttWindow *win = mutt_window_new(WT_CUSTOM, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED,
@@ -231,7 +226,7 @@ int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete
     mbstate_t mbstate = { 0 };
 
     // clang-format off
-    struct EnterWindowData wdata = { buf, col, complete, multiple, m, files, numfiles, es, comp_api, cdata,
+    struct EnterWindowData wdata = { buf, col, complete, es, comp_api, cdata,
       ENTER_REDRAW_NONE, (complete & MUTT_COMP_PASS), true, 0, NULL, 0, &mbstate, 0, false, NULL };
     // clang-format on
     win->wdata = &wdata;

--- a/enter/window.c
+++ b/enter/window.c
@@ -47,8 +47,6 @@
 #include "state.h" // IWYU pragma: keep
 #include "wdata.h"
 
-struct CompleteOps;
-
 /// Help Bar for the Command Line Editor
 static const struct Mapping EditorHelp[] = {
   // clang-format off
@@ -190,7 +188,7 @@ bool self_insert(struct EnterWindowData *wdata, int ch)
  */
 int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete,
                  bool multiple, struct Mailbox *m, char ***files, int *numfiles,
-                 struct CompleteOps *comp_api, void *cdata)
+                 const struct CompleteOps *comp_api, void *cdata)
 {
   struct MuttWindow *win = mutt_window_new(WT_CUSTOM, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED,
                                            MUTT_WIN_SIZE_UNLIMITED, 1);

--- a/enter/window.c
+++ b/enter/window.c
@@ -187,7 +187,7 @@ bool self_insert(struct EnterWindowData *wdata, int ch)
  * See #OpEditor for a list of functions.
  */
 int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete,
-                 const struct CompleteOps *comp_api, void *cdata)
+                 enum HistoryClass hclass, const struct CompleteOps *comp_api, void *cdata)
 {
   struct MuttWindow *win = mutt_window_new(WT_CUSTOM, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED,
                                            MUTT_WIN_SIZE_UNLIMITED, 1);
@@ -226,8 +226,8 @@ int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete
     mbstate_t mbstate = { 0 };
 
     // clang-format off
-    struct EnterWindowData wdata = { buf, col, complete, es, comp_api, cdata,
-      ENTER_REDRAW_NONE, (complete & MUTT_COMP_PASS), true, 0, NULL, 0, &mbstate, 0, false, NULL };
+    struct EnterWindowData wdata = { buf, col, complete, es, hclass, comp_api, cdata,
+      ENTER_REDRAW_NONE, (complete & MUTT_COMP_PASS), true, NULL, 0, &mbstate, 0, false, NULL };
     // clang-format on
     win->wdata = &wdata;
 
@@ -244,21 +244,6 @@ int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete
       wdata.redraw = ENTER_REDRAW_LINE;
       wdata.first = false;
     }
-
-    if (wdata.flags & MUTT_COMP_FILE)
-      wdata.hclass = HC_FILE;
-    else if (wdata.flags & MUTT_COMP_FILE_MBOX)
-      wdata.hclass = HC_MBOX;
-    else if (wdata.flags & MUTT_COMP_FILE_SIMPLE)
-      wdata.hclass = HC_CMD;
-    else if (wdata.flags & MUTT_COMP_ALIAS)
-      wdata.hclass = HC_ALIAS;
-    else if (wdata.flags & MUTT_COMP_COMMAND)
-      wdata.hclass = HC_COMMAND;
-    else if (wdata.flags & MUTT_COMP_PATTERN)
-      wdata.hclass = HC_PATTERN;
-    else
-      wdata.hclass = HC_OTHER;
 
     do
     {

--- a/enter/window.c
+++ b/enter/window.c
@@ -131,14 +131,18 @@ bool self_insert(struct EnterWindowData *wdata, int ch)
     if (!wdata->pass)
       mutt_hist_add(wdata->hclass, buf_string(wdata->buffer), true);
 
-    if (wdata->multiple)
+    if (wdata->cdata)
     {
-      char **tfiles = NULL;
-      *wdata->numfiles = 1;
-      tfiles = mutt_mem_calloc(*wdata->numfiles, sizeof(char *));
-      buf_expand_path_regex(wdata->buffer, false);
-      tfiles[0] = buf_strdup(wdata->buffer);
-      *wdata->files = tfiles;
+      struct FileCompletionData *cdata = wdata->cdata;
+      if (cdata->multiple)
+      {
+        char **tfiles = NULL;
+        *cdata->numfiles = 1;
+        tfiles = mutt_mem_calloc(*cdata->numfiles, sizeof(char *));
+        buf_expand_path_regex(wdata->buffer, false);
+        tfiles[0] = buf_strdup(wdata->buffer);
+        *cdata->files = tfiles;
+      }
     }
     return true;
   }

--- a/enter/window.c
+++ b/enter/window.c
@@ -47,6 +47,8 @@
 #include "state.h" // IWYU pragma: keep
 #include "wdata.h"
 
+struct CompleteOps;
+
 /// Help Bar for the Command Line Editor
 static const struct Mapping EditorHelp[] = {
   // clang-format off
@@ -173,6 +175,8 @@ bool self_insert(struct EnterWindowData *wdata, int ch)
  * @param[in]  m        Mailbox
  * @param[out] files    List of files selected
  * @param[out] numfiles Number of files selected
+ * @param[in]  comp_api Auto-completion API
+ * @param[in]  cdata    Auto-completion private data
  * @retval 0  Selection made
  * @retval -1 Aborted
  *
@@ -185,7 +189,8 @@ bool self_insert(struct EnterWindowData *wdata, int ch)
  * See #OpEditor for a list of functions.
  */
 int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete,
-                 bool multiple, struct Mailbox *m, char ***files, int *numfiles)
+                 bool multiple, struct Mailbox *m, char ***files, int *numfiles,
+                 struct CompleteOps *comp_api, void *cdata)
 {
   struct MuttWindow *win = mutt_window_new(WT_CUSTOM, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED,
                                            MUTT_WIN_SIZE_UNLIMITED, 1);
@@ -224,8 +229,8 @@ int mw_get_field(const char *field, struct Buffer *buf, CompletionFlags complete
     mbstate_t mbstate = { 0 };
 
     // clang-format off
-    struct EnterWindowData wdata = { buf, col, complete, multiple, m, files, numfiles, es, ENTER_REDRAW_NONE,
-      (complete & MUTT_COMP_PASS), true, 0, NULL, 0, &mbstate, 0, false, NULL };
+    struct EnterWindowData wdata = { buf, col, complete, multiple, m, files, numfiles, es, comp_api, cdata,
+      ENTER_REDRAW_NONE, (complete & MUTT_COMP_PASS), true, 0, NULL, 0, &mbstate, 0, false, NULL };
     // clang-format on
     win->wdata = &wdata;
 

--- a/envelope/functions.c
+++ b/envelope/functions.c
@@ -119,7 +119,7 @@ static bool edit_address_list(enum HeaderField field, struct AddressList *al)
   mutt_addrlist_write(al, new_list, false);
   buf_fix_dptr(new_list);
   buf_copy(old_list, new_list);
-  if (mw_get_field(_(Prompts[field]), new_list, MUTT_COMP_ALIAS, HC_ALIAS,
+  if (mw_get_field(_(Prompts[field]), new_list, MUTT_COMP_NO_FLAGS, HC_ALIAS,
                    &CompleteAliasOps, NULL) == 0)
   {
     mutt_addrlist_clear(al);
@@ -231,8 +231,8 @@ static int op_envelope_edit_fcc(struct EnvelopeWindowData *wdata, int op)
   buf_copy(fname, wdata->fcc);
 
   struct FileCompletionData cdata = { false, NULL, NULL, NULL };
-  if (mw_get_field(Prompts[HDR_FCC], fname, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                   HC_FILE, &CompleteMailboxOps, &cdata) != 0)
+  if (mw_get_field(Prompts[HDR_FCC], fname, MUTT_COMP_CLEAR, HC_FILE,
+                   &CompleteMailboxOps, &cdata) != 0)
   {
     goto done; // aborted
   }

--- a/envelope/functions.c
+++ b/envelope/functions.c
@@ -118,8 +118,7 @@ static bool edit_address_list(enum HeaderField field, struct AddressList *al)
   mutt_addrlist_write(al, new_list, false);
   buf_fix_dptr(new_list);
   buf_copy(old_list, new_list);
-  if (mw_get_field(_(Prompts[field]), new_list, MUTT_COMP_ALIAS, false, NULL,
-                   NULL, NULL, &CompleteAliasOps, NULL) == 0)
+  if (mw_get_field(_(Prompts[field]), new_list, MUTT_COMP_ALIAS, &CompleteAliasOps, NULL) == 0)
   {
     mutt_addrlist_clear(al);
     mutt_addrlist_parse2(al, buf_string(new_list));
@@ -231,7 +230,7 @@ static int op_envelope_edit_fcc(struct EnvelopeWindowData *wdata, int op)
 
   struct FileCompletionData cdata = { false, NULL, NULL, NULL };
   if (mw_get_field(Prompts[HDR_FCC], fname, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                   false, NULL, NULL, NULL, &CompleteMailboxOps, &cdata) != 0)
+                   &CompleteMailboxOps, &cdata) != 0)
   {
     goto done; // aborted
   }
@@ -283,8 +282,7 @@ static int op_envelope_edit_subject(struct EnvelopeWindowData *wdata, int op)
   struct Buffer *buf = buf_pool_get();
 
   buf_strcpy(buf, wdata->email->env->subject);
-  if (mw_get_field(Prompts[HDR_SUBJECT], buf, MUTT_COMP_NO_FLAGS, false, NULL,
-                   NULL, NULL, NULL, NULL) != 0)
+  if (mw_get_field(Prompts[HDR_SUBJECT], buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
   {
     goto done; // aborted
   }
@@ -447,8 +445,7 @@ static int op_envelope_edit_followup_to(struct EnvelopeWindowData *wdata, int op
   struct Buffer *buf = buf_pool_get();
 
   buf_strcpy(buf, wdata->email->env->followup_to);
-  if (mw_get_field(Prompts[HDR_FOLLOWUPTO], buf, MUTT_COMP_NO_FLAGS, false,
-                   NULL, NULL, NULL, NULL, NULL) == 0)
+  if (mw_get_field(Prompts[HDR_FOLLOWUPTO], buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0)
   {
     mutt_str_replace(&wdata->email->env->followup_to, buf_string(buf));
     mutt_env_notify_send(wdata->email, NT_ENVELOPE_FOLLOWUP_TO);
@@ -471,8 +468,7 @@ static int op_envelope_edit_newsgroups(struct EnvelopeWindowData *wdata, int op)
   struct Buffer *buf = buf_pool_get();
 
   buf_strcpy(buf, wdata->email->env->newsgroups);
-  if (mw_get_field(Prompts[HDR_NEWSGROUPS], buf, MUTT_COMP_NO_FLAGS, false,
-                   NULL, NULL, NULL, NULL, NULL) == 0)
+  if (mw_get_field(Prompts[HDR_NEWSGROUPS], buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0)
   {
     mutt_str_replace(&wdata->email->env->newsgroups, buf_string(buf));
     mutt_env_notify_send(wdata->email, NT_ENVELOPE_NEWSGROUPS);
@@ -496,8 +492,7 @@ static int op_envelope_edit_x_comment_to(struct EnvelopeWindowData *wdata, int o
   struct Buffer *buf = buf_pool_get();
 
   buf_strcpy(buf, wdata->email->env->x_comment_to);
-  if (mw_get_field(Prompts[HDR_XCOMMENTTO], buf, MUTT_COMP_NO_FLAGS, false,
-                   NULL, NULL, NULL, NULL, NULL) == 0)
+  if (mw_get_field(Prompts[HDR_XCOMMENTTO], buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0)
   {
     mutt_str_replace(&wdata->email->env->x_comment_to, buf_string(buf));
     mutt_env_notify_send(wdata->email, NT_ENVELOPE_X_COMMENT_TO);

--- a/envelope/functions.c
+++ b/envelope/functions.c
@@ -229,8 +229,9 @@ static int op_envelope_edit_fcc(struct EnvelopeWindowData *wdata, int op)
   struct Buffer *fname = buf_pool_get();
   buf_copy(fname, wdata->fcc);
 
+  struct FileCompletionData cdata = { false, NULL, NULL, NULL };
   if (mw_get_field(Prompts[HDR_FCC], fname, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                   false, NULL, NULL, NULL, &CompleteMailboxOps, NULL) != 0)
+                   false, NULL, NULL, NULL, &CompleteMailboxOps, &cdata) != 0)
   {
     goto done; // aborted
   }

--- a/envelope/functions.c
+++ b/envelope/functions.c
@@ -117,7 +117,8 @@ static bool edit_address_list(enum HeaderField field, struct AddressList *al)
   mutt_addrlist_write(al, new_list, false);
   buf_fix_dptr(new_list);
   buf_copy(old_list, new_list);
-  if (mw_get_field(_(Prompts[field]), new_list, MUTT_COMP_ALIAS, false, NULL, NULL, NULL) == 0)
+  if (mw_get_field(_(Prompts[field]), new_list, MUTT_COMP_ALIAS, false, NULL,
+                   NULL, NULL, NULL, NULL) == 0)
   {
     mutt_addrlist_clear(al);
     mutt_addrlist_parse2(al, buf_string(new_list));
@@ -228,7 +229,7 @@ static int op_envelope_edit_fcc(struct EnvelopeWindowData *wdata, int op)
   buf_copy(fname, wdata->fcc);
 
   if (mw_get_field(Prompts[HDR_FCC], fname, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                   false, NULL, NULL, NULL) != 0)
+                   false, NULL, NULL, NULL, NULL, NULL) != 0)
   {
     goto done; // aborted
   }
@@ -280,7 +281,8 @@ static int op_envelope_edit_subject(struct EnvelopeWindowData *wdata, int op)
   struct Buffer *buf = buf_pool_get();
 
   buf_strcpy(buf, wdata->email->env->subject);
-  if (mw_get_field(Prompts[HDR_SUBJECT], buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0)
+  if (mw_get_field(Prompts[HDR_SUBJECT], buf, MUTT_COMP_NO_FLAGS, false, NULL,
+                   NULL, NULL, NULL, NULL) != 0)
   {
     goto done; // aborted
   }
@@ -444,7 +446,7 @@ static int op_envelope_edit_followup_to(struct EnvelopeWindowData *wdata, int op
 
   buf_strcpy(buf, wdata->email->env->followup_to);
   if (mw_get_field(Prompts[HDR_FOLLOWUPTO], buf, MUTT_COMP_NO_FLAGS, false,
-                   NULL, NULL, NULL) == 0)
+                   NULL, NULL, NULL, NULL, NULL) == 0)
   {
     mutt_str_replace(&wdata->email->env->followup_to, buf_string(buf));
     mutt_env_notify_send(wdata->email, NT_ENVELOPE_FOLLOWUP_TO);
@@ -468,7 +470,7 @@ static int op_envelope_edit_newsgroups(struct EnvelopeWindowData *wdata, int op)
 
   buf_strcpy(buf, wdata->email->env->newsgroups);
   if (mw_get_field(Prompts[HDR_NEWSGROUPS], buf, MUTT_COMP_NO_FLAGS, false,
-                   NULL, NULL, NULL) == 0)
+                   NULL, NULL, NULL, NULL, NULL) == 0)
   {
     mutt_str_replace(&wdata->email->env->newsgroups, buf_string(buf));
     mutt_env_notify_send(wdata->email, NT_ENVELOPE_NEWSGROUPS);
@@ -493,7 +495,7 @@ static int op_envelope_edit_x_comment_to(struct EnvelopeWindowData *wdata, int o
 
   buf_strcpy(buf, wdata->email->env->x_comment_to);
   if (mw_get_field(Prompts[HDR_XCOMMENTTO], buf, MUTT_COMP_NO_FLAGS, false,
-                   NULL, NULL, NULL) == 0)
+                   NULL, NULL, NULL, NULL, NULL) == 0)
   {
     mutt_str_replace(&wdata->email->env->x_comment_to, buf_string(buf));
     mutt_env_notify_send(wdata->email, NT_ENVELOPE_X_COMMENT_TO);

--- a/envelope/functions.c
+++ b/envelope/functions.c
@@ -40,6 +40,7 @@
 #include "mutt.h"
 #include "functions.h"
 #include "lib.h"
+#include "browser/lib.h"
 #include "enter/lib.h"
 #include "ncrypt/lib.h"
 #include "question/lib.h"
@@ -118,7 +119,7 @@ static bool edit_address_list(enum HeaderField field, struct AddressList *al)
   buf_fix_dptr(new_list);
   buf_copy(old_list, new_list);
   if (mw_get_field(_(Prompts[field]), new_list, MUTT_COMP_ALIAS, false, NULL,
-                   NULL, NULL, NULL, NULL) == 0)
+                   NULL, NULL, &CompleteAliasOps, NULL) == 0)
   {
     mutt_addrlist_clear(al);
     mutt_addrlist_parse2(al, buf_string(new_list));
@@ -229,7 +230,7 @@ static int op_envelope_edit_fcc(struct EnvelopeWindowData *wdata, int op)
   buf_copy(fname, wdata->fcc);
 
   if (mw_get_field(Prompts[HDR_FCC], fname, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                   false, NULL, NULL, NULL, NULL, NULL) != 0)
+                   false, NULL, NULL, NULL, &CompleteMailboxOps, NULL) != 0)
   {
     goto done; // aborted
   }

--- a/envelope/functions.c
+++ b/envelope/functions.c
@@ -42,6 +42,7 @@
 #include "lib.h"
 #include "browser/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "ncrypt/lib.h"
 #include "question/lib.h"
 #include "hook.h"
@@ -118,7 +119,8 @@ static bool edit_address_list(enum HeaderField field, struct AddressList *al)
   mutt_addrlist_write(al, new_list, false);
   buf_fix_dptr(new_list);
   buf_copy(old_list, new_list);
-  if (mw_get_field(_(Prompts[field]), new_list, MUTT_COMP_ALIAS, &CompleteAliasOps, NULL) == 0)
+  if (mw_get_field(_(Prompts[field]), new_list, MUTT_COMP_ALIAS, HC_ALIAS,
+                   &CompleteAliasOps, NULL) == 0)
   {
     mutt_addrlist_clear(al);
     mutt_addrlist_parse2(al, buf_string(new_list));
@@ -230,7 +232,7 @@ static int op_envelope_edit_fcc(struct EnvelopeWindowData *wdata, int op)
 
   struct FileCompletionData cdata = { false, NULL, NULL, NULL };
   if (mw_get_field(Prompts[HDR_FCC], fname, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                   &CompleteMailboxOps, &cdata) != 0)
+                   HC_FILE, &CompleteMailboxOps, &cdata) != 0)
   {
     goto done; // aborted
   }
@@ -282,7 +284,7 @@ static int op_envelope_edit_subject(struct EnvelopeWindowData *wdata, int op)
   struct Buffer *buf = buf_pool_get();
 
   buf_strcpy(buf, wdata->email->env->subject);
-  if (mw_get_field(Prompts[HDR_SUBJECT], buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
+  if (mw_get_field(Prompts[HDR_SUBJECT], buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0)
   {
     goto done; // aborted
   }
@@ -445,7 +447,7 @@ static int op_envelope_edit_followup_to(struct EnvelopeWindowData *wdata, int op
   struct Buffer *buf = buf_pool_get();
 
   buf_strcpy(buf, wdata->email->env->followup_to);
-  if (mw_get_field(Prompts[HDR_FOLLOWUPTO], buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0)
+  if (mw_get_field(Prompts[HDR_FOLLOWUPTO], buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) == 0)
   {
     mutt_str_replace(&wdata->email->env->followup_to, buf_string(buf));
     mutt_env_notify_send(wdata->email, NT_ENVELOPE_FOLLOWUP_TO);
@@ -468,7 +470,7 @@ static int op_envelope_edit_newsgroups(struct EnvelopeWindowData *wdata, int op)
   struct Buffer *buf = buf_pool_get();
 
   buf_strcpy(buf, wdata->email->env->newsgroups);
-  if (mw_get_field(Prompts[HDR_NEWSGROUPS], buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0)
+  if (mw_get_field(Prompts[HDR_NEWSGROUPS], buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) == 0)
   {
     mutt_str_replace(&wdata->email->env->newsgroups, buf_string(buf));
     mutt_env_notify_send(wdata->email, NT_ENVELOPE_NEWSGROUPS);
@@ -492,7 +494,7 @@ static int op_envelope_edit_x_comment_to(struct EnvelopeWindowData *wdata, int o
   struct Buffer *buf = buf_pool_get();
 
   buf_strcpy(buf, wdata->email->env->x_comment_to);
-  if (mw_get_field(Prompts[HDR_XCOMMENTTO], buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0)
+  if (mw_get_field(Prompts[HDR_XCOMMENTTO], buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) == 0)
   {
     mutt_str_replace(&wdata->email->env->x_comment_to, buf_string(buf));
     mutt_env_notify_send(wdata->email, NT_ENVELOPE_X_COMMENT_TO);

--- a/external.c
+++ b/external.c
@@ -48,6 +48,7 @@
 #include "browser/lib.h"
 #include "complete/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "ncrypt/lib.h"
 #include "parse/lib.h"
 #include "progress/lib.h"
@@ -119,7 +120,8 @@ void index_bounce_message(struct Mailbox *m, struct EmailArray *ea)
   else
     buf_strcpy(prompt, _("Bounce tagged messages to: "));
 
-  rc = mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, &CompleteAliasOps, NULL);
+  rc = mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, HC_ALIAS,
+                    &CompleteAliasOps, NULL);
   if ((rc != 0) || buf_is_empty(buf))
     goto done;
 
@@ -430,7 +432,7 @@ void mutt_pipe_message(struct Mailbox *m, struct EmailArray *ea)
   struct Buffer *buf = buf_pool_get();
 
   if (mw_get_field(_("Pipe to command: "), buf, MUTT_COMP_FILE_SIMPLE,
-                   &CompleteFileOps, NULL) != 0)
+                   HC_COMMAND, &CompleteFileOps, NULL) != 0)
   {
     goto cleanup;
   }
@@ -599,7 +601,7 @@ bool mutt_shell_escape(void)
   bool rc = false;
   struct Buffer *buf = buf_pool_get();
 
-  if (mw_get_field(_("Shell command: "), buf, MUTT_COMP_FILE_SIMPLE,
+  if (mw_get_field(_("Shell command: "), buf, MUTT_COMP_FILE_SIMPLE, HC_COMMAND,
                    &CompleteFileOps, NULL) != 0)
   {
     goto done;
@@ -643,7 +645,7 @@ void mutt_enter_command(void)
 
   window_redraw(NULL);
   /* if enter is pressed after : with no command, just return */
-  if ((mw_get_field(":", buf, MUTT_COMP_COMMAND, &CompleteCommandOps, NULL) != 0) ||
+  if ((mw_get_field(":", buf, MUTT_COMP_COMMAND, HC_COMMAND, &CompleteCommandOps, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;
@@ -1118,7 +1120,7 @@ bool mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp)
     }
   }
 
-  if ((mw_get_field("Content-Type: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
+  if ((mw_get_field("Content-Type: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;

--- a/external.c
+++ b/external.c
@@ -46,6 +46,7 @@
 #include "external.h"
 #include "attach/lib.h"
 #include "browser/lib.h"
+#include "complete/lib.h"
 #include "enter/lib.h"
 #include "ncrypt/lib.h"
 #include "parse/lib.h"
@@ -119,7 +120,7 @@ void index_bounce_message(struct Mailbox *m, struct EmailArray *ea)
     buf_strcpy(prompt, _("Bounce tagged messages to: "));
 
   rc = mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, false, NULL, NULL,
-                    NULL, NULL, NULL);
+                    NULL, &CompleteAliasOps, NULL);
   if ((rc != 0) || buf_is_empty(buf))
     goto done;
 
@@ -430,7 +431,7 @@ void mutt_pipe_message(struct Mailbox *m, struct EmailArray *ea)
   struct Buffer *buf = buf_pool_get();
 
   if (mw_get_field(_("Pipe to command: "), buf, MUTT_COMP_FILE_SIMPLE, false,
-                   NULL, NULL, NULL, NULL, NULL) != 0)
+                   NULL, NULL, NULL, &CompleteFileOps, NULL) != 0)
   {
     goto cleanup;
   }
@@ -600,7 +601,7 @@ bool mutt_shell_escape(void)
   struct Buffer *buf = buf_pool_get();
 
   if (mw_get_field(_("Shell command: "), buf, MUTT_COMP_FILE_SIMPLE, false,
-                   NULL, NULL, NULL, NULL, NULL) != 0)
+                   NULL, NULL, NULL, &CompleteFileOps, NULL) != 0)
   {
     goto done;
   }
@@ -643,7 +644,8 @@ void mutt_enter_command(void)
 
   window_redraw(NULL);
   /* if enter is pressed after : with no command, just return */
-  if ((mw_get_field(":", buf, MUTT_COMP_COMMAND, false, NULL, NULL, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field(":", buf, MUTT_COMP_COMMAND, false, NULL, NULL, NULL,
+                    &CompleteCommandOps, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;

--- a/external.c
+++ b/external.c
@@ -118,7 +118,8 @@ void index_bounce_message(struct Mailbox *m, struct EmailArray *ea)
   else
     buf_strcpy(prompt, _("Bounce tagged messages to: "));
 
-  rc = mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, false, NULL, NULL, NULL);
+  rc = mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, false, NULL, NULL,
+                    NULL, NULL, NULL);
   if ((rc != 0) || buf_is_empty(buf))
     goto done;
 
@@ -429,7 +430,7 @@ void mutt_pipe_message(struct Mailbox *m, struct EmailArray *ea)
   struct Buffer *buf = buf_pool_get();
 
   if (mw_get_field(_("Pipe to command: "), buf, MUTT_COMP_FILE_SIMPLE, false,
-                   NULL, NULL, NULL) != 0)
+                   NULL, NULL, NULL, NULL, NULL) != 0)
   {
     goto cleanup;
   }
@@ -599,7 +600,7 @@ bool mutt_shell_escape(void)
   struct Buffer *buf = buf_pool_get();
 
   if (mw_get_field(_("Shell command: "), buf, MUTT_COMP_FILE_SIMPLE, false,
-                   NULL, NULL, NULL) != 0)
+                   NULL, NULL, NULL, NULL, NULL) != 0)
   {
     goto done;
   }
@@ -642,7 +643,7 @@ void mutt_enter_command(void)
 
   window_redraw(NULL);
   /* if enter is pressed after : with no command, just return */
-  if ((mw_get_field(":", buf, MUTT_COMP_COMMAND, false, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field(":", buf, MUTT_COMP_COMMAND, false, NULL, NULL, NULL, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;
@@ -1117,7 +1118,8 @@ bool mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp)
     }
   }
 
-  if ((mw_get_field("Content-Type: ", buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field("Content-Type: ", buf, MUTT_COMP_NO_FLAGS, false, NULL,
+                    NULL, NULL, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;

--- a/external.c
+++ b/external.c
@@ -119,8 +119,7 @@ void index_bounce_message(struct Mailbox *m, struct EmailArray *ea)
   else
     buf_strcpy(prompt, _("Bounce tagged messages to: "));
 
-  rc = mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, false, NULL, NULL,
-                    NULL, &CompleteAliasOps, NULL);
+  rc = mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, &CompleteAliasOps, NULL);
   if ((rc != 0) || buf_is_empty(buf))
     goto done;
 
@@ -430,8 +429,8 @@ void mutt_pipe_message(struct Mailbox *m, struct EmailArray *ea)
 
   struct Buffer *buf = buf_pool_get();
 
-  if (mw_get_field(_("Pipe to command: "), buf, MUTT_COMP_FILE_SIMPLE, false,
-                   NULL, NULL, NULL, &CompleteFileOps, NULL) != 0)
+  if (mw_get_field(_("Pipe to command: "), buf, MUTT_COMP_FILE_SIMPLE,
+                   &CompleteFileOps, NULL) != 0)
   {
     goto cleanup;
   }
@@ -600,8 +599,8 @@ bool mutt_shell_escape(void)
   bool rc = false;
   struct Buffer *buf = buf_pool_get();
 
-  if (mw_get_field(_("Shell command: "), buf, MUTT_COMP_FILE_SIMPLE, false,
-                   NULL, NULL, NULL, &CompleteFileOps, NULL) != 0)
+  if (mw_get_field(_("Shell command: "), buf, MUTT_COMP_FILE_SIMPLE,
+                   &CompleteFileOps, NULL) != 0)
   {
     goto done;
   }
@@ -644,8 +643,7 @@ void mutt_enter_command(void)
 
   window_redraw(NULL);
   /* if enter is pressed after : with no command, just return */
-  if ((mw_get_field(":", buf, MUTT_COMP_COMMAND, false, NULL, NULL, NULL,
-                    &CompleteCommandOps, NULL) != 0) ||
+  if ((mw_get_field(":", buf, MUTT_COMP_COMMAND, &CompleteCommandOps, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;
@@ -1120,8 +1118,7 @@ bool mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp)
     }
   }
 
-  if ((mw_get_field("Content-Type: ", buf, MUTT_COMP_NO_FLAGS, false, NULL,
-                    NULL, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field("Content-Type: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;

--- a/external.c
+++ b/external.c
@@ -120,7 +120,7 @@ void index_bounce_message(struct Mailbox *m, struct EmailArray *ea)
   else
     buf_strcpy(prompt, _("Bounce tagged messages to: "));
 
-  rc = mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, HC_ALIAS,
+  rc = mw_get_field(buf_string(prompt), buf, MUTT_COMP_NO_FLAGS, HC_ALIAS,
                     &CompleteAliasOps, NULL);
   if ((rc != 0) || buf_is_empty(buf))
     goto done;
@@ -431,8 +431,8 @@ void mutt_pipe_message(struct Mailbox *m, struct EmailArray *ea)
 
   struct Buffer *buf = buf_pool_get();
 
-  if (mw_get_field(_("Pipe to command: "), buf, MUTT_COMP_FILE_SIMPLE,
-                   HC_COMMAND, &CompleteFileOps, NULL) != 0)
+  if (mw_get_field(_("Pipe to command: "), buf, MUTT_COMP_NO_FLAGS, HC_COMMAND,
+                   &CompleteFileOps, NULL) != 0)
   {
     goto cleanup;
   }
@@ -601,7 +601,7 @@ bool mutt_shell_escape(void)
   bool rc = false;
   struct Buffer *buf = buf_pool_get();
 
-  if (mw_get_field(_("Shell command: "), buf, MUTT_COMP_FILE_SIMPLE, HC_COMMAND,
+  if (mw_get_field(_("Shell command: "), buf, MUTT_COMP_NO_FLAGS, HC_COMMAND,
                    &CompleteFileOps, NULL) != 0)
   {
     goto done;
@@ -645,7 +645,7 @@ void mutt_enter_command(void)
 
   window_redraw(NULL);
   /* if enter is pressed after : with no command, just return */
-  if ((mw_get_field(":", buf, MUTT_COMP_COMMAND, HC_COMMAND, &CompleteCommandOps, NULL) != 0) ||
+  if ((mw_get_field(":", buf, MUTT_COMP_NO_FLAGS, HC_COMMAND, &CompleteCommandOps, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -483,8 +483,9 @@ int mw_enter_fname(const char *prompt, struct Buffer *fname, bool mailbox,
       mutt_unget_op(event.op);
 
     buf_alloc(fname, 1024);
+    struct FileCompletionData cdata = { multiple, m, files, numfiles };
     if (mw_get_field(pc, fname, (mailbox ? MUTT_COMP_FILE_MBOX : MUTT_COMP_FILE) | MUTT_COMP_CLEAR,
-                     multiple, m, files, numfiles, &CompleteMailboxOps, NULL) != 0)
+                     multiple, m, files, numfiles, &CompleteMailboxOps, &cdata) != 0)
     {
       buf_reset(fname);
     }

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -484,7 +484,7 @@ int mw_enter_fname(const char *prompt, struct Buffer *fname, bool mailbox,
 
     buf_alloc(fname, 1024);
     if (mw_get_field(pc, fname, (mailbox ? MUTT_COMP_FILE_MBOX : MUTT_COMP_FILE) | MUTT_COMP_CLEAR,
-                     multiple, m, files, numfiles, NULL, NULL) != 0)
+                     multiple, m, files, numfiles, &CompleteMailboxOps, NULL) != 0)
     {
       buf_reset(fname);
     }

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -484,7 +484,7 @@ int mw_enter_fname(const char *prompt, struct Buffer *fname, bool mailbox,
 
     buf_alloc(fname, 1024);
     if (mw_get_field(pc, fname, (mailbox ? MUTT_COMP_FILE_MBOX : MUTT_COMP_FILE) | MUTT_COMP_CLEAR,
-                     multiple, m, files, numfiles) != 0)
+                     multiple, m, files, numfiles, NULL, NULL) != 0)
     {
       buf_reset(fname);
     }

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -46,6 +46,7 @@
 #include "browser/lib.h"
 #include "color/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "question/lib.h"
 #include "globals.h"
 #include "keymap.h"
@@ -484,8 +485,9 @@ int mw_enter_fname(const char *prompt, struct Buffer *fname, bool mailbox,
 
     buf_alloc(fname, 1024);
     struct FileCompletionData cdata = { multiple, m, files, numfiles };
-    if (mw_get_field(pc, fname, (mailbox ? MUTT_COMP_FILE_MBOX : MUTT_COMP_FILE) | MUTT_COMP_CLEAR,
-                     &CompleteMailboxOps, &cdata) != 0)
+    CompletionFlags cflags = (mailbox ? MUTT_COMP_FILE_MBOX : MUTT_COMP_FILE) | MUTT_COMP_CLEAR;
+    enum HistoryClass hclass = mailbox ? HC_MBOX : HC_FILE;
+    if (mw_get_field(pc, fname, cflags, hclass, &CompleteMailboxOps, &cdata) != 0)
     {
       buf_reset(fname);
     }

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -485,7 +485,7 @@ int mw_enter_fname(const char *prompt, struct Buffer *fname, bool mailbox,
     buf_alloc(fname, 1024);
     struct FileCompletionData cdata = { multiple, m, files, numfiles };
     if (mw_get_field(pc, fname, (mailbox ? MUTT_COMP_FILE_MBOX : MUTT_COMP_FILE) | MUTT_COMP_CLEAR,
-                     multiple, m, files, numfiles, &CompleteMailboxOps, &cdata) != 0)
+                     &CompleteMailboxOps, &cdata) != 0)
     {
       buf_reset(fname);
     }

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -485,9 +485,8 @@ int mw_enter_fname(const char *prompt, struct Buffer *fname, bool mailbox,
 
     buf_alloc(fname, 1024);
     struct FileCompletionData cdata = { multiple, m, files, numfiles };
-    CompletionFlags cflags = (mailbox ? MUTT_COMP_FILE_MBOX : MUTT_COMP_FILE) | MUTT_COMP_CLEAR;
     enum HistoryClass hclass = mailbox ? HC_MBOX : HC_FILE;
-    if (mw_get_field(pc, fname, cflags, hclass, &CompleteMailboxOps, &cdata) != 0)
+    if (mw_get_field(pc, fname, MUTT_COMP_CLEAR, hclass, &CompleteMailboxOps, &cdata) != 0)
     {
       buf_reset(fname);
     }

--- a/gui/curs_lib.h
+++ b/gui/curs_lib.h
@@ -42,6 +42,17 @@ enum FormatJustify
   JUSTIFY_RIGHT = 1,  ///< Right justify the text
 };
 
+/**
+ * struct FileCompletionData - Input for the file completion function
+ */
+struct FileCompletionData
+{
+  bool            multiple; ///< Allow multiple selections
+  struct Mailbox *mailbox;  ///< Mailbox
+  char         ***files;    ///< List of files selected
+  int            *numfiles; ///< Number of files selected
+};
+
 int          mutt_addwch(struct MuttWindow *win, wchar_t wc);
 int          mutt_any_key_to_continue(const char *s);
 void         mutt_beep(bool force);

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -408,7 +408,7 @@ int imap_mailbox_create(const char *path)
   }
 
   if (mw_get_field(_("Create mailbox: "), name, MUTT_COMP_FILE, false, NULL,
-                   NULL, NULL, NULL, NULL) != 0)
+                   NULL, NULL, &CompleteMailboxOps, NULL) != 0)
   {
     goto done;
   }
@@ -468,7 +468,7 @@ int imap_mailbox_rename(const char *path)
   buf_strcpy(newname, mdata->name);
 
   if (mw_get_field(buf_string(buf), newname, MUTT_COMP_FILE, false, NULL, NULL,
-                   NULL, NULL, NULL) != 0)
+                   NULL, &CompleteMailboxOps, NULL) != 0)
   {
     goto done;
   }

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -407,7 +407,8 @@ int imap_mailbox_create(const char *path)
     buf_addch(name, adata->delim);
   }
 
-  if (mw_get_field(_("Create mailbox: "), name, MUTT_COMP_FILE, false, NULL, NULL, NULL) != 0)
+  if (mw_get_field(_("Create mailbox: "), name, MUTT_COMP_FILE, false, NULL,
+                   NULL, NULL, NULL, NULL) != 0)
   {
     goto done;
   }
@@ -466,7 +467,8 @@ int imap_mailbox_rename(const char *path)
   buf_printf(buf, _("Rename mailbox %s to: "), mdata->name);
   buf_strcpy(newname, mdata->name);
 
-  if (mw_get_field(buf_string(buf), newname, MUTT_COMP_FILE, false, NULL, NULL, NULL) != 0)
+  if (mw_get_field(buf_string(buf), newname, MUTT_COMP_FILE, false, NULL, NULL,
+                   NULL, NULL, NULL) != 0)
   {
     goto done;
   }

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -38,6 +38,7 @@
 #include "email/lib.h"
 #include "core/lib.h"
 #include "conn/lib.h"
+#include "gui/lib.h"
 #include "mutt.h"
 #include "lib.h"
 #include "browser/lib.h"
@@ -407,8 +408,9 @@ int imap_mailbox_create(const char *path)
     buf_addch(name, adata->delim);
   }
 
+  struct FileCompletionData cdata = { false, NULL, NULL, NULL };
   if (mw_get_field(_("Create mailbox: "), name, MUTT_COMP_FILE, false, NULL,
-                   NULL, NULL, &CompleteMailboxOps, NULL) != 0)
+                   NULL, NULL, &CompleteMailboxOps, &cdata) != 0)
   {
     goto done;
   }
@@ -467,8 +469,9 @@ int imap_mailbox_rename(const char *path)
   buf_printf(buf, _("Rename mailbox %s to: "), mdata->name);
   buf_strcpy(newname, mdata->name);
 
+  struct FileCompletionData cdata = { false, NULL, NULL, NULL };
   if (mw_get_field(buf_string(buf), newname, MUTT_COMP_FILE, false, NULL, NULL,
-                   NULL, &CompleteMailboxOps, NULL) != 0)
+                   NULL, &CompleteMailboxOps, &cdata) != 0)
   {
     goto done;
   }

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -43,6 +43,7 @@
 #include "lib.h"
 #include "browser/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "adata.h"
 #include "mdata.h"
 #include "mutt_logging.h"
@@ -409,7 +410,7 @@ int imap_mailbox_create(const char *path)
   }
 
   struct FileCompletionData cdata = { false, NULL, NULL, NULL };
-  if (mw_get_field(_("Create mailbox: "), name, MUTT_COMP_FILE,
+  if (mw_get_field(_("Create mailbox: "), name, MUTT_COMP_FILE, HC_FILE,
                    &CompleteMailboxOps, &cdata) != 0)
   {
     goto done;
@@ -470,7 +471,8 @@ int imap_mailbox_rename(const char *path)
   buf_strcpy(newname, mdata->name);
 
   struct FileCompletionData cdata = { false, NULL, NULL, NULL };
-  if (mw_get_field(buf_string(buf), newname, MUTT_COMP_FILE, &CompleteMailboxOps, &cdata) != 0)
+  if (mw_get_field(buf_string(buf), newname, MUTT_COMP_FILE, HC_FILE,
+                   &CompleteMailboxOps, &cdata) != 0)
   {
     goto done;
   }

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -409,8 +409,8 @@ int imap_mailbox_create(const char *path)
   }
 
   struct FileCompletionData cdata = { false, NULL, NULL, NULL };
-  if (mw_get_field(_("Create mailbox: "), name, MUTT_COMP_FILE, false, NULL,
-                   NULL, NULL, &CompleteMailboxOps, &cdata) != 0)
+  if (mw_get_field(_("Create mailbox: "), name, MUTT_COMP_FILE,
+                   &CompleteMailboxOps, &cdata) != 0)
   {
     goto done;
   }
@@ -470,8 +470,7 @@ int imap_mailbox_rename(const char *path)
   buf_strcpy(newname, mdata->name);
 
   struct FileCompletionData cdata = { false, NULL, NULL, NULL };
-  if (mw_get_field(buf_string(buf), newname, MUTT_COMP_FILE, false, NULL, NULL,
-                   NULL, &CompleteMailboxOps, &cdata) != 0)
+  if (mw_get_field(buf_string(buf), newname, MUTT_COMP_FILE, &CompleteMailboxOps, &cdata) != 0)
   {
     goto done;
   }

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -410,7 +410,7 @@ int imap_mailbox_create(const char *path)
   }
 
   struct FileCompletionData cdata = { false, NULL, NULL, NULL };
-  if (mw_get_field(_("Create mailbox: "), name, MUTT_COMP_FILE, HC_FILE,
+  if (mw_get_field(_("Create mailbox: "), name, MUTT_COMP_NO_FLAGS, HC_FILE,
                    &CompleteMailboxOps, &cdata) != 0)
   {
     goto done;
@@ -471,7 +471,7 @@ int imap_mailbox_rename(const char *path)
   buf_strcpy(newname, mdata->name);
 
   struct FileCompletionData cdata = { false, NULL, NULL, NULL };
-  if (mw_get_field(buf_string(buf), newname, MUTT_COMP_FILE, HC_FILE,
+  if (mw_get_field(buf_string(buf), newname, MUTT_COMP_NO_FLAGS, HC_FILE,
                    &CompleteMailboxOps, &cdata) != 0)
   {
     goto done;

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2191,7 +2191,7 @@ static int imap_tags_edit(struct Mailbox *m, const char *tags, struct Buffer *bu
   if (tags)
     buf_strcpy(buf, tags);
 
-  if (mw_get_field("Tags: ", buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL, NULL, NULL) != 0)
+  if (mw_get_field("Tags: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
     return -1;
 
   /* each keyword must be atom defined by rfc822 as:

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -47,6 +47,7 @@
 #include "mutt.h"
 #include "lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "parse/lib.h"
 #include "progress/lib.h"
 #include "question/lib.h"
@@ -2191,7 +2192,7 @@ static int imap_tags_edit(struct Mailbox *m, const char *tags, struct Buffer *bu
   if (tags)
     buf_strcpy(buf, tags);
 
-  if (mw_get_field("Tags: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
+  if (mw_get_field("Tags: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0)
     return -1;
 
   /* each keyword must be atom defined by rfc822 as:

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2191,7 +2191,7 @@ static int imap_tags_edit(struct Mailbox *m, const char *tags, struct Buffer *bu
   if (tags)
     buf_strcpy(buf, tags);
 
-  if (mw_get_field("Tags: ", buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0)
+  if (mw_get_field("Tags: ", buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL, NULL, NULL) != 0)
     return -1;
 
   /* each keyword must be atom defined by rfc822 as:

--- a/index/functions.c
+++ b/index/functions.c
@@ -682,8 +682,7 @@ static int op_jump(struct IndexSharedData *shared, struct IndexPrivateData *priv
   }
 
   int msg_num = 0;
-  if ((mw_get_field(_("Jump to message: "), buf, MUTT_COMP_NO_FLAGS, false,
-                    NULL, NULL, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field(_("Jump to message: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     mutt_message(_("Nothing to do"));
@@ -1743,8 +1742,7 @@ static int op_mark_msg(struct IndexSharedData *shared, struct IndexPrivateData *
     /* L10N: This is the prompt for <mark-message>.  Whatever they
        enter will be prefixed by $mark_macro_prefix and will become
        a macro hotkey to jump to the currently selected message. */
-    if ((mw_get_field(_("Enter macro stroke: "), buf, MUTT_COMP_NO_FLAGS, false,
-                      NULL, NULL, NULL, NULL, NULL) == 0) &&
+    if ((mw_get_field(_("Enter macro stroke: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0) &&
         !buf_is_empty(buf))
     {
       const char *const c_mark_macro_prefix = cs_subset_string(shared->sub, "mark_macro_prefix");
@@ -2469,8 +2467,7 @@ static int op_get_message(struct IndexSharedData *shared,
 
   if (op == OP_GET_MESSAGE)
   {
-    if ((mw_get_field(_("Enter Message-Id: "), buf, MUTT_COMP_NO_FLAGS, false,
-                      NULL, NULL, NULL, NULL, NULL) != 0) ||
+    if ((mw_get_field(_("Enter Message-Id: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
         buf_is_empty(buf))
     {
       goto done;
@@ -2732,8 +2729,7 @@ static int op_main_vfolder_from_query(struct IndexSharedData *shared,
   int rc = FR_SUCCESS;
   struct Buffer *buf = buf_pool_get();
 
-  if ((mw_get_field("Query: ", buf, MUTT_COMP_NM_QUERY, false, NULL, NULL, NULL,
-                    &CompleteNmQueryOps, NULL) != 0) ||
+  if ((mw_get_field("Query: ", buf, MUTT_COMP_NM_QUERY, &CompleteNmQueryOps, NULL) != 0) ||
       buf_is_empty(buf))
   {
     mutt_message(_("No query, aborting"));

--- a/index/functions.c
+++ b/index/functions.c
@@ -43,6 +43,7 @@
 #include "attach/lib.h"
 #include "browser/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "menu/lib.h"
 #include "ncrypt/lib.h"
 #include "pager/lib.h"
@@ -682,7 +683,7 @@ static int op_jump(struct IndexSharedData *shared, struct IndexPrivateData *priv
   }
 
   int msg_num = 0;
-  if ((mw_get_field(_("Jump to message: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
+  if ((mw_get_field(_("Jump to message: "), buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     mutt_message(_("Nothing to do"));
@@ -1742,7 +1743,8 @@ static int op_mark_msg(struct IndexSharedData *shared, struct IndexPrivateData *
     /* L10N: This is the prompt for <mark-message>.  Whatever they
        enter will be prefixed by $mark_macro_prefix and will become
        a macro hotkey to jump to the currently selected message. */
-    if ((mw_get_field(_("Enter macro stroke: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0) &&
+    if ((mw_get_field(_("Enter macro stroke: "), buf, MUTT_COMP_NO_FLAGS,
+                      HC_OTHER, NULL, NULL) == 0) &&
         !buf_is_empty(buf))
     {
       const char *const c_mark_macro_prefix = cs_subset_string(shared->sub, "mark_macro_prefix");
@@ -2467,7 +2469,8 @@ static int op_get_message(struct IndexSharedData *shared,
 
   if (op == OP_GET_MESSAGE)
   {
-    if ((mw_get_field(_("Enter Message-Id: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
+    if ((mw_get_field(_("Enter Message-Id: "), buf, MUTT_COMP_NO_FLAGS,
+                      HC_OTHER, NULL, NULL) != 0) ||
         buf_is_empty(buf))
     {
       goto done;
@@ -2729,7 +2732,8 @@ static int op_main_vfolder_from_query(struct IndexSharedData *shared,
   int rc = FR_SUCCESS;
   struct Buffer *buf = buf_pool_get();
 
-  if ((mw_get_field("Query: ", buf, MUTT_COMP_NM_QUERY, &CompleteNmQueryOps, NULL) != 0) ||
+  if ((mw_get_field("Query: ", buf, MUTT_COMP_NM_QUERY, HC_OTHER,
+                    &CompleteNmQueryOps, NULL) != 0) ||
       buf_is_empty(buf))
   {
     mutt_message(_("No query, aborting"));

--- a/index/functions.c
+++ b/index/functions.c
@@ -683,7 +683,7 @@ static int op_jump(struct IndexSharedData *shared, struct IndexPrivateData *priv
 
   int msg_num = 0;
   if ((mw_get_field(_("Jump to message: "), buf, MUTT_COMP_NO_FLAGS, false,
-                    NULL, NULL, NULL) != 0) ||
+                    NULL, NULL, NULL, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     mutt_message(_("Nothing to do"));
@@ -1744,7 +1744,7 @@ static int op_mark_msg(struct IndexSharedData *shared, struct IndexPrivateData *
        enter will be prefixed by $mark_macro_prefix and will become
        a macro hotkey to jump to the currently selected message. */
     if ((mw_get_field(_("Enter macro stroke: "), buf, MUTT_COMP_NO_FLAGS, false,
-                      NULL, NULL, NULL) == 0) &&
+                      NULL, NULL, NULL, NULL, NULL) == 0) &&
         !buf_is_empty(buf))
     {
       const char *const c_mark_macro_prefix = cs_subset_string(shared->sub, "mark_macro_prefix");
@@ -2470,7 +2470,7 @@ static int op_get_message(struct IndexSharedData *shared,
   if (op == OP_GET_MESSAGE)
   {
     if ((mw_get_field(_("Enter Message-Id: "), buf, MUTT_COMP_NO_FLAGS, false,
-                      NULL, NULL, NULL) != 0) ||
+                      NULL, NULL, NULL, NULL, NULL) != 0) ||
         buf_is_empty(buf))
     {
       goto done;
@@ -2732,7 +2732,8 @@ static int op_main_vfolder_from_query(struct IndexSharedData *shared,
   int rc = FR_SUCCESS;
   struct Buffer *buf = buf_pool_get();
 
-  if ((mw_get_field("Query: ", buf, MUTT_COMP_NM_QUERY, false, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field("Query: ", buf, MUTT_COMP_NM_QUERY, false, NULL, NULL, NULL,
+                    NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     mutt_message(_("No query, aborting"));

--- a/index/functions.c
+++ b/index/functions.c
@@ -2732,7 +2732,7 @@ static int op_main_vfolder_from_query(struct IndexSharedData *shared,
   int rc = FR_SUCCESS;
   struct Buffer *buf = buf_pool_get();
 
-  if ((mw_get_field("Query: ", buf, MUTT_COMP_NM_QUERY, HC_OTHER,
+  if ((mw_get_field("Query: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER,
                     &CompleteNmQueryOps, NULL) != 0) ||
       buf_is_empty(buf))
   {

--- a/index/functions.c
+++ b/index/functions.c
@@ -2733,7 +2733,7 @@ static int op_main_vfolder_from_query(struct IndexSharedData *shared,
   struct Buffer *buf = buf_pool_get();
 
   if ((mw_get_field("Query: ", buf, MUTT_COMP_NM_QUERY, false, NULL, NULL, NULL,
-                    NULL, NULL) != 0) ||
+                    &CompleteNmQueryOps, NULL) != 0) ||
       buf_is_empty(buf))
   {
     mutt_message(_("No query, aborting"));

--- a/menu/functions.c
+++ b/menu/functions.c
@@ -38,6 +38,7 @@
 #include "functions.h"
 #include "lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "opcodes.h"
 #include "protos.h"
 #include "type.h"
@@ -68,7 +69,7 @@ static int search(struct Menu *menu, int op)
   {
     buf_strcpy(buf, search_buf && (search_buf[0] != '\0') ? search_buf : "");
     if ((mw_get_field(((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ? _("Search for: ") : _("Reverse search for: "),
-                      buf, MUTT_COMP_CLEAR, NULL, NULL) != 0) ||
+                      buf, MUTT_COMP_CLEAR, HC_OTHER, NULL, NULL) != 0) ||
         buf_is_empty(buf))
     {
       goto done;
@@ -251,7 +252,7 @@ static int op_jump(struct Menu *menu, int op)
   }
 
   struct Buffer *buf = buf_pool_get();
-  if ((mw_get_field(_("Jump to: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0) &&
+  if ((mw_get_field(_("Jump to: "), buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) == 0) &&
       !buf_is_empty(buf))
   {
     int n = 0;

--- a/menu/functions.c
+++ b/menu/functions.c
@@ -68,7 +68,7 @@ static int search(struct Menu *menu, int op)
   {
     buf_strcpy(buf, search_buf && (search_buf[0] != '\0') ? search_buf : "");
     if ((mw_get_field(((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ? _("Search for: ") : _("Reverse search for: "),
-                      buf, MUTT_COMP_CLEAR, false, NULL, NULL, NULL, NULL, NULL) != 0) ||
+                      buf, MUTT_COMP_CLEAR, NULL, NULL) != 0) ||
         buf_is_empty(buf))
     {
       goto done;
@@ -251,8 +251,7 @@ static int op_jump(struct Menu *menu, int op)
   }
 
   struct Buffer *buf = buf_pool_get();
-  if ((mw_get_field(_("Jump to: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
-                    NULL, NULL, NULL) == 0) &&
+  if ((mw_get_field(_("Jump to: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) == 0) &&
       !buf_is_empty(buf))
   {
     int n = 0;

--- a/menu/functions.c
+++ b/menu/functions.c
@@ -68,7 +68,7 @@ static int search(struct Menu *menu, int op)
   {
     buf_strcpy(buf, search_buf && (search_buf[0] != '\0') ? search_buf : "");
     if ((mw_get_field(((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ? _("Search for: ") : _("Reverse search for: "),
-                      buf, MUTT_COMP_CLEAR, false, NULL, NULL, NULL) != 0) ||
+                      buf, MUTT_COMP_CLEAR, false, NULL, NULL, NULL, NULL, NULL) != 0) ||
         buf_is_empty(buf))
     {
       goto done;
@@ -251,7 +251,8 @@ static int op_jump(struct Menu *menu, int op)
   }
 
   struct Buffer *buf = buf_pool_get();
-  if ((mw_get_field(_("Jump to: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) == 0) &&
+  if ((mw_get_field(_("Jump to: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
+                    NULL, NULL, NULL) == 0) &&
       !buf_is_empty(buf))
   {
     int n = 0;

--- a/mutt.h
+++ b/mutt.h
@@ -51,20 +51,11 @@
 
 extern bool StartupComplete;
 
-typedef uint16_t CompletionFlags;       ///< Flags for mutt_enter_string_full(), e.g. #MUTT_COMP_ALIAS
-#define MUTT_COMP_NO_FLAGS          0   ///< No flags are set
-#define MUTT_COMP_ALIAS       (1 << 0)  ///< Alias completion (in alias dialog)
-#define MUTT_COMP_COMMAND     (1 << 1)  ///< Complete a NeoMutt command
-#define MUTT_COMP_FILE        (1 << 2)  ///< File completion (in browser)
-#define MUTT_COMP_FILE_MBOX   (1 << 3)  ///< File completion, plus incoming folders (in browser)
-#define MUTT_COMP_FILE_SIMPLE (1 << 4)  ///< File completion (no browser)
-#define MUTT_COMP_LABEL       (1 << 5)  ///< Label completion
-#define MUTT_COMP_NM_QUERY    (1 << 6)  ///< Notmuch query mode
-#define MUTT_COMP_NM_TAG      (1 << 7)  ///< Notmuch tag +/- mode
-#define MUTT_COMP_PATTERN     (1 << 8)  ///< Pattern mode (in pattern dialog)
-#define MUTT_COMP_CLEAR       (1 << 9)  ///< Clear input if printable character is pressed
-#define MUTT_COMP_PASS        (1 << 10) ///< Password mode (no echo)
-#define MUTT_COMP_UNBUFFERED  (1 << 11) ///< Ignore macro buffer
+typedef uint8_t CompletionFlags;       ///< Flags for mutt_enter_string_full(), e.g. #MUTT_COMP_NO_FLAGS
+#define MUTT_COMP_NO_FLAGS          0  ///< No flags are set
+#define MUTT_COMP_CLEAR       (1 << 0) ///< Clear input if printable character is pressed
+#define MUTT_COMP_PASS        (1 << 1) ///< Password mode (no echo)
+#define MUTT_COMP_UNBUFFERED  (1 << 2) ///< Ignore macro buffer
 
 /**
  * enum MessageType - To set flags or match patterns

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -143,8 +143,7 @@ int mutt_label_message(struct MailboxView *mv, struct EmailArray *ea)
       buf_strcpy(buf, e->env->x_label);
   }
 
-  if (mw_get_field("Label: ", buf, MUTT_COMP_LABEL, false, NULL, NULL, NULL,
-                   &CompleteLabelOps, NULL) != 0)
+  if (mw_get_field("Label: ", buf, MUTT_COMP_LABEL, &CompleteLabelOps, NULL) != 0)
   {
     goto done;
   }

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -144,7 +144,7 @@ int mutt_label_message(struct MailboxView *mv, struct EmailArray *ea)
       buf_strcpy(buf, e->env->x_label);
   }
 
-  if (mw_get_field("Label: ", buf, MUTT_COMP_LABEL, HC_OTHER, &CompleteLabelOps, NULL) != 0)
+  if (mw_get_field("Label: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER, &CompleteLabelOps, NULL) != 0)
   {
     goto done;
   }

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -142,7 +142,7 @@ int mutt_label_message(struct MailboxView *mv, struct EmailArray *ea)
       buf_strcpy(buf, e->env->x_label);
   }
 
-  if (mw_get_field("Label: ", buf, MUTT_COMP_LABEL, false, NULL, NULL, NULL) != 0)
+  if (mw_get_field("Label: ", buf, MUTT_COMP_LABEL, false, NULL, NULL, NULL, NULL, NULL) != 0)
   {
     goto done;
   }

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -40,6 +40,7 @@
 #include "gui/lib.h"
 #include "mutt.h"
 #include "mutt_header.h"
+#include "complete/lib.h"
 #include "enter/lib.h"
 #include "index/lib.h"
 #include "ncrypt/lib.h"
@@ -142,7 +143,8 @@ int mutt_label_message(struct MailboxView *mv, struct EmailArray *ea)
       buf_strcpy(buf, e->env->x_label);
   }
 
-  if (mw_get_field("Label: ", buf, MUTT_COMP_LABEL, false, NULL, NULL, NULL, NULL, NULL) != 0)
+  if (mw_get_field("Label: ", buf, MUTT_COMP_LABEL, false, NULL, NULL, NULL,
+                   &CompleteLabelOps, NULL) != 0)
   {
     goto done;
   }

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -42,6 +42,7 @@
 #include "mutt_header.h"
 #include "complete/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "index/lib.h"
 #include "ncrypt/lib.h"
 #include "postpone/lib.h"
@@ -143,7 +144,7 @@ int mutt_label_message(struct MailboxView *mv, struct EmailArray *ea)
       buf_strcpy(buf, e->env->x_label);
   }
 
-  if (mw_get_field("Label: ", buf, MUTT_COMP_LABEL, &CompleteLabelOps, NULL) != 0)
+  if (mw_get_field("Label: ", buf, MUTT_COMP_LABEL, HC_OTHER, &CompleteLabelOps, NULL) != 0)
   {
     goto done;
   }

--- a/muttlib.c
+++ b/muttlib.c
@@ -49,6 +49,7 @@
 #include "gui/lib.h"
 #include "mutt.h"
 #include "muttlib.h"
+#include "browser/lib.h"
 #include "enter/lib.h"
 #include "ncrypt/lib.h"
 #include "parse/lib.h"
@@ -622,7 +623,7 @@ int mutt_check_overwrite(const char *attname, const char *path, struct Buffer *f
     struct Buffer *tmp = buf_pool_get();
     buf_strcpy(tmp, mutt_path_basename(NONULL(attname)));
     if ((mw_get_field(_("File under directory: "), tmp, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                      false, NULL, NULL, NULL, NULL, NULL) != 0) ||
+                      false, NULL, NULL, NULL, &CompleteMailboxOps, NULL) != 0) ||
         buf_is_empty(tmp))
     {
       buf_pool_release(&tmp);

--- a/muttlib.c
+++ b/muttlib.c
@@ -624,7 +624,7 @@ int mutt_check_overwrite(const char *attname, const char *path, struct Buffer *f
     buf_strcpy(tmp, mutt_path_basename(NONULL(attname)));
     struct FileCompletionData cdata = { false, NULL, NULL, NULL };
     if ((mw_get_field(_("File under directory: "), tmp, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                      false, NULL, NULL, NULL, &CompleteMailboxOps, &cdata) != 0) ||
+                      &CompleteMailboxOps, &cdata) != 0) ||
         buf_is_empty(tmp))
     {
       buf_pool_release(&tmp);

--- a/muttlib.c
+++ b/muttlib.c
@@ -51,6 +51,7 @@
 #include "muttlib.h"
 #include "browser/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "ncrypt/lib.h"
 #include "parse/lib.h"
 #include "question/lib.h"
@@ -624,7 +625,7 @@ int mutt_check_overwrite(const char *attname, const char *path, struct Buffer *f
     buf_strcpy(tmp, mutt_path_basename(NONULL(attname)));
     struct FileCompletionData cdata = { false, NULL, NULL, NULL };
     if ((mw_get_field(_("File under directory: "), tmp, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                      &CompleteMailboxOps, &cdata) != 0) ||
+                      HC_FILE, &CompleteMailboxOps, &cdata) != 0) ||
         buf_is_empty(tmp))
     {
       buf_pool_release(&tmp);

--- a/muttlib.c
+++ b/muttlib.c
@@ -624,7 +624,7 @@ int mutt_check_overwrite(const char *attname, const char *path, struct Buffer *f
     struct Buffer *tmp = buf_pool_get();
     buf_strcpy(tmp, mutt_path_basename(NONULL(attname)));
     struct FileCompletionData cdata = { false, NULL, NULL, NULL };
-    if ((mw_get_field(_("File under directory: "), tmp, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
+    if ((mw_get_field(_("File under directory: "), tmp, MUTT_COMP_CLEAR,
                       HC_FILE, &CompleteMailboxOps, &cdata) != 0) ||
         buf_is_empty(tmp))
     {

--- a/muttlib.c
+++ b/muttlib.c
@@ -622,8 +622,9 @@ int mutt_check_overwrite(const char *attname, const char *path, struct Buffer *f
 
     struct Buffer *tmp = buf_pool_get();
     buf_strcpy(tmp, mutt_path_basename(NONULL(attname)));
+    struct FileCompletionData cdata = { false, NULL, NULL, NULL };
     if ((mw_get_field(_("File under directory: "), tmp, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                      false, NULL, NULL, NULL, &CompleteMailboxOps, NULL) != 0) ||
+                      false, NULL, NULL, NULL, &CompleteMailboxOps, &cdata) != 0) ||
         buf_is_empty(tmp))
     {
       buf_pool_release(&tmp);

--- a/muttlib.c
+++ b/muttlib.c
@@ -622,7 +622,7 @@ int mutt_check_overwrite(const char *attname, const char *path, struct Buffer *f
     struct Buffer *tmp = buf_pool_get();
     buf_strcpy(tmp, mutt_path_basename(NONULL(attname)));
     if ((mw_get_field(_("File under directory: "), tmp, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
-                      false, NULL, NULL, NULL) != 0) ||
+                      false, NULL, NULL, NULL, NULL, NULL) != 0) ||
         buf_is_empty(tmp))
     {
       buf_pool_release(&tmp);

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3371,7 +3371,7 @@ static struct CryptKeyInfo *crypt_ask_for_key(const char *tag, const char *whatf
   while (true)
   {
     buf_reset(resp);
-    if (mw_get_field(tag, resp, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0)
+    if (mw_get_field(tag, resp, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL, NULL, NULL) != 0)
     {
       goto done;
     }

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3371,7 +3371,7 @@ static struct CryptKeyInfo *crypt_ask_for_key(const char *tag, const char *whatf
   while (true)
   {
     buf_reset(resp);
-    if (mw_get_field(tag, resp, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL, NULL, NULL) != 0)
+    if (mw_get_field(tag, resp, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
     {
       goto done;
     }

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -56,6 +56,7 @@
 #include "lib.h"
 #include "attach/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "question/lib.h"
 #include "send/lib.h"
 #include "crypt.h"
@@ -3371,7 +3372,7 @@ static struct CryptKeyInfo *crypt_ask_for_key(const char *tag, const char *whatf
   while (true)
   {
     buf_reset(resp);
-    if (mw_get_field(tag, resp, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
+    if (mw_get_field(tag, resp, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0)
     {
       goto done;
     }

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -101,7 +101,7 @@ bool pgp_class_valid_passphrase(void)
   struct Buffer *buf = buf_pool_get();
   const int rc = mw_get_field(_("Enter PGP passphrase:"), buf,
                               MUTT_COMP_PASS | MUTT_COMP_UNBUFFERED, false,
-                              NULL, NULL, NULL);
+                              NULL, NULL, NULL, NULL, NULL);
   mutt_str_copy(PgpPass, buf_string(buf), sizeof(PgpPass));
   buf_pool_release(&buf);
 

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -50,6 +50,7 @@
 #include "lib.h"
 #include "attach/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "question/lib.h"
 #include "send/lib.h"
 #include "crypt.h"
@@ -100,7 +101,7 @@ bool pgp_class_valid_passphrase(void)
 
   struct Buffer *buf = buf_pool_get();
   const int rc = mw_get_field(_("Enter PGP passphrase:"), buf,
-                              MUTT_COMP_PASS | MUTT_COMP_UNBUFFERED, NULL, NULL);
+                              MUTT_COMP_PASS | MUTT_COMP_UNBUFFERED, HC_OTHER, NULL, NULL);
   mutt_str_copy(PgpPass, buf_string(buf), sizeof(PgpPass));
   buf_pool_release(&buf);
 

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -100,8 +100,7 @@ bool pgp_class_valid_passphrase(void)
 
   struct Buffer *buf = buf_pool_get();
   const int rc = mw_get_field(_("Enter PGP passphrase:"), buf,
-                              MUTT_COMP_PASS | MUTT_COMP_UNBUFFERED, false,
-                              NULL, NULL, NULL, NULL, NULL);
+                              MUTT_COMP_PASS | MUTT_COMP_UNBUFFERED, NULL, NULL);
   mutt_str_copy(PgpPass, buf_string(buf), sizeof(PgpPass));
   buf_pool_release(&buf);
 

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -45,6 +45,7 @@
 #include "pgpkey.h"
 #include "lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "send/lib.h"
 #include "crypt.h"
 #include "globals.h" // IWYU pragma: keep
@@ -200,7 +201,7 @@ struct PgpKeyInfo *pgp_ask_for_key(char *tag, const char *whatfor,
   while (true)
   {
     buf_reset(resp);
-    if (mw_get_field(tag, resp, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
+    if (mw_get_field(tag, resp, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0)
     {
       goto done;
     }

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -200,7 +200,7 @@ struct PgpKeyInfo *pgp_ask_for_key(char *tag, const char *whatfor,
   while (true)
   {
     buf_reset(resp);
-    if (mw_get_field(tag, resp, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0)
+    if (mw_get_field(tag, resp, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL, NULL, NULL) != 0)
     {
       goto done;
     }

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -200,7 +200,7 @@ struct PgpKeyInfo *pgp_ask_for_key(char *tag, const char *whatfor,
   while (true)
   {
     buf_reset(resp);
-    if (mw_get_field(tag, resp, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL, NULL, NULL) != 0)
+    if (mw_get_field(tag, resp, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
     {
       goto done;
     }

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -184,7 +184,7 @@ bool smime_class_valid_passphrase(void)
   struct Buffer *buf = buf_pool_get();
   const int rc = mw_get_field(_("Enter S/MIME passphrase:"), buf,
                               MUTT_COMP_PASS | MUTT_COMP_UNBUFFERED, false,
-                              NULL, NULL, NULL);
+                              NULL, NULL, NULL, NULL, NULL);
   mutt_str_copy(SmimePass, buf_string(buf), sizeof(SmimePass));
   buf_pool_release(&buf);
 
@@ -751,7 +751,8 @@ static struct SmimeKey *smime_ask_for_key(char *prompt, KeyFlags abilities, bool
   while (true)
   {
     buf_reset(resp);
-    if (mw_get_field(prompt, resp, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0)
+    if (mw_get_field(prompt, resp, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL,
+                     NULL, NULL) != 0)
     {
       goto done;
     }
@@ -1204,7 +1205,7 @@ void smime_class_invoke_import(const char *infile, const char *mailbox)
   if (c_smime_ask_cert_label)
   {
     if ((mw_get_field(_("Label for certificate: "), buf, MUTT_COMP_NO_FLAGS,
-                      false, NULL, NULL, NULL) != 0) ||
+                      false, NULL, NULL, NULL, NULL, NULL) != 0) ||
         buf_is_empty(buf))
     {
       goto done;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -183,8 +183,7 @@ bool smime_class_valid_passphrase(void)
 
   struct Buffer *buf = buf_pool_get();
   const int rc = mw_get_field(_("Enter S/MIME passphrase:"), buf,
-                              MUTT_COMP_PASS | MUTT_COMP_UNBUFFERED, false,
-                              NULL, NULL, NULL, NULL, NULL);
+                              MUTT_COMP_PASS | MUTT_COMP_UNBUFFERED, NULL, NULL);
   mutt_str_copy(SmimePass, buf_string(buf), sizeof(SmimePass));
   buf_pool_release(&buf);
 
@@ -751,8 +750,7 @@ static struct SmimeKey *smime_ask_for_key(char *prompt, KeyFlags abilities, bool
   while (true)
   {
     buf_reset(resp);
-    if (mw_get_field(prompt, resp, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL,
-                     NULL, NULL) != 0)
+    if (mw_get_field(prompt, resp, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
     {
       goto done;
     }
@@ -1204,8 +1202,7 @@ void smime_class_invoke_import(const char *infile, const char *mailbox)
   const bool c_smime_ask_cert_label = cs_subset_bool(NeoMutt->sub, "smime_ask_cert_label");
   if (c_smime_ask_cert_label)
   {
-    if ((mw_get_field(_("Label for certificate: "), buf, MUTT_COMP_NO_FLAGS,
-                      false, NULL, NULL, NULL, NULL, NULL) != 0) ||
+    if ((mw_get_field(_("Label for certificate: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
         buf_is_empty(buf))
     {
       goto done;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -48,6 +48,7 @@
 #include "mutt.h"
 #include "lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "question/lib.h"
 #include "send/lib.h"
 #include "copy.h"
@@ -183,7 +184,7 @@ bool smime_class_valid_passphrase(void)
 
   struct Buffer *buf = buf_pool_get();
   const int rc = mw_get_field(_("Enter S/MIME passphrase:"), buf,
-                              MUTT_COMP_PASS | MUTT_COMP_UNBUFFERED, NULL, NULL);
+                              MUTT_COMP_PASS | MUTT_COMP_UNBUFFERED, HC_OTHER, NULL, NULL);
   mutt_str_copy(SmimePass, buf_string(buf), sizeof(SmimePass));
   buf_pool_release(&buf);
 
@@ -750,7 +751,7 @@ static struct SmimeKey *smime_ask_for_key(char *prompt, KeyFlags abilities, bool
   while (true)
   {
     buf_reset(resp);
-    if (mw_get_field(prompt, resp, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
+    if (mw_get_field(prompt, resp, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0)
     {
       goto done;
     }
@@ -1202,7 +1203,8 @@ void smime_class_invoke_import(const char *infile, const char *mailbox)
   const bool c_smime_ask_cert_label = cs_subset_bool(NeoMutt->sub, "smime_ask_cert_label");
   if (c_smime_ask_cert_label)
   {
-    if ((mw_get_field(_("Label for certificate: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
+    if ((mw_get_field(_("Label for certificate: "), buf, MUTT_COMP_NO_FLAGS,
+                      HC_OTHER, NULL, NULL) != 0) ||
         buf_is_empty(buf))
     {
       goto done;

--- a/notmuch/complete.c
+++ b/notmuch/complete.c
@@ -242,3 +242,17 @@ int complete_nm_tag(struct EnterWindowData *wdata, int op)
   replace_part(wdata->state, 0, buf_string(wdata->buffer));
   return rc;
 }
+
+/**
+ * CompleteNmQueryOps - Auto-Completion of NmQuerys
+ */
+const struct CompleteOps CompleteNmQueryOps = {
+  .complete = complete_nm_query,
+};
+
+/**
+ * CompleteNmTagOps - Auto-Completion of NmTags
+ */
+const struct CompleteOps CompleteNmTagOps = {
+  .complete = complete_nm_tag,
+};

--- a/notmuch/complete.c
+++ b/notmuch/complete.c
@@ -36,6 +36,7 @@
 #include "enter/lib.h"
 #include "index/lib.h"
 #include "notmuch/lib.h"
+#include "opcodes.h"
 
 /**
  * complete_all_nm_tags - Pass a list of Notmuch tags to the completion code
@@ -208,12 +209,13 @@ bool mutt_nm_tag_complete(struct CompletionData *cd, struct Buffer *buf, int num
 }
 
 /**
- * complete_nm_query - Complete a Notmuch Query
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ * complete_nm_query - Complete a Notmuch Query - Implements ::complete_function_t -- @ingroup complete_api
  */
-int complete_nm_query(struct EnterWindowData *wdata)
+int complete_nm_query(struct EnterWindowData *wdata, int op)
 {
+  if (!wdata || (op != OP_EDITOR_COMPLETE))
+    return FR_NO_ACTION;
+
   int rc = FR_SUCCESS;
   buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
   size_t len = buf_len(wdata->buffer);
@@ -225,12 +227,13 @@ int complete_nm_query(struct EnterWindowData *wdata)
 }
 
 /**
- * complete_nm_tag - Complete a Notmuch Tag
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ * complete_nm_tag - Complete a Notmuch Tag - Implements ::complete_function_t -- @ingroup complete_api
  */
-int complete_nm_tag(struct EnterWindowData *wdata)
+int complete_nm_tag(struct EnterWindowData *wdata, int op)
 {
+  if (!wdata || (op != OP_EDITOR_COMPLETE))
+    return FR_NO_ACTION;
+
   int rc = FR_SUCCESS;
   buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
   if (!mutt_nm_tag_complete(wdata->cd, wdata->buffer, wdata->tabs))

--- a/notmuch/complete.c
+++ b/notmuch/complete.c
@@ -1,0 +1,241 @@
+/**
+ * @file
+ * Notmuch Auto-Completion
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page nm_complete Notmuch Auto-Completion
+ *
+ * Notmuch Auto-Completion
+ */
+
+#include "config.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "complete/lib.h"
+#include "enter/lib.h"
+#include "index/lib.h"
+#include "notmuch/lib.h"
+
+/**
+ * complete_all_nm_tags - Pass a list of Notmuch tags to the completion code
+ * @param cd Completion Data
+ * @param pt List of all Notmuch tags
+ * @retval  0 Success
+ * @retval -1 Error
+ */
+int complete_all_nm_tags(struct CompletionData *cd, const char *pt)
+{
+  struct Mailbox *m_cur = get_current_mailbox();
+  int tag_count_1 = 0;
+  int tag_count_2 = 0;
+  int rc = -1;
+
+  mutt_str_copy(cd->user_typed, pt, sizeof(cd->user_typed));
+  memset(cd->match_list, 0, cd->match_list_len);
+  memset(cd->completed, 0, sizeof(cd->completed));
+  cd->free_match_strings = true;
+
+  nm_db_longrun_init(m_cur, false);
+
+  /* Work out how many tags there are. */
+  if ((nm_get_all_tags(m_cur, NULL, &tag_count_1) != 0) || (tag_count_1 == 0))
+    goto done;
+
+  /* Get all the tags. */
+  const char **nm_tags = mutt_mem_calloc(tag_count_1, sizeof(char *));
+  if ((nm_get_all_tags(m_cur, nm_tags, &tag_count_2) != 0) || (tag_count_1 != tag_count_2))
+  {
+    completion_data_free_match_strings(cd);
+    goto done;
+  }
+
+  /* Put them into the completion machinery. */
+  for (int i = 0; i < tag_count_1; i++)
+  {
+    if (!candidate(cd, cd->user_typed, nm_tags[i], cd->completed, sizeof(cd->completed)))
+      FREE(&nm_tags[i]);
+  }
+
+  matches_ensure_morespace(cd, cd->num_matched);
+  cd->match_list[cd->num_matched++] = mutt_str_dup(cd->user_typed);
+  rc = 0;
+
+done:
+  FREE(&nm_tags);
+  nm_db_longrun_done(m_cur);
+  return rc;
+}
+
+/**
+ * mutt_nm_query_complete - Complete to the nearest notmuch tag
+ * @param cd      Completion Data
+ * @param buf     Buffer for the result
+ * @param pos     Cursor position in the buffer
+ * @param numtabs Number of times the user has hit 'tab'
+ * @retval true  Success, a match
+ * @retval false Error, no match
+ *
+ * Complete the nearest "tag:"-prefixed string previous to pos.
+ */
+bool mutt_nm_query_complete(struct CompletionData *cd, struct Buffer *buf, int pos, int numtabs)
+{
+  char *pt = buf->data;
+  int spaces;
+
+  SKIPWS(pt);
+  spaces = pt - buf->data;
+
+  pt = (char *) mutt_strn_rfind((char *) buf, pos, "tag:");
+  if (pt)
+  {
+    pt += 4;
+    if (numtabs == 1)
+    {
+      /* First TAB. Collect all the matches */
+      complete_all_nm_tags(cd, pt);
+
+      /* All matches are stored. Longest non-ambiguous string is ""
+       * i.e. don't change 'buf'. Fake successful return this time.  */
+      if (cd->user_typed[0] == '\0')
+        return true;
+    }
+
+    if ((cd->completed[0] == '\0') && (cd->user_typed[0] != '\0'))
+      return false;
+
+    /* cd->num_matched will _always_ be at least 1 since the initial
+     * user-typed string is always stored */
+    if ((numtabs == 1) && (cd->num_matched == 2))
+    {
+      snprintf(cd->completed, sizeof(cd->completed), "%s", cd->match_list[0]);
+    }
+    else if ((numtabs > 1) && (cd->num_matched > 2))
+    {
+      /* cycle through all the matches */
+      snprintf(cd->completed, sizeof(cd->completed), "%s",
+               cd->match_list[(numtabs - 2) % cd->num_matched]);
+    }
+
+    /* return the completed query */
+    strncpy(pt, cd->completed, buf->data + buf->dsize - pt - spaces);
+  }
+  else
+  {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * mutt_nm_tag_complete - Complete to the nearest notmuch tag
+ * @param cd      Completion Data
+ * @param buf     Buffer for the result
+ * @param numtabs Number of times the user has hit 'tab'
+ * @retval true  Success, a match
+ * @retval false Error, no match
+ *
+ * Complete the nearest "+" or "-" -prefixed string previous to pos.
+ */
+bool mutt_nm_tag_complete(struct CompletionData *cd, struct Buffer *buf, int numtabs)
+{
+  if (!buf)
+    return false;
+
+  char *pt = buf->data;
+
+  /* Only examine the last token */
+  char *last_space = strrchr(buf->data, ' ');
+  if (last_space)
+    pt = (last_space + 1);
+
+  /* Skip the +/- */
+  if ((pt[0] == '+') || (pt[0] == '-'))
+    pt++;
+
+  if (numtabs == 1)
+  {
+    /* First TAB. Collect all the matches */
+    complete_all_nm_tags(cd, pt);
+
+    /* All matches are stored. Longest non-ambiguous string is ""
+     * i.e. don't change 'buf'. Fake successful return this time.  */
+    if (cd->user_typed[0] == '\0')
+      return true;
+  }
+
+  if ((cd->completed[0] == '\0') && (cd->user_typed[0] != '\0'))
+    return false;
+
+  /* cd->num_matched will _always_ be at least 1 since the initial
+   * user-typed string is always stored */
+  if ((numtabs == 1) && (cd->num_matched == 2))
+  {
+    snprintf(cd->completed, sizeof(cd->completed), "%s", cd->match_list[0]);
+  }
+  else if ((numtabs > 1) && (cd->num_matched > 2))
+  {
+    /* cycle through all the matches */
+    snprintf(cd->completed, sizeof(cd->completed), "%s",
+             cd->match_list[(numtabs - 2) % cd->num_matched]);
+  }
+
+  /* return the completed query */
+  strncpy(pt, cd->completed, buf->data + buf->dsize - pt);
+
+  return true;
+}
+
+/**
+ * complete_nm_query - Complete a Notmuch Query
+ * @param wdata Enter window data
+ * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ */
+int complete_nm_query(struct EnterWindowData *wdata)
+{
+  int rc = FR_SUCCESS;
+  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
+  size_t len = buf_len(wdata->buffer);
+  if (!mutt_nm_query_complete(wdata->cd, wdata->buffer, len, wdata->tabs))
+    rc = FR_ERROR;
+
+  replace_part(wdata->state, 0, buf_string(wdata->buffer));
+  return rc;
+}
+
+/**
+ * complete_nm_tag - Complete a Notmuch Tag
+ * @param wdata Enter window data
+ * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ */
+int complete_nm_tag(struct EnterWindowData *wdata)
+{
+  int rc = FR_SUCCESS;
+  buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
+  if (!mutt_nm_tag_complete(wdata->cd, wdata->buffer, wdata->tabs))
+    rc = FR_ERROR;
+
+  replace_part(wdata->state, 0, buf_string(wdata->buffer));
+  return rc;
+}

--- a/notmuch/lib.h
+++ b/notmuch/lib.h
@@ -25,16 +25,17 @@
  *
  * Notmuch virtual mailbox type
  *
- * | File               | Description         |
- * | :----------------- | :------------------ |
- * | notmuch/adata.c    | @subpage nm_adata   |
- * | notmuch/config.c   | @subpage nm_config  |
- * | notmuch/db.c       | @subpage nm_db      |
- * | notmuch/edata.c    | @subpage nm_edata   |
- * | notmuch/mdata.c    | @subpage nm_mdata   |
- * | notmuch/notmuch.c  | @subpage nm_notmuch |
- * | notmuch/query.c    | @subpage nm_query   |
- * | notmuch/tag.c      | @subpage nm_tag     |
+ * | File               | Description          |
+ * | :----------------- | :------------------- |
+ * | notmuch/adata.c    | @subpage nm_adata    |
+ * | notmuch/complete.c | @subpage nm_complete |
+ * | notmuch/config.c   | @subpage nm_config   |
+ * | notmuch/db.c       | @subpage nm_db       |
+ * | notmuch/edata.c    | @subpage nm_edata    |
+ * | notmuch/mdata.c    | @subpage nm_mdata    |
+ * | notmuch/notmuch.c  | @subpage nm_notmuch  |
+ * | notmuch/query.c    | @subpage nm_query    |
+ * | notmuch/tag.c      | @subpage nm_tag      |
  */
 
 #ifndef MUTT_NOTMUCH_LIB_H

--- a/notmuch/lib.h
+++ b/notmuch/lib.h
@@ -44,9 +44,13 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include "core/lib.h"
+#include "complete/lib.h"
 
 struct Email;
 struct stat;
+
+extern const struct CompleteOps CompleteNmQueryOps;
+extern const struct CompleteOps CompleteNmTagOps;
 
 extern const struct MxOps MxNotmuchOps;
 

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2389,7 +2389,8 @@ static int nm_msg_close(struct Mailbox *m, struct Message *msg)
 static int nm_tags_edit(struct Mailbox *m, const char *tags, struct Buffer *buf)
 {
   buf_reset(buf);
-  if (mw_get_field("Add/remove labels: ", buf, MUTT_COMP_NM_TAG, false, NULL, NULL, NULL) != 0)
+  if (mw_get_field("Add/remove labels: ", buf, MUTT_COMP_NM_TAG, false, NULL,
+                   NULL, NULL, NULL, NULL) != 0)
   {
     return -1;
   }

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2389,8 +2389,7 @@ static int nm_msg_close(struct Mailbox *m, struct Message *msg)
 static int nm_tags_edit(struct Mailbox *m, const char *tags, struct Buffer *buf)
 {
   buf_reset(buf);
-  if (mw_get_field("Add/remove labels: ", buf, MUTT_COMP_NM_TAG, false, NULL,
-                   NULL, NULL, &CompleteNmTagOps, NULL) != 0)
+  if (mw_get_field("Add/remove labels: ", buf, MUTT_COMP_NM_TAG, &CompleteNmTagOps, NULL) != 0)
   {
     return -1;
   }

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -59,6 +59,7 @@
 #include "lib.h"
 #include "enter/lib.h"
 #include "hcache/lib.h"
+#include "history/lib.h"
 #include "index/lib.h"
 #include "maildir/lib.h"
 #include "progress/lib.h"
@@ -2389,7 +2390,8 @@ static int nm_msg_close(struct Mailbox *m, struct Message *msg)
 static int nm_tags_edit(struct Mailbox *m, const char *tags, struct Buffer *buf)
 {
   buf_reset(buf);
-  if (mw_get_field("Add/remove labels: ", buf, MUTT_COMP_NM_TAG, &CompleteNmTagOps, NULL) != 0)
+  if (mw_get_field("Add/remove labels: ", buf, MUTT_COMP_NM_TAG, HC_OTHER,
+                   &CompleteNmTagOps, NULL) != 0)
   {
     return -1;
   }

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2390,7 +2390,7 @@ static int nm_msg_close(struct Mailbox *m, struct Message *msg)
 static int nm_tags_edit(struct Mailbox *m, const char *tags, struct Buffer *buf)
 {
   buf_reset(buf);
-  if (mw_get_field("Add/remove labels: ", buf, MUTT_COMP_NM_TAG, HC_OTHER,
+  if (mw_get_field("Add/remove labels: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER,
                    &CompleteNmTagOps, NULL) != 0)
   {
     return -1;

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2390,7 +2390,7 @@ static int nm_tags_edit(struct Mailbox *m, const char *tags, struct Buffer *buf)
 {
   buf_reset(buf);
   if (mw_get_field("Add/remove labels: ", buf, MUTT_COMP_NM_TAG, false, NULL,
-                   NULL, NULL, NULL, NULL) != 0)
+                   NULL, NULL, &CompleteNmTagOps, NULL) != 0)
   {
     return -1;
   }

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -312,7 +312,8 @@ static int op_pager_search(struct IndexSharedData *shared,
 
   buf_strcpy(buf, priv->search_str);
   if (mw_get_field(((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ? _("Search for: ") : _("Reverse search for: "),
-                   buf, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, false, NULL, NULL, NULL) != 0)
+                   buf, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, false, NULL, NULL,
+                   NULL, NULL, NULL) != 0)
   {
     goto done;
   }

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -42,6 +42,7 @@
 #include "attach/lib.h"
 #include "color/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "index/lib.h"
 #include "menu/lib.h"
 #include "pattern/lib.h"
@@ -313,7 +314,8 @@ static int op_pager_search(struct IndexSharedData *shared,
 
   buf_strcpy(buf, priv->search_str);
   if (mw_get_field(((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ? _("Search for: ") : _("Reverse search for: "),
-                   buf, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, &CompletePatternOps, NULL) != 0)
+                   buf, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, HC_PATTERN,
+                   &CompletePatternOps, NULL) != 0)
   {
     goto done;
   }

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -313,8 +313,7 @@ static int op_pager_search(struct IndexSharedData *shared,
 
   buf_strcpy(buf, priv->search_str);
   if (mw_get_field(((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ? _("Search for: ") : _("Reverse search for: "),
-                   buf, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, false, NULL, NULL,
-                   NULL, &CompletePatternOps, NULL) != 0)
+                   buf, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, &CompletePatternOps, NULL) != 0)
   {
     goto done;
   }

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -314,8 +314,7 @@ static int op_pager_search(struct IndexSharedData *shared,
 
   buf_strcpy(buf, priv->search_str);
   if (mw_get_field(((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ? _("Search for: ") : _("Reverse search for: "),
-                   buf, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, HC_PATTERN,
-                   &CompletePatternOps, NULL) != 0)
+                   buf, MUTT_COMP_CLEAR, HC_PATTERN, &CompletePatternOps, NULL) != 0)
   {
     goto done;
   }

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -44,6 +44,7 @@
 #include "enter/lib.h"
 #include "index/lib.h"
 #include "menu/lib.h"
+#include "pattern/lib.h"
 #include "display.h"
 #include "opcodes.h"
 #include "private_data.h"
@@ -313,7 +314,7 @@ static int op_pager_search(struct IndexSharedData *shared,
   buf_strcpy(buf, priv->search_str);
   if (mw_get_field(((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ? _("Search for: ") : _("Reverse search for: "),
                    buf, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, false, NULL, NULL,
-                   NULL, NULL, NULL) != 0)
+                   NULL, &CompletePatternOps, NULL) != 0)
   {
     goto done;
   }

--- a/pattern/complete.c
+++ b/pattern/complete.c
@@ -33,14 +33,16 @@
 #include "lib.h"
 #include "complete/lib.h"
 #include "enter/lib.h"
+#include "opcodes.h"
 
 /**
- * complete_pattern - Complete a NeoMutt Pattern
- * @param wdata Enter window data
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ * complete_pattern - Complete a NeoMutt Pattern - Implements ::complete_function_t -- @ingroup complete_api
  */
-int complete_pattern(struct EnterWindowData *wdata)
+int complete_pattern(struct EnterWindowData *wdata, int op)
 {
+  if (!wdata || (op != OP_EDITOR_COMPLETE))
+    return FR_NO_ACTION;
+
   size_t i = wdata->state->curpos;
   if (i && (wdata->state->wbuf[i - 1] == '~'))
   {

--- a/pattern/complete.c
+++ b/pattern/complete.c
@@ -1,0 +1,75 @@
+/**
+ * @file
+ * Pattern Auto-Completion
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page pattern_complete Pattern Auto-Completion
+ *
+ * Pattern Auto-Completion
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "lib.h"
+#include "complete/lib.h"
+#include "enter/lib.h"
+
+/**
+ * complete_pattern - Complete a NeoMutt Pattern
+ * @param wdata Enter window data
+ * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ */
+int complete_pattern(struct EnterWindowData *wdata)
+{
+  size_t i = wdata->state->curpos;
+  if (i && (wdata->state->wbuf[i - 1] == '~'))
+  {
+    if (dlg_pattern(wdata->buffer->data, wdata->buffer->dsize))
+      replace_part(wdata->state, i - 1, wdata->buffer->data);
+    buf_fix_dptr(wdata->buffer);
+    return FR_CONTINUE;
+  }
+
+  for (; (i > 0) && (wdata->state->wbuf[i - 1] != '~'); i--)
+    ; // do nothing
+
+  if ((i > 0) && (i < wdata->state->curpos) &&
+      (wdata->state->wbuf[i - 1] == '~') && (wdata->state->wbuf[i] == 'y'))
+  {
+    i++;
+    buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf + i, wdata->state->curpos - i);
+    int rc = mutt_label_complete(wdata->cd, wdata->buffer, wdata->tabs);
+    replace_part(wdata->state, i, wdata->buffer->data);
+    buf_fix_dptr(wdata->buffer);
+    if (rc != 1)
+    {
+      return FR_CONTINUE;
+    }
+  }
+  else
+  {
+    return FR_NO_ACTION;
+  }
+
+  return FR_SUCCESS;
+}

--- a/pattern/complete.c
+++ b/pattern/complete.c
@@ -75,3 +75,10 @@ int complete_pattern(struct EnterWindowData *wdata, int op)
 
   return FR_SUCCESS;
 }
+
+/**
+ * CompletePatternOps - Auto-Completion of Patterns
+ */
+const struct CompleteOps CompletePatternOps = {
+  .complete = complete_pattern,
+};

--- a/pattern/lib.h
+++ b/pattern/lib.h
@@ -29,6 +29,7 @@
  * | File                   | Description                   |
  * | :--------------------- | :---------------------------- |
  * | pattern/compile.c      | @subpage pattern_compile      |
+ * | pattern/complete.c     | @subpage pattern_complete     |
  * | pattern/config.c       | @subpage pattern_config       |
  * | pattern/dlg_pattern.c  | @subpage pattern_dlg_pattern  |
  * | pattern/exec.c         | @subpage pattern_exec         |

--- a/pattern/lib.h
+++ b/pattern/lib.h
@@ -49,6 +49,7 @@
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "mutt.h"
+#include "complete/lib.h"
 #include "search_state.h" // IWYU pragma: keep
 
 struct AliasMenuData;
@@ -60,6 +61,8 @@ struct MailboxView;
 struct Menu;
 
 #define MUTT_ALIAS_SIMPLESEARCH "~f %s | ~t %s | ~c %s"
+
+extern const struct CompleteOps CompletePatternOps;
 
 typedef uint8_t PatternCompFlags;           ///< Flags for mutt_pattern_comp(), e.g. #MUTT_PC_FULL_MSG
 #define MUTT_PC_NO_FLAGS                0   ///< No flags are set

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -197,7 +197,7 @@ int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata, struct Me
   if (prompt)
   {
     if ((mw_get_field(prompt, buf, MUTT_COMP_PATTERN | MUTT_COMP_CLEAR, false,
-                      NULL, NULL, NULL) != 0) ||
+                      NULL, NULL, NULL, NULL, NULL) != 0) ||
         buf_is_empty(buf))
     {
       buf_pool_release(&buf);
@@ -303,7 +303,7 @@ int mutt_pattern_func(struct MailboxView *mv, int op, char *prompt)
   if (prompt || (op != MUTT_LIMIT))
   {
     if ((mw_get_field(prompt, buf, MUTT_COMP_PATTERN | MUTT_COMP_CLEAR, false,
-                      NULL, NULL, NULL) != 0) ||
+                      NULL, NULL, NULL, NULL, NULL) != 0) ||
         buf_is_empty(buf))
     {
       buf_pool_release(&buf);
@@ -452,7 +452,7 @@ int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
   {
     if ((mw_get_field((state->reverse) ? _("Reverse search for: ") : _("Search for: "),
                       state->string, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, false,
-                      NULL, NULL, NULL) != 0) ||
+                      NULL, NULL, NULL, NULL, NULL) != 0) ||
         buf_is_empty(state->string))
     {
       goto done;
@@ -607,7 +607,7 @@ int mutt_search_alias_command(struct Menu *menu, int cur,
   {
     if ((mw_get_field((flags & OP_SEARCH_REVERSE) ? _("Reverse search for: ") : _("Search for: "),
                       state->string, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, false,
-                      NULL, NULL, NULL) != 0) ||
+                      NULL, NULL, NULL, NULL, NULL) != 0) ||
         buf_is_empty(state->string))
     {
       goto done;

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -197,8 +197,7 @@ int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata, struct Me
   buf_strcpy(buf, mdata->limit);
   if (prompt)
   {
-    if ((mw_get_field(prompt, buf, MUTT_COMP_PATTERN | MUTT_COMP_CLEAR,
-                      HC_PATTERN, &CompletePatternOps, NULL) != 0) ||
+    if ((mw_get_field(prompt, buf, MUTT_COMP_CLEAR, HC_PATTERN, &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(buf))
     {
       buf_pool_release(&buf);
@@ -303,8 +302,7 @@ int mutt_pattern_func(struct MailboxView *mv, int op, char *prompt)
   buf_strcpy(buf, NONULL(mv->pattern));
   if (prompt || (op != MUTT_LIMIT))
   {
-    if ((mw_get_field(prompt, buf, MUTT_COMP_PATTERN | MUTT_COMP_CLEAR,
-                      HC_PATTERN, &CompletePatternOps, NULL) != 0) ||
+    if ((mw_get_field(prompt, buf, MUTT_COMP_CLEAR, HC_PATTERN, &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(buf))
     {
       buf_pool_release(&buf);
@@ -452,8 +450,8 @@ int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
   if (buf_is_empty(state->string) || (flags & SEARCH_PROMPT))
   {
     if ((mw_get_field((state->reverse) ? _("Reverse search for: ") : _("Search for: "),
-                      state->string, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN,
-                      HC_PATTERN, &CompletePatternOps, NULL) != 0) ||
+                      state->string, MUTT_COMP_CLEAR, HC_PATTERN,
+                      &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(state->string))
     {
       goto done;
@@ -607,8 +605,8 @@ int mutt_search_alias_command(struct Menu *menu, int cur,
   if (buf_is_empty(state->string) || flags & SEARCH_PROMPT)
   {
     if ((mw_get_field((flags & OP_SEARCH_REVERSE) ? _("Reverse search for: ") : _("Search for: "),
-                      state->string, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN,
-                      HC_PATTERN, &CompletePatternOps, NULL) != 0) ||
+                      state->string, MUTT_COMP_CLEAR, HC_PATTERN,
+                      &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(state->string))
     {
       goto done;

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -196,8 +196,8 @@ int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata, struct Me
   buf_strcpy(buf, mdata->limit);
   if (prompt)
   {
-    if ((mw_get_field(prompt, buf, MUTT_COMP_PATTERN | MUTT_COMP_CLEAR, false,
-                      NULL, NULL, NULL, &CompletePatternOps, NULL) != 0) ||
+    if ((mw_get_field(prompt, buf, MUTT_COMP_PATTERN | MUTT_COMP_CLEAR,
+                      &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(buf))
     {
       buf_pool_release(&buf);
@@ -302,8 +302,8 @@ int mutt_pattern_func(struct MailboxView *mv, int op, char *prompt)
   buf_strcpy(buf, NONULL(mv->pattern));
   if (prompt || (op != MUTT_LIMIT))
   {
-    if ((mw_get_field(prompt, buf, MUTT_COMP_PATTERN | MUTT_COMP_CLEAR, false,
-                      NULL, NULL, NULL, &CompletePatternOps, NULL) != 0) ||
+    if ((mw_get_field(prompt, buf, MUTT_COMP_PATTERN | MUTT_COMP_CLEAR,
+                      &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(buf))
     {
       buf_pool_release(&buf);
@@ -451,8 +451,8 @@ int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
   if (buf_is_empty(state->string) || (flags & SEARCH_PROMPT))
   {
     if ((mw_get_field((state->reverse) ? _("Reverse search for: ") : _("Search for: "),
-                      state->string, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, false,
-                      NULL, NULL, NULL, &CompletePatternOps, NULL) != 0) ||
+                      state->string, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN,
+                      &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(state->string))
     {
       goto done;
@@ -606,8 +606,8 @@ int mutt_search_alias_command(struct Menu *menu, int cur,
   if (buf_is_empty(state->string) || flags & SEARCH_PROMPT)
   {
     if ((mw_get_field((flags & OP_SEARCH_REVERSE) ? _("Reverse search for: ") : _("Search for: "),
-                      state->string, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, false,
-                      NULL, NULL, NULL, &CompletePatternOps, NULL) != 0) ||
+                      state->string, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN,
+                      &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(state->string))
     {
       goto done;

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -41,6 +41,7 @@
 #include "mutt.h"
 #include "lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "menu/lib.h"
 #include "progress/lib.h"
 #include "globals.h" // IWYU pragma: keep
@@ -197,7 +198,7 @@ int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata, struct Me
   if (prompt)
   {
     if ((mw_get_field(prompt, buf, MUTT_COMP_PATTERN | MUTT_COMP_CLEAR,
-                      &CompletePatternOps, NULL) != 0) ||
+                      HC_PATTERN, &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(buf))
     {
       buf_pool_release(&buf);
@@ -303,7 +304,7 @@ int mutt_pattern_func(struct MailboxView *mv, int op, char *prompt)
   if (prompt || (op != MUTT_LIMIT))
   {
     if ((mw_get_field(prompt, buf, MUTT_COMP_PATTERN | MUTT_COMP_CLEAR,
-                      &CompletePatternOps, NULL) != 0) ||
+                      HC_PATTERN, &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(buf))
     {
       buf_pool_release(&buf);
@@ -452,7 +453,7 @@ int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
   {
     if ((mw_get_field((state->reverse) ? _("Reverse search for: ") : _("Search for: "),
                       state->string, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN,
-                      &CompletePatternOps, NULL) != 0) ||
+                      HC_PATTERN, &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(state->string))
     {
       goto done;
@@ -607,7 +608,7 @@ int mutt_search_alias_command(struct Menu *menu, int cur,
   {
     if ((mw_get_field((flags & OP_SEARCH_REVERSE) ? _("Reverse search for: ") : _("Search for: "),
                       state->string, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN,
-                      &CompletePatternOps, NULL) != 0) ||
+                      HC_PATTERN, &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(state->string))
     {
       goto done;

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -197,7 +197,7 @@ int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata, struct Me
   if (prompt)
   {
     if ((mw_get_field(prompt, buf, MUTT_COMP_PATTERN | MUTT_COMP_CLEAR, false,
-                      NULL, NULL, NULL, NULL, NULL) != 0) ||
+                      NULL, NULL, NULL, &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(buf))
     {
       buf_pool_release(&buf);
@@ -303,7 +303,7 @@ int mutt_pattern_func(struct MailboxView *mv, int op, char *prompt)
   if (prompt || (op != MUTT_LIMIT))
   {
     if ((mw_get_field(prompt, buf, MUTT_COMP_PATTERN | MUTT_COMP_CLEAR, false,
-                      NULL, NULL, NULL, NULL, NULL) != 0) ||
+                      NULL, NULL, NULL, &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(buf))
     {
       buf_pool_release(&buf);
@@ -452,7 +452,7 @@ int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
   {
     if ((mw_get_field((state->reverse) ? _("Reverse search for: ") : _("Search for: "),
                       state->string, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, false,
-                      NULL, NULL, NULL, NULL, NULL) != 0) ||
+                      NULL, NULL, NULL, &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(state->string))
     {
       goto done;
@@ -607,7 +607,7 @@ int mutt_search_alias_command(struct Menu *menu, int cur,
   {
     if ((mw_get_field((flags & OP_SEARCH_REVERSE) ? _("Reverse search for: ") : _("Search for: "),
                       state->string, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, false,
-                      NULL, NULL, NULL, NULL, NULL) != 0) ||
+                      NULL, NULL, NULL, &CompletePatternOps, NULL) != 0) ||
         buf_is_empty(state->string))
     {
       goto done;

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -206,7 +206,7 @@ void attach_bounce_message(struct Mailbox *m, FILE *fp, struct AttachCtx *actx,
   else
     buf_strcpy(prompt, _("Bounce tagged messages to: "));
 
-  if ((mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, HC_ALIAS,
+  if ((mw_get_field(buf_string(prompt), buf, MUTT_COMP_NO_FLAGS, HC_ALIAS,
                     &CompleteAliasOps, NULL) != 0) ||
       buf_is_empty(buf))
   {

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -42,6 +42,7 @@
 #include "recvcmd.h"
 #include "attach/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "question/lib.h"
 #include "send/lib.h"
 #include "copy.h"
@@ -205,7 +206,8 @@ void attach_bounce_message(struct Mailbox *m, FILE *fp, struct AttachCtx *actx,
   else
     buf_strcpy(prompt, _("Bounce tagged messages to: "));
 
-  if ((mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, &CompleteAliasOps, NULL) != 0) ||
+  if ((mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, HC_ALIAS,
+                    &CompleteAliasOps, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -205,8 +205,7 @@ void attach_bounce_message(struct Mailbox *m, FILE *fp, struct AttachCtx *actx,
   else
     buf_strcpy(prompt, _("Bounce tagged messages to: "));
 
-  if ((mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, false, NULL, NULL,
-                    NULL, &CompleteAliasOps, NULL) != 0) ||
+  if ((mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, &CompleteAliasOps, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -206,7 +206,7 @@ void attach_bounce_message(struct Mailbox *m, FILE *fp, struct AttachCtx *actx,
     buf_strcpy(prompt, _("Bounce tagged messages to: "));
 
   if ((mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, false, NULL, NULL,
-                    NULL, NULL, NULL) != 0) ||
+                    NULL, &CompleteAliasOps, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -205,7 +205,8 @@ void attach_bounce_message(struct Mailbox *m, FILE *fp, struct AttachCtx *actx,
   else
     buf_strcpy(prompt, _("Bounce tagged messages to: "));
 
-  if ((mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, false, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field(buf_string(prompt), buf, MUTT_COMP_ALIAS, false, NULL, NULL,
+                    NULL, NULL, NULL) != 0) ||
       buf_is_empty(buf))
   {
     goto done;

--- a/send/send.c
+++ b/send/send.c
@@ -48,6 +48,7 @@
 #include "browser/lib.h"
 #include "compose/lib.h"
 #include "enter/lib.h"
+#include "history/lib.h"
 #include "ncrypt/lib.h"
 #include "pager/lib.h"
 #include "parse/lib.h"
@@ -192,7 +193,7 @@ int mutt_edit_address(struct AddressList *al, const char *field, bool expand_ali
     mutt_addrlist_to_local(al);
     buf_reset(buf);
     mutt_addrlist_write(al, buf, false);
-    if (mw_get_field(field, buf, MUTT_COMP_ALIAS, &CompleteAliasOps, NULL) != 0)
+    if (mw_get_field(field, buf, MUTT_COMP_ALIAS, HC_ALIAS, &CompleteAliasOps, NULL) != 0)
     {
       rc = -1;
       goto done;
@@ -236,7 +237,7 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
     else
       buf_reset(buf);
 
-    if (mw_get_field("Newsgroups: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
+    if (mw_get_field("Newsgroups: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0)
     {
       goto done;
     }
@@ -248,8 +249,8 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
       buf_reset(buf);
 
     const bool c_ask_followup_to = cs_subset_bool(sub, "ask_followup_to");
-    if (c_ask_followup_to &&
-        (mw_get_field("Followup-To: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0))
+    if (c_ask_followup_to && (mw_get_field("Followup-To: ", buf, MUTT_COMP_NO_FLAGS,
+                                           HC_OTHER, NULL, NULL) != 0))
     {
       goto done;
     }
@@ -263,7 +264,7 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
     const bool c_x_comment_to = cs_subset_bool(sub, "x_comment_to");
     const bool c_ask_x_comment_to = cs_subset_bool(sub, "ask_x_comment_to");
     if (c_x_comment_to && c_ask_x_comment_to &&
-        (mw_get_field("X-Comment-To: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0))
+        (mw_get_field("X-Comment-To: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0))
     {
       goto done;
     }
@@ -335,7 +336,7 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
   }
 
   const enum QuadOption c_abort_nosubject = cs_subset_quad(sub, "abort_nosubject");
-  if ((mw_get_field(_("Subject: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
+  if ((mw_get_field(_("Subject: "), buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0) ||
       (buf_is_empty(buf) &&
        (query_quadoption(c_abort_nosubject, _("No subject, abort?")) != MUTT_NO)))
   {

--- a/send/send.c
+++ b/send/send.c
@@ -192,7 +192,8 @@ int mutt_edit_address(struct AddressList *al, const char *field, bool expand_ali
     mutt_addrlist_to_local(al);
     buf_reset(buf);
     mutt_addrlist_write(al, buf, false);
-    if (mw_get_field(field, buf, MUTT_COMP_ALIAS, false, NULL, NULL, NULL, NULL, NULL) != 0)
+    if (mw_get_field(field, buf, MUTT_COMP_ALIAS, false, NULL, NULL, NULL,
+                     &CompleteAliasOps, NULL) != 0)
     {
       rc = -1;
       goto done;

--- a/send/send.c
+++ b/send/send.c
@@ -193,7 +193,7 @@ int mutt_edit_address(struct AddressList *al, const char *field, bool expand_ali
     mutt_addrlist_to_local(al);
     buf_reset(buf);
     mutt_addrlist_write(al, buf, false);
-    if (mw_get_field(field, buf, MUTT_COMP_ALIAS, HC_ALIAS, &CompleteAliasOps, NULL) != 0)
+    if (mw_get_field(field, buf, MUTT_COMP_NO_FLAGS, HC_ALIAS, &CompleteAliasOps, NULL) != 0)
     {
       rc = -1;
       goto done;

--- a/send/send.c
+++ b/send/send.c
@@ -192,7 +192,7 @@ int mutt_edit_address(struct AddressList *al, const char *field, bool expand_ali
     mutt_addrlist_to_local(al);
     buf_reset(buf);
     mutt_addrlist_write(al, buf, false);
-    if (mw_get_field(field, buf, MUTT_COMP_ALIAS, false, NULL, NULL, NULL) != 0)
+    if (mw_get_field(field, buf, MUTT_COMP_ALIAS, false, NULL, NULL, NULL, NULL, NULL) != 0)
     {
       rc = -1;
       goto done;
@@ -236,7 +236,8 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
     else
       buf_reset(buf);
 
-    if (mw_get_field("Newsgroups: ", buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0)
+    if (mw_get_field("Newsgroups: ", buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
+                     NULL, NULL, NULL) != 0)
     {
       goto done;
     }
@@ -249,7 +250,7 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
 
     const bool c_ask_followup_to = cs_subset_bool(sub, "ask_followup_to");
     if (c_ask_followup_to && (mw_get_field("Followup-To: ", buf, MUTT_COMP_NO_FLAGS,
-                                           false, NULL, NULL, NULL) != 0))
+                                           false, NULL, NULL, NULL, NULL, NULL) != 0))
     {
       goto done;
     }
@@ -263,7 +264,8 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
     const bool c_x_comment_to = cs_subset_bool(sub, "x_comment_to");
     const bool c_ask_x_comment_to = cs_subset_bool(sub, "ask_x_comment_to");
     if (c_x_comment_to && c_ask_x_comment_to &&
-        (mw_get_field("X-Comment-To: ", buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0))
+        (mw_get_field("X-Comment-To: ", buf, MUTT_COMP_NO_FLAGS, false, NULL,
+                      NULL, NULL, NULL, NULL) != 0))
     {
       goto done;
     }
@@ -335,7 +337,8 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
   }
 
   const enum QuadOption c_abort_nosubject = cs_subset_quad(sub, "abort_nosubject");
-  if ((mw_get_field(_("Subject: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field(_("Subject: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
+                    NULL, NULL, NULL) != 0) ||
       (buf_is_empty(buf) &&
        (query_quadoption(c_abort_nosubject, _("No subject, abort?")) != MUTT_NO)))
   {

--- a/send/send.c
+++ b/send/send.c
@@ -192,8 +192,7 @@ int mutt_edit_address(struct AddressList *al, const char *field, bool expand_ali
     mutt_addrlist_to_local(al);
     buf_reset(buf);
     mutt_addrlist_write(al, buf, false);
-    if (mw_get_field(field, buf, MUTT_COMP_ALIAS, false, NULL, NULL, NULL,
-                     &CompleteAliasOps, NULL) != 0)
+    if (mw_get_field(field, buf, MUTT_COMP_ALIAS, &CompleteAliasOps, NULL) != 0)
     {
       rc = -1;
       goto done;
@@ -237,8 +236,7 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
     else
       buf_reset(buf);
 
-    if (mw_get_field("Newsgroups: ", buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
-                     NULL, NULL, NULL) != 0)
+    if (mw_get_field("Newsgroups: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0)
     {
       goto done;
     }
@@ -250,8 +248,8 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
       buf_reset(buf);
 
     const bool c_ask_followup_to = cs_subset_bool(sub, "ask_followup_to");
-    if (c_ask_followup_to && (mw_get_field("Followup-To: ", buf, MUTT_COMP_NO_FLAGS,
-                                           false, NULL, NULL, NULL, NULL, NULL) != 0))
+    if (c_ask_followup_to &&
+        (mw_get_field("Followup-To: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0))
     {
       goto done;
     }
@@ -265,8 +263,7 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
     const bool c_x_comment_to = cs_subset_bool(sub, "x_comment_to");
     const bool c_ask_x_comment_to = cs_subset_bool(sub, "ask_x_comment_to");
     if (c_x_comment_to && c_ask_x_comment_to &&
-        (mw_get_field("X-Comment-To: ", buf, MUTT_COMP_NO_FLAGS, false, NULL,
-                      NULL, NULL, NULL, NULL) != 0))
+        (mw_get_field("X-Comment-To: ", buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0))
     {
       goto done;
     }
@@ -338,8 +335,7 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
   }
 
   const enum QuadOption c_abort_nosubject = cs_subset_quad(sub, "abort_nosubject");
-  if ((mw_get_field(_("Subject: "), buf, MUTT_COMP_NO_FLAGS, false, NULL, NULL,
-                    NULL, NULL, NULL) != 0) ||
+  if ((mw_get_field(_("Subject: "), buf, MUTT_COMP_NO_FLAGS, NULL, NULL) != 0) ||
       (buf_is_empty(buf) &&
        (query_quadoption(c_abort_nosubject, _("No subject, abort?")) != MUTT_NO)))
   {

--- a/test/common.c
+++ b/test/common.c
@@ -32,6 +32,8 @@
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"
+#include "copy.h"
+#include "mx.h"
 
 struct MuttWindow;
 struct PagerView;
@@ -42,6 +44,7 @@ char *HomeDir = NULL;
 int SigInt = 0;
 int SigWinch = 0;
 char *ShortHostname = "example";
+bool MonitorContextChanged = false;
 
 #define TEST_DIR "NEOMUTT_TEST_DIR"
 
@@ -208,4 +211,54 @@ void buf_pretty_mailbox(struct Buffer *buf)
 
 void buf_expand_path_regex(struct Buffer *buf, bool regex)
 {
+}
+
+struct HashTable *mutt_make_id_hash(struct Mailbox *m)
+{
+  return NULL;
+}
+
+void mx_alloc_memory(struct Mailbox *m, int req_size)
+{
+}
+
+struct Mailbox *mx_path_resolve(const char *path)
+{
+  return NULL;
+}
+
+bool mx_mbox_ac_link(struct Mailbox *m)
+{
+  return false;
+}
+
+void mutt_encode_path(struct Buffer *buf, const char *src)
+{
+}
+
+void mutt_set_header_color(struct Mailbox *m, struct Email *e)
+{
+}
+
+enum CommandResult parse_unmailboxes(struct Buffer *buf, struct Buffer *s,
+                                     intptr_t data, struct Buffer *err)
+{
+  return MUTT_CMD_SUCCESS;
+}
+
+enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
+                                   intptr_t data, struct Buffer *err)
+{
+  return MUTT_CMD_SUCCESS;
+}
+
+struct Message *mx_msg_open_new(struct Mailbox *m, const struct Email *e, MsgOpenFlags flags)
+{
+  return NULL;
+}
+
+int mutt_copy_message(FILE *fp_out, struct Email *e, struct Message *msg,
+                      CopyMessageFlags cmflags, CopyHeaderFlags chflags, int wraplen)
+{
+  return 0;
 }

--- a/test/common.c
+++ b/test/common.c
@@ -32,6 +32,7 @@
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"
+#include "complete/lib.h"
 #include "copy.h"
 #include "mx.h"
 
@@ -47,6 +48,8 @@ char *ShortHostname = "example";
 bool MonitorContextChanged = false;
 
 #define TEST_DIR "NEOMUTT_TEST_DIR"
+
+const struct CompleteOps CompleteMailboxOps = { 0 };
 
 static struct ConfigDef Vars[] = {
   // clang-format off

--- a/test/email/common.c
+++ b/test/email/common.c
@@ -30,3 +30,7 @@ int mutt_autocrypt_process_autocrypt_header(struct Email *e, struct Envelope *en
 {
   return -1;
 }
+
+void nm_edata_free(void **ptr)
+{
+}

--- a/test/email/common.c
+++ b/test/email/common.c
@@ -30,7 +30,3 @@ int mutt_autocrypt_process_autocrypt_header(struct Email *e, struct Envelope *en
 {
   return -1;
 }
-
-void nm_edata_free(void **ptr)
-{
-}

--- a/test/parse/common.c
+++ b/test/parse/common.c
@@ -33,12 +33,6 @@ struct Command mutt_commands[] = {
   // clang-format on
 };
 
-size_t commands_array(struct Command **first)
-{
-  *first = mutt_commands;
-  return mutt_array_size(mutt_commands);
-}
-
 void buf_expand_path(struct Buffer *buf)
 {
   buf_insert(buf, 0, "expanded");

--- a/test/parse/parse_rc_line.c
+++ b/test/parse/parse_rc_line.c
@@ -26,6 +26,7 @@
 #include "core/lib.h"
 #include "parse/lib.h"
 #include "test_common.h"
+#include "common.h"
 
 // clang-format off
 static struct ConfigDef ConfigVars[] = {
@@ -1012,6 +1013,8 @@ void test_command_set(void)
     TEST_MSG("Failed to register config variables\n");
     return;
   }
+
+  commands_register(mutt_commands, 4);
 
   struct Buffer *err = buf_pool_get();
   TEST_CHECK(test_set(err));

--- a/test/pattern/dummy.c
+++ b/test/pattern/dummy.c
@@ -30,6 +30,7 @@
 #include "core/lib.h"
 #include "history/lib.h"
 #include "menu/lib.h"
+#include "keymap.h"
 #include "mview.h"
 
 struct Address;
@@ -39,12 +40,6 @@ struct Envelope;
 struct Keymap;
 struct Pager;
 struct Pattern;
-
-struct KeyEvent
-{
-  int ch; ///< raw key pressed
-  int op; ///< function op
-};
 
 enum WindowType
 {
@@ -91,6 +86,8 @@ bool OptForceRefresh;
 bool OptKeepQuiet;
 bool OptNoCurses;
 bool OptSearchInvalid;
+
+const struct MenuFuncOp OpGeneric[] = { 0 };
 
 typedef uint8_t MuttFormatFlags;
 typedef uint16_t CompletionFlags;
@@ -279,12 +276,17 @@ int global_function_dispatcher(struct MuttWindow *win, int op)
   return 0;
 }
 
-int km_dokey(enum MenuType mtype)
+int km_dokey(enum MenuType mtype, GetChFlags flags)
 {
   return 0;
 }
 
-struct KeyEvent km_dokey_event(enum MenuType mtype)
+const struct MenuFuncOp *km_get_table(enum MenuType mtype)
+{
+  return OpGeneric;
+}
+
+struct KeyEvent km_dokey_event(enum MenuType mtype, GetChFlags flags)
 {
   struct KeyEvent ke = { 0 };
   return ke;
@@ -292,11 +294,6 @@ struct KeyEvent km_dokey_event(enum MenuType mtype)
 
 void km_error_key(enum MenuType mtype)
 {
-}
-
-int mutt_command_complete(char *buf, size_t buflen, int pos, int numtabs)
-{
-  return 0;
 }
 
 int mutt_complete(char *buf, size_t buflen)
@@ -313,34 +310,14 @@ void mutt_help(enum MenuType menu)
 {
 }
 
-int mutt_label_complete(char *buf, size_t buflen, int numtabs)
-{
-  return 0;
-}
-
 struct Mailbox *mutt_mailbox_next(struct Mailbox *m_cur, struct Buffer *s)
 {
   return NULL;
 }
 
-bool mutt_nm_query_complete(char *buf, size_t buflen, int pos, int numtabs)
-{
-  return false;
-}
-
-bool mutt_nm_tag_complete(char *buf, size_t buflen, int numtabs)
-{
-  return false;
-}
-
 void mutt_select_file(char *file, size_t filelen, SelectFileFlags flags,
                       struct Mailbox *m, char ***files, int *numfiles)
 {
-}
-
-int mutt_var_value_complete(char *buf, size_t buflen, int pos)
-{
-  return 0;
 }
 
 const char *opcodes_get_name(int op)


### PR DESCRIPTION
**NOTE**: this _is_ working, but I need to do some more testing.

Deep within libenter there are lots of dependencies caused by auto-completion and history.

Users call `mw_get_field()` with arguments like `COMP_ALIAS` which determine which completion function to use and where to save the history.
Worse still is the fact that the alias code is in libenter.
and browser code and notmuch code and pattern code...

This PR creates a basic Completion API that passes in a function to do the work.
It should help with: #3955  Neomutt completion API

All the functions on the right are now in more appropriate places.
The abstraction isn't perfect, but it's a step forward.

<img height="350" src="https://flatcap.org/mutt/keys/op_editor_complete.svg">

Source: [graphviz](https://flatcap.org/mutt/keys/op_editor_complete.gv), [svg](https://flatcap.org/mutt/keys/op_editor_complete.svg)