### PR TITLE
Header parsing fixes from Mutt

### DIFF
--- a/send/header.c
+++ b/send/header.c
@@ -367,7 +367,7 @@ static struct UserHdrsOverride write_userhdrs(FILE *fp, const struct ListHead *u
   struct ListNode *tmp = NULL;
   STAILQ_FOREACH(tmp, userhdrs, entries)
   {
-    char *const colon = strchr(tmp->data, ':');
+    char *const colon = strchr(NONULL(tmp->data), ':');
     if (!colon)
     {
       continue;

--- a/send/header.c
+++ b/send/header.c
@@ -294,7 +294,7 @@ static int write_one_header(FILE *fp, int pfxw, int max, int wraplen, const char
                             const char *start, const char *end, CopyHeaderFlags chflags)
 {
   const char *t = strchr(start, ':');
-  if (!t || (t > end))
+  if (!t || (t >= end))
   {
     mutt_debug(LL_DEBUG1, "#2 warning: header not in 'key: value' format!\n");
     return 0;

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -673,7 +673,7 @@ static void encode_headers(struct ListHead *h, struct ConfigSubset *sub)
   struct ListNode *np = NULL;
   STAILQ_FOREACH(np, h, entries)
   {
-    p = strchr(np->data, ':');
+    p = strchr(NONULL(np->data), ':');
     if (!p)
       continue;
 


### PR DESCRIPTION
* **What does this PR do?**

Port of two string-handling fixes from Mutt [issue 456](https://gitlab.com/muttmua/mutt/-/issues/456). In Mutt, these are reachable for external input due to an invalid `continue` statement in `rfc2047_decode_word`. Neomutt's corresponding `rfc2047.c:decode_word` calls out to `mutt_b64_decode` instead of using an ad-hoc base64 decoder, and does not appear vulnerable; I could not reproduce ASAN crashes with the PoC included in the issue. 

Hence AFAICT the fixed issues do not appear to be a security issue in Neomutt.

See Mutt commit messages (linked to in the commits) for detailed descriptions of the changes.

* **What are the relevant issue numbers?**

Mutt [issue 456](https://gitlab.com/muttmua/mutt/-/issues/456). No Neomutt issue.