### PR TITLE
fix 32-bit date overflow

### DIFF
--- a/mutt/date.c
+++ b/mutt/date.c
@@ -458,7 +458,7 @@ uint64_t mutt_date_now_ms(void)
   gettimeofday(&tv, NULL);
   /* We assume that gettimeofday doesn't modify its first argument on failure.
    * We also kind of assume that gettimeofday does not fail. */
-  return (uint64_t) (tv.tv_sec * 1000) + (tv.tv_usec / 1000);
+  return ((uint64_t) tv.tv_sec * 1000) + (tv.tv_usec / 1000);
 }
 
 /**


### PR DESCRIPTION
A misplaced `(` meant that `tv.tv_sec` would overflow before being converted to a sufficiently long type.
