### PR TITLE
fix crash on exit

### DIFF
--- a/gui/rootwin.c
+++ b/gui/rootwin.c
@@ -201,6 +201,8 @@ static int rootwin_window_observer(struct NotifyCallback *nc)
  */
 void rootwin_cleanup(void)
 {
+  AllDialogsWindow = NULL;
+  MessageContainer = NULL;
   mutt_window_free(&RootWindow);
 }
 


### PR DESCRIPTION
I couldn't repeat the crash, but I _think_ I can see how it _might_ be happening.

On exit, `main()` calls `rootwin_cleanup()` to free the `MuttWindow`s.
There are a couple of helper globals that don't get cleared by this:
- `AllDialogsWindow`
- `MessageContainer`

If some code were to try to clear the `MessageWindow` after `rootwin_cleanup()`, it would use a dangling pointer.

Probably fixes: #4059
