### PR TITLE
msgwin: check for dupe text

### DIFF
--- a/gui/msgwin.c
+++ b/gui/msgwin.c
@@ -490,6 +490,9 @@ void msgwin_set_text(struct MuttWindow *win, const char *text, enum ColorId colo
 
   struct MsgWinWindowData *wdata = win->wdata;
 
+  if (mutt_str_equal(buf_string(wdata->text), text))
+    return;
+
   buf_strcpy(wdata->text, text);
   ARRAY_FREE(&wdata->chars);
   if (wdata->text)


### PR DESCRIPTION
Return early from `msgwin_set_text()` if the text hasn't changed.

Fixes: #4055 

`msgwin_set_text()` is called to set or clear a message.

Displaying a long message would require the `MsgWin` to resize itself.
Later, calling `msgwin_set_text(NULL)` to clear the message would cause the `MsgWin` to shrink back to 1 line.

However, if the `MsgWin` wasn't visible, e.g. a progress bar was in use, then it would get into an infinite loop trying to resize itself.

Fix: If the text isn't changing, then don't try to resize yourself. 