### PR TITLE
Refactor the Message Window Usage

### DIFF
--- a/attach/recvattach.c
+++ b/attach/recvattach.c
@@ -555,7 +555,7 @@ static void query_pipe_attachment(const char *command, FILE *fp, struct Body *bo
              _("WARNING!  You are about to overwrite %s, continue?"), body->filename);
     if (query_yesorno(warning, MUTT_NO) != MUTT_YES)
     {
-      msgwin_clear_text();
+      msgwin_clear_text(NULL);
       buf_pool_release(&tfile);
       return;
     }

--- a/conn/dlg_verifycert.c
+++ b/conn/dlg_verifycert.c
@@ -232,7 +232,7 @@ int dlg_certificate(const char *title, struct CertArray *carr, bool allow_always
       mdata.keys = _("ro");
     }
   }
-  msgwin_set_text(mdata.prompt, MT_COLOR_PROMPT);
+  msgwin_set_text(NULL, mdata.prompt, MT_COLOR_PROMPT);
 
   // ---------------------------------------------------------------------------
   // Event Loop
@@ -241,7 +241,7 @@ int dlg_certificate(const char *title, struct CertArray *carr, bool allow_always
   do
   {
     window_redraw(NULL);
-    msgwin_set_text(mdata.prompt, MT_COLOR_PROMPT);
+    msgwin_set_text(NULL, mdata.prompt, MT_COLOR_PROMPT);
 
     // Try to catch dialog keys before ops
     if (menu_dialog_dokey(menu, &op) != 0)

--- a/enter/wdata.h
+++ b/enter/wdata.h
@@ -54,6 +54,7 @@ struct EnterWindowData
   void *cdata;                    ///< Auto-Completion private data
 
   // Local variables
+  const char *prompt;             ///< Prompt
   enum EnterRedrawFlags redraw;   ///< What needs redrawing? See #EnterRedrawFlags
   bool pass;                      ///< Password mode, conceal characters
   bool first;                     ///< First time through, no input yet

--- a/external.c
+++ b/external.c
@@ -96,8 +96,6 @@ void index_bounce_message(struct Mailbox *m, struct EmailArray *ea)
 
   struct Buffer *buf = buf_pool_get();
   struct Buffer *prompt = buf_pool_get();
-  struct Buffer *scratch = NULL;
-
   struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
   char *err = NULL;
   int rc;
@@ -144,22 +142,8 @@ void index_bounce_message(struct Mailbox *m, struct EmailArray *ea)
   buf_reset(buf);
   mutt_addrlist_write(&al, buf, true);
 
-#define EXTRA_SPACE (15 + 7 + 2)
-  scratch = buf_pool_get();
-  buf_printf(scratch, ngettext("Bounce message to %s?", "Bounce messages to %s?", msg_count),
+  buf_printf(prompt, ngettext("Bounce message to %s?", "Bounce messages to %s?", msg_count),
              buf_string(buf));
-
-  const size_t width = msgwin_get_width();
-  if (mutt_strwidth(buf_string(scratch)) > (width - EXTRA_SPACE))
-  {
-    mutt_simple_format(prompt->data, prompt->dsize, 0, width - EXTRA_SPACE,
-                       JUSTIFY_LEFT, 0, scratch->data, scratch->dsize, false);
-    buf_addstr(prompt, "...?");
-  }
-  else
-  {
-    buf_copy(prompt, scratch);
-  }
 
   const enum QuadOption c_bounce = cs_subset_quad(NeoMutt->sub, "bounce");
   if (query_quadoption(c_bounce, buf_string(prompt)) != MUTT_YES)
@@ -197,7 +181,6 @@ done:
   mutt_addrlist_clear(&al);
   buf_pool_release(&buf);
   buf_pool_release(&prompt);
-  buf_pool_release(&scratch);
 }
 
 /**

--- a/external.c
+++ b/external.c
@@ -164,12 +164,12 @@ void index_bounce_message(struct Mailbox *m, struct EmailArray *ea)
   const enum QuadOption c_bounce = cs_subset_quad(NeoMutt->sub, "bounce");
   if (query_quadoption(c_bounce, buf_string(prompt)) != MUTT_YES)
   {
-    msgwin_clear_text();
+    msgwin_clear_text(NULL);
     mutt_message(ngettext("Message not bounced", "Messages not bounced", msg_count));
     goto done;
   }
 
-  msgwin_clear_text();
+  msgwin_clear_text(NULL);
 
   struct Message *msg = NULL;
   ARRAY_FOREACH(ep, ea)
@@ -618,7 +618,7 @@ bool mutt_shell_escape(void)
     goto done;
   }
 
-  msgwin_clear_text();
+  msgwin_clear_text(NULL);
   mutt_endwin();
   fflush(stdout);
   int rc2 = mutt_system(buf_string(buf));

--- a/flags.c
+++ b/flags.c
@@ -477,7 +477,7 @@ int mw_change_flag(struct Mailbox *m, struct EmailArray *ea, bool bf)
   mutt_curses_set_cursor(old_cursor);
 
   window_set_focus(old_focus);
-  msgwin_clear_text();
+  msgwin_clear_text(NULL);
 
   if (event.op == OP_ABORT)
     return -1;

--- a/flags.c
+++ b/flags.c
@@ -29,12 +29,14 @@
 #include "config.h"
 #include <stddef.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "email/lib.h"
 #include "core/lib.h"
 #include "gui/lib.h"
 #include "mutt.h"
+#include "color/lib.h"
 #include "index/lib.h"
 #include "keymap.h"
 #include "mutt_thread.h"
@@ -452,36 +454,45 @@ done:
  */
 int mw_change_flag(struct Mailbox *m, struct EmailArray *ea, bool bf)
 {
-  struct MuttWindow *win = msgwin_get_window();
-  if (!win)
-    return -1;
-
   if (!m || !ea || ARRAY_EMPTY(ea))
     return -1;
 
-  enum MessageType flag = MUTT_NONE;
-  struct KeyEvent event = { 0, OP_NULL };
+  // blank window (0, 0)
+  struct MuttWindow *win = msgwin_new(true);
+  if (!win)
+    return -1;
+
+  char prompt[256] = { 0 };
+  snprintf(prompt, sizeof(prompt),
+           "%s? (D/N/O/r/*/!): ", bf ? _("Set flag") : _("Clear flag"));
+  msgwin_set_text(win, prompt, MT_COLOR_PROMPT);
+  // text, WA_RECALC
+
+  msgcont_push_window(win);
+  // resized, text, WA_RECALC
 
   struct MuttWindow *old_focus = window_set_focus(win);
 
-  mutt_window_mvprintw(win, 0, 0, "%s? (D/N/O/r/*/!): ", bf ? _("Set flag") : _("Clear flag"));
-  mutt_window_clrtoeol(win);
-  window_redraw(NULL);
+  window_redraw(win);
+  // recalc, repaint
 
+  struct KeyEvent event = { 0, OP_NULL };
   enum MuttCursorState old_cursor = mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
   do
   {
-    mutt_refresh();
+    window_redraw(NULL);
     event = mutt_getch(GETCH_NO_FLAGS);
   } while ((event.op == OP_TIMEOUT) || (event.op == OP_REPAINT));
   mutt_curses_set_cursor(old_cursor);
 
   window_set_focus(old_focus);
-  msgwin_clear_text(NULL);
+  win = msgcont_pop_window();
+  mutt_window_free(&win);
 
   if (event.op == OP_ABORT)
     return -1;
 
+  enum MessageType flag = MUTT_NONE;
   switch (event.ch)
   {
     case 'd':

--- a/gui/msgcont.c
+++ b/gui/msgcont.c
@@ -64,6 +64,9 @@ struct MuttWindow *msgcont_pop_window(void)
   if (!TAILQ_PREV(win_pop, MuttWindowList, entries))
     return NULL;
 
+  // Hide the old window
+  window_set_visible(win_pop, false);
+
   // Make the top of the stack visible
   struct MuttWindow *win_top = TAILQ_PREV(win_pop, MuttWindowList, entries);
 
@@ -75,6 +78,7 @@ struct MuttWindow *msgcont_pop_window(void)
     win_top->actions |= WA_RECALC;
   }
 
+  mutt_window_reflow(NULL);
   window_redraw(NULL);
 #ifdef USE_DEBUG_WINDOW
   debug_win_dump();
@@ -96,7 +100,7 @@ void msgcont_push_window(struct MuttWindow *win)
   window_set_visible(win_top, false);
 
   mutt_window_add_child(MessageContainer, win);
-  win->actions |= WA_RECALC;
+  mutt_window_reflow(NULL);
   window_redraw(NULL);
 #ifdef USE_DEBUG_WINDOW
   debug_win_dump();

--- a/gui/msgcont.c
+++ b/gui/msgcont.c
@@ -37,7 +37,7 @@
 #endif
 
 /// Window acting as a stack for the message windows
-static struct MuttWindow *MessageContainer = NULL;
+struct MuttWindow *MessageContainer = NULL;
 
 /**
  * msgcont_new - Create a new Message Container

--- a/gui/msgcont.c
+++ b/gui/msgcont.c
@@ -102,3 +102,25 @@ void msgcont_push_window(struct MuttWindow *win)
   debug_win_dump();
 #endif
 }
+
+/**
+ * msgcont_get_msgwin - Get the Message Window
+ * @retval ptr Message Window
+ *
+ * The Message Window is the first child of the MessageContainer and will have
+ * type WT_MESSAGE.
+ */
+struct MuttWindow *msgcont_get_msgwin(void)
+{
+  if (!MessageContainer)
+    return NULL;
+
+  struct MuttWindow *win = TAILQ_FIRST(&MessageContainer->children);
+  if (!win)
+    return NULL;
+
+  if (win->type != WT_MESSAGE)
+    return NULL;
+
+  return win;
+}

--- a/gui/msgcont.h
+++ b/gui/msgcont.h
@@ -25,6 +25,8 @@
 
 struct MuttWindow;
 
+extern struct MuttWindow *MessageContainer;
+
 struct MuttWindow *msgcont_get_msgwin(void);
 struct MuttWindow *msgcont_new(void);
 struct MuttWindow *msgcont_pop_window(void);

--- a/gui/msgcont.h
+++ b/gui/msgcont.h
@@ -25,6 +25,7 @@
 
 struct MuttWindow;
 
+struct MuttWindow *msgcont_get_msgwin(void);
 struct MuttWindow *msgcont_new(void);
 struct MuttWindow *msgcont_pop_window(void);
 void               msgcont_push_window(struct MuttWindow *win);

--- a/gui/msgwin.c
+++ b/gui/msgwin.c
@@ -83,6 +83,9 @@
  */
 
 #include "config.h"
+#include <stdbool.h>
+#include <string.h>
+#include <wchar.h>
 #include "mutt/lib.h"
 #include "msgwin.h"
 #include "color/lib.h"
@@ -92,16 +95,155 @@
 #include "mutt_window.h"
 
 /**
+ * measure - Measure a string in bytes and cells
+ * @param chars    Results
+ * @param str      String to measure
+ * @param ac_color Colour to associate
+ *
+ * Calculate the size of each character in a string in bytes and screen cells.
+ */
+void measure(struct MwCharArray *chars, const char *str, const struct AttrColor *ac_color)
+{
+  if (!str || !*str)
+    return;
+
+  int total_width = 0;
+  mbstate_t mbstate = { 0 };
+  struct MwChar mwc = { 0 };
+
+  size_t str_len = mutt_str_len(str);
+
+  while (*str && (str_len > 0))
+  {
+    wchar_t wc = L'\0';
+    size_t consumed = mbrtowc(&wc, str, str_len, &mbstate);
+    if (consumed == 0)
+      break;
+
+    if (consumed == ICONV_ILLEGAL_SEQ)
+    {
+      memset(&mbstate, 0, sizeof(mbstate));
+      wc = ReplacementChar;
+      consumed = 1;
+    }
+    else if (consumed == ICONV_BUF_TOO_SMALL)
+    {
+      wc = ReplacementChar;
+      consumed = str_len;
+    }
+
+    int wchar_width = wcwidth(wc);
+    if (wchar_width < 0)
+      wchar_width = 1;
+
+    if (wc == 0xfe0f) // Emoji variation
+    {
+      size_t size = ARRAY_SIZE(chars);
+      if (size > 0)
+      {
+        struct MwChar *es_prev = ARRAY_GET(chars, size - 1);
+        if (es_prev->width == 1)
+          es_prev->width = 2;
+      }
+    }
+
+    mwc = (struct MwChar){ wchar_width, consumed, ac_color };
+    ARRAY_ADD(chars, mwc);
+
+    total_width += wchar_width;
+    str += consumed;
+    str_len -= consumed;
+  }
+}
+
+/**
  * msgwin_recalc - Recalculate the display of the Message Window - Implements MuttWindow::recalc() - @ingroup window_recalc
  */
 static int msgwin_recalc(struct MuttWindow *win)
 {
-  if (window_is_focused(win)) // Someone else is using it
-    return 0;
-
   win->actions |= WA_REPAINT;
   mutt_debug(LL_DEBUG5, "recalc done, request WA_REPAINT\n");
   return 0;
+}
+
+/**
+ * msgwin_calc_rows - How many rows will a string need?
+ * @param wdata Window data
+ * @param cols  Columns to wrap at
+ * @param str   Text to measure
+ * @retval num Number of rows required
+ * @retval   0 Error
+ *
+ * Divide the width of a string by the width of the Message Window.
+ */
+int msgwin_calc_rows(struct MsgWinWindowData *wdata, int cols, const char *str)
+{
+  if (!wdata || !str || !*str)
+    return 0;
+
+  for (int i = 0; i < MSGWIN_MAX_ROWS; i++)
+  {
+    ARRAY_FREE(&wdata->rows[i]);
+  }
+
+  int width = 0;  ///< Screen width used
+  int offset = 0; ///< Offset into str
+  int row = 0;    ///< Current row
+  bool new_row = false;
+
+  struct MwChunk *chunk = NULL;
+  struct MwChar *mwc = NULL;
+  ARRAY_FOREACH(mwc, &wdata->chars)
+  {
+    const bool nl = (mwc->bytes == 1) && (str[offset] == '\n');
+    if (nl)
+    {
+      new_row = true;
+      offset += mwc->bytes;
+      continue;
+    }
+
+    if (((width + mwc->width) > cols) || new_row)
+    {
+      // ROW IS FULL
+      new_row = false;
+
+      row++;
+      if (row >= MSGWIN_MAX_ROWS)
+      {
+        // NO MORE ROOM
+        break;
+      }
+
+      // Start a new row
+      struct MwChunk tmp = { offset, mwc->bytes, mwc->width, mwc->ac_color };
+
+      mutt_debug(LL_DEBUG1, "row = %d\n", row);
+      ARRAY_ADD(&wdata->rows[row], tmp);
+      chunk = ARRAY_LAST(&wdata->rows[row]);
+
+      width = 0;
+    }
+    else if (!chunk || (mwc->ac_color != chunk->ac_color))
+    {
+      // CHANGE OF COLOUR
+      struct MwChunk tmp = { offset, mwc->bytes, mwc->width, mwc->ac_color };
+      ARRAY_ADD(&wdata->rows[row], tmp);
+      chunk = ARRAY_LAST(&wdata->rows[row]);
+    }
+    else
+    {
+      // MORE OF THE SAME
+      chunk->bytes += mwc->bytes;
+      chunk->width += mwc->width;
+    }
+
+    offset += mwc->bytes;
+    width += mwc->width;
+  }
+
+  mutt_debug(LL_DEBUG1, "msgwin_calc_rows() => %d\n", row + 1);
+  return row + 1;
 }
 
 /**
@@ -109,21 +251,66 @@ static int msgwin_recalc(struct MuttWindow *win)
  */
 static int msgwin_repaint(struct MuttWindow *win)
 {
-  if (window_is_focused(win)) // someone else is using it
-    return 0;
-
   struct MsgWinWindowData *wdata = win->wdata;
 
-  mutt_window_move(win, 0, 0);
+  if (win->actions & WA_REPAINT)
+  {
+    const char *str = buf_string(wdata->text);
+    for (int i = 0; i < MSGWIN_MAX_ROWS; i++)
+    {
+      mutt_window_move(win, 0, i);
+      if (ARRAY_EMPTY(&wdata->rows[i]))
+        break;
 
-  mutt_curses_set_normal_backed_color_by_id(wdata->cid);
-  mutt_window_move(win, 0, 0);
-  mutt_window_addstr(win, wdata->text);
-  mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
-  mutt_window_clrtoeol(win);
+      struct MwChunk *chunk = NULL;
+      ARRAY_FOREACH(chunk, &wdata->rows[i])
+      {
+        mutt_curses_set_color(chunk->ac_color);
+        mutt_window_addnstr(win, str + chunk->offset, chunk->bytes);
+      }
+      mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
+      mutt_window_clrtoeol(win);
+    }
+    mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
+    mutt_window_clrtoeol(win);
 
-  mutt_debug(LL_DEBUG5, "repaint done\n");
+    if (wdata->interactive)
+    {
+      mutt_window_get_coords(win, &wdata->col, &wdata->row);
+    }
+  }
+  else if (wdata->interactive)
+  {
+    mutt_window_move(win, wdata->col, wdata->row);
+  }
+
+  mutt_debug(LL_DEBUG1, "MSGWIN repaint done\n");
   return 0;
+}
+
+/**
+ * msgwin_set_rows - Resize the Message Window
+ * @param win  Message Window
+ * @param rows Number of rows required
+ *
+ * Resize the other Windows to allow a multi-line message to be displayed.
+ *
+ * @note rows will be clamped between 1 and 3 (#MSGWIN_MAX_ROWS) inclusive
+ */
+void msgwin_set_rows(struct MuttWindow *win, short rows)
+{
+  if (!win)
+    win = msgcont_get_msgwin();
+  if (!win)
+    return;
+
+  rows = CLAMP(rows, 1, MSGWIN_MAX_ROWS);
+
+  if (rows != win->state.rows)
+  {
+    win->req_rows = rows;
+    mutt_window_reflow(NULL);
+  }
 }
 
 /**
@@ -148,8 +335,23 @@ static int msgwin_window_observer(struct NotifyCallback *nc)
 
   if (nc->event_subtype == NT_WINDOW_STATE)
   {
-    win->actions |= WA_RECALC;
-    mutt_debug(LL_NOTIFY, "window state done, request WA_RECALC\n");
+    if (ev_w->flags & WN_HIDDEN)
+    {
+      msgwin_clear_text(win);
+    }
+
+    if (ev_w->flags & (WN_NARROWER | WN_WIDER))
+    {
+      struct MsgWinWindowData *wdata = win->wdata;
+      msgwin_set_rows(win, msgwin_calc_rows(wdata, win->state.cols,
+                                            buf_string(wdata->text)));
+      win->actions |= WA_RECALC;
+    }
+    else
+    {
+      win->actions |= WA_REPAINT;
+    }
+    mutt_debug(LL_DEBUG1, "window state done, request WA_RECALC\n");
   }
   else if (nc->event_subtype == NT_WINDOW_DELETE)
   {
@@ -163,14 +365,23 @@ static int msgwin_window_observer(struct NotifyCallback *nc)
  * msgwin_new - Create the Message Window
  * @retval ptr New Window
  */
-struct MuttWindow *msgwin_new(void)
+struct MuttWindow *msgwin_new(bool interactive)
 {
-  struct MuttWindow *win = mutt_window_new(WT_MESSAGE, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED,
+  enum WindowType type = interactive ? WT_MSG_FOCUS : WT_MESSAGE;
+
+  struct MuttWindow *win = mutt_window_new(type, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED,
                                            MUTT_WIN_SIZE_UNLIMITED, 1);
-  win->wdata = msgwin_wdata_new();
+
+  struct MsgWinWindowData *wdata = msgwin_wdata_new();
+  wdata->interactive = interactive;
+
+  win->wdata = wdata;
   win->wdata_free = msgwin_wdata_free;
   win->recalc = msgwin_recalc;
   win->repaint = msgwin_repaint;
+
+  // Copy the container's dimensions
+  win->state = MessageContainer->state;
 
   notify_observer_add(win->notify, NT_WINDOW, msgwin_window_observer, win);
 
@@ -193,18 +404,16 @@ const char *msgwin_get_text(struct MuttWindow *win)
 
   struct MsgWinWindowData *wdata = win->wdata;
 
-  return wdata->text;
+  return buf_string(wdata->text);
 }
 
 /**
- * msgwin_set_text - Set the text for the Message Window
- * @param win Message Window
- * @param text Text to set
- * @param cid  Colour Id, e.g. #MT_COLOR_MESSAGE
- *
- * @note The text string will be copied
+ * msgwin_add_text - Add text to the Message Window
+ * @param win      Message Window
+ * @param text     Text to add
+ * @param ac_color Colour for text
  */
-void msgwin_set_text(struct MuttWindow *win, const char *text, enum ColorId cid)
+void msgwin_add_text(struct MuttWindow *win, const char *text, const struct AttrColor *ac_color)
 {
   if (!win)
     win = msgcont_get_msgwin();
@@ -213,9 +422,84 @@ void msgwin_set_text(struct MuttWindow *win, const char *text, enum ColorId cid)
 
   struct MsgWinWindowData *wdata = win->wdata;
 
-  wdata->cid = cid;
-  mutt_str_replace(&wdata->text, text);
+  if (text)
+  {
+    buf_addstr(wdata->text, text);
+    measure(&wdata->chars, text, ac_color);
+    mutt_debug(LL_DEBUG1, "MW ADD: %zu, %s\n", buf_len(wdata->text),
+               buf_string(wdata->text));
+  }
+  else
+  {
+    int rows = msgwin_calc_rows(wdata, win->state.cols, buf_string(wdata->text));
+    msgwin_set_rows(win, rows);
+    win->actions |= WA_RECALC;
+  }
+}
 
+/**
+ * msgwin_add_text_n - Add some text to the Message Window
+ * @param win      Message Window
+ * @param text     Text to add
+ * @param bytes    Number of bytes of text to add
+ * @param ac_color Colour for text
+ */
+void msgwin_add_text_n(struct MuttWindow *win, const char *text, int bytes,
+                       const struct AttrColor *ac_color)
+{
+  if (!win)
+    win = msgcont_get_msgwin();
+  if (!win)
+    return;
+
+  struct MsgWinWindowData *wdata = win->wdata;
+
+  if (text)
+  {
+    const char *dptr = wdata->text->dptr;
+    buf_addstr_n(wdata->text, text, bytes);
+    measure(&wdata->chars, dptr, ac_color);
+    mutt_debug(LL_DEBUG1, "MW ADD: %zu, %s\n", buf_len(wdata->text),
+               buf_string(wdata->text));
+  }
+  else
+  {
+    int rows = msgwin_calc_rows(wdata, win->state.cols, buf_string(wdata->text));
+    msgwin_set_rows(win, rows);
+    win->actions |= WA_RECALC;
+  }
+}
+
+/**
+ * msgwin_set_text - Set the text for the Message Window
+ * @param win   Message Window
+ * @param text  Text to set
+ * @param color Colour for text
+ *
+ * @note The text string will be copied
+ */
+void msgwin_set_text(struct MuttWindow *win, const char *text, enum ColorId color)
+{
+  if (!win)
+    win = msgcont_get_msgwin();
+  if (!win)
+    return;
+
+  struct MsgWinWindowData *wdata = win->wdata;
+
+  buf_strcpy(wdata->text, text);
+  ARRAY_FREE(&wdata->chars);
+  if (wdata->text)
+  {
+    const struct AttrColor *ac_color = simple_color_get(MT_COLOR_PROMPT);
+    measure(&wdata->chars, buf_string(wdata->text), ac_color);
+  }
+
+  mutt_debug(LL_DEBUG1, "MW SET: %zu, %s\n", buf_len(wdata->text),
+             buf_string(wdata->text));
+
+  int rows = msgwin_calc_rows(wdata, win->state.cols, buf_string(wdata->text));
+  msgwin_set_rows(win, rows);
   win->actions |= WA_RECALC;
 }
 

--- a/gui/msgwin.c
+++ b/gui/msgwin.c
@@ -83,6 +83,7 @@
  */
 
 #include "config.h"
+#include <stddef.h>
 #include <stdbool.h>
 #include <string.h>
 #include <wchar.h>
@@ -521,40 +522,4 @@ void msgwin_clear_text(struct MuttWindow *win)
 struct MuttWindow *msgwin_get_window(void)
 {
   return msgcont_get_msgwin();
-}
-
-/**
- * msgwin_get_width - Get the width of the Message Window
- * @retval num Width of Message Window
- */
-size_t msgwin_get_width(void)
-{
-  struct MuttWindow *win = msgcont_get_msgwin();
-  if (!win)
-    return 0;
-
-  return win->state.cols;
-}
-
-/**
- * msgwin_set_height - Resize the Message Window
- * @param height Number of rows required
- *
- * Resize the other Windows to allow a multi-line message to be displayed.
- */
-void msgwin_set_height(short height)
-{
-  struct MuttWindow *win = msgcont_get_msgwin();
-  if (!win)
-    return;
-
-  if (height < 1)
-    height = 1;
-  else if (height > 3)
-    height = 3;
-
-  struct MuttWindow *win_cont = win->parent;
-
-  win_cont->req_rows = height;
-  mutt_window_reflow(win_cont->parent);
 }

--- a/gui/msgwin.h
+++ b/gui/msgwin.h
@@ -23,7 +23,6 @@
 #ifndef MUTT_GUI_MSGWIN_H
 #define MUTT_GUI_MSGWIN_H
 
-#include <stddef.h>
 #include <stdbool.h>
 #include "color/lib.h"
 
@@ -34,9 +33,8 @@ struct MuttWindow *msgwin_new       (bool interactive);
 void               msgwin_add_text  (struct MuttWindow *win, const char *text, const struct AttrColor *ac_color);
 void               msgwin_add_text_n(struct MuttWindow *win, const char *text, int bytes, const struct AttrColor *ac_color);
 const char *       msgwin_get_text  (struct MuttWindow *win);
-size_t             msgwin_get_width (void);
 struct MuttWindow *msgwin_get_window(void);
-void               msgwin_set_height(short height);
-void               msgwin_set_text  (struct MuttWindow *win, const char *text, enum ColorId cid);
+void               msgwin_set_rows  (struct MuttWindow *win, short rows);
+void               msgwin_set_text  (struct MuttWindow *win, const char *text, enum ColorId color);
 
 #endif /* MUTT_GUI_MSGWIN_H */

--- a/gui/msgwin.h
+++ b/gui/msgwin.h
@@ -23,13 +23,16 @@
 #ifndef MUTT_GUI_MSGWIN_H
 #define MUTT_GUI_MSGWIN_H
 
-#include <stdio.h>
+#include <stddef.h>
+#include <stdbool.h>
 #include "color/lib.h"
 
 struct MuttWindow;
 
 void               msgwin_clear_text(struct MuttWindow *win);
-struct MuttWindow *msgwin_new       (void);
+struct MuttWindow *msgwin_new       (bool interactive);
+void               msgwin_add_text  (struct MuttWindow *win, const char *text, const struct AttrColor *ac_color);
+void               msgwin_add_text_n(struct MuttWindow *win, const char *text, int bytes, const struct AttrColor *ac_color);
 const char *       msgwin_get_text  (struct MuttWindow *win);
 size_t             msgwin_get_width (void);
 struct MuttWindow *msgwin_get_window(void);

--- a/gui/msgwin.h
+++ b/gui/msgwin.h
@@ -26,12 +26,14 @@
 #include <stdio.h>
 #include "color/lib.h"
 
-void               msgwin_clear_text(void);
+struct MuttWindow;
+
+void               msgwin_clear_text(struct MuttWindow *win);
 struct MuttWindow *msgwin_new       (void);
-const char *       msgwin_get_text  (void);
+const char *       msgwin_get_text  (struct MuttWindow *win);
 size_t             msgwin_get_width (void);
 struct MuttWindow *msgwin_get_window(void);
 void               msgwin_set_height(short height);
-void               msgwin_set_text  (const char *text, enum ColorId cid);
+void               msgwin_set_text  (struct MuttWindow *win, const char *text, enum ColorId cid);
 
 #endif /* MUTT_GUI_MSGWIN_H */

--- a/gui/msgwin_wdata.c
+++ b/gui/msgwin_wdata.c
@@ -27,6 +27,7 @@
  */
 
 #include "config.h"
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "msgwin_wdata.h"
 
@@ -40,7 +41,14 @@ void msgwin_wdata_free(struct MuttWindow *win, void **ptr)
 
   struct MsgWinWindowData *wdata = *ptr;
 
-  FREE(&wdata->text);
+  for (int i = 0; i < MSGWIN_MAX_ROWS; i++)
+  {
+    ARRAY_FREE(&wdata->rows[i]);
+  }
+
+  // We don't own MwChar->ac_color, so there's nothing but the ARRAY to free
+  ARRAY_FREE(&wdata->chars);
+  buf_free(&wdata->text);
 
   FREE(ptr);
 }
@@ -51,9 +59,9 @@ void msgwin_wdata_free(struct MuttWindow *win, void **ptr)
  */
 struct MsgWinWindowData *msgwin_wdata_new(void)
 {
-  struct MsgWinWindowData *msgwin_data = mutt_mem_calloc(1, sizeof(struct MsgWinWindowData));
+  struct MsgWinWindowData *wdata = mutt_mem_calloc(1, sizeof(struct MsgWinWindowData));
 
-  msgwin_data->cid = MT_COLOR_NORMAL;
+  wdata->text = buf_new(NULL);
 
-  return msgwin_data;
+  return wdata;
 }

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -57,6 +57,7 @@ static const struct Mapping WindowNames[] = {
   { "WT_DLG_HISTORY",     WT_DLG_HISTORY },
   { "WT_DLG_INDEX",       WT_DLG_INDEX },
   { "WT_DLG_PAGER",       WT_DLG_PAGER },
+  { "WT_DLG_PATTERN",     WT_DLG_PATTERN },
   { "WT_DLG_PGP",         WT_DLG_PGP },
   { "WT_DLG_POSTPONE",    WT_DLG_POSTPONE },
   { "WT_DLG_QUERY",       WT_DLG_QUERY },
@@ -66,6 +67,7 @@ static const struct Mapping WindowNames[] = {
   { "WT_INDEX",           WT_INDEX },
   { "WT_MENU",            WT_MENU },
   { "WT_MESSAGE",         WT_MESSAGE },
+  { "WT_MSG_FOCUS",       WT_MSG_FOCUS },
   { "WT_PAGER",           WT_PAGER },
   { "WT_ROOT",            WT_ROOT },
   { "WT_SIDEBAR",         WT_SIDEBAR },
@@ -348,7 +350,10 @@ void mutt_window_reflow(struct MuttWindow *win)
   if (!win)
     win = RootWindow;
 
-  mutt_debug(LL_DEBUG2, "entering\n");
+  window_reflow(win);
+  window_notify_all(win);
+
+  // Allow Windows to resize themselves based on the first reflow
   window_reflow(win);
   window_notify_all(win);
 
@@ -615,6 +620,12 @@ void window_redraw(struct MuttWindow *win)
 
   window_recalc(win);
   window_repaint(win);
+
+  // Give the focussed window an opportunity to set the cursor position
+  win = window_get_focus();
+  if (win && win->repaint)
+    win->repaint(win);
+
   mutt_refresh();
 }
 

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -96,7 +96,8 @@ enum WindowType
   WT_HELP_BAR,        ///< Help Bar containing list of useful key bindings
   WT_INDEX,           ///< A panel containing the Index Window
   WT_MENU,            ///< An Window containing a Menu
-  WT_MESSAGE,         ///< Window for messages/errors and command entry
+  WT_MESSAGE,         ///< Window for messages/errors
+  WT_MSG_FOCUS,       ///< Message Window that has focus
   WT_PAGER,           ///< A panel containing the Pager Window
   WT_SIDEBAR,         ///< Side panel containing Accounts or groups of data
   WT_STATUS_BAR,      ///< Status Bar containing extra info about the Index/Pager/etc

--- a/gui/rootwin.c
+++ b/gui/rootwin.c
@@ -232,7 +232,7 @@ void rootwin_new(void)
   }
 
   struct MuttWindow *win_cont = msgcont_new();
-  struct MuttWindow *win_msg = msgwin_new();
+  struct MuttWindow *win_msg = msgwin_new(false);
   mutt_window_add_child(win_cont, win_msg);
   mutt_window_add_child(win_root, win_cont);
 

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -1240,7 +1240,7 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
     /* give visual indication that the next command is a tag- command */
     if (priv->tag_prefix)
     {
-      msgwin_set_text("tag-", MT_COLOR_NORMAL);
+      msgwin_set_text(NULL, "tag-", MT_COLOR_NORMAL);
     }
 
     const bool c_arrow_cursor = cs_subset_bool(shared->sub, "arrow_cursor");
@@ -1271,7 +1271,7 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
       priv->menu->top = 0; /* so we scroll the right amount */
       /* force a real complete redraw.  clrtobot() doesn't seem to be able
        * to handle every case without this.  */
-      msgwin_clear_text();
+      msgwin_clear_text(NULL);
       mutt_refresh();
       continue;
     }
@@ -1280,7 +1280,7 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
     if (op < OP_NULL)
     {
       if (priv->tag_prefix)
-        msgwin_clear_text();
+        msgwin_clear_text(NULL);
       continue;
     }
 
@@ -1294,7 +1294,7 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
       if (priv->tag_prefix)
       {
         priv->tag_prefix = false;
-        msgwin_clear_text();
+        msgwin_clear_text(NULL);
         continue;
       }
 

--- a/index/functions.c
+++ b/index/functions.c
@@ -885,7 +885,7 @@ static int op_main_change_folder(struct IndexSharedData *shared,
 
   if (buf_is_empty(folderbuf))
   {
-    msgwin_clear_text();
+    msgwin_clear_text(NULL);
     goto changefoldercleanup;
   }
 
@@ -2585,7 +2585,7 @@ static int op_main_change_group(struct IndexSharedData *shared,
 
   if (buf_is_empty(folderbuf))
   {
-    msgwin_clear_text();
+    msgwin_clear_text(NULL);
     goto changefoldercleanup2;
   }
 

--- a/keymap.c
+++ b/keymap.c
@@ -1842,6 +1842,10 @@ void mw_what_key(void)
 
   enum MuttCursorState old_cursor = mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
 
+  char keys[256] = { 0 };
+  const struct AttrColor *ac_normal = simple_color_get(MT_COLOR_NORMAL);
+  const struct AttrColor *ac_prompt = simple_color_get(MT_COLOR_PROMPT);
+
   // ---------------------------------------------------------------------------
   // Event Loop
   timeout(1000); // 1 second
@@ -1879,9 +1883,12 @@ void mw_what_key(void)
       continue;
     }
 
-    snprintf(prompt, sizeof(prompt), _("Char = %s, Octal = %o, Decimal = %d"),
+    msgwin_clear_text(win);
+    snprintf(keys, sizeof(keys), _("Char = %s, Octal = %o, Decimal = %d\n"),
              km_keyname(ch), ch, ch);
-    msgwin_set_text(win, prompt, MT_COLOR_NORMAL);
+    msgwin_add_text(win, keys, ac_normal);
+    msgwin_add_text(win, prompt, ac_prompt);
+    msgwin_add_text(win, NULL, NULL);
     window_redraw(NULL);
   }
   // ---------------------------------------------------------------------------

--- a/keymap.c
+++ b/keymap.c
@@ -48,7 +48,6 @@
 #include "parse/lib.h"
 #include "functions.h"
 #include "globals.h"
-#include "mutt_logging.h"
 #include "opcodes.h"
 
 /**
@@ -1829,15 +1828,18 @@ enum CommandResult mutt_parse_exec(struct Buffer *buf, struct Buffer *s,
  */
 void mw_what_key(void)
 {
-  int ch;
-
-  struct MuttWindow *win = msgwin_get_window();
+  struct MuttWindow *win = msgwin_new(true);
   if (!win)
     return;
 
-  mutt_curses_set_normal_backed_color_by_id(MT_COLOR_PROMPT);
-  mutt_window_mvprintw(win, 0, 0, _("Enter keys (%s to abort): "), km_keyname(AbortKey));
-  mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
+  char prompt[256] = { 0 };
+  snprintf(prompt, sizeof(prompt), _("Enter keys (%s to abort): "), km_keyname(AbortKey));
+  msgwin_set_text(win, prompt, MT_COLOR_PROMPT);
+
+  msgcont_push_window(win);
+  struct MuttWindow *old_focus = window_set_focus(win);
+  window_redraw(win);
+
   enum MuttCursorState old_cursor = mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
 
   // ---------------------------------------------------------------------------
@@ -1845,7 +1847,7 @@ void mw_what_key(void)
   timeout(1000); // 1 second
   while (true)
   {
-    ch = getch();
+    int ch = getch();
     if (ch == AbortKey)
       break;
 
@@ -1867,25 +1869,28 @@ void mw_what_key(void)
       {
         SigWinch = false;
         notify_send(NeoMutt->notify_resize, NT_RESIZE, 0, NULL);
+        window_redraw(NULL);
       }
       else
       {
         notify_send(NeoMutt->notify_timeout, NT_TIMEOUT, 0, NULL);
       }
 
-      mutt_refresh();
       continue;
     }
 
-    mutt_message(_("Char = %s, Octal = %o, Decimal = %d"), km_keyname(ch), ch, ch);
-    mutt_window_move(win, 0, 0);
+    snprintf(prompt, sizeof(prompt), _("Char = %s, Octal = %o, Decimal = %d"),
+             km_keyname(ch), ch, ch);
+    msgwin_set_text(win, prompt, MT_COLOR_NORMAL);
+    window_redraw(NULL);
   }
   // ---------------------------------------------------------------------------
 
   mutt_curses_set_cursor(old_cursor);
 
-  mutt_flushinp();
-  mutt_clear_error();
+  window_set_focus(old_focus);
+  win = msgcont_pop_window();
+  mutt_window_free(&win);
 }
 
 /**

--- a/main.c
+++ b/main.c
@@ -785,7 +785,7 @@ main
 
     /* check whether terminal status is supported (must follow curses init) */
     TsSupported = mutt_ts_capability();
-    rootwin_set_size(COLS, LINES);
+    mutt_resize_screen();
   }
 
   /* set defaults and read init files */
@@ -1370,6 +1370,9 @@ main
     mutt_startup_shutdown_hook(MUTT_STARTUP_HOOK);
     mutt_debug(LL_NOTIFY, "NT_GLOBAL_STARTUP\n");
     notify_send(NeoMutt->notify, NT_GLOBAL, NT_GLOBAL_STARTUP, NULL);
+
+    notify_send(NeoMutt->notify_resize, NT_RESIZE, 0, NULL);
+    window_redraw(NULL);
 
     repeat_error = true;
     struct Mailbox *m = mx_resolve(buf_string(&folder));

--- a/menu/observer.c
+++ b/menu/observer.c
@@ -27,6 +27,7 @@
  */
 
 #include "config.h"
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"
@@ -119,7 +120,7 @@ static int menu_window_observer(struct NotifyCallback *nc)
     notify_observer_remove(NeoMutt->sub->notify, menu_config_observer, menu);
     notify_observer_remove(win->notify, menu_window_observer, menu);
     mutt_color_observer_remove(menu_color_observer, menu);
-    msgwin_clear_text();
+    msgwin_clear_text(NULL);
     mutt_debug(LL_DEBUG5, "window delete done\n");
   }
 

--- a/menu/tagging.c
+++ b/menu/tagging.c
@@ -27,6 +27,7 @@
  */
 
 #include "config.h"
+#include <stddef.h>
 #include <stdbool.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
@@ -49,17 +50,17 @@ static void menu_set_prefix(struct Menu *menu)
   mutt_debug(LL_DEBUG1, "tag_prefix = %d\n", menu->tag_prefix);
 
   // Don't overwrite error messages
-  const char *msg_text = msgwin_get_text();
+  const char *msg_text = msgwin_get_text(NULL);
   if (msg_text && !mutt_str_equal(msg_text, "tag-"))
     return;
 
   if (menu->tag_prefix)
   {
-    msgwin_set_text("tag-", MT_COLOR_NORMAL);
+    msgwin_set_text(NULL, "tag-", MT_COLOR_NORMAL);
   }
   else
   {
-    msgwin_clear_text();
+    msgwin_clear_text(NULL);
   }
 }
 
@@ -129,7 +130,7 @@ static int op_tag(struct Menu *menu, int op)
   /* give visual indication that the next command is a tag- command */
   if (menu->tag_prefix)
   {
-    msgwin_set_text("tag-", MT_COLOR_NORMAL);
+    msgwin_set_text(NULL, "tag-", MT_COLOR_NORMAL);
   }
 
   menu->win->actions |= WA_REPAINT;

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -126,9 +126,7 @@ int log_disp_curses(time_t stamp, const char *file, int line, const char *functi
   if ((level > LL_ERROR) && OptMsgErr && !dupe)
     error_pause();
 
-  size_t width = msgwin_get_width();
-  mutt_simple_format(ErrorBuf, sizeof(ErrorBuf), 0, width ? width : sizeof(ErrorBuf),
-                     JUSTIFY_LEFT, 0, buf, sizeof(buf), false);
+  mutt_str_copy(ErrorBuf, buf, sizeof(ErrorBuf));
   ErrorBufMessage = true;
 
   if (!OptKeepQuiet)

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -78,7 +78,7 @@ void mutt_clear_error(void)
 
   ErrorBufMessage = false;
   if (!OptNoCurses)
-    msgwin_clear_text();
+    msgwin_clear_text(NULL);
 }
 
 /**
@@ -148,7 +148,7 @@ int log_disp_curses(time_t stamp, const char *file, int line, const char *functi
         break;
     }
 
-    msgwin_set_text(ErrorBuf, cid);
+    msgwin_set_text(NULL, ErrorBuf, cid);
   }
 
   if ((level <= LL_ERROR) && !dupe)

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -33,7 +33,6 @@
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"
-#include "gui/lib.h"
 #include "mutt_mailbox.h"
 #include "postpone/lib.h"
 #include "muttlib.h"
@@ -271,16 +270,9 @@ bool mutt_mailbox_list(void)
     buf_strcpy(path, mailbox_path(np->mailbox));
     buf_pretty_mailbox(path);
 
-    const size_t width = msgwin_get_width();
-    if (!first && (width >= 7) && ((pos + buf_len(path)) >= (width - 7)))
-    {
-      break;
-    }
-
     if (!first)
       pos += strlen(strncat(mailboxlist + pos, ", ", sizeof(mailboxlist) - 1 - pos));
 
-    /* Prepend an asterisk to mailboxes not already notified */
     if (!np->mailbox->notified)
     {
       np->mailbox->notified = true;
@@ -290,11 +282,6 @@ bool mutt_mailbox_list(void)
     first = 0;
   }
   neomutt_mailboxlist_clear(&ml);
-
-  if (!first && np)
-  {
-    strncat(mailboxlist + pos, ", ...", sizeof(mailboxlist) - 1 - pos);
-  }
 
   buf_pool_release(&path);
 

--- a/muttlib.c
+++ b/muttlib.c
@@ -1413,7 +1413,7 @@ int mutt_save_confirm(const char *s, struct stat *st)
     }
   }
 
-  msgwin_clear_text();
+  msgwin_clear_text(NULL);
   return rc;
 }
 

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -469,7 +469,7 @@ int dlg_pager(struct PagerView *pview)
       priv->pager_redraw = false;
       mutt_resize_screen();
       clearok(stdscr, true); /* force complete redraw */
-      msgwin_clear_text();
+      msgwin_clear_text(NULL);
 
       pager_queue_redraw(priv, PAGER_REDRAW_FLOW);
       if (pview->flags & MUTT_PAGER_RETWINCH)

--- a/question/question.c
+++ b/question/question.c
@@ -38,9 +38,6 @@
 #include "color/lib.h"
 #include "keymap.h"
 #include "opcodes.h"
-#ifdef HAVE_SYS_PARAM_H
-#include <sys/param.h>
-#endif
 
 /**
  * mw_multi_choice - Offer the user a multiple choice question - @ingroup gui_mw
@@ -58,14 +55,11 @@
  */
 int mw_multi_choice(const char *prompt, const char *letters)
 {
-  struct MuttWindow *win = msgwin_get_window();
+  struct MuttWindow *win = msgwin_new(true);
   if (!win)
     return -1;
 
-  struct KeyEvent event = { 0, OP_NULL };
-  int choice;
-  bool redraw = true;
-  int prompt_lines = 1;
+  int choice = 0;
 
   const struct AttrColor *ac_opts = NULL;
   if (simple_color_is_set(MT_COLOR_OPTIONS))
@@ -77,111 +71,84 @@ int mw_multi_choice(const char *prompt, const char *letters)
     ac_opts = merged_color_overlay(ac_base, ac_opts);
   }
 
+  const struct AttrColor *ac_normal = simple_color_get(MT_COLOR_NORMAL);
+  const struct AttrColor *ac_prompt = simple_color_get(MT_COLOR_PROMPT);
+
+  if (ac_opts)
+  {
+    char *cur = NULL;
+
+    while ((cur = strchr(prompt, '(')))
+    {
+      // write the part between prompt and cur using MT_COLOR_PROMPT
+      msgwin_add_text_n(win, prompt, cur - prompt, ac_prompt);
+
+      if (isalnum(cur[1]) && (cur[2] == ')'))
+      {
+        // we have a single letter within parentheses
+        // MT_COLOR_OPTIONS
+        msgwin_add_text_n(win, cur + 1, 1, ac_opts);
+        prompt = cur + 3;
+      }
+      else
+      {
+        // we have a parenthesis followed by something else
+        msgwin_add_text_n(win, cur, 1, ac_prompt);
+        prompt = cur + 1;
+      }
+    }
+  }
+
+  msgwin_add_text(win, prompt, ac_prompt);
+  msgwin_add_text(win, " ", ac_normal);
+
+  msgcont_push_window(win);
+
   struct MuttWindow *old_focus = window_set_focus(win);
+  window_redraw(win);
+
+  // ---------------------------------------------------------------------------
+  // Event Loop
+  struct KeyEvent event = { 0, OP_NULL };
   enum MuttCursorState old_cursor = mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
-  window_redraw(NULL);
   while (true)
   {
-    if (redraw)
-    {
-      redraw = false;
-      if (win->state.cols)
-      {
-        int width = mutt_strwidth(prompt) + 2; // + '?' + space
-        /* If we're going to colour the options,
-         * make an assumption about the modified prompt size. */
-        if (ac_opts)
-          width -= 2 * mutt_str_len(letters);
-
-        prompt_lines = (width + win->state.cols - 1) / win->state.cols;
-        prompt_lines = MAX(1, MIN(3, prompt_lines));
-      }
-      if (prompt_lines != win->state.rows)
-      {
-        msgwin_set_height(prompt_lines);
-        window_redraw(NULL);
-      }
-
-      mutt_window_move(win, 0, 0);
-
-      if (ac_opts)
-      {
-        char *cur = NULL;
-
-        while ((cur = strchr(prompt, '(')))
-        {
-          // write the part between prompt and cur using MT_COLOR_PROMPT
-          mutt_curses_set_normal_backed_color_by_id(MT_COLOR_PROMPT);
-          mutt_window_addnstr(win, prompt, cur - prompt);
-
-          if (isalnum(cur[1]) && (cur[2] == ')'))
-          {
-            // we have a single letter within parentheses
-            mutt_curses_set_color(ac_opts);
-            mutt_window_addch(win, cur[1]);
-            prompt = cur + 3;
-          }
-          else
-          {
-            // we have a parenthesis followed by something else
-            mutt_window_addch(win, cur[0]);
-            prompt = cur + 1;
-          }
-        }
-      }
-
-      mutt_curses_set_normal_backed_color_by_id(MT_COLOR_PROMPT);
-      mutt_window_addstr(win, prompt);
-      mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
-
-      mutt_window_addch(win, ' ');
-      mutt_window_clrtoeol(win);
-    }
-
-    mutt_refresh();
     event = mutt_getch(GETCH_NO_FLAGS);
+    mutt_debug(LL_DEBUG1, "mw_multi_choice: EVENT(%d,%d)\n", event.ch, event.op);
+
+    if (event.op == OP_REPAINT)
+      window_redraw(NULL);
+
     if ((event.op == OP_TIMEOUT) || (event.op == OP_REPAINT))
-    {
-      mutt_refresh();
       continue;
-    }
+
     if ((event.op == OP_ABORT) || key_is_return(event.ch))
     {
       choice = -1;
       break;
     }
-    else
+
+    char *p = strchr(letters, event.ch);
+    if (p)
     {
-      char *p = strchr(letters, event.ch);
-      if (p)
-      {
-        choice = p - letters + 1;
-        break;
-      }
-      else if ((event.ch <= '9') && (event.ch > '0'))
-      {
-        choice = event.ch - '0';
-        if (choice <= mutt_str_len(letters))
-          break;
-      }
+      choice = p - letters + 1;
+      break;
     }
-    mutt_beep(false);
-  }
 
-  if (win->state.rows == 1)
-  {
-    mutt_window_clearline(win, 0);
+    if ((event.ch > '0') && (event.ch <= '9'))
+    {
+      choice = event.ch - '0';
+      if (choice <= mutt_str_len(letters))
+        break;
+    }
   }
-  else
-  {
-    msgwin_set_height(1);
-    window_redraw(NULL);
-  }
+  // ---------------------------------------------------------------------------
 
-  mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
-  window_set_focus(old_focus);
   mutt_curses_set_cursor(old_cursor);
-  mutt_refresh();
+  window_set_focus(old_focus);
+  win = msgcont_pop_window();
+  mutt_window_free(&win);
+
   return choice;
 }
 

--- a/question/question.c
+++ b/question/question.c
@@ -398,7 +398,7 @@ enum QuadOption query_quadoption(enum QuadOption opt, const char *prompt)
 
     default:
       opt = query_yesorno(prompt, (opt == MUTT_ASKYES) ? MUTT_YES : MUTT_NO);
-      msgwin_clear_text();
+      msgwin_clear_text(NULL);
       return opt;
   }
 

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -234,25 +234,8 @@ void attach_bounce_message(struct Mailbox *m, FILE *fp, struct AttachCtx *actx,
   buf_alloc(buf, 8192);
   mutt_addrlist_write(&al, buf, true);
 
-#define EXTRA_SPACE (15 + 7 + 2)
-  /* See commands.c.  */
   buf_printf(prompt, ngettext("Bounce message to %s?", "Bounce messages to %s?", num_msg),
              buf_string(buf));
-
-  const size_t width = msgwin_get_width();
-  if (mutt_strwidth(buf_string(prompt)) > (width - EXTRA_SPACE))
-  {
-    struct Buffer *scratch = buf_pool_get();
-    mutt_simple_format(scratch->data, scratch->dsize - 4, 0, width - EXTRA_SPACE,
-                       JUSTIFY_LEFT, 0, prompt->data, prompt->dsize, false);
-    buf_addstr(scratch, "...?");
-    buf_copy(prompt, scratch);
-    buf_pool_release(&scratch);
-  }
-  else
-  {
-    buf_addstr(prompt, "?");
-  }
 
   const enum QuadOption c_bounce = cs_subset_quad(NeoMutt->sub, "bounce");
   if (query_quadoption(c_bounce, buf_string(prompt)) != MUTT_YES)

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -257,12 +257,12 @@ void attach_bounce_message(struct Mailbox *m, FILE *fp, struct AttachCtx *actx,
   const enum QuadOption c_bounce = cs_subset_quad(NeoMutt->sub, "bounce");
   if (query_quadoption(c_bounce, buf_string(prompt)) != MUTT_YES)
   {
-    msgwin_clear_text();
+    msgwin_clear_text(NULL);
     mutt_message(ngettext("Message not bounced", "Messages not bounced", num_msg));
     goto done;
   }
 
-  msgwin_clear_text();
+  msgwin_clear_text(NULL);
 
   int rc = 0;
   if (cur)


### PR DESCRIPTION
## Overview

The Message Window is a one-line area at the bottom of the screen.
It's used by a large number of places in the code for messages and text entry.

Historically, each of these places was responsible for their own painting and resizing.

NeoMutt's first step to improvement was to create a dedicated Message Window.
The text and colour could be set, typically by `mutt_message()`, and friends.
The Window had a `repaint()` function which allowed it to redraw itself.

Other users, e.g. `mw_get_field()` or `mw_yesorno()` were still responsible for painting themselves.
Some magic was used to temporarily disable the Message Window's `repaint()` function.

The next step was to add a Message Container.
This Window was a wrapper around a **stack** of Windows.
As a new Window was added, the others would be made invisible, e.g.

<img src="https://raw.githubusercontent.com/neomutt/gfx/main/screenshots/window/msgcont1.svg">

<img src="https://raw.githubusercontent.com/neomutt/gfx/main/screenshots/window/msgcont2.svg">

<img src="https://raw.githubusercontent.com/neomutt/gfx/main/screenshots/window/msgcont3.svg">

The final step, this PR, centralises the painting for all the simple cases.
This simplifies lots of callers.

## Changes

**Note:** There are some minor behavioural changes, marked :exclamation:

- f3c4aa207 force initial window size
  Recheck the window size early on to prevent NeoMutt painting at 80x24 only to resize immediately after

- e4f3b9380 msgwin: indefinite article
  Eliminate global MessageWindow, in preparation for a generic message window.
  We will transition from "the" message window to "a" message window.

- 2a9b54b18 msgwin: features
  Create a general Message Window that can handle text, colours, wrapping, repainting

- c72f788cb msgcont: redraw
  Fix redrawing of the Message Container

- fdecaa498 msgwin: yes/no/quad
  Upgrade quad- and yes/no questions and to use the new Message Window

- 34d3dc7ae msgwin: multi
  Upgrade multi-choice questions to use the new Message Window

- 39afafc89 msgwin: upgrade mw_change_flag()
  Upgrade mw_change_flag() to use the new Message Window

- 98d6473ac msgwin: `<what-key>`
  Upgrade `<what-key>` to use the new Message Window

- 7ad9cf591 `<what-key>` 2-line
  :exclamation: Change `<what-key>` to use two lines
  Keep the prompt on-screen with the instructions of how to exit

- 446e420ac msgwin: bounce
  :exclamation: Prevent `<bounce-message>` from abbreviating questions
  Using the new Message Window, the questions can use multiple lines.

- d861164d4 msgwin: new mail in...
  :exclamation: Change the 'new mail in' message to use the new Message Window.
  Rather than trickle-feeding information to the user, use multiple lines.

- ddb5bc953 msgwin: curses logging
  :exclamation: Change the main message display to use the new Message Window.
  `mutt_message()` and friends can now use multiple lines.

- 816adce17 msgwin: enter fname
  Upgrade `mw_enter_fname()` to use the new Message Window

- a56572eb1 refactor mw_get_field()
  Refactor `mw_get_field()` loop to create `recalc()` / `repaint()` functions

- a65b3b81a tidy old functions
  Remove some now-unused functions

## New Message Window

The new Message Window displays text to the user.

The callers can either set the text with a single colour,
or add blocks of text, specifying a colour for each.

The Window is then responsible for painting and colouring the text.
It also handles resizing, wrapping the text up to a maximum of 3 rows (`MSGWIN_MAX_ROWS`).

When text is added, it is measured to allow efficient wrapping.
For each character, the Window records three attributes:
- Number of bytes
- Number of screen cells required to display it
- Colour

In the `recalc()` stage, the Window divides the characters into chunks.
If a character is a different colour to the previous one, or it overflows onto a new line, then it gets a new chunk.