### PR TITLE
track new-mail check time per mailbox

### DIFF
--- a/core/mailbox.h
+++ b/core/mailbox.h
@@ -102,6 +102,7 @@ struct Mailbox
   enum MailboxType type;              ///< Mailbox type
   bool newly_created;                 ///< Mbox or mmdf just popped into existence
   struct timespec last_visited;       ///< Time of last exit from this mailbox
+  time_t last_checked;                ///< Last time we checked this mailbox for new mail
 
   const struct MxOps *mx_ops;         ///< MXAPI callback functions
 

--- a/editmsg.c
+++ b/editmsg.c
@@ -239,7 +239,7 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
   mx_msg_close(m, &msg);
 
   mx_mbox_close(m);
-  mx_mbox_reset_check();
+  m->last_checked = 0; // force a check on the next mx_mbox_check() call
 
 bail:
   mutt_file_fclose(&fp);

--- a/gui/global.c
+++ b/gui/global.c
@@ -84,9 +84,8 @@ static int op_shell_escape(int op)
   if (mutt_shell_escape())
   {
     struct Mailbox *m_cur = get_current_mailbox();
+    m_cur->last_checked = 0; // force a check on the next mx_mbox_check() call
     mutt_mailbox_check(m_cur, MUTT_MAILBOX_CHECK_FORCE);
-    /* This forces a refresh on the next mx_mbox_check() call. */
-    mx_mbox_reset_check();
   }
   return FR_SUCCESS;
 }

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1081,7 +1081,7 @@ enum MxStatus imap_check_mailbox(struct Mailbox *m, bool force)
   mdata->check_status = IMAP_OPEN_NO_FLAGS;
 
   if (force)
-    mx_mbox_reset_check();
+    m->last_checked = 0; // force a check on the next mx_mbox_check() call
   return check;
 }
 

--- a/mx.c
+++ b/mx.c
@@ -71,8 +71,6 @@
 #include <libintl.h>
 #endif
 
-static time_t MailboxTime = 0; ///< last time we started checking for mail
-
 /// Lookup table of mailbox types
 static const struct Mapping MboxTypeMap[] = {
   // clang-format off
@@ -1104,10 +1102,10 @@ enum MxStatus mx_mbox_check(struct Mailbox *m)
   const short c_mail_check = cs_subset_number(NeoMutt->sub, "mail_check");
 
   time_t t = mutt_date_now();
-  if ((t - MailboxTime) < c_mail_check)
+  if ((t - m->last_checked) < c_mail_check)
     return MX_STATUS_OK;
 
-  MailboxTime = t;
+  m->last_checked = t;
 
   enum MxStatus rc = m->mx_ops->mbox_check(m);
   if ((rc == MX_STATUS_NEW_MAIL) || (rc == MX_STATUS_REOPENED))
@@ -1116,17 +1114,6 @@ enum MxStatus mx_mbox_check(struct Mailbox *m)
   }
 
   return rc;
-}
-
-/**
- * mx_mbox_reset_check - Reset last mail check time.
- *
- * @note This effectively forces a check on the next mx_mbox_check() call.
- */
-void mx_mbox_reset_check(void)
-{
-  const short c_mail_check = cs_subset_number(NeoMutt->sub, "mail_check");
-  MailboxTime = mutt_date_now() - c_mail_check - 1;
 }
 
 /**

--- a/mx.h
+++ b/mx.h
@@ -75,6 +75,5 @@ void                 mx_fastclose_mailbox (struct Mailbox *m, bool keep_account)
 const struct MxOps * mx_get_ops           (enum MailboxType type);
 bool                 mx_tags_is_supported (struct Mailbox *m);
 int                  mx_toggle_write      (struct Mailbox *m);
-void                 mx_mbox_reset_check  (void);
 
 #endif /* MUTT_MX_H */


### PR DESCRIPTION
Instead of using one variable `MailboxTime` to keep track of when we last checked any mailbox for mail, store that information on the `Mailbox` itself.

I didn't notice any immediate issue related to this but I still think something like this could happen:

1. regular mail check on all mailboxes -> set `MailboxTime`
2. `mx_mbox_check()` on current mailbox -> set `MailboxTime`
3. regular mail check not run because not enough time elapsed since last run (on a single mailbox only)