### PR TITLE
force mail check on current mailbox after <shell-escape> (fixes #4048)

### DIFF
--- a/gui/global.c
+++ b/gui/global.c
@@ -84,6 +84,8 @@ static int op_shell_escape(int op)
   {
     struct Mailbox *m_cur = get_current_mailbox();
     mutt_mailbox_check(m_cur, MUTT_MAILBOX_CHECK_FORCE);
+    /* This forces a refresh on the next mx_mbox_check() call. */
+    mx_mbox_reset_check();
   }
   return FR_SUCCESS;
 }

--- a/mx.c
+++ b/mx.c
@@ -1151,6 +1151,17 @@ enum MxStatus mx_mbox_check(struct Mailbox *m)
 }
 
 /**
+ * mx_mbox_reset_check - Reset last mail check time.
+ *
+ * @note This effectively forces a check on the next mx_mbox_check() call.
+ */
+void mx_mbox_reset_check(void)
+{
+  const short c_mail_check = cs_subset_number(NeoMutt->sub, "mail_check");
+  MailboxTime = mutt_date_now() - c_mail_check - 1;
+}
+
+/**
  * mx_msg_open - Return a stream pointer for a message
  * @param m Mailbox
  * @param e Email

--- a/mx.h
+++ b/mx.h
@@ -77,5 +77,6 @@ void                 mx_fastclose_mailbox (struct Mailbox *m, bool keep_account)
 const struct MxOps * mx_get_ops           (enum MailboxType type);
 bool                 mx_tags_is_supported (struct Mailbox *m);
 int                  mx_toggle_write      (struct Mailbox *m);
+void                 mx_mbox_reset_check  (void);
 
 #endif /* MUTT_MX_H */


### PR DESCRIPTION
Workaround to fix #4048. By backdating the last mailbox check time we restore the previous behavior.

A cleaner way would be to rethink the whole mail (stats) check, notification and `new_mail_command` situation. I'll open a discussion with some thoughts later. But I don't think we want to include another big change like that in the next release.