### PR TITLE
fix header colour

### DIFF
--- a/pager/display.c
+++ b/pager/display.c
@@ -1302,10 +1302,6 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
       const enum ColorId cid = ((line_num % 2) == 0) ? MT_COLOR_STRIPE_ODD : MT_COLOR_STRIPE_EVEN;
       mutt_curses_set_color_by_id(cid);
     }
-    else
-    {
-      mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
-    }
     mutt_window_clrtoeol(win_pager);
   }
 


### PR DESCRIPTION
`color header` should extend to the end of the line.
(`color quoted` too)

Remove a spurious `mutt_curses_set_color_by_id()` that was resetting the colour to normal.

---

This bug was introduced as I refactored the stripes code.
The PR fixes the problem and everything seems ok, stripes included.