### PR TITLE
color_directcolor: Also set the default/initial value on startup

### DIFF
--- a/init.c
+++ b/init.c
@@ -367,7 +367,8 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
     if (env_colorterm && (mutt_str_equal(env_colorterm, "truecolor") ||
                           mutt_str_equal(env_colorterm, "24bit")))
     {
-      cs_subset_str_native_set(NeoMutt->sub, "color_directcolor", true, NULL);
+      cs_str_initial_set(cs, "color_directcolor", "yes", NULL);
+      cs_str_reset(cs, "color_directcolor", NULL);
     }
   }
 #endif


### PR DESCRIPTION
On startup we try to detect the terminals capability for direct color and set value of $color_directcolor accordingly.  However, we forgot to set its initial/default value.

Set the initial/default value for $color_directcolor like we do for all other config variables which depend on the environment, e.g. $editor.

## The difference in behaviour can be observed with

Config file `neomuttrc-reset`:
```
reset all
```

### Before this commit:

```
EDITOR=foo TERM=xterm-direct neomutt -F /dev/null
:set color_directcolor?  # ==> "yes"
:set editor? # ==> "foo"
EDITOR=foo TERM=xterm-direct neomutt -F neomuttrc-reset
:set color_directcolor?  # ==> "no"
:set editor? # ==> "foo"
```

### After this commit:

```
EDITOR=foo TERM=xterm-direct neomutt -F /dev/null
:set color_directcolor?  # ==> "yes"
:set editor? # ==> "foo"
EDITOR=foo TERM=xterm-direct neomutt -F neomuttrc-reset
:set color_directcolor?  # ==> "yes"
:set editor? # ==> "foo"
```

(The test obviously requires a terminal which supports directcolors)