### PR TITLE
remove global EnvList from mutt/filter.c

### DIFF
--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -90,6 +90,7 @@
 #include "alias.h"
 #include "format_flags.h"
 #include "functions.h"
+#include "globals.h" // IWYU pragma: keep
 #include "gui.h"
 #include "keymap.h"
 #include "mutt_logging.h"
@@ -270,7 +271,7 @@ int query_run(const char *s, bool verbose, struct AliasList *al, const struct Co
   const char *const c_query_command = cs_subset_string(sub, "query_command");
   buf_file_expand_fmt_quote(cmd, c_query_command, s);
 
-  pid_t pid = filter_create(buf_string(cmd), NULL, &fp, NULL);
+  pid_t pid = filter_create(buf_string(cmd), NULL, &fp, NULL, EnvList);
   if (pid < 0)
   {
     mutt_debug(LL_DEBUG1, "unable to fork command: %s\n", buf_string(cmd));

--- a/attach/mutt_attach.c
+++ b/attach/mutt_attach.c
@@ -564,8 +564,8 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
       }
       unlink_pagerfile = true;
 
-      pid = filter_create_fd(buf_string(cmd), NULL, NULL, NULL,
-                             use_pipe ? fd_temp : -1, use_pager ? fd_pager : -1, -1);
+      pid = filter_create_fd(buf_string(cmd), NULL, NULL, NULL, use_pipe ? fd_temp : -1,
+                             use_pager ? fd_pager : -1, -1, EnvList);
 
       if (pid == -1)
       {
@@ -772,9 +772,9 @@ int mutt_pipe_attachment(FILE *fp, struct Body *b, const char *path, const char 
   mutt_endwin();
 
   if (outfile && *outfile)
-    pid = filter_create_fd(path, &fp_filter, NULL, NULL, -1, out, -1);
+    pid = filter_create_fd(path, &fp_filter, NULL, NULL, -1, out, -1, EnvList);
   else
-    pid = filter_create(path, &fp_filter, NULL, NULL);
+    pid = filter_create(path, &fp_filter, NULL, NULL, EnvList);
   if (pid < 0)
   {
     mutt_perror(_("Can't create filter"));
@@ -1198,7 +1198,7 @@ int mutt_print_attachment(FILE *fp, struct Body *a)
         goto mailcap_cleanup;
       }
 
-      pid = filter_create(buf_string(cmd), &fp_out, NULL, NULL);
+      pid = filter_create(buf_string(cmd), &fp_out, NULL, NULL, EnvList);
       if (pid < 0)
       {
         mutt_perror(_("Can't create filter"));
@@ -1263,7 +1263,7 @@ int mutt_print_attachment(FILE *fp, struct Body *a)
       mutt_debug(LL_DEBUG2, "successfully opened %s read-only\n", buf_string(newfile));
 
       mutt_endwin();
-      pid = filter_create(NONULL(c_print_command), &fp_out, NULL, NULL);
+      pid = filter_create(NONULL(c_print_command), &fp_out, NULL, NULL, EnvList);
       if (pid < 0)
       {
         mutt_perror(_("Can't create filter"));

--- a/attach/recvattach.c
+++ b/attach/recvattach.c
@@ -50,6 +50,7 @@
 #include "send/lib.h"
 #include "attach.h"
 #include "external.h"
+#include "globals.h" // IWYU pragma: keep
 #include "handler.h"
 #include "hook.h"
 #include "mailcap.h"
@@ -746,7 +747,7 @@ void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
   if (!filter && !c_attach_split)
   {
     mutt_endwin();
-    pid_t pid = filter_create(buf_string(buf), &state.fp_out, NULL, NULL);
+    pid_t pid = filter_create(buf_string(buf), &state.fp_out, NULL, NULL, EnvList);
     pipe_attachment_list(buf_string(buf), actx, fp, tag, top, filter, &state);
     mutt_file_fclose(&state.fp_out);
     const bool c_wait_key = cs_subset_bool(NeoMutt->sub, "wait_key");
@@ -911,7 +912,7 @@ void mutt_print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag, stru
       return;
     mutt_endwin();
     const char *const c_print_command = cs_subset_string(NeoMutt->sub, "print_command");
-    pid_t pid = filter_create(NONULL(c_print_command), &state.fp_out, NULL, NULL);
+    pid_t pid = filter_create(NONULL(c_print_command), &state.fp_out, NULL, NULL, EnvList);
     print_attachment_list(actx, fp, tag, top, &state);
     mutt_file_fclose(&state.fp_out);
     const bool c_wait_key = cs_subset_bool(NeoMutt->sub, "wait_key");

--- a/conn/accountcmd.c
+++ b/conn/accountcmd.c
@@ -35,6 +35,7 @@
 #include "core/lib.h"
 #include "accountcmd.h"
 #include "connaccount.h"
+#include "globals.h" // IWYU pragma: keep
 #include "mutt_account.h"
 
 /**
@@ -135,7 +136,7 @@ static MuttAccountFlags call_cmd(struct ConnAccount *cac, const struct Buffer *c
   MuttAccountFlags rc = MUTT_ACCT_NO_FLAGS;
 
   FILE *fp = NULL;
-  pid_t pid = filter_create(buf_string(cmd), NULL, &fp, NULL);
+  pid_t pid = filter_create(buf_string(cmd), NULL, &fp, NULL, EnvList);
   if (pid < 0)
   {
     mutt_perror(_("Unable to run account command"));

--- a/conn/connaccount.c
+++ b/conn/connaccount.c
@@ -212,7 +212,7 @@ char *mutt_account_getoauthbearer(struct ConnAccount *cac, bool xoauth2)
   }
 
   FILE *fp = NULL;
-  pid_t pid = filter_create(cmd, NULL, &fp, NULL);
+  pid_t pid = filter_create(cmd, NULL, &fp, NULL, EnvList);
   if (pid < 0)
   {
     mutt_perror(_("Unable to run refresh command"));

--- a/external.c
+++ b/external.c
@@ -323,7 +323,7 @@ static int pipe_message(struct Mailbox *m, struct EmailArray *ea, const char *cm
     }
     mutt_endwin();
 
-    pid = filter_create(cmd, &fp_out, NULL, NULL);
+    pid = filter_create(cmd, &fp_out, NULL, NULL, EnvList);
     if (pid < 0)
     {
       mutt_perror(_("Can't create filter process"));
@@ -369,7 +369,7 @@ static int pipe_message(struct Mailbox *m, struct EmailArray *ea, const char *cm
         struct Email *e = *ep;
         mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
         mutt_endwin();
-        pid = filter_create(cmd, &fp_out, NULL, NULL);
+        pid = filter_create(cmd, &fp_out, NULL, NULL, EnvList);
         if (pid < 0)
         {
           mutt_perror(_("Can't create filter process"));
@@ -389,7 +389,7 @@ static int pipe_message(struct Mailbox *m, struct EmailArray *ea, const char *cm
     else
     {
       mutt_endwin();
-      pid = filter_create(cmd, &fp_out, NULL, NULL);
+      pid = filter_create(cmd, &fp_out, NULL, NULL, EnvList);
       if (pid < 0)
       {
         mutt_perror(_("Can't create filter process"));

--- a/handler.c
+++ b/handler.c
@@ -574,12 +574,12 @@ static int autoview_handler(struct Body *a, struct State *state)
       fflush(fp_in);
       rewind(fp_in);
       pid = filter_create_fd(buf_string(cmd), NULL, &fp_out, &fp_err,
-                             fileno(fp_in), -1, -1);
+                             fileno(fp_in), -1, -1, EnvList);
     }
     else
     {
       mutt_file_fclose(&fp_in);
-      pid = filter_create(buf_string(cmd), NULL, &fp_out, &fp_err);
+      pid = filter_create(buf_string(cmd), NULL, &fp_out, &fp_err, EnvList);
     }
 
     if (pid < 0)

--- a/mixmaster/remailer.c
+++ b/mixmaster/remailer.c
@@ -36,6 +36,7 @@
 #include "core/lib.h"
 #include "gui/lib.h"
 #include "remailer.h"
+#include "globals.h" // IWYU pragma: keep
 
 /**
  * remailer_free - Free a Remailer
@@ -129,7 +130,8 @@ struct RemailerArray remailer_get_hosts(void)
   struct Buffer *cmd = buf_pool_get();
   buf_printf(cmd, "%s -T", c_mixmaster);
 
-  pid_t mm_pid = filter_create_fd(buf_string(cmd), NULL, &fp, NULL, fd_null, -1, fd_null);
+  pid_t mm_pid = filter_create_fd(buf_string(cmd), NULL, &fp, NULL, fd_null, -1,
+                                  fd_null, EnvList);
   window_invalidate_all();
   if (mm_pid == -1)
   {

--- a/mutt/filter.c
+++ b/mutt/filter.c
@@ -32,18 +32,18 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include "filter.h"
-#include "globals.h"
 #include "signal2.h"
 
 /**
  * filter_create_fd - Run a command on a pipe (optionally connect stdin/stdout)
- * @param[in]  cmd    Command line to invoke using `sh -c`
- * @param[out] fp_in  File stream pointing to stdin for the command process, can be NULL
- * @param[out] fp_out File stream pointing to stdout for the command process, can be NULL
- * @param[out] fp_err File stream pointing to stderr for the command process, can be NULL
- * @param[in]  fdin   If `in` is NULL and fdin is not -1 then fdin will be used as stdin for the command process
- * @param[in]  fdout  If `out` is NULL and fdout is not -1 then fdout will be used as stdout for the command process
- * @param[in]  fderr  If `error` is NULL and fderr is not -1 then fderr will be used as stderr for the command process
+ * @param[in]  cmd     Command line to invoke using `sh -c`
+ * @param[out] fp_in   File stream pointing to stdin for the command process, can be NULL
+ * @param[out] fp_out  File stream pointing to stdout for the command process, can be NULL
+ * @param[out] fp_err  File stream pointing to stderr for the command process, can be NULL
+ * @param[in]  fdin    If `in` is NULL and fdin is not -1 then fdin will be used as stdin for the command process
+ * @param[in]  fdout   If `out` is NULL and fdout is not -1 then fdout will be used as stdout for the command process
+ * @param[in]  fderr   If `error` is NULL and fderr is not -1 then fderr will be used as stderr for the command process
+ * @param[in]  envlist Environment variables
  * @retval num PID of the created process
  * @retval -1  Error creating pipes or forking
  *
@@ -58,8 +58,8 @@
  * Additionally, fp_in, fp_out, and fp_err will point to FILE* streams
  * representing the processes stdin, stdout, and stderr.
  */
-pid_t filter_create_fd(const char *cmd, FILE **fp_in, FILE **fp_out,
-                       FILE **fp_err, int fdin, int fdout, int fderr)
+pid_t filter_create_fd(const char *cmd, FILE **fp_in, FILE **fp_out, FILE **fp_err,
+                       int fdin, int fdout, int fderr, char **envlist)
 {
   int pin[2], pout[2], perr[2], pid;
 
@@ -146,7 +146,7 @@ pid_t filter_create_fd(const char *cmd, FILE **fp_in, FILE **fp_out,
       close(fderr);
     }
 
-    execle(EXEC_SHELL, "sh", "-c", cmd, NULL, EnvList);
+    execle(EXEC_SHELL, "sh", "-c", cmd, NULL, envlist);
     _exit(127);
   }
   else if (pid == -1)
@@ -197,15 +197,16 @@ pid_t filter_create_fd(const char *cmd, FILE **fp_in, FILE **fp_out,
 
 /**
  * filter_create - Set up filter program
- * @param[in]  cmd    Command string
- * @param[out] fp_in  FILE pointer of stdin
- * @param[out] fp_out FILE pointer of stdout
- * @param[out] fp_err FILE pointer of stderr
+ * @param[in]  cmd     Command string
+ * @param[out] fp_in   FILE pointer of stdin
+ * @param[out] fp_out  FILE pointer of stdout
+ * @param[out] fp_err  FILE pointer of stderr
+ * @param[in]  envlist Environment variables
  * @retval num PID of filter
  */
-pid_t filter_create(const char *cmd, FILE **fp_in, FILE **fp_out, FILE **fp_err)
+pid_t filter_create(const char *cmd, FILE **fp_in, FILE **fp_out, FILE **fp_err, char **envlist)
 {
-  return filter_create_fd(cmd, fp_in, fp_out, fp_err, -1, -1, -1);
+  return filter_create_fd(cmd, fp_in, fp_out, fp_err, -1, -1, -1, envlist);
 }
 
 /**

--- a/mutt/filter.h
+++ b/mutt/filter.h
@@ -26,8 +26,8 @@
 
 #define EXEC_SHELL "/bin/sh"
 
-pid_t filter_create   (const char *cmd, FILE **fp_in, FILE **fp_out, FILE **fp_err);
-pid_t filter_create_fd(const char *cmd, FILE **fp_in, FILE **fp_out, FILE **fp_err, int fdin, int fdout, int fderr);
+pid_t filter_create   (const char *cmd, FILE **fp_in, FILE **fp_out, FILE **fp_err, char **envlist);
+pid_t filter_create_fd(const char *cmd, FILE **fp_in, FILE **fp_out, FILE **fp_err, int fdin, int fdout, int fderr, char **envlist);
 int   filter_wait     (pid_t pid);
 
 #endif /* MUTT_MUTT_FILTER_H */

--- a/muttlib.c
+++ b/muttlib.c
@@ -836,7 +836,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
 
       col -= wlen; /* reset to passed in value */
       wptr = buf;  /* reset write ptr */
-      pid_t pid = filter_create(cmd.data, NULL, &fp_filter, NULL);
+      pid_t pid = filter_create(cmd.data, NULL, &fp_filter, NULL, EnvList);
       if (pid != -1)
       {
         int rc;
@@ -1298,7 +1298,7 @@ FILE *mutt_open_read(const char *path, pid_t *thepid)
 
     p[len - 1] = 0;
     mutt_endwin();
-    *thepid = filter_create(p, NULL, &fp, NULL);
+    *thepid = filter_create(p, NULL, &fp, NULL, EnvList);
     FREE(&p);
   }
   else

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -43,6 +43,7 @@
 #include "pgpinvoke.h"
 #include "lib.h"
 #include "format_flags.h"
+#include "globals.h" // IWYU pragma: keep
 #include "mutt_logging.h"
 #include "muttlib.h"
 #include "pgpkey.h"
@@ -235,7 +236,7 @@ static pid_t pgp_invoke(FILE **fp_pgp_in, FILE **fp_pgp_out, FILE **fp_pgp_err,
   mutt_pgp_command(cmd, sizeof(cmd), &cctx, format);
 
   return filter_create_fd(cmd, fp_pgp_in, fp_pgp_out, fp_pgp_err, fd_pgp_in,
-                          fd_pgp_out, fd_pgp_err);
+                          fd_pgp_out, fd_pgp_err, EnvList);
 }
 
 /*

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -55,6 +55,7 @@
 #include "crypt.h"
 #include "cryptglue.h"
 #include "format_flags.h"
+#include "globals.h" // IWYU pragma: keep
 #include "handler.h"
 #include "mutt_logging.h"
 #include "muttlib.h"
@@ -445,7 +446,7 @@ static pid_t smime_invoke(FILE **fp_smime_in, FILE **fp_smime_out, FILE **fp_smi
   smime_command(cmd, sizeof(cmd), &cctx, format);
 
   return filter_create_fd(cmd, fp_smime_in, fp_smime_out, fp_smime_err,
-                          fp_smime_infd, fp_smime_outfd, fp_smime_errfd);
+                          fp_smime_infd, fp_smime_outfd, fp_smime_errfd, EnvList);
 }
 
 /**

--- a/pager/message.c
+++ b/pager/message.c
@@ -240,7 +240,7 @@ static int email_to_file(struct Message *msg, struct Buffer *tempfile,
     fp_filter_out = fp_out;
     fp_out = NULL;
     filterpid = filter_create_fd(c_display_filter, &fp_out, NULL, NULL, -1,
-                                 fileno(fp_filter_out), -1);
+                                 fileno(fp_filter_out), -1, EnvList);
     if (filterpid < 0)
     {
       mutt_error(_("Can't create display filter"));

--- a/parse/extract.c
+++ b/parse/extract.c
@@ -35,6 +35,7 @@
 #include "config/lib.h"
 #include "core/lib.h"
 #include "extract.h"
+#include "globals.h" // IWYU pragma: keep
 
 /**
  * parse_extract_token - Extract one token from a string
@@ -194,7 +195,7 @@ int parse_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flag
         cmd.data = mutt_str_dup(tok->dptr);
       }
       *pc = '`';
-      pid = filter_create(cmd.data, NULL, &fp, NULL);
+      pid = filter_create(cmd.data, NULL, &fp, NULL, EnvList);
       if (pid < 0)
       {
         mutt_debug(LL_DEBUG1, "unable to fork command: %s\n", cmd.data);

--- a/pattern/compile.c
+++ b/pattern/compile.c
@@ -44,6 +44,7 @@
 #include "core/lib.h"
 #include "lib.h"
 #include "parse/lib.h"
+#include "globals.h" // IWYU pragma: keep
 #include "mview.h"
 
 struct Menu;
@@ -189,7 +190,7 @@ static bool eat_query(struct Pattern *pat, PatternCompFlags flags,
   mutt_message(_("Running search command: %s ..."), cmd_buf->data);
   pat->is_multi = true;
   mutt_list_clear(&pat->p.multi_cases);
-  pid_t pid = filter_create(cmd_buf->data, NULL, &fp, NULL);
+  pid_t pid = filter_create(cmd_buf->data, NULL, &fp, NULL, EnvList);
   if (pid < 0)
   {
     buf_printf(err, "unable to fork command: %s\n", cmd_buf->data);

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -573,7 +573,7 @@ static void run_mime_type_query(struct Body *att, struct ConfigSubset *sub)
 
   buf_file_expand_fmt_quote(cmd, c_mime_type_query_command, att->filename);
 
-  pid = filter_create(buf_string(cmd), NULL, &fp, &fp_err);
+  pid = filter_create(buf_string(cmd), NULL, &fp, &fp_err, EnvList);
   if (pid < 0)
   {
     mutt_error(_("Error running \"%s\""), buf_string(cmd));

--- a/test/filter/filter_create.c
+++ b/test/filter/filter_create.c
@@ -31,6 +31,6 @@ void test_filter_create(void)
   // pid_t filter_create(const char *cmd, FILE **fp_in, FILE **fp_out, FILE **fp_err);
 
   {
-    TEST_CHECK(filter_create("false", NULL, NULL, NULL) > 0);
+    TEST_CHECK(filter_create("false", NULL, NULL, NULL, NULL) > 0);
   }
 }

--- a/test/filter/filter_create_fd.c
+++ b/test/filter/filter_create_fd.c
@@ -33,6 +33,6 @@ void test_filter_create_fd(void)
   // pid_t filter_create_fd(const char *cmd, FILE **fp_in, FILE **fp_out, FILE **fp_err, int fdin, int fdout, int fderr)
 
   {
-    TEST_CHECK(filter_create_fd("false", NULL, NULL, NULL, -1, -1, -1) > 0);
+    TEST_CHECK(filter_create_fd("false", NULL, NULL, NULL, -1, -1, -1, EnvList) > 0);
   }
 }


### PR DESCRIPTION
Change `filter_create_fd()` and `filter_create()` to accept the environment variables as parameter. This removes `globals.h` from `mutt/filter.c`. 

Discussion: https://github.com/neomutt/neomutt/discussions/3993