### PR TITLE
Buffer: make parameters of buf_str_equal const

### DIFF
--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -650,7 +650,7 @@ char buf_at(struct Buffer *buf, size_t offset)
  * @retval true  Strings are equal
  * @retval false String are not equal
  */
-bool buf_str_equal(struct Buffer *a, struct Buffer *b)
+bool buf_str_equal(const struct Buffer *a, const struct Buffer *b)
 {
   return mutt_str_equal(buf_string(a), buf_string(b));
 }

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -53,7 +53,7 @@ void           buf_seek            (struct Buffer *buf, size_t offset);
 const char*    buf_find_string     (struct Buffer *buf, const char *s);
 const char*    buf_find_char       (struct Buffer *buf, const char c);
 char           buf_at              (struct Buffer *buf, size_t offset);
-bool           buf_str_equal       (struct Buffer *a, struct Buffer *b);
+bool           buf_str_equal       (const struct Buffer *a, const struct Buffer *b);
 bool           buf_istr_equal      (struct Buffer *a, struct Buffer *b);
 int            buf_coll            (struct Buffer *a, struct Buffer *b);
 size_t         buf_startswith      (struct Buffer *buf, const char *prefix);


### PR DESCRIPTION
* **What does this PR do?**

Make parameters of buf_str_equal `const`.

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/code)

* **What are the relevant issue numbers?**