### PR TITLE
remove unused count of new mails from index private data

### DIFF
--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -1212,8 +1212,7 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
     if (!shared->attach_msg)
     {
       /* check for new mail in the incoming folders */
-      priv->oldcount = priv->newcount;
-      priv->newcount = mutt_mailbox_check(shared->mailbox, MUTT_MAILBOX_CHECK_NO_FLAGS);
+      mutt_mailbox_check(shared->mailbox, MUTT_MAILBOX_CHECK_NO_FLAGS);
       if (priv->do_mailbox_notify)
       {
         if (mutt_mailbox_notify(shared->mailbox))

--- a/index/private_data.c
+++ b/index/private_data.c
@@ -51,7 +51,6 @@ struct IndexPrivateData *index_private_data_new(struct IndexSharedData *shared)
   struct IndexPrivateData *priv = mutt_mem_calloc(1, sizeof(struct IndexPrivateData));
 
   priv->shared = shared;
-  priv->newcount = -1;
   priv->oldcount = -1;
 
   return priv;

--- a/index/private_data.h
+++ b/index/private_data.h
@@ -34,8 +34,7 @@ struct MuttWindow;
 struct IndexPrivateData
 {
   bool tag_prefix;               ///< tag-prefix has been pressed
-  int  oldcount;                 ///< Old count of Emails in the Mailbox
-  int  newcount;                 ///< New count of Emails in the Mailbox
+  int  oldcount;                 ///< Old count of mails in the mailbox
   bool do_mailbox_notify;        ///< Do we need to notify the user of new mail?
 
   struct IndexSharedData *shared; ///< Shared Index data


### PR DESCRIPTION
This seems to be unused. Setting `oldcount` is wrong because that is the count of mails in the mailbox and never the count of mailboxes with new mail.