### PR TITLE
complete: relax complete/query checks

### DIFF
--- a/alias/complete.c
+++ b/alias/complete.c
@@ -36,7 +36,7 @@
 #include "opcodes.h"
 
 /**
- * complete_alias_complete - Complete an Alias - Implements ::complete_function_t -- @ingroup complete_api
+ * complete_alias_complete - Complete an Alias - Implements ::complete_function_t - @ingroup complete_api
  */
 int complete_alias_complete(struct EnterWindowData *wdata, int op)
 {
@@ -65,11 +65,11 @@ int complete_alias_complete(struct EnterWindowData *wdata, int op)
 }
 
 /**
- * complete_alias_query - Complete an Alias Query - Implements ::complete_function_t -- @ingroup complete_api
+ * complete_alias_query - Complete an Alias Query - Implements ::complete_function_t - @ingroup complete_api
  */
 int complete_alias_query(struct EnterWindowData *wdata, int op)
 {
-  if (!wdata || (op != OP_EDITOR_COMPLETE))
+  if (!wdata || (op != OP_EDITOR_COMPLETE_QUERY))
     return FR_NO_ACTION;
 
   size_t i = wdata->state->curpos;
@@ -90,7 +90,7 @@ int complete_alias_query(struct EnterWindowData *wdata, int op)
 }
 
 /**
- * complete_alias - Alias completion wrapper - Implements ::complete_function_t -- @ingroup complete_api
+ * complete_alias - Alias completion wrapper - Implements ::complete_function_t - @ingroup complete_api
  */
 int complete_alias(struct EnterWindowData *wdata, int op)
 {

--- a/browser/complete.c
+++ b/browser/complete.c
@@ -42,7 +42,7 @@
 #include "opcodes.h"
 
 /**
- * complete_file_mbox - Complete a Mailbox - Implements ::complete_function_t -- @ingroup complete_api
+ * complete_file_mbox - Complete a Mailbox - Implements ::complete_function_t - @ingroup complete_api
  */
 int complete_file_mbox(struct EnterWindowData *wdata, int op)
 {
@@ -62,7 +62,7 @@ int complete_file_mbox(struct EnterWindowData *wdata, int op)
     return FR_SUCCESS;
   }
 
-  if (op != OP_EDITOR_COMPLETE)
+  if ((op != OP_EDITOR_COMPLETE) && (op != OP_EDITOR_COMPLETE_QUERY))
     return FR_NO_ACTION;
 
   int rc = FR_SUCCESS;
@@ -109,11 +109,11 @@ int complete_file_mbox(struct EnterWindowData *wdata, int op)
 }
 
 /**
- * complete_file_simple - Complete a filename - Implements ::complete_function_t -- @ingroup complete_api
+ * complete_file_simple - Complete a filename - Implements ::complete_function_t - @ingroup complete_api
  */
 int complete_file_simple(struct EnterWindowData *wdata, int op)
 {
-  if (!wdata || (op != OP_EDITOR_COMPLETE))
+  if (!wdata || ((op != OP_EDITOR_COMPLETE) && (op != OP_EDITOR_COMPLETE_QUERY)))
     return FR_NO_ACTION;
 
   int rc = FR_SUCCESS;

--- a/complete/helpers.c
+++ b/complete/helpers.c
@@ -419,11 +419,11 @@ int mutt_var_value_complete(struct CompletionData *cd, struct Buffer *buf, int p
 }
 
 /**
- * complete_command - Complete a NeoMutt Command - Implements ::complete_function_t -- @ingroup complete_api
+ * complete_command - Complete a NeoMutt Command - Implements ::complete_function_t - @ingroup complete_api
  */
 int complete_command(struct EnterWindowData *wdata, int op)
 {
-  if (!wdata || (op != OP_EDITOR_COMPLETE))
+  if (!wdata || ((op != OP_EDITOR_COMPLETE) && (op != OP_EDITOR_COMPLETE_QUERY)))
     return FR_NO_ACTION;
 
   int rc = FR_SUCCESS;
@@ -444,11 +444,11 @@ int complete_command(struct EnterWindowData *wdata, int op)
 }
 
 /**
- * complete_label - Complete a label - Implements ::complete_function_t -- @ingroup complete_api
+ * complete_label - Complete a label - Implements ::complete_function_t - @ingroup complete_api
  */
 int complete_label(struct EnterWindowData *wdata, int op)
 {
-  if (!wdata || (op != OP_EDITOR_COMPLETE))
+  if (!wdata || ((op != OP_EDITOR_COMPLETE) && (op != OP_EDITOR_COMPLETE_QUERY)))
     return FR_NO_ACTION;
 
   size_t i;

--- a/notmuch/complete.c
+++ b/notmuch/complete.c
@@ -209,11 +209,11 @@ bool mutt_nm_tag_complete(struct CompletionData *cd, struct Buffer *buf, int num
 }
 
 /**
- * complete_nm_query - Complete a Notmuch Query - Implements ::complete_function_t -- @ingroup complete_api
+ * complete_nm_query - Complete a Notmuch Query - Implements ::complete_function_t - @ingroup complete_api
  */
 int complete_nm_query(struct EnterWindowData *wdata, int op)
 {
-  if (!wdata || (op != OP_EDITOR_COMPLETE))
+  if (!wdata || ((op != OP_EDITOR_COMPLETE) && (op != OP_EDITOR_COMPLETE_QUERY)))
     return FR_NO_ACTION;
 
   int rc = FR_SUCCESS;
@@ -227,11 +227,11 @@ int complete_nm_query(struct EnterWindowData *wdata, int op)
 }
 
 /**
- * complete_nm_tag - Complete a Notmuch Tag - Implements ::complete_function_t -- @ingroup complete_api
+ * complete_nm_tag - Complete a Notmuch Tag - Implements ::complete_function_t - @ingroup complete_api
  */
 int complete_nm_tag(struct EnterWindowData *wdata, int op)
 {
-  if (!wdata || (op != OP_EDITOR_COMPLETE))
+  if (!wdata || ((op != OP_EDITOR_COMPLETE) && (op != OP_EDITOR_COMPLETE_QUERY)))
     return FR_NO_ACTION;
 
   int rc = FR_SUCCESS;

--- a/pattern/complete.c
+++ b/pattern/complete.c
@@ -36,11 +36,11 @@
 #include "opcodes.h"
 
 /**
- * complete_pattern - Complete a NeoMutt Pattern - Implements ::complete_function_t -- @ingroup complete_api
+ * complete_pattern - Complete a NeoMutt Pattern - Implements ::complete_function_t - @ingroup complete_api
  */
 int complete_pattern(struct EnterWindowData *wdata, int op)
 {
-  if (!wdata || (op != OP_EDITOR_COMPLETE))
+  if (!wdata || ((op != OP_EDITOR_COMPLETE) && (op != OP_EDITOR_COMPLETE_QUERY)))
     return FR_NO_ACTION;
 
   size_t i = wdata->state->curpos;


### PR DESCRIPTION
Only the Alias completion needs to distinguish between `<complete-query>` and `<complete>`.
In other places, treat `<complete-query>` as `<complete>`.

This restores the behaviour that we had before the completion refactor.

Fixes: #4032