### PR TITLE
Add Help to Quad/Yes/No Questions

### DIFF
--- a/attach/functions.c
+++ b/attach/functions.c
@@ -571,11 +571,11 @@ static int op_followup(struct AttachPrivateData *priv, int op)
   if (check_attach())
     return FR_ERROR;
 
-  const enum QuadOption c_followup_to_poster = cs_subset_quad(NeoMutt->sub, "followup_to_poster");
   struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
   if (!cur_att->body->email->env->followup_to ||
       !mutt_istr_equal(cur_att->body->email->env->followup_to, "poster") ||
-      (query_quadoption(c_followup_to_poster, _("Reply by mail as poster prefers?")) != MUTT_YES))
+      (query_quadoption(_("Reply by mail as poster prefers?"), NeoMutt->sub,
+                        "followup_to_poster") != MUTT_YES))
   {
     mutt_attach_reply(cur_att->fp, priv->mailbox, priv->actx->email, priv->actx,
                       priv->menu->tag_prefix ? NULL : cur_att->body, SEND_NEWS | SEND_REPLY);

--- a/attach/recvattach.c
+++ b/attach/recvattach.c
@@ -897,8 +897,7 @@ void mutt_print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag, stru
            tag ? ngettext("Print tagged attachment?", "Print %d tagged attachments?", tagmsgcount) :
                  _("Print attachment?"),
            tagmsgcount);
-  const enum QuadOption c_print = cs_subset_quad(NeoMutt->sub, "print");
-  if (query_quadoption(c_print, prompt) != MUTT_YES)
+  if (query_quadoption(prompt, NeoMutt->sub, "print") != MUTT_YES)
     return;
 
   const bool c_attach_split = cs_subset_bool(NeoMutt->sub, "attach_split");

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1806,8 +1806,8 @@ static int op_compose_send_message(struct ComposeSharedData *shared, int op)
 
   if (!shared->fcc_set && !buf_is_empty(shared->fcc))
   {
-    const enum QuadOption c_copy = cs_subset_quad(shared->sub, "copy");
-    enum QuadOption ans = query_quadoption(c_copy, _("Save a copy of this message?"));
+    enum QuadOption ans = query_quadoption(_("Save a copy of this message?"),
+                                           shared->sub, "copy");
     if (ans == MUTT_ABORT)
       return FR_NO_ACTION;
     else if (ans == MUTT_NO)
@@ -1876,8 +1876,8 @@ static int op_display_headers(struct ComposeSharedData *shared, int op)
  */
 static int op_exit(struct ComposeSharedData *shared, int op)
 {
-  const enum QuadOption c_postpone = cs_subset_quad(shared->sub, "postpone");
-  enum QuadOption ans = query_quadoption(c_postpone, _("Save (postpone) draft message?"));
+  enum QuadOption ans = query_quadoption(_("Save (postpone) draft message?"),
+                                         shared->sub, "postpone");
   if (ans == MUTT_NO)
   {
     for (int i = 0; i < shared->adata->actx->idxlen; i++)

--- a/external.c
+++ b/external.c
@@ -145,8 +145,7 @@ void index_bounce_message(struct Mailbox *m, struct EmailArray *ea)
   buf_printf(prompt, ngettext("Bounce message to %s?", "Bounce messages to %s?", msg_count),
              buf_string(buf));
 
-  const enum QuadOption c_bounce = cs_subset_quad(NeoMutt->sub, "bounce");
-  if (query_quadoption(c_bounce, buf_string(prompt)) != MUTT_YES)
+  if (query_quadoption(buf_string(prompt), NeoMutt->sub, "bounce") != MUTT_YES)
   {
     msgwin_clear_text(NULL);
     mutt_message(ngettext("Message not bounced", "Messages not bounced", msg_count));
@@ -453,7 +452,7 @@ void mutt_print_message(struct Mailbox *m, struct EmailArray *ea)
 
   int msg_count = ARRAY_SIZE(ea);
   const char *msg = ngettext("Print message?", "Print tagged messages?", msg_count);
-  if (query_quadoption(c_print, msg) != MUTT_YES)
+  if (query_quadoption(msg, NeoMutt->sub, "print") != MUTT_YES)
   {
     return;
   }

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -757,12 +757,12 @@ int imap_open_connection(struct ImapAccountData *adata)
     {
       enum QuadOption ans;
 
-      const enum QuadOption c_ssl_starttls = cs_subset_quad(NeoMutt->sub, "ssl_starttls");
       if (c_ssl_force_tls)
       {
         ans = MUTT_YES;
       }
-      else if ((ans = query_quadoption(c_ssl_starttls, _("Secure connection with TLS?"))) == MUTT_ABORT)
+      else if ((ans = query_quadoption(_("Secure connection with TLS?"),
+                                       NeoMutt->sub, "ssl_starttls")) == MUTT_ABORT)
       {
         goto bail;
       }
@@ -1420,7 +1420,8 @@ int imap_fast_trash(struct Mailbox *m, const char *dest)
       mutt_debug(LL_DEBUG3, "server suggests TRYCREATE\n");
       snprintf(prompt, sizeof(prompt), _("Create %s?"), dest_mdata->name);
       const bool c_confirm_create = cs_subset_bool(NeoMutt->sub, "confirm_create");
-      if (c_confirm_create && (query_yesorno(prompt, MUTT_YES) != MUTT_YES))
+      if (c_confirm_create &&
+          (query_yesorno_help(prompt, MUTT_YES, NeoMutt->sub, "confirm_create") != MUTT_YES))
       {
         mutt_clear_error();
         goto out;
@@ -2076,7 +2077,8 @@ static bool imap_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
   char buf[PATH_MAX + 64];
   snprintf(buf, sizeof(buf), _("Create %s?"), mdata->name);
   const bool c_confirm_create = cs_subset_bool(NeoMutt->sub, "confirm_create");
-  if (c_confirm_create && (query_yesorno(buf, MUTT_YES) != MUTT_YES))
+  if (c_confirm_create &&
+      (query_yesorno_help(buf, MUTT_YES, NeoMutt->sub, "confirm_create") != MUTT_YES))
     return false;
 
   if (imap_create_mailbox(adata, mdata->name) < 0)

--- a/imap/message.c
+++ b/imap/message.c
@@ -1799,7 +1799,8 @@ int imap_copy_messages(struct Mailbox *m, struct EmailArray *ea,
       mutt_debug(LL_DEBUG3, "server suggests TRYCREATE\n");
       snprintf(prompt, sizeof(prompt), _("Create %s?"), mbox);
       const bool c_confirm_create = cs_subset_bool(NeoMutt->sub, "confirm_create");
-      if (c_confirm_create && (query_yesorno(prompt, MUTT_YES) != MUTT_YES))
+      if (c_confirm_create &&
+          (query_yesorno_help(prompt, MUTT_YES, NeoMutt->sub, "confirm_create") != MUTT_YES))
       {
         mutt_clear_error();
         goto out;

--- a/index/functions.c
+++ b/index/functions.c
@@ -532,8 +532,7 @@ static int op_exit(struct IndexSharedData *shared, struct IndexPrivateData *priv
   if (priv->attach_msg)
     return FR_DONE;
 
-  const enum QuadOption c_quit = cs_subset_quad(shared->sub, "quit");
-  if (query_quadoption(c_quit, _("Exit NeoMutt without saving?")) == MUTT_YES)
+  if (query_quadoption(_("Exit NeoMutt without saving?"), shared->sub, "quit") == MUTT_YES)
   {
     if (shared->mailbox_view)
     {
@@ -1876,8 +1875,7 @@ static int op_quit(struct IndexSharedData *shared, struct IndexPrivateData *priv
   if (priv->attach_msg)
     return FR_DONE;
 
-  const enum QuadOption c_quit = cs_subset_quad(shared->sub, "quit");
-  if (query_quadoption(c_quit, _("Quit NeoMutt?")) == MUTT_YES)
+  if (query_quadoption(_("Quit NeoMutt?"), shared->sub, "quit") == MUTT_YES)
   {
     priv->oldcount = shared->mailbox ? shared->mailbox->msg_count : 0;
 
@@ -2618,16 +2616,15 @@ static int op_post(struct IndexSharedData *shared, struct IndexPrivateData *priv
   if (!shared->email)
     return FR_NO_ACTION;
 
-  const enum QuadOption c_followup_to_poster = cs_subset_quad(shared->sub, "followup_to_poster");
   if ((op != OP_FOLLOWUP) || !shared->email->env->followup_to ||
       !mutt_istr_equal(shared->email->env->followup_to, "poster") ||
-      (query_quadoption(c_followup_to_poster, _("Reply by mail as poster prefers?")) != MUTT_YES))
+      (query_quadoption(_("Reply by mail as poster prefers?"), shared->sub,
+                        "followup_to_poster") != MUTT_YES))
   {
-    const enum QuadOption c_post_moderated = cs_subset_quad(shared->sub, "post_moderated");
     if (shared->mailbox && (shared->mailbox->type == MUTT_NNTP) &&
         !((struct NntpMboxData *) shared->mailbox->mdata)->allowed &&
-        (query_quadoption(c_post_moderated, _("Posting to this group not allowed, may be moderated. Continue?")) !=
-         MUTT_YES))
+        (query_quadoption(_("Posting to this group not allowed, may be moderated. Continue?"),
+                          shared->sub, "post_moderated") != MUTT_YES))
     {
       return FR_ERROR;
     }

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -1056,3 +1056,24 @@ int mutt_str_asprintf(char **strp, const char *fmt, ...)
   /* not reached */
 }
 #endif /* HAVE_ASPRINTF */
+
+/**
+ * mutt_str_hyphenate - Hyphenate a snake-case string
+ * @param buf    Buffer for the result
+ * @param buflen Length of the buffer
+ * @param str    String to convert
+ *
+ * Replace underscores (`_`) with hyphens -`).
+ */
+void mutt_str_hyphenate(char *buf, size_t buflen, const char *str)
+{
+  if (!buf || (buflen == 0) || !str)
+    return;
+
+  mutt_str_copy(buf, str, buflen);
+  for (; *buf != '\0'; buf++)
+  {
+    if (*buf == '_')
+      *buf = '-';
+  }
+}

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -60,6 +60,7 @@ int         mutt_str_coll(const char *a, const char *b);
 void        mutt_str_dequote_comment(char *str);
 const char *mutt_str_find_word(const char *src);
 const char *mutt_str_getenv(const char *name);
+void        mutt_str_hyphenate(char *buf, size_t buflen, const char *str);
 bool        mutt_str_inline_replace(char *buf, size_t buflen, size_t xlen, const char *rstr);
 bool        mutt_str_is_ascii(const char *str, size_t len);
 size_t      mutt_str_len(const char *a);

--- a/muttlib.c
+++ b/muttlib.c
@@ -1345,7 +1345,8 @@ int mutt_save_confirm(const char *s, struct stat *st)
     {
       struct Buffer *tmp = buf_pool_get();
       buf_printf(tmp, _("Append messages to %s?"), s);
-      enum QuadOption ans = query_yesorno(buf_string(tmp), MUTT_YES);
+      enum QuadOption ans = query_yesorno_help(buf_string(tmp), MUTT_YES,
+                                               NeoMutt->sub, "confirm_append");
       if (ans == MUTT_NO)
         rc = 1;
       else if (ans == MUTT_ABORT)
@@ -1383,7 +1384,8 @@ int mutt_save_confirm(const char *s, struct stat *st)
       {
         struct Buffer *tmp = buf_pool_get();
         buf_printf(tmp, _("Create %s?"), s);
-        enum QuadOption ans = query_yesorno(buf_string(tmp), MUTT_YES);
+        enum QuadOption ans = query_yesorno_help(buf_string(tmp), MUTT_YES,
+                                                 NeoMutt->sub, "confirm_create");
         if (ans == MUTT_NO)
           rc = 1;
         else if (ans == MUTT_ABORT)

--- a/mx.c
+++ b/mx.c
@@ -641,9 +641,8 @@ enum MxStatus mx_mbox_close(struct Mailbox *m)
 
     if (mdata && mdata->adata && mdata->group)
     {
-      const enum QuadOption c_catchup_newsgroup = cs_subset_quad(NeoMutt->sub, "catchup_newsgroup");
-      enum QuadOption ans = query_quadoption(c_catchup_newsgroup,
-                                             _("Mark all articles read?"));
+      enum QuadOption ans = query_quadoption(_("Mark all articles read?"),
+                                             NeoMutt->sub, "catchup_newsgroup");
       if (ans == MUTT_ABORT)
         goto cleanup;
       if (ans == MUTT_YES)
@@ -696,7 +695,7 @@ enum MxStatus mx_mbox_close(struct Mailbox *m)
                             moved, the second argument is the target mailbox. */
                  ngettext("Move %d read message to %s?", "Move %d read messages to %s?", read_msgs),
                  read_msgs, buf_string(mbox));
-      move_messages = query_quadoption(c_move, buf_string(buf));
+      move_messages = query_quadoption(buf_string(buf), NeoMutt->sub, "move");
       if (move_messages == MUTT_ABORT)
         goto cleanup;
     }
@@ -709,8 +708,7 @@ enum MxStatus mx_mbox_close(struct Mailbox *m)
   {
     buf_printf(buf, ngettext("Purge %d deleted message?", "Purge %d deleted messages?", m->msg_deleted),
                m->msg_deleted);
-    const enum QuadOption c_delete = cs_subset_quad(NeoMutt->sub, "delete");
-    purge = query_quadoption(c_delete, buf_string(buf));
+    purge = query_quadoption(buf_string(buf), NeoMutt->sub, "delete");
     if (purge == MUTT_ABORT)
       goto cleanup;
   }
@@ -968,8 +966,7 @@ enum MxStatus mx_mbox_sync(struct Mailbox *m)
     snprintf(buf, sizeof(buf),
              ngettext("Purge %d deleted message?", "Purge %d deleted messages?", m->msg_deleted),
              m->msg_deleted);
-    const enum QuadOption c_delete = cs_subset_quad(NeoMutt->sub, "delete");
-    purge = query_quadoption(c_delete, buf);
+    purge = query_quadoption(buf, NeoMutt->sub, "delete");
     if (purge == MUTT_ABORT)
       return MX_STATUS_ERROR;
     if (purge == MUTT_NO)

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -184,11 +184,10 @@ int mutt_protect(struct Email *e, char *keylist, bool postpone)
   if (((WithCrypto & APPLICATION_PGP) != 0) && !(security & SEC_AUTOCRYPT) &&
       ((security & PGP_INLINE) == PGP_INLINE))
   {
-    const enum QuadOption c_pgp_mime_auto = cs_subset_quad(NeoMutt->sub, "pgp_mime_auto");
     if ((e->body->type != TYPE_TEXT) || !mutt_istr_equal(e->body->subtype, "plain"))
     {
-      if (query_quadoption(c_pgp_mime_auto, _("Inline PGP can't be used with attachments.  Revert to PGP/MIME?")) !=
-          MUTT_YES)
+      if (query_quadoption(_("Inline PGP can't be used with attachments.  Revert to PGP/MIME?"),
+                           NeoMutt->sub, "pgp_mime_auto") != MUTT_YES)
       {
         mutt_error(_("Mail not sent: inline PGP can't be used with attachments"));
         return -1;
@@ -196,8 +195,8 @@ int mutt_protect(struct Email *e, char *keylist, bool postpone)
     }
     else if (mutt_istr_equal("flowed", mutt_param_get(&e->body->parameter, "format")))
     {
-      if ((query_quadoption(c_pgp_mime_auto, _("Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"))) !=
-          MUTT_YES)
+      if ((query_quadoption(_("Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"),
+                            NeoMutt->sub, "pgp_mime_auto")) != MUTT_YES)
       {
         mutt_error(_("Mail not sent: inline PGP can't be used with format=flowed"));
         return -1;
@@ -219,8 +218,8 @@ int mutt_protect(struct Email *e, char *keylist, bool postpone)
       }
 
       /* otherwise inline won't work...ask for revert */
-      if (query_quadoption(c_pgp_mime_auto,
-                           _("Message can't be sent inline.  Revert to using PGP/MIME?")) != MUTT_YES)
+      if (query_quadoption(_("Message can't be sent inline.  Revert to using PGP/MIME?"),
+                           NeoMutt->sub, "pgp_mime_auto") != MUTT_YES)
       {
         mutt_error(_("Mail not sent"));
         return -1;

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3453,7 +3453,7 @@ static char *find_keys(const struct AddressList *addrlist, unsigned int app, boo
         {
           snprintf(buf, sizeof(buf), _("Use keyID = \"%s\" for %s?"), keyid,
                    buf_string(p->mailbox));
-          ans = query_yesorno(buf, MUTT_YES);
+          ans = query_yesorno_help(buf, MUTT_YES, NeoMutt->sub, "crypt_confirm_hook");
         }
         if (ans == MUTT_YES)
         {

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1500,7 +1500,7 @@ char *pgp_class_find_keys(const struct AddressList *addrlist, bool oppenc_mode)
         {
           snprintf(buf, sizeof(buf), _("Use keyID = \"%s\" for %s?"), keyid,
                    buf_string(p->mailbox));
-          ans = query_yesorno(buf, MUTT_YES);
+          ans = query_yesorno_help(buf, MUTT_YES, NeoMutt->sub, "crypt_confirm_hook");
         }
         if (ans == MUTT_YES)
         {

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1809,10 +1809,9 @@ int nntp_open_connection(struct NntpAccountData *adata)
   {
     if (adata->use_tls == 0)
     {
-      const enum QuadOption c_ssl_starttls = cs_subset_quad(NeoMutt->sub, "ssl_starttls");
       adata->use_tls = c_ssl_force_tls ||
-                               (query_quadoption(c_ssl_starttls,
-                                                 _("Secure connection with TLS?")) == MUTT_YES) ?
+                               (query_quadoption(_("Secure connection with TLS?"),
+                                                 NeoMutt->sub, "ssl_starttls") == MUTT_YES) ?
                            2 :
                            1;
     }

--- a/pager/message.c
+++ b/pager/message.c
@@ -203,8 +203,7 @@ static int email_to_file(struct Message *msg, struct Buffer *tempfile,
     {
       /* find out whether or not the verify signature */
       /* L10N: Used for the $crypt_verify_sig prompt */
-      const enum QuadOption c_crypt_verify_sig = cs_subset_quad(NeoMutt->sub, "crypt_verify_sig");
-      if (query_quadoption(c_crypt_verify_sig, _("Verify signature?")) == MUTT_YES)
+      if (query_quadoption(_("Verify signature?"), NeoMutt->sub, "crypt_verify_sig") == MUTT_YES)
       {
         *cmflags |= MUTT_CM_VERIFY;
       }

--- a/pop/lib.c
+++ b/pop/lib.c
@@ -336,8 +336,8 @@ int pop_open_connection(struct PopAccountData *adata)
       adata->use_stls = 2;
     if (adata->use_stls == 0)
     {
-      const enum QuadOption c_ssl_starttls = cs_subset_quad(NeoMutt->sub, "ssl_starttls");
-      enum QuadOption ans = query_quadoption(c_ssl_starttls, _("Secure connection with TLS?"));
+      enum QuadOption ans = query_quadoption(_("Secure connection with TLS?"),
+                                             NeoMutt->sub, "ssl_starttls");
       if (ans == MUTT_ABORT)
         return -2;
       adata->use_stls = 1;
@@ -642,8 +642,8 @@ int pop_reconnect(struct Mailbox *m)
     if (rc < -1)
       return -1;
 
-    const enum QuadOption c_pop_reconnect = cs_subset_quad(NeoMutt->sub, "pop_reconnect");
-    if (query_quadoption(c_pop_reconnect, _("Connection lost. Reconnect to POP server?")) != MUTT_YES)
+    if (query_quadoption(_("Connection lost. Reconnect to POP server?"),
+                         NeoMutt->sub, "pop_reconnect") != MUTT_YES)
     {
       return -1;
     }

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -596,8 +596,8 @@ void pop_fetch_mail(void)
   bool old_append = m_spool->append;
   m_spool->append = true;
 
-  const enum QuadOption c_pop_delete = cs_subset_quad(NeoMutt->sub, "pop_delete");
-  enum QuadOption delanswer = query_quadoption(c_pop_delete, _("Delete messages from server?"));
+  enum QuadOption delanswer = query_quadoption(_("Delete messages from server?"),
+                                               NeoMutt->sub, "pop_delete");
 
   snprintf(msgbuf, sizeof(msgbuf),
            ngettext("Reading new messages (%d byte)...",

--- a/question/lib.h
+++ b/question/lib.h
@@ -38,6 +38,7 @@
 
 int             mw_multi_choice   (const char *prompt, const char *letters);
 enum QuadOption query_yesorno     (const char *prompt, enum QuadOption def);
-enum QuadOption query_quadoption  (enum QuadOption opt, const char *prompt);
+enum QuadOption query_yesorno_help(const char *prompt, enum QuadOption def, struct ConfigSubset *sub, const char *name);
+enum QuadOption query_quadoption  (const char *prompt, struct ConfigSubset *sub, const char *name);
 
 #endif /* MUTT_QUESTION_LIB_H */

--- a/question/question.c
+++ b/question/question.c
@@ -27,9 +27,12 @@
  */
 
 #include "config.h"
+#include <assert.h>
 #include <ctype.h>
 #include <langinfo.h>
+#include <limits.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include "mutt/lib.h"
@@ -46,12 +49,14 @@
  * @retval >=1 1-based user selection
  * @retval  -1 Selection aborted
  *
- * This function uses the message window.
+ * This function uses a message window.
  *
  * Ask the user a multiple-choice question, using shortcut letters, e.g.
  * `PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear?`
  *
- * The shortcuts can be coloured using `color options`.
+ * Colours:
+ * - Question:  `color prompt`
+ * - Shortcuts: `color options`
  */
 int mw_multi_choice(const char *prompt, const char *letters)
 {
@@ -85,8 +90,7 @@ int mw_multi_choice(const char *prompt, const char *letters)
 
       if (isalnum(cur[1]) && (cur[2] == ')'))
       {
-        // we have a single letter within parentheses
-        // MT_COLOR_OPTIONS
+        // we have a single letter within parentheses - MT_COLOR_OPTIONS
         msgwin_add_text_n(win, cur + 1, 1, ac_opts);
         prompt = cur + 3;
       }
@@ -153,12 +157,13 @@ int mw_multi_choice(const char *prompt, const char *letters)
 }
 
 /**
- * query_yesorno - Ask the user a Yes/No question - @ingroup gui_mw
+ * mw_yesorno - Ask the user a Yes/No question offering help - @ingroup gui_mw
  * @param prompt Prompt
- * @param def    Default answer, #MUTT_YES or #MUTT_NO (see #QuadOption)
+ * @param def    Default answer, e.g. #MUTT_YES
+ * @param cdef   Config definition for help
  * @retval enum #QuadOption, Selection made
  *
- * This function uses the message window.
+ * This function uses a message window.
  *
  * Ask the user a yes/no question, using shortcut letters, e.g.
  * `Quit NeoMutt? ([yes]/no):`
@@ -166,8 +171,15 @@ int mw_multi_choice(const char *prompt, const char *letters)
  * This question can be answered using locale-dependent letters, e.g.
  * - English, `[+1yY]` or `[-0nN]`
  * - Serbian, `[+1yYdDДд]` or `[-0nNНн]`
+ *
+ * If a config variable (cdef) is given, then help is offered.
+ * The options change to: `([yes]/no/?)`
+ *
+ * Pressing '?' will show the name and one-line description of the config variable.
+ * Additionally, if `$help` is set, a link to the config's documentation is shown.
  */
-enum QuadOption query_yesorno(const char *prompt, enum QuadOption def)
+static enum QuadOption mw_yesorno(const char *prompt, enum QuadOption def,
+                                  struct ConfigDef *cdef)
 {
   struct MuttWindow *win = msgwin_new(true);
   if (!win)
@@ -231,9 +243,11 @@ enum QuadOption query_yesorno(const char *prompt, enum QuadOption def)
     }
   }
 
+  bool show_help_prompt = cdef;
+
   struct Buffer *text = buf_pool_get();
-  buf_printf(text, "%s ([%s]/%s): ", prompt, (def == MUTT_YES) ? yes : no,
-             (def == MUTT_YES) ? no : yes);
+  buf_printf(text, "%s ([%s]/%s%s): ", prompt, (def == MUTT_YES) ? yes : no,
+             (def == MUTT_YES) ? no : yes, show_help_prompt ? "/?" : "");
 
   msgwin_set_text(win, buf_string(text), MT_COLOR_PROMPT);
   msgcont_push_window(win);
@@ -274,6 +288,21 @@ enum QuadOption query_yesorno(const char *prompt, enum QuadOption def)
       def = MUTT_NO;
       break;
     }
+    if (show_help_prompt && (event.ch == '?'))
+    {
+      show_help_prompt = false;
+      msgwin_clear_text(win);
+      buf_printf(text, "$%s - %s\n", cdef->name, cdef->docs);
+      msgwin_add_text(win, buf_string(text), simple_color_get(MT_COLOR_NORMAL));
+
+      buf_printf(text, "%s ([%s]/%s): ", prompt, (def == MUTT_YES) ? yes : no,
+                 (def == MUTT_YES) ? no : yes);
+      msgwin_add_text(win, buf_string(text), simple_color_get(MT_COLOR_PROMPT));
+      msgwin_add_text(win, NULL, NULL);
+
+      window_redraw(NULL);
+      mutt_refresh();
+    }
 
     mutt_beep(false);
   }
@@ -293,15 +322,65 @@ enum QuadOption query_yesorno(const char *prompt, enum QuadOption def)
 }
 
 /**
- * query_quadoption - Ask the user a quad-question
- * @param opt    Option to use
- * @param prompt Message to show to the user
- * @retval #QuadOption Result, e.g. #MUTT_NO
+ * query_yesorno - Ask the user a Yes/No question
+ * @param prompt Prompt
+ * @param def Default answer, e.g. #MUTT_YES
+ * @retval enum #QuadOption, Selection made
+ *
+ * Wrapper for mw_yesorno().
  */
-enum QuadOption query_quadoption(enum QuadOption opt, const char *prompt)
+enum QuadOption query_yesorno(const char *prompt, enum QuadOption def)
 {
-  if ((opt == MUTT_YES) || (opt == MUTT_NO))
-    return opt;
+  return mw_yesorno(prompt, def, NULL);
+}
 
-  return query_yesorno(prompt, (opt == MUTT_ASKYES) ? MUTT_YES : MUTT_NO);
+/**
+ * query_yesorno_help - Ask the user a Yes/No question offering help
+ * @param prompt Prompt
+ * @param def    Default answer, e.g. #MUTT_YES
+ * @param sub    Config Subset
+ * @param name   Name of controlling config variable
+ * @retval enum #QuadOption, Selection made
+ *
+ * Wrapper for mw_yesorno().
+ */
+enum QuadOption query_yesorno_help(const char *prompt, enum QuadOption def,
+                                   struct ConfigSubset *sub, const char *name)
+{
+  struct HashElem *he = cs_subset_create_inheritance(sub, name);
+  struct HashElem *he_base = cs_get_base(he);
+  assert(DTYPE(he_base->type) == DT_BOOL);
+
+  intptr_t value = cs_subset_he_native_get(sub, he, NULL);
+  assert(value != INT_MIN);
+
+  struct ConfigDef *cdef = he_base->data;
+  return mw_yesorno(prompt, def, cdef);
+}
+
+/**
+ * query_quadoption - Ask the user a quad-question
+ * @param prompt Message to show to the user
+ * @param sub    Config Subset
+ * @param name   Name of controlling config variable
+ * @retval #QuadOption Result, e.g. #MUTT_NO
+ *
+ * If the config variable is set to 'yes' or 'no', the function returns immediately.
+ * Otherwise, the job is delegated to mw_yesorno().
+ */
+enum QuadOption query_quadoption(const char *prompt, struct ConfigSubset *sub, const char *name)
+{
+  struct HashElem *he = cs_subset_create_inheritance(sub, name);
+  struct HashElem *he_base = cs_get_base(he);
+  assert(DTYPE(he_base->type) == DT_QUAD);
+
+  intptr_t value = cs_subset_he_native_get(sub, he, NULL);
+  assert(value != INT_MIN);
+
+  if ((value == MUTT_YES) || (value == MUTT_NO))
+    return value;
+
+  struct ConfigDef *cdef = he_base->data;
+  enum QuadOption def = (value == MUTT_ASKYES) ? MUTT_YES : MUTT_NO;
+  return mw_yesorno(prompt, def, cdef);
 }

--- a/question/question.c
+++ b/question/question.c
@@ -37,6 +37,7 @@
 #include <string.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
+#include "core/lib.h"
 #include "gui/lib.h"
 #include "color/lib.h"
 #include "keymap.h"
@@ -293,6 +294,11 @@ static enum QuadOption mw_yesorno(const char *prompt, enum QuadOption def,
       show_help_prompt = false;
       msgwin_clear_text(win);
       buf_printf(text, "$%s - %s\n", cdef->name, cdef->docs);
+
+      char hyphen[128] = { 0 };
+      mutt_str_hyphenate(hyphen, sizeof(hyphen), cdef->name);
+      buf_add_printf(text, "https://neomutt.org/guide/reference#%s\n", hyphen);
+
       msgwin_add_text(win, buf_string(text), simple_color_get(MT_COLOR_NORMAL));
 
       buf_printf(text, "%s ([%s]/%s): ", prompt, (def == MUTT_YES) ? yes : no,

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -237,8 +237,7 @@ void attach_bounce_message(struct Mailbox *m, FILE *fp, struct AttachCtx *actx,
   buf_printf(prompt, ngettext("Bounce message to %s?", "Bounce messages to %s?", num_msg),
              buf_string(buf));
 
-  const enum QuadOption c_bounce = cs_subset_quad(NeoMutt->sub, "bounce");
-  if (query_quadoption(c_bounce, buf_string(prompt)) != MUTT_YES)
+  if (query_quadoption(buf_string(prompt), NeoMutt->sub, "bounce") != MUTT_YES)
   {
     msgwin_clear_text(NULL);
     mutt_message(ngettext("Message not bounced", "Messages not bounced", num_msg));
@@ -542,9 +541,8 @@ static void attach_forward_bodies(FILE *fp, struct Email *e, struct AttachCtx *a
    *
    * The next part is more interesting: either include the message bodies,
    * or attach them.  */
-  const enum QuadOption c_mime_forward = cs_subset_quad(NeoMutt->sub, "mime_forward");
   if ((!cur || mutt_can_decode(cur)) &&
-      ((ans = query_quadoption(c_mime_forward, _("Forward as attachments?"))) == MUTT_YES))
+      ((ans = query_quadoption(_("Forward as attachments?"), NeoMutt->sub, "mime_forward")) == MUTT_YES))
   {
     mime_fwd_all = true;
   }
@@ -557,9 +555,8 @@ static void attach_forward_bodies(FILE *fp, struct Email *e, struct AttachCtx *a
    * Is this intuitive?  */
   if (!mime_fwd_all && !cur && (nattach > 1) && !check_can_decode(actx, cur))
   {
-    const enum QuadOption c_mime_forward_rest = cs_subset_quad(NeoMutt->sub, "mime_forward_rest");
-    ans = query_quadoption(c_mime_forward_rest,
-                           _("Can't decode all tagged attachments.  MIME-forward the others?"));
+    ans = query_quadoption(_("Can't decode all tagged attachments.  MIME-forward the others?"),
+                           NeoMutt->sub, "mime_forward_rest");
     if (ans == MUTT_ABORT)
       goto bail;
     else if (ans == MUTT_NO)
@@ -690,8 +687,7 @@ static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx,
 
   tmpbody = buf_pool_get();
 
-  const enum QuadOption c_mime_forward = cs_subset_quad(NeoMutt->sub, "mime_forward");
-  ans = query_quadoption(c_mime_forward, _("Forward MIME encapsulated?"));
+  ans = query_quadoption(_("Forward MIME encapsulated?"), NeoMutt->sub, "mime_forward");
   if (ans == MUTT_NO)
   {
     /* no MIME encapsulation */
@@ -988,10 +984,8 @@ void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
 
   if ((nattach > 1) && !check_can_decode(actx, e_cur))
   {
-    const enum QuadOption c_mime_forward_rest = cs_subset_quad(NeoMutt->sub, "mime_forward_rest");
-    const enum QuadOption ans = query_quadoption(
-        c_mime_forward_rest,
-        _("Can't decode all tagged attachments.  MIME-encapsulate the others?"));
+    const enum QuadOption ans = query_quadoption(_("Can't decode all tagged attachments.  MIME-encapsulate the others?"),
+                                                 NeoMutt->sub, "mime_forward_rest");
     if (ans == MUTT_ABORT)
       return;
     if (ans == MUTT_YES)

--- a/send/smtp.c
+++ b/send/smtp.c
@@ -1043,14 +1043,14 @@ static int smtp_open(struct SmtpAccountData *adata, bool esmtp)
 
 #ifdef USE_SSL
   const bool c_ssl_force_tls = cs_subset_bool(adata->sub, "ssl_force_tls");
-  const enum QuadOption c_ssl_starttls = cs_subset_quad(adata->sub, "ssl_starttls");
   enum QuadOption ans = MUTT_NO;
   if (adata->conn->ssf != 0)
     ans = MUTT_NO;
   else if (c_ssl_force_tls)
     ans = MUTT_YES;
   else if ((adata->capabilities & SMTP_CAP_STARTTLS) &&
-           ((ans = query_quadoption(c_ssl_starttls, _("Secure connection with TLS?"))) == MUTT_ABORT))
+           ((ans = query_quadoption(_("Secure connection with TLS?"),
+                                    adata->sub, "ssl_starttls")) == MUTT_ABORT))
   {
     return -1;
   }

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -570,6 +570,7 @@ STRING_OBJS	= test/string/mutt_istrn_cmp.o \
 		  test/string/mutt_str_equal.o \
 		  test/string/mutt_str_find_word.o \
 		  test/string/mutt_str_getenv.o \
+		  test/string/mutt_str_hyphenate.o \
 		  test/string/mutt_str_inline_replace.o \
 		  test/string/mutt_str_is_ascii.o \
 		  test/string/mutt_str_is_email_wsp.o \

--- a/test/main.c
+++ b/test/main.c
@@ -591,6 +591,7 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_mutt_str_equal)                                       \
   NEOMUTT_TEST_ITEM(test_mutt_str_find_word)                                   \
   NEOMUTT_TEST_ITEM(test_mutt_str_getenv)                                      \
+  NEOMUTT_TEST_ITEM(test_mutt_str_hyphenate)                                   \
   NEOMUTT_TEST_ITEM(test_mutt_str_inline_replace)                              \
   NEOMUTT_TEST_ITEM(test_mutt_str_is_ascii)                                    \
   NEOMUTT_TEST_ITEM(test_mutt_str_is_email_wsp)                                \

--- a/test/string/mutt_str_hyphenate.c
+++ b/test/string/mutt_str_hyphenate.c
@@ -1,0 +1,81 @@
+/**
+ * @file
+ * Test code for mutt_str_hyphenate()
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <string.h>
+#include "mutt/lib.h"
+#include "test_common.h"
+
+struct HyphenTest
+{
+  const char *input;
+  const char *expected;
+};
+
+void test_mutt_str_hyphenate(void)
+{
+  // void mutt_str_hyphenate(char *buf, size_t buflen, const char *str);
+
+  static const struct HyphenTest tests[] = {
+    // clang-format off
+    { "",             ""             },
+    { "apple",        "apple"        },
+    { "apple_banana", "apple-banana" },
+    { "a_b_c",        "a-b-c"        },
+    { "_apple",       "-apple"       },
+    { "__apple",      "--apple"      },
+    { "apple_",       "apple-"       },
+    { "apple__",      "apple--"      },
+    { "_",            "-"            },
+    { "__",           "--"           },
+    { "___",          "---"          },
+    // clang-format on
+  };
+
+  {
+    char result[128] = { 0 };
+    mutt_str_hyphenate(NULL, sizeof(result), "apple");
+    mutt_str_hyphenate(result, 0, "apple");
+    mutt_str_hyphenate(result, sizeof(result), NULL);
+  }
+
+  {
+    // buffer too small
+    char result[10] = { 0 };
+    mutt_str_hyphenate(result, sizeof(result), "apple_banana_cherry");
+    TEST_CHECK_STR_EQ(result, "apple-ban");
+  }
+
+  {
+    char result[128];
+
+    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    {
+      memset(result, 0, sizeof(result));
+      TEST_CASE(tests[i].input);
+      mutt_str_hyphenate(result, sizeof(result), tests[i].input);
+      TEST_CHECK_STR_EQ(result, tests[i].expected);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds an upstream feature and extends it.

Many of the questions in NeoMutt are associated with config variables.
(All quad-options and many bools)

When the user is presented with a 

**Before**:
```
Append messages to work? ([yes]/no): 
```

**After**:  (note the '/?' )
```
Append messages to work? ([yes]/no/?): 
```

**Press <kbd>?</kbd>** to get:

```
$confirm_append - Confirm before appending emails to a mailbox
Append messages to work? ([yes]/no): 
```

**Additionally**, if `$help` is set (as beginners might):

```
$confirm_append - Confirm before appending emails to a mailbox
https://neomutt.org/guide/reference#confirm-append
Append messages to work? ([yes]/no): 
```

---

- dd32bddae query help y/n/?
  Add help to quad option and some y/n questions

- b4fd3a4a9 query help web link
  Display a web link if `$help` is set

---

For comparision, Mutt displays:

```
See $confirmappend for more information.
Append message(s) to work? ([yes]/no): 
```