### PR TITLE
refactor cursor positioning

### DIFF
--- a/enter/wdata.h
+++ b/enter/wdata.h
@@ -46,7 +46,6 @@ struct EnterWindowData
 {
   // Function parameters
   struct Buffer *buffer;          ///< struct Buffer for the result
-  int col;                        ///< Initial cursor positions
   CompletionFlags flags;          ///< Flags, see #CompletionFlags
   struct EnterState *state;       ///< Current state of text entry
   enum HistoryClass hclass;       ///< History to use, e.g. #HC_COMMAND
@@ -66,6 +65,9 @@ struct EnterWindowData
   bool done;                      ///< Is text-entry done?
 
   struct CompletionData *cd;      ///< Auto-completion state data
+
+  int row;                        ///< Cursor row
+  int col;                        ///< Cursor column
 };
 
 #endif /* MUTT_ENTER_WDATA_H */

--- a/flags.c
+++ b/flags.c
@@ -466,27 +466,20 @@ int mw_change_flag(struct Mailbox *m, struct EmailArray *ea, bool bf)
   snprintf(prompt, sizeof(prompt),
            "%s? (D/N/O/r/*/!): ", bf ? _("Set flag") : _("Clear flag"));
   msgwin_set_text(win, prompt, MT_COLOR_PROMPT);
-  // text, WA_RECALC
 
   msgcont_push_window(win);
-  // resized, text, WA_RECALC
-
   struct MuttWindow *old_focus = window_set_focus(win);
-
   window_redraw(win);
-  // recalc, repaint
 
   struct KeyEvent event = { 0, OP_NULL };
-  enum MuttCursorState old_cursor = mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
   do
   {
     window_redraw(NULL);
     event = mutt_getch(GETCH_NO_FLAGS);
   } while ((event.op == OP_TIMEOUT) || (event.op == OP_REPAINT));
-  mutt_curses_set_cursor(old_cursor);
 
-  window_set_focus(old_focus);
   win = msgcont_pop_window();
+  window_set_focus(old_focus);
   mutt_window_free(&win);
 
   if (event.op == OP_ABORT)

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -442,12 +442,9 @@ int mw_enter_fname(const char *prompt, struct Buffer *fname, bool mailbox,
   msgwin_set_text(win, text, MT_COLOR_NORMAL);
 
   msgcont_push_window(win);
-
   struct MuttWindow *old_focus = window_set_focus(win);
-
   window_redraw(win);
 
-  enum MuttCursorState old_cursor = mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
   struct KeyEvent event = { 0, OP_NULL };
   do
   {
@@ -456,11 +453,10 @@ int mw_enter_fname(const char *prompt, struct Buffer *fname, bool mailbox,
       window_redraw(win);
 
   } while ((event.op == OP_TIMEOUT) || (event.op == OP_REPAINT));
-  mutt_curses_set_cursor(old_cursor);
 
   mutt_refresh();
-  window_set_focus(old_focus);
   win = msgcont_pop_window();
+  window_set_focus(old_focus);
   mutt_window_free(&win);
 
   if (event.ch < 0)

--- a/gui/msgwin_wdata.h
+++ b/gui/msgwin_wdata.h
@@ -23,7 +23,6 @@
 #ifndef MUTT_GUI_MSGWIN_WDATA_H
 #define MUTT_GUI_MSGWIN_WDATA_H
 
-#include <stdbool.h>
 #include "mutt/lib.h"
 
 struct MuttWindow;
@@ -68,7 +67,6 @@ struct MsgWinWindowData
   struct Buffer *text;                       ///< Cached display string
   struct MwCharArray chars;                  ///< Text: Breakdown of bytes and widths
   struct MwChunkArray rows[MSGWIN_MAX_ROWS]; ///< String byte counts for each row
-  bool interactive;                          ///< Is this an interactive window?
   int row;                                   ///< Cursor row
   int col;                                   ///< Cursor column
 };

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -67,7 +67,6 @@ static const struct Mapping WindowNames[] = {
   { "WT_INDEX",           WT_INDEX },
   { "WT_MENU",            WT_MENU },
   { "WT_MESSAGE",         WT_MESSAGE },
-  { "WT_MSG_FOCUS",       WT_MSG_FOCUS },
   { "WT_PAGER",           WT_PAGER },
   { "WT_ROOT",            WT_ROOT },
   { "WT_SIDEBAR",         WT_SIDEBAR },

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -605,6 +605,25 @@ static void window_repaint(struct MuttWindow *win)
 }
 
 /**
+ * window_recursor - Recursor the focussed Window
+ *
+ * Give the focussed Window an opportunity to set the position and
+ * visibility of its cursor.
+ */
+static void window_recursor(void)
+{
+  // Give the focussed window an opportunity to set the cursor position
+  struct MuttWindow *win = window_get_focus();
+  if (!win)
+    return;
+
+  if (win->recursor && win->recursor(win))
+    return;
+
+  mutt_curses_set_cursor(MUTT_CURSOR_INVISIBLE);
+}
+
+/**
  * window_redraw - Reflow, recalc and repaint a tree of Windows
  * @param win Window to start at
  *
@@ -620,11 +639,7 @@ void window_redraw(struct MuttWindow *win)
 
   window_recalc(win);
   window_repaint(win);
-
-  // Give the focussed window an opportunity to set the cursor position
-  win = window_get_focus();
-  if (win && win->repaint)
-    win->repaint(win);
+  window_recursor();
 
   mutt_refresh();
 }

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -167,6 +167,9 @@ struct MuttWindow
    * @param win Window
    * @retval  0 Success
    * @retval -1 Error
+   *
+   * @pre win is not NULL
+   * @pre win is visible
    */
   int (*recalc)(struct MuttWindow *win);
 
@@ -178,8 +181,29 @@ struct MuttWindow
    * @param win Window
    * @retval  0 Success
    * @retval -1 Error
+   *
+   * @pre win is not NULL
+   * @pre win is visible
    */
   int (*repaint)(struct MuttWindow *win);
+
+  /**
+   * @defgroup window_recursor recursor()
+   * @ingroup window_api
+   *
+   * recursor - Recursor the Window
+   * @param win Window
+   * @retval true Cursor set
+   *
+   * @pre win is not NULL
+   *
+   * After all the repainting is done, the focussed window will be given an
+   * opportunity to set the position and visibility of the cursor.
+   *
+   * If the focussed window doesn't implement recursor(), then the cursor will
+   * be hidden.
+   */
+  bool (*recursor)(struct MuttWindow *win);
 };
 
 typedef uint8_t WindowNotifyFlags; ///< Flags for Changes to a MuttWindow, e.g. #WN_TALLER

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -97,7 +97,6 @@ enum WindowType
   WT_INDEX,           ///< A panel containing the Index Window
   WT_MENU,            ///< An Window containing a Menu
   WT_MESSAGE,         ///< Window for messages/errors
-  WT_MSG_FOCUS,       ///< Message Window that has focus
   WT_PAGER,           ///< A panel containing the Pager Window
   WT_SIDEBAR,         ///< Side panel containing Accounts or groups of data
   WT_STATUS_BAR,      ///< Status Bar containing extra info about the Index/Pager/etc

--- a/keymap.c
+++ b/keymap.c
@@ -1840,8 +1840,6 @@ void mw_what_key(void)
   struct MuttWindow *old_focus = window_set_focus(win);
   window_redraw(win);
 
-  enum MuttCursorState old_cursor = mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
-
   char keys[256] = { 0 };
   const struct AttrColor *ac_normal = simple_color_get(MT_COLOR_NORMAL);
   const struct AttrColor *ac_prompt = simple_color_get(MT_COLOR_PROMPT);
@@ -1893,10 +1891,8 @@ void mw_what_key(void)
   }
   // ---------------------------------------------------------------------------
 
-  mutt_curses_set_cursor(old_cursor);
-
-  window_set_focus(old_focus);
   win = msgcont_pop_window();
+  window_set_focus(old_focus);
   mutt_window_free(&win);
 }
 

--- a/question/question.c
+++ b/question/question.c
@@ -108,14 +108,12 @@ int mw_multi_choice(const char *prompt, const char *letters)
   msgwin_add_text(win, " ", ac_normal);
 
   msgcont_push_window(win);
-
   struct MuttWindow *old_focus = window_set_focus(win);
   window_redraw(win);
 
   // ---------------------------------------------------------------------------
   // Event Loop
   struct KeyEvent event = { 0, OP_NULL };
-  enum MuttCursorState old_cursor = mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
   while (true)
   {
     event = mutt_getch(GETCH_NO_FLAGS);
@@ -149,9 +147,8 @@ int mw_multi_choice(const char *prompt, const char *letters)
   }
   // ---------------------------------------------------------------------------
 
-  mutt_curses_set_cursor(old_cursor);
-  window_set_focus(old_focus);
   win = msgcont_pop_window();
+  window_set_focus(old_focus);
   mutt_window_free(&win);
 
   return choice;
@@ -252,11 +249,9 @@ static enum QuadOption mw_yesorno(const char *prompt, enum QuadOption def,
 
   msgwin_set_text(win, buf_string(text), MT_COLOR_PROMPT);
   msgcont_push_window(win);
-
   struct MuttWindow *old_focus = window_set_focus(win);
 
   struct KeyEvent event = { 0, OP_NULL };
-  enum MuttCursorState old_cursor = mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
   window_redraw(NULL);
   while (true)
   {
@@ -312,10 +307,9 @@ static enum QuadOption mw_yesorno(const char *prompt, enum QuadOption def,
 
     mutt_beep(false);
   }
-  mutt_curses_set_cursor(old_cursor);
 
-  window_set_focus(old_focus);
   win = msgcont_pop_window();
+  window_set_focus(old_focus);
   mutt_window_free(&win);
 
   if (reyes_ok)


### PR DESCRIPTION
Painting the screen inevitably means moving the cursor.
After the painting is done, an interactive Window, e.g. `mw_multi_choice()` needs an opportunity to restore the cursor position.
This can be achieved by implementing `Window.recursor()`.

---

- 529c04bc2 window: add recursor()
  After all the repainting is done, the focussed window will be given an
  opportunity to set the position and visibility of the cursor.

- adb3c45f9 msgwin: implement recursor()
  - Drop WT_MSG_FOCUS Window type
  - Drop MsgWinWindowData.interactive
  - Move cursor setting to msgwin_recursor()

- ef419f630 upgrade simple MessageWindow users
  Let the MessageWindow do the cursor setting.

- 0bc3cce1b mw_get_field: implement recursor()
  - Drop EnterWindowData.col
    A local variable in enter_repaint() was sufficient
  - Add EnterWindowData.row, col to store the cursor position
  - Move the cursor setting to enter_recursor()