### PR TITLE
email/rfc2047: avoid reading past `len` in QP decode.

### DIFF
--- a/email/rfc2047.c
+++ b/email/rfc2047.c
@@ -358,12 +358,15 @@ static void finalize_chunk(struct Buffer *res, struct Buffer *buf, char *charset
  * @param enc Encoding type
  * @retval ptr Decoded string
  *
- * @note The caller must free the returned string
+ * @note The input string must be null-terminated; the len parameter is
+ *       an optimization. The caller must free the returned string.
  */
 static char *decode_word(const char *s, size_t len, enum ContentEncoding enc)
 {
   const char *it = s;
   const char *end = s + len;
+
+  assert(*end == '\0');
 
   if (enc == ENC_QUOTED_PRINTABLE)
   {


### PR DESCRIPTION
* **What does this PR do?**

When `decode_word` handles quoted-printable encoded text, it will look past the current point when it encounters a `=` to check whether it looks like a hex-encoded character. If passed a malformed QP string with a `=` at the end, this may read past the end of the buffer as given by `len`.

In practice this shouldn't make a difference, because AFAICT the buffer passed from `rfc2047_decode` will have `?=` at the end. But to avoid surprises, do a bounds check anyway.

* **What are the relevant issue numbers?**

No issue opened.