### PR TITLE
explicitly set the focus

### DIFF
--- a/alias/dlg_alias.c
+++ b/alias/dlg_alias.c
@@ -337,6 +337,7 @@ static bool dlg_alias(struct Buffer *buf, struct AliasMenuData *mdata)
     avp->num = ARRAY_FOREACH_IDX;
   }
 
+  struct MuttWindow *old_focus = window_set_focus(menu->win);
   // ---------------------------------------------------------------------------
   // Event Loop
   int rc = 0;
@@ -365,6 +366,7 @@ static bool dlg_alias(struct Buffer *buf, struct AliasMenuData *mdata)
   } while ((rc != FR_DONE) && (rc != FR_CONTINUE));
   // ---------------------------------------------------------------------------
 
+  window_set_focus(old_focus);
   simple_dialog_free(&dlg);
   window_redraw(NULL);
   return (rc == FR_CONTINUE); // Was a selection made?

--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -413,6 +413,7 @@ static bool dlg_query(struct Buffer *buf, struct AliasMenuData *mdata)
     avp->num = ARRAY_FOREACH_IDX;
   }
 
+  struct MuttWindow *old_focus = window_set_focus(menu->win);
   // ---------------------------------------------------------------------------
   // Event Loop
   int rc = 0;
@@ -441,6 +442,7 @@ static bool dlg_query(struct Buffer *buf, struct AliasMenuData *mdata)
   } while ((rc != FR_DONE) && (rc != FR_CONTINUE));
   // ---------------------------------------------------------------------------
 
+  window_set_focus(old_focus);
   simple_dialog_free(&dlg);
   window_redraw(NULL);
   return (rc == FR_CONTINUE); // Was a selection made?

--- a/attach/dlg_attach.c
+++ b/attach/dlg_attach.c
@@ -505,6 +505,7 @@ void dlg_attachment(struct ConfigSubset *sub, struct MailboxView *mv,
   struct MuttWindow *sbar = window_find_child(dlg, WT_STATUS_BAR);
   sbar_set_title(sbar, _("Attachments"));
 
+  struct MuttWindow *old_focus = window_set_focus(menu->win);
   // ---------------------------------------------------------------------------
   // Event Loop
   int rc = 0;
@@ -539,5 +540,6 @@ void dlg_attachment(struct ConfigSubset *sub, struct MailboxView *mv,
   } while (rc != FR_DONE);
   // ---------------------------------------------------------------------------
 
+  window_set_focus(old_focus);
   simple_dialog_free(&dlg);
 }

--- a/autocrypt/dlg_autocrypt.c
+++ b/autocrypt/dlg_autocrypt.c
@@ -333,6 +333,7 @@ void dlg_autocrypt(void)
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, autocrypt_config_observer, menu);
   notify_observer_add(menu->win->notify, NT_WINDOW, autocrypt_window_observer, menu->win);
 
+  struct MuttWindow *old_focus = window_set_focus(menu->win);
   // ---------------------------------------------------------------------------
   // Event Loop
   int op = OP_NULL;
@@ -361,5 +362,6 @@ void dlg_autocrypt(void)
   } while (!ad.done);
   // ---------------------------------------------------------------------------
 
+  window_set_focus(old_focus);
   simple_dialog_free(&dlg);
 }

--- a/browser/dlg_browser.c
+++ b/browser/dlg_browser.c
@@ -1467,6 +1467,8 @@ void dlg_browser(struct Buffer *file, SelectFileFlags flags, struct Mailbox *m,
   notify_observer_add(win_menu->notify, NT_WINDOW, browser_window_observer, priv);
   notify_observer_add(NeoMutt->notify, NT_MAILBOX, browser_mailbox_observer, priv);
 
+  struct MuttWindow *old_focus = window_set_focus(priv->menu->win);
+
   if (priv->state.is_mailbox_list)
   {
     examine_mailboxes(m, NULL, &priv->state);
@@ -1517,6 +1519,7 @@ void dlg_browser(struct Buffer *file, SelectFileFlags flags, struct Mailbox *m,
   // ---------------------------------------------------------------------------
 
 bail:
+  window_set_focus(old_focus);
   simple_dialog_free(&dlg);
   browser_private_data_free(&priv);
 }

--- a/compose/dlg_compose.c
+++ b/compose/dlg_compose.c
@@ -291,7 +291,6 @@ static struct MuttWindow *compose_dlg_init(struct ConfigSubset *sub,
 
   dlg->help_data = ComposeHelp;
   dlg->help_menu = MENU_COMPOSE;
-  dlg->focus = win_attach;
 
   return dlg;
 }
@@ -323,7 +322,6 @@ int dlg_compose(struct Email *e, struct Buffer *fcc, uint8_t flags, struct Confi
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, compose_config_observer, dlg);
   notify_observer_add(e->notify, NT_ALL, compose_email_observer, shared);
   notify_observer_add(dlg->notify, NT_WINDOW, compose_window_observer, dlg);
-  dialog_push(dlg);
 
 #ifdef USE_NNTP
   if (OptNewsSend)
@@ -339,6 +337,8 @@ int dlg_compose(struct Email *e, struct Buffer *fcc, uint8_t flags, struct Confi
 
   struct MuttWindow *win_env = window_find_child(dlg, WT_CUSTOM);
 
+  dialog_push(dlg);
+  struct MuttWindow *old_focus = window_set_focus(menu->win);
   // ---------------------------------------------------------------------------
   // Event Loop
   int rc = 0;
@@ -388,6 +388,7 @@ int dlg_compose(struct Email *e, struct Buffer *fcc, uint8_t flags, struct Confi
 
   rc = shared->rc;
 
+  window_set_focus(old_focus);
   dialog_pop();
   mutt_window_free(&dlg);
 

--- a/conn/dlg_verifycert.c
+++ b/conn/dlg_verifycert.c
@@ -234,6 +234,7 @@ int dlg_certificate(const char *title, struct CertArray *carr, bool allow_always
   }
   msgwin_set_text(NULL, mdata.prompt, MT_COLOR_PROMPT);
 
+  struct MuttWindow *old_focus = window_set_focus(menu->win);
   // ---------------------------------------------------------------------------
   // Event Loop
   int choice = 0;
@@ -302,6 +303,7 @@ int dlg_certificate(const char *title, struct CertArray *carr, bool allow_always
   } while (choice == 0);
   // ---------------------------------------------------------------------------
 
+  window_set_focus(old_focus);
   simple_dialog_free(&dlg);
 
   return choice;

--- a/gui/dialog.c
+++ b/gui/dialog.c
@@ -127,7 +127,6 @@ void dialog_push(struct MuttWindow *dlg)
   dlg->state.visible = true;
   dlg->parent = AllDialogsWindow;
   mutt_window_reflow(AllDialogsWindow);
-  window_set_focus(dlg);
 
 #ifdef USE_DEBUG_WINDOW
   debug_win_dump();
@@ -164,7 +163,6 @@ void dialog_pop(void)
   {
     last->state.visible = true;
     mutt_window_reflow(AllDialogsWindow);
-    window_set_focus(last);
   }
   else
   {

--- a/gui/dialog.c
+++ b/gui/dialog.c
@@ -219,22 +219,3 @@ struct MuttWindow *alldialogs_new(void)
 
   return win_alldlgs;
 }
-
-/**
- * alldialogs_get_current - Get the currently active Dialog
- * @retval ptr Active Dialog
- */
-struct MuttWindow *alldialogs_get_current(void)
-{
-  if (!AllDialogsWindow)
-    return NULL;
-
-  struct MuttWindow *np = NULL;
-  TAILQ_FOREACH(np, &AllDialogsWindow->children, entries)
-  {
-    if (mutt_window_is_visible(np))
-      return np;
-  }
-
-  return NULL;
-}

--- a/gui/dialog.h
+++ b/gui/dialog.h
@@ -31,7 +31,6 @@ struct MuttWindow *dialog_find(struct MuttWindow *win);
 void               dialog_pop(void);
 void               dialog_push(struct MuttWindow *dlg);
 
-struct MuttWindow *alldialogs_get_current(void);
 struct MuttWindow *alldialogs_new(void);
 
 #endif /* MUTT_GUI_DIALOG_H */

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -474,6 +474,9 @@ struct MuttWindow *mutt_window_remove_child(struct MuttWindow *parent, struct Mu
   TAILQ_REMOVE(&parent->children, child, entries);
   child->parent = NULL;
 
+  if (parent->focus == child)
+    parent->focus = NULL;
+
   notify_set_parent(child->notify, NULL);
 
   return child;
@@ -692,9 +695,7 @@ struct MuttWindow *window_set_focus(struct MuttWindow *win)
   for (; parent; child = parent, parent = parent->parent)
     parent->focus = child;
 
-  // Find the most focused Window
-  while (win && win->focus)
-    win = win->focus;
+  win->focus = NULL;
 
   if (win == old_focus)
     return NULL;
@@ -706,6 +707,7 @@ struct MuttWindow *window_set_focus(struct MuttWindow *win)
 #ifdef USE_DEBUG_WINDOW
   debug_win_dump();
 #endif
+
   return old_focus;
 }
 

--- a/gui/simple.c
+++ b/gui/simple.c
@@ -139,7 +139,6 @@ struct MuttWindow *simple_dialog_new(enum MenuType mtype, enum WindowType wtype,
   dlg->help_data = help_data;
 
   struct MuttWindow *win_menu = menu_window_new(mtype, NeoMutt->sub);
-  dlg->focus = win_menu;
   dlg->wdata = win_menu->wdata;
 
   struct MuttWindow *win_sbar = sbar_new();

--- a/history/dlg_history.c
+++ b/history/dlg_history.c
@@ -146,6 +146,7 @@ void dlg_history(char *buf, size_t buflen, char **matches, int match_count)
                             menu,  matches, match_count };
   dlg->wdata = &hd;
 
+  struct MuttWindow *old_focus = window_set_focus(menu->win);
   // ---------------------------------------------------------------------------
   // Event Loop
   int op = OP_NULL;
@@ -173,5 +174,6 @@ void dlg_history(char *buf, size_t buflen, char **matches, int match_count)
   } while (!hd.done);
   // ---------------------------------------------------------------------------
 
+  window_set_focus(old_focus);
   simple_dialog_free(&dlg);
 }

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -1091,6 +1091,8 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
   priv->menu->color = index_color;
   priv->menu->max = shared->mailbox ? shared->mailbox->vcount : 0;
   menu_set_index(priv->menu, find_first_message(shared->mailbox_view));
+
+  struct MuttWindow *old_focus = window_set_focus(priv->menu->win);
   mutt_window_reflow(NULL);
 
   if (!priv->attach_msg)
@@ -1361,6 +1363,7 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
   } while (rc != FR_DONE);
 
   mview_free(&shared->mailbox_view);
+  window_set_focus(old_focus);
 
   return shared->mailbox;
 }
@@ -1420,8 +1423,6 @@ struct MuttWindow *index_pager_init(void)
 
   mutt_window_add_child(dlg, panel_index);
   mutt_window_add_child(dlg, panel_pager);
-
-  dlg->focus = panel_index;
 
   return dlg;
 }

--- a/index/ipanel.c
+++ b/index/ipanel.c
@@ -129,7 +129,6 @@ struct MuttWindow *ipanel_new(bool status_on_top, struct IndexSharedData *shared
   panel_index->wdata_free = index_private_data_free;
 
   struct MuttWindow *win_index = index_window_new(priv);
-  panel_index->focus = win_index;
 
   struct MuttWindow *win_ibar = ibar_new(panel_index, shared, priv);
   if (status_on_top)

--- a/menu/menu.c
+++ b/menu/menu.c
@@ -84,9 +84,7 @@ void menu_init(void)
  */
 enum MenuType menu_get_current_type(void)
 {
-  struct MuttWindow *win = alldialogs_get_current();
-  while (win && win->focus)
-    win = win->focus;
+  struct MuttWindow *win = window_get_focus();
 
   // This should only happen before the first window is created
   if (!win)

--- a/mixmaster/dlg_mixmaster.c
+++ b/mixmaster/dlg_mixmaster.c
@@ -201,6 +201,7 @@ void dlg_mixmaster(struct ListHead *chainhead)
   mutt_list_free(chainhead);
 
   dialog_push(dlg);
+  struct MuttWindow *old_focus = window_set_focus(priv.win_hosts);
 
   // ---------------------------------------------------------------------------
   // Event Loop
@@ -235,6 +236,7 @@ void dlg_mixmaster(struct ListHead *chainhead)
   if (rc == FR_DONE)
     win_chain_extract(priv.win_chain, chainhead);
 
+  window_set_focus(old_focus);
   dialog_pop();
   mutt_window_free(&dlg);
 

--- a/ncrypt/dlg_gpgme.c
+++ b/ncrypt/dlg_gpgme.c
@@ -740,6 +740,7 @@ struct CryptKeyInfo *dlg_gpgme(struct CryptKeyInfo *keys, struct Address *p,
 
   mutt_clear_error();
 
+  struct MuttWindow *old_focus = window_set_focus(menu->win);
   // ---------------------------------------------------------------------------
   // Event Loop
   int op = OP_NULL;
@@ -768,6 +769,7 @@ struct CryptKeyInfo *dlg_gpgme(struct CryptKeyInfo *keys, struct Address *p,
   } while (!gd.done);
   // ---------------------------------------------------------------------------
 
+  window_set_focus(old_focus);
   simple_dialog_free(&dlg);
   return gd.key;
 }

--- a/ncrypt/dlg_pgp.c
+++ b/ncrypt/dlg_pgp.c
@@ -631,6 +631,7 @@ struct PgpKeyInfo *dlg_pgp(struct PgpKeyInfo *keys, struct Address *p, const cha
 
   mutt_clear_error();
 
+  struct MuttWindow *old_focus = window_set_focus(menu->win);
   // ---------------------------------------------------------------------------
   // Event Loop
   int op = OP_NULL;
@@ -659,6 +660,7 @@ struct PgpKeyInfo *dlg_pgp(struct PgpKeyInfo *keys, struct Address *p, const cha
   } while (!pd.done);
   // ---------------------------------------------------------------------------
 
+  window_set_focus(old_focus);
   simple_dialog_free(&dlg);
   return pd.key;
 }

--- a/ncrypt/dlg_smime.c
+++ b/ncrypt/dlg_smime.c
@@ -230,6 +230,7 @@ struct SmimeKey *dlg_smime(struct SmimeKey *keys, const char *query)
 
   mutt_clear_error();
 
+  struct MuttWindow *old_focus = window_set_focus(menu->win);
   // ---------------------------------------------------------------------------
   // Event Loop
   int op = OP_NULL;
@@ -257,6 +258,7 @@ struct SmimeKey *dlg_smime(struct SmimeKey *keys, const char *query)
       rc = global_function_dispatcher(NULL, op);
   } while (!sd.done);
 
+  window_set_focus(old_focus);
   simple_dialog_free(&dlg);
   return sd.key;
 }

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -359,7 +359,7 @@ int dlg_pager(struct PagerView *pview)
   mutt_window_reflow(dlg);
   window_invalidate_all();
 
-  window_set_focus(pview->win_pager);
+  struct MuttWindow *old_focus = window_set_focus(pview->win_pager);
 
   //---------- jump to the bottom if requested ------------------------------
   if (pview->flags & MUTT_PAGER_BOTTOM)
@@ -564,6 +564,7 @@ int dlg_pager(struct PagerView *pview)
       mutt_flushinp();
 
   } while (priv->loop == PAGER_LOOP_CONTINUE);
+  window_set_focus(old_focus);
 
   //-------------------------------------------------------------------------
   // END OF ACT 3: Read user input loop - while (op != OP_ABORT)

--- a/pattern/dlg_pattern.c
+++ b/pattern/dlg_pattern.c
@@ -347,6 +347,7 @@ bool dlg_pattern(char *buf, size_t buflen)
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, pattern_config_observer, menu);
   notify_observer_add(menu->win->notify, NT_WINDOW, pattern_window_observer, menu->win);
 
+  struct MuttWindow *old_focus = window_set_focus(menu->win);
   // ---------------------------------------------------------------------------
   // Event Loop
   int op = OP_NULL;
@@ -374,6 +375,7 @@ bool dlg_pattern(char *buf, size_t buflen)
   } while (!pd.done);
   // ---------------------------------------------------------------------------
 
+  window_set_focus(old_focus);
   simple_dialog_free(&dlg);
   return pd.selection;
 }

--- a/postpone/dlg_postpone.c
+++ b/postpone/dlg_postpone.c
@@ -227,6 +227,7 @@ struct Email *dlg_postponed(struct Mailbox *m)
   const enum SortType c_sort = cs_subset_sort(NeoMutt->sub, "sort");
   cs_subset_str_native_set(NeoMutt->sub, "sort", SORT_ORDER, NULL);
 
+  struct MuttWindow *old_focus = window_set_focus(menu->win);
   // ---------------------------------------------------------------------------
   // Event Loop
   int op = OP_NULL;
@@ -258,6 +259,7 @@ struct Email *dlg_postponed(struct Mailbox *m)
   mview_free(&mv);
   cs_subset_str_native_set(NeoMutt->sub, "sort", c_sort, NULL);
   search_state_free(&pd.search_state);
+  window_set_focus(old_focus);
   simple_dialog_free(&dlg);
 
   return pd.email;


### PR DESCRIPTION
Explicitly set and restore the Window focus.
Before, this used to happen in helper functions.