### PR TITLE
eliminate global OptAttachMsg

### DIFF
--- a/attach/dlg_attach.c
+++ b/attach/dlg_attach.c
@@ -459,17 +459,18 @@ static int attach_window_observer(struct NotifyCallback *nc)
 
 /**
  * dlg_attachment - Show the attachments in a Menu - @ingroup gui_dlg
- * @param sub Config Subset
- * @param mv  Mailbox view
- * @param e   Email
- * @param fp File with the content of the email, or NULL
+ * @param sub        Config Subset
+ * @param mv         Mailbox view
+ * @param e          Email
+ * @param fp         File with the content of the email, or NULL
+ * @param attach_msg Are we in "attach message" mode?
  *
  * The Select Attachment dialog shows an Email's attachments.
  * They can be viewed using the Pager or Mailcap programs.
  * They can also be saved, printed, deleted, etc.
  */
 void dlg_attachment(struct ConfigSubset *sub, struct MailboxView *mv,
-                    struct Email *e, FILE *fp)
+                    struct Email *e, FILE *fp, bool attach_msg)
 {
   if (!mv || !mv->mailbox || !e || !fp)
     return;
@@ -495,6 +496,7 @@ void dlg_attachment(struct ConfigSubset *sub, struct MailboxView *mv,
   priv->actx = actx;
   priv->sub = sub;
   priv->mailbox = m;
+  priv->attach_msg = attach_msg;
   menu->mdata = priv;
   menu->mdata_free = attach_private_data_free;
 

--- a/attach/functions.c
+++ b/attach/functions.c
@@ -90,11 +90,12 @@ static void attach_collapse(struct AttachCtx *actx, struct Menu *menu)
 
 /**
  * check_attach - Check if in attach-message mode
+ * @param priv Private Attach data
  * @retval true Mailbox is readonly
  */
-static bool check_attach(void)
+static bool check_attach(struct AttachPrivateData *priv)
 {
-  if (OptAttachMsg)
+  if (priv->attach_msg)
   {
     mutt_flushinp();
     mutt_error("%s", _(Function_not_permitted_in_attach_message_mode));
@@ -409,7 +410,7 @@ static int op_attachment_view_text(struct AttachPrivateData *priv, int op)
  */
 static int op_bounce_message(struct AttachPrivateData *priv, int op)
 {
-  if (check_attach())
+  if (check_attach(priv))
     return FR_ERROR;
   struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
   attach_bounce_message(priv->mailbox, cur_att->fp, priv->actx,
@@ -437,7 +438,7 @@ static int op_check_traditional(struct AttachPrivateData *priv, int op)
  */
 static int op_compose_to_sender(struct AttachPrivateData *priv, int op)
 {
-  if (check_attach())
+  if (check_attach(priv))
     return FR_ERROR;
   struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
   mutt_attach_mail_sender(priv->actx, priv->menu->tag_prefix ? NULL : cur_att->body);
@@ -494,7 +495,7 @@ static int op_forget_passphrase(struct AttachPrivateData *priv, int op)
  */
 static int op_forward_message(struct AttachPrivateData *priv, int op)
 {
-  if (check_attach())
+  if (check_attach(priv))
     return FR_ERROR;
   struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
   mutt_attach_forward(cur_att->fp, priv->actx->email, priv->actx,
@@ -508,7 +509,7 @@ static int op_forward_message(struct AttachPrivateData *priv, int op)
  */
 static int op_list_subscribe(struct AttachPrivateData *priv, int op)
 {
-  if (!check_attach())
+  if (!check_attach(priv))
     mutt_send_list_subscribe(priv->mailbox, priv->actx->email);
   return FR_SUCCESS;
 }
@@ -518,7 +519,7 @@ static int op_list_subscribe(struct AttachPrivateData *priv, int op)
  */
 static int op_list_unsubscribe(struct AttachPrivateData *priv, int op)
 {
-  if (!check_attach())
+  if (!check_attach(priv))
     mutt_send_list_unsubscribe(priv->mailbox, priv->actx->email);
   return FR_SUCCESS;
 }
@@ -528,7 +529,7 @@ static int op_list_unsubscribe(struct AttachPrivateData *priv, int op)
  */
 static int op_reply(struct AttachPrivateData *priv, int op)
 {
-  if (check_attach())
+  if (check_attach(priv))
     return FR_ERROR;
 
   SendFlags flags = SEND_REPLY;
@@ -551,7 +552,7 @@ static int op_reply(struct AttachPrivateData *priv, int op)
  */
 static int op_resend(struct AttachPrivateData *priv, int op)
 {
-  if (check_attach())
+  if (check_attach(priv))
     return FR_ERROR;
   struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
   mutt_attach_resend(cur_att->fp, priv->mailbox, priv->actx,
@@ -568,7 +569,7 @@ static int op_resend(struct AttachPrivateData *priv, int op)
  */
 static int op_followup(struct AttachPrivateData *priv, int op)
 {
-  if (check_attach())
+  if (check_attach(priv))
     return FR_ERROR;
 
   struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
@@ -591,7 +592,7 @@ static int op_followup(struct AttachPrivateData *priv, int op)
  */
 static int op_forward_to_group(struct AttachPrivateData *priv, int op)
 {
-  if (check_attach())
+  if (check_attach(priv))
     return FR_ERROR;
   struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
   mutt_attach_forward(cur_att->fp, priv->actx->email, priv->actx,

--- a/attach/private_data.h
+++ b/attach/private_data.h
@@ -24,6 +24,7 @@
 #define MUTT_ATTACH_PRIVATE_DATA_H
 
 #include "config.h"
+#include <stdbool.h>
 
 struct Menu;
 
@@ -32,11 +33,12 @@ struct Menu;
  */
 struct AttachPrivateData
 {
-  struct Menu *menu;        ///< Current Menu
-  struct AttachCtx *actx;   ///< List of all Attachments
-  struct ConfigSubset *sub; ///< Config subset
-  struct Mailbox *mailbox;  ///< Current Mailbox
-  int op;                   ///< Op returned from the Pager, e.g. OP_NEXT_ENTRY
+  struct Menu         *menu;        ///< Current Menu
+  struct AttachCtx    *actx;        ///< List of all Attachments
+  struct ConfigSubset *sub;         ///< Config subset
+  struct Mailbox      *mailbox;     ///< Current Mailbox
+  int                  op;          ///< Op returned from the Pager, e.g. OP_NEXT_ENTRY
+  bool                 attach_msg;  ///< Are we in "attach message" mode?
 };
 
 void                      attach_private_data_free(struct Menu *menu, void **ptr);

--- a/attach/recvattach.h
+++ b/attach/recvattach.h
@@ -42,7 +42,7 @@ void mutt_attach_init(struct AttachCtx *actx);
 void mutt_update_tree(struct AttachCtx *actx);
 
 const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, char op, const char *src, const char *prec, const char *if_str, const char *else_str, intptr_t data, MuttFormatFlags flags);
-void dlg_attachment(struct ConfigSubset *sub, struct MailboxView *mv, struct Email *e, FILE *fp);
+void dlg_attachment(struct ConfigSubset *sub, struct MailboxView *mv, struct Email *e, FILE *fp, bool attach_msg);
 
 void mutt_generate_recvattach_list(struct AttachCtx *actx, struct Email *e, struct Body *parts, FILE *fp, int parent_type, int level, bool decrypted);
 struct AttachPtr *current_attachment(struct AttachCtx *actx, struct Menu *menu);

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -770,14 +770,14 @@ static int op_attachment_attach_message(struct ComposeSharedData *shared, int op
   const enum SortType old_sort_aux = cs_subset_sort(shared->sub, "sort_aux");
   const unsigned char old_use_threads = cs_subset_enum(shared->sub, "use_threads");
 
-  OptAttachMsg = true;
   mutt_message(_("Tag the messages you want to attach"));
   struct MuttWindow *dlg = index_pager_init();
+  struct IndexSharedData *index_shared = dlg->wdata;
+  index_shared->attach_msg = true;
   dialog_push(dlg);
   struct Mailbox *m_attach_new = dlg_index(dlg, m_attach);
   dialog_pop();
   mutt_window_free(&dlg);
-  OptAttachMsg = false;
 
   if (!shared->mailbox)
   {

--- a/globals.c
+++ b/globals.c
@@ -63,7 +63,6 @@ enum MenuType CurrentMenu; ///< Current Menu, e.g. #MENU_PAGER
 
 /* pseudo options */
 // clang-format off
-bool OptAttachMsg;          ///< (pseudo) used by attach-message
 #ifdef USE_AUTOCRYPT
 bool OptAutocryptGpgme;     ///< (pseudo) use Autocrypt context inside ncrypt/crypt_gpgme.c
 #endif

--- a/globals.h
+++ b/globals.h
@@ -58,7 +58,6 @@ extern SIG_ATOMIC_VOLATILE_T SigWinch; ///< true after SIGWINCH is received
 extern enum MenuType CurrentMenu; ///< Current Menu, e.g. #MENU_PAGER
 
 /* pseudo options */
-extern bool OptAttachMsg;           ///< (pseudo) used by attach-message
 #ifdef USE_AUTOCRYPT
 extern bool OptAutocryptGpgme;      ///< (pseudo) use Autocrypt context inside ncrypt/crypt_gpgme.c
 #endif

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -1068,12 +1068,12 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
   index_adjust_sort_threads(NeoMutt->sub);
 
   struct IndexSharedData *shared = dlg->wdata;
+  shared->attach_msg = OptAttachMsg;
   index_shared_data_set_mview(shared, mview_new(m_init, NeoMutt->notify));
 
   struct MuttWindow *panel_index = window_find_child(dlg, WT_INDEX);
 
   struct IndexPrivateData *priv = panel_index->wdata;
-  priv->attach_msg = OptAttachMsg;
   priv->win_index = window_find_child(panel_index, WT_MENU);
 
   int op = OP_NULL;
@@ -1095,7 +1095,7 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
   struct MuttWindow *old_focus = window_set_focus(priv->menu->win);
   mutt_window_reflow(NULL);
 
-  if (!priv->attach_msg)
+  if (!shared->attach_msg)
   {
     /* force the mailbox check after we enter the folder */
     mutt_mailbox_check(shared->mailbox, MUTT_MAILBOX_CHECK_FORCE);
@@ -1208,7 +1208,7 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
                                                               menu_get_index(priv->menu)));
     }
 
-    if (!priv->attach_msg)
+    if (!shared->attach_msg)
     {
       /* check for new mail in the incoming folders */
       priv->oldcount = priv->newcount;

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -1068,7 +1068,6 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
   index_adjust_sort_threads(NeoMutt->sub);
 
   struct IndexSharedData *shared = dlg->wdata;
-  shared->attach_msg = OptAttachMsg;
   index_shared_data_set_mview(shared, mview_new(m_init, NeoMutt->notify));
 
   struct MuttWindow *panel_index = window_find_child(dlg, WT_INDEX);

--- a/index/private_data.h
+++ b/index/private_data.h
@@ -37,7 +37,6 @@ struct IndexPrivateData
   int  oldcount;                 ///< Old count of Emails in the Mailbox
   int  newcount;                 ///< New count of Emails in the Mailbox
   bool do_mailbox_notify;        ///< Do we need to notify the user of new mail?
-  bool attach_msg;               ///< Are we in "attach message" mode?
 
   struct IndexSharedData *shared; ///< Shared Index data
   struct Menu *menu;              ///< Menu controlling the index

--- a/index/shared_data.h
+++ b/index/shared_data.h
@@ -43,6 +43,7 @@ struct IndexSharedData
   size_t               email_seq;      ///< Sequence number of the current email
   struct Notify       *notify;         ///< Notifications: #NotifyIndex, #IndexSharedData
   struct SearchState  *search_state;   ///< State of the current search
+  bool                 attach_msg;     ///< Are we in "attach message" mode?
 };
 
 void                    index_shared_data_free(struct MuttWindow *win, void **ptr);

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -34,7 +34,6 @@
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"
-#include "globals.h"
 #include "init.h"
 #include "mutt_logging.h"
 #include "mutt_thread.h"
@@ -107,19 +106,6 @@ static int multipart_validator(const struct ConfigSet *cs, const struct ConfigDe
     return CSR_SUCCESS;
 
   buf_printf(err, _("Invalid value for option %s: %s"), cdef->name, str);
-  return CSR_ERR_INVALID;
-}
-
-/**
- * reply_validator - Validate the "reply_regex" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator
- */
-static int reply_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                           intptr_t value, struct Buffer *err)
-{
-  if (!OptAttachMsg)
-    return CSR_SUCCESS;
-
-  buf_printf(err, _("Option %s may not be set when in attach-message mode"), cdef->name);
   return CSR_ERR_INVALID;
 }
 
@@ -434,7 +420,7 @@ static struct ConfigDef MainVars[] = {
   { "reflow_wrap", DT_NUMBER, 78, 0, NULL,
     "Maximum paragraph width for reformatting 'format=flowed' text"
   },
-  { "reply_regex", DT_REGEX|R_INDEX|R_RESORT, IP "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*", 0, reply_validator,
+  { "reply_regex", DT_REGEX|R_INDEX|R_RESORT, IP "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*", 0, NULL,
     "Regex to match message reply subjects like 're: '"
   },
   { "resolve", DT_BOOL, true, 0, NULL,

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -406,7 +406,7 @@ int dlg_pager(struct PagerView *pview)
     // tries to emulate concurrency.
     //-------------------------------------------------------------------------
     bool do_new_mail = false;
-    if (shared->mailbox && !OptAttachMsg)
+    if (shared->mailbox && !shared->attach_msg)
     {
       int oldcount = shared->mailbox->msg_count;
       /* check for new mail */

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -751,7 +751,8 @@ static int op_view_attachments(struct IndexSharedData *shared,
 
   if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
     return FR_NOT_IMPL;
-  dlg_attachment(NeoMutt->sub, shared->mailbox_view, shared->email, pview->pdata->fp);
+  dlg_attachment(NeoMutt->sub, shared->mailbox_view, shared->email,
+                 pview->pdata->fp, shared->attach_msg);
   if (shared->email->attach_del)
     shared->mailbox->changed = true;
   pager_queue_redraw(priv, PAGER_REDRAW_PAGER);

--- a/status.c
+++ b/status.c
@@ -333,13 +333,13 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
 
       if (m)
       {
-        i = OptAttachMsg ? 3 :
-                           ((m->readonly || m->dontwrite) ? 2 :
-                            (m->changed ||
-                             /* deleted doesn't necessarily mean changed in IMAP */
-                             (m->type != MUTT_IMAP && m->msg_deleted)) ?
-                                                            1 :
-                                                            0);
+        i = shared->attach_msg ? 3 :
+                                 ((m->readonly || m->dontwrite) ? 2 :
+                                  (m->changed ||
+                                   /* deleted doesn't necessarily mean changed in IMAP */
+                                   (m->type != MUTT_IMAP && m->msg_deleted)) ?
+                                                                  1 :
+                                                                  0);
       }
 
       const struct MbTable *c_status_chars = cs_subset_mbtable(NeoMutt->sub, "status_chars");


### PR DESCRIPTION
* move `attach_msg` flag from `IndexPrivateData` to `IndexSharedData`
* add `attach_msg` flag to `AttachPrivateData`
* replace uses of `OptAttachMsg` with this flags
* remove `reply_validator()` and drop global `OptAttachMsg`

Triggered by this discussion: https://github.com/neomutt/neomutt/discussions/3996