### PR TITLE
color: refactor parsing

### DIFF
--- a/color/ansi.c
+++ b/color/ansi.c
@@ -29,8 +29,6 @@
 #include "config.h"
 #include <stdbool.h>
 #include "mutt/lib.h"
-#include "config/lib.h"
-#include "core/lib.h"
 #include "gui/lib.h"
 #include "ansi.h"
 #include "attr.h"
@@ -75,6 +73,17 @@ static void ansi_color_list_add(struct AttrColorList *acl, struct AnsiColor *ans
   color_t fg = ansi->fg.color;
   color_t bg = ansi->bg.color;
 
+#ifdef NEOMUTT_DIRECT_COLORS
+  if ((ansi->fg.type == CT_SIMPLE) || (ansi->fg.type == CT_PALETTE))
+    fg = color_xterm256_to_24bit(fg);
+  else if (fg < 8)
+    fg = 8;
+  if ((ansi->bg.type == CT_SIMPLE) || (ansi->bg.type == CT_PALETTE))
+    bg = color_xterm256_to_24bit(bg);
+  else if (bg < 8)
+    bg = 8;
+#endif
+
   struct AttrColor *ac = attr_color_list_find(acl, fg, bg, ansi->attrs);
   if (ac)
   {
@@ -84,21 +93,8 @@ static void ansi_color_list_add(struct AttrColorList *acl, struct AnsiColor *ans
 
   ac = attr_color_new();
   ac->attrs = ansi->attrs;
-
-#ifdef NEOMUTT_DIRECT_COLORS
-  const bool c_color_directcolor = cs_subset_bool(NeoMutt->sub, "color_directcolor");
-  if (c_color_directcolor)
-  {
-    /* If we are running in direct color mode, we must convert the xterm
-     * color numbers 0-255 to an RGB value. */
-    fg = color_xterm256_to_24bit(fg);
-    if (fg < 8)
-      fg = 8;
-    bg = color_xterm256_to_24bit(bg);
-    if (bg < 8)
-      bg = 8;
-  }
-#endif
+  ac->fg = ansi->fg;
+  ac->bg = ansi->bg;
 
   struct CursesColor *cc = curses_color_new(fg, bg);
   ac->curses_color = cc;

--- a/color/ansi.c
+++ b/color/ansi.c
@@ -54,11 +54,11 @@ static void ansi_color_list_add(struct AttrColorList *acl, struct AnsiColor *ans
   if (!acl || !ansi)
     return;
 
-  if ((ansi->fg == COLOR_DEFAULT) && (ansi->bg == COLOR_DEFAULT))
+  if ((ansi->fg.color == COLOR_DEFAULT) && (ansi->bg.color == COLOR_DEFAULT))
   {
     switch (ansi->attrs)
     {
-      case 0:
+      case A_NORMAL:
         return;
       case A_BOLD:
         ansi->attr_color = simple_color_get(MT_COLOR_BOLD);
@@ -72,7 +72,10 @@ static void ansi_color_list_add(struct AttrColorList *acl, struct AnsiColor *ans
     }
   }
 
-  struct AttrColor *ac = attr_color_list_find(acl, ansi->fg, ansi->bg, ansi->attrs);
+  color_t fg = ansi->fg.color;
+  color_t bg = ansi->bg.color;
+
+  struct AttrColor *ac = attr_color_list_find(acl, fg, bg, ansi->attrs);
   if (ac)
   {
     ansi->attr_color = ac;
@@ -81,9 +84,6 @@ static void ansi_color_list_add(struct AttrColorList *acl, struct AnsiColor *ans
 
   ac = attr_color_new();
   ac->attrs = ansi->attrs;
-
-  color_t fg = ansi->fg;
-  color_t bg = ansi->bg;
 
 #ifdef NEOMUTT_DIRECT_COLORS
   const bool c_color_directcolor = cs_subset_bool(NeoMutt->sub, "color_directcolor");

--- a/color/ansi.h
+++ b/color/ansi.h
@@ -24,19 +24,19 @@
 #define MUTT_COLOR_ANSI_H
 
 #include <stdbool.h>
-#include "curses2.h"
-
-struct AttrColorList;
+#include "attr.h"
 
 /**
  * struct AnsiColor - An ANSI escape sequence
+ * 
+ * @note AnsiColor doesn't own the AttrColor
  */
 struct AnsiColor
 {
+  struct ColorElement fg;              ///< Foreground colour
+  struct ColorElement bg;              ///< Background colour
+  int attrs;                           ///< Text attributes, e.g. A_BOLD
   const struct AttrColor *attr_color;  ///< Curses colour of text
-  int attrs;                           ///< Attributes, e.g. A_BOLD
-  color_t fg;                          ///< Foreground colour
-  color_t bg;                          ///< Background colour
 };
 
 int ansi_color_parse     (const char *str, struct AnsiColor *ansi, struct AttrColorList *acl, bool dry_run);

--- a/color/ansi.h
+++ b/color/ansi.h
@@ -39,7 +39,6 @@ struct AnsiColor
   const struct AttrColor *attr_color;  ///< Curses colour of text
 };
 
-int ansi_color_parse     (const char *str, struct AnsiColor *ansi, struct AttrColorList *acl, bool dry_run);
-int ansi_color_seq_length(const char *str);
+int ansi_color_parse(const char *str, struct AnsiColor *ansi, struct AttrColorList *acl, bool dry_run);
 
 #endif /* MUTT_COLOR_ANSI_H */

--- a/color/attr.c
+++ b/color/attr.c
@@ -30,9 +30,11 @@
 #include "config.h"
 #include <stddef.h>
 #include <assert.h>
+#include <string.h>
 #include "mutt/lib.h"
 #include "gui/lib.h"
 #include "attr.h"
+#include "color.h"
 #include "curses2.h"
 #include "debug.h"
 
@@ -50,7 +52,13 @@ void attr_color_clear(struct AttrColor *ac)
   if (ac->curses_color)
     color_debug(LL_DEBUG5, "clear %p\n", (void *) ac);
   curses_color_free(&ac->curses_color);
-  ac->attrs = 0;
+
+  memset(&ac->fg, 0, sizeof(ac->fg));
+  memset(&ac->bg, 0, sizeof(ac->bg));
+
+  ac->fg.color = COLOR_DEFAULT;
+  ac->bg.color = COLOR_DEFAULT;
+  ac->attrs = A_NORMAL;
 }
 
 /**
@@ -81,6 +89,16 @@ void attr_color_free(struct AttrColor **ptr)
 struct AttrColor *attr_color_new(void)
 {
   struct AttrColor *ac = mutt_mem_calloc(1, sizeof(*ac));
+
+  ac->fg.color = COLOR_DEFAULT;
+  ac->fg.type = CT_SIMPLE;
+  ac->fg.prefix = COLOR_PREFIX_NONE;
+
+  ac->bg.color = COLOR_DEFAULT;
+  ac->bg.type = CT_SIMPLE;
+  ac->bg.prefix = COLOR_PREFIX_NONE;
+
+  ac->attrs = A_NORMAL;
 
   ac->ref_count = 1;
 
@@ -163,7 +181,7 @@ bool attr_color_is_set(const struct AttrColor *ac)
   if (!ac)
     return false;
 
-  return ((ac->attrs != 0) || ac->curses_color);
+  return ((ac->attrs != A_NORMAL) || ac->curses_color);
 }
 
 /**

--- a/color/attr.c
+++ b/color/attr.c
@@ -380,3 +380,25 @@ color_t color_xterm256_to_24bit(const color_t color)
   return rgb;
 }
 #endif
+
+/**
+ * attr_color_overwrite - Update an AttrColor in-place
+ * @param ac_old AttrColor to overwrite
+ * @param ac_new AttrColor to copy
+ */
+void attr_color_overwrite(struct AttrColor *ac_old, struct AttrColor *ac_new)
+{
+  if (!ac_old || !ac_new)
+    return;
+
+  color_t fg = ac_new->fg.color;
+  color_t bg = ac_new->bg.color;
+  int attrs = ac_new->attrs;
+
+  struct CursesColor *cc = curses_color_new(fg, bg);
+  curses_color_free(&ac_old->curses_color);
+  ac_old->fg = ac_new->fg;
+  ac_old->bg = ac_new->bg;
+  ac_old->attrs = attrs;
+  ac_old->curses_color = cc;
+}

--- a/color/attr.h
+++ b/color/attr.h
@@ -29,6 +29,16 @@
 #include "curses2.h"
 
 /**
+ * enum ColorType - Type of Colour
+ */
+enum ColorType
+{
+  CT_SIMPLE,    ///< Simple colour,  e.g. "Red"
+  CT_PALETTE,   ///< Palette colour, e.g. "color207"
+  CT_RGB,       ///< True colour,    e.g. "#11AAFF"
+};
+
+/**
  * ColorPrefix - Constants for colour prefixes of named colours
  */
 enum ColorPrefix
@@ -40,12 +50,24 @@ enum ColorPrefix
 };
 
 /**
+ * struct ColorElement - One element of a Colour
+ */
+struct ColorElement
+{
+  color_t          color;           ///< Colour
+  enum ColorType   type;            ///< Type of Colour
+  enum ColorPrefix prefix;          ///< Optional Colour Modifier
+};
+
+/**
  * struct AttrColor - A curses colour and its attributes
  */
 struct AttrColor
 {
-  struct CursesColor *curses_color; ///< Underlying Curses colour
+  struct ColorElement fg;           ///< Foreground colour
+  struct ColorElement bg;           ///< Background colour
   int attrs;                        ///< Text attributes, e.g. A_BOLD
+  struct CursesColor *curses_color; ///< Underlying Curses colour
   short ref_count;                  ///< Number of users
   TAILQ_ENTRY(AttrColor) entries;   ///< Linked list
 };

--- a/color/attr.h
+++ b/color/attr.h
@@ -83,4 +83,6 @@ struct AttrColor *attr_color_new   (void);
 void              attr_color_list_clear(struct AttrColorList *acl);
 struct AttrColor *attr_color_list_find (struct AttrColorList *acl, color_t fg, color_t bg, int attrs);
 
+void attr_color_overwrite(struct AttrColor *ac_old, struct AttrColor *ac_new);
+
 #endif /* MUTT_COLOR_ATTR_H */

--- a/color/color.c
+++ b/color/color.c
@@ -74,10 +74,12 @@ void mutt_colors_init(void)
 {
   color_debug(LL_DEBUG5, "init\n");
   color_notify_init();
-  simple_colors_init();
-  regex_colors_init();
+
   curses_colors_init();
   merged_colors_init();
+  quoted_colors_init();
+  regex_colors_init();
+  simple_colors_init();
 
   start_color();
   use_default_colors();

--- a/color/command2.h
+++ b/color/command2.h
@@ -26,8 +26,8 @@
 #include "config.h"
 #include <stdint.h>
 #include "core/lib.h"
-#include "curses2.h"
 
+struct AttrColor;
 struct Buffer;
 
 /**
@@ -37,15 +37,12 @@ struct Buffer;
  *
  * @param[in]  buf   Temporary Buffer space
  * @param[in]  s     Buffer containing string to be parsed
- * @param[out] fg    Foreground colour
- * @param[out] bg    Background colour
- * @param[out] attrs Attributes, e.g. A_UNDERLINE
+ * @param[out] ac    Colour
  * @param[out] err   Buffer for error messages
  * @retval  0 Success
  * @retval -1 Error
  */
-typedef int (*parser_callback_t)(struct Buffer *buf, struct Buffer *s, color_t *fg,
-                                 color_t *bg, int *attrs, struct Buffer *err);
+typedef int (*parser_callback_t)(struct Buffer *buf, struct Buffer *s, struct AttrColor *ac, struct Buffer *err);
 
 enum CommandResult mutt_parse_color  (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult mutt_parse_mono   (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);

--- a/color/curses.c
+++ b/color/curses.c
@@ -89,11 +89,14 @@ static int curses_color_init(color_t fg, color_t bg)
   color_debug(LL_DEBUG5, "lowest index = %d\n", index);
   if (index >= COLOR_PAIRS)
   {
-    static bool warned = false;
-    if (!warned)
+    if (COLOR_PAIRS > 0)
     {
-      mutt_error(_("Too many colors: %d / %d"), index, COLOR_PAIRS);
-      warned = true;
+      static bool warned = false;
+      if (!warned)
+      {
+        mutt_error(_("Too many colors: %d / %d"), index, COLOR_PAIRS);
+        warned = true;
+      }
     }
     return 0;
   }

--- a/color/merged.c
+++ b/color/merged.c
@@ -142,6 +142,8 @@ const struct AttrColor *merged_color_overlay(const struct AttrColor *base,
   ac = attr_color_new();
   ac->curses_color = curses_color_new(fg, bg);
   ac->attrs = attrs;
+  ac->fg = (base->fg.color == COLOR_DEFAULT) ? over->fg : base->fg;
+  ac->bg = (base->bg.color == COLOR_DEFAULT) ? over->bg : base->bg;
   TAILQ_INSERT_TAIL(&MergedColors, ac, entries);
   merged_colors_dump();
 

--- a/color/parse_color.h
+++ b/color/parse_color.h
@@ -24,11 +24,11 @@
 #define MUTT_COLOR_PARSE_COLOR_H
 
 #include "core/lib.h"
-#include "curses2.h"
 
+struct AttrColor;
 struct Buffer;
 
-enum CommandResult parse_attr_spec (struct Buffer *buf, struct Buffer *s, color_t *fg, color_t *bg, int *attrs, struct Buffer *err);
-enum CommandResult parse_color_pair(struct Buffer *buf, struct Buffer *s, color_t *fg, color_t *bg, int *attrs, struct Buffer *err);
+enum CommandResult parse_attr_spec (struct Buffer *buf, struct Buffer *s, struct AttrColor *ac, struct Buffer *err);
+enum CommandResult parse_color_pair(struct Buffer *buf, struct Buffer *s, struct AttrColor *ac, struct Buffer *err);
 
 #endif /* MUTT_COLOR_PARSE_COLOR_H */

--- a/color/quoted.c
+++ b/color/quoted.c
@@ -44,6 +44,20 @@ struct AttrColor QuotedColors[COLOR_QUOTES_MAX]; ///< Array of colours for quote
 int NumQuotedColors; ///< Number of colours for quoted email text
 
 /**
+ * quoted_colors_init - Initialise the Quoted colours
+ */
+void quoted_colors_init(void)
+{
+  for (size_t i = 0; i < COLOR_QUOTES_MAX; i++)
+  {
+    struct AttrColor *ac = &QuotedColors[i];
+    ac->fg.color = COLOR_DEFAULT;
+    ac->bg.color = COLOR_DEFAULT;
+  }
+  NumQuotedColors = 0;
+}
+
+/**
  * find_highest_used - Find the highest-numbered quotedN in use
  * @retval num Highest number
  */

--- a/color/quoted.c
+++ b/color/quoted.c
@@ -108,16 +108,14 @@ int quoted_colors_num_used(void)
 /**
  * quoted_colors_parse_color - Parse the 'color quoted' command
  * @param cid     Colour Id, should be #MT_COLOR_QUOTED
- * @param fg      Foreground colour
- * @param bg      Background colour
- * @param attrs   Attributes, e.g. A_UNDERLINE
+ * @param ac_val  Colour value to use
  * @param q_level Quoting depth level
  * @param rc      Return code, e.g. #MUTT_CMD_SUCCESS
  * @param err     Buffer for error messages
  * @retval true Colour was parsed
  */
-bool quoted_colors_parse_color(enum ColorId cid, color_t fg, color_t bg,
-                               int attrs, int q_level, int *rc, struct Buffer *err)
+bool quoted_colors_parse_color(enum ColorId cid, struct AttrColor *ac_val,
+                               int q_level, int *rc, struct Buffer *err)
 {
   if (cid != MT_COLOR_QUOTED)
     return false;
@@ -134,12 +132,10 @@ bool quoted_colors_parse_color(enum ColorId cid, color_t fg, color_t bg,
 
   struct AttrColor *ac = &QuotedColors[q_level];
   const bool was_set = ((ac->attrs != 0) || ac->curses_color);
-  ac->attrs = attrs;
 
-  struct CursesColor *cc = curses_color_new(fg, bg);
-  curses_color_free(&ac->curses_color);
-  ac->curses_color = cc;
+  attr_color_overwrite(ac, ac_val);
 
+  struct CursesColor *cc = ac->curses_color;
   if (!cc)
     NumQuotedColors = find_highest_used();
 

--- a/color/quoted.h
+++ b/color/quoted.h
@@ -74,6 +74,7 @@ struct QuoteStyle
   struct QuoteStyle *up, *down;     ///< Parent (less quoted) and child (more quoted) levels
 };
 
+void               quoted_colors_init(void);
 void               quoted_colors_cleanup(void);
 struct AttrColor * quoted_colors_get(int q);
 int                quoted_colors_num_used(void);

--- a/color/quoted.h
+++ b/color/quoted.h
@@ -29,7 +29,6 @@
 #include "core/lib.h"
 #include "attr.h"
 #include "color.h"
-#include "curses2.h"
 
 struct Buffer;
 
@@ -79,7 +78,7 @@ void               quoted_colors_cleanup(void);
 struct AttrColor * quoted_colors_get(int q);
 int                quoted_colors_num_used(void);
 
-bool               quoted_colors_parse_color  (enum ColorId cid, color_t fg, color_t bg, int attrs, int q_level, int *rc, struct Buffer *err);
+bool               quoted_colors_parse_color  (enum ColorId cid, struct AttrColor *ac_val, int q_level, int *rc, struct Buffer *err);
 enum CommandResult quoted_colors_parse_uncolor(enum ColorId cid, int q_level, struct Buffer *err);
 
 struct QuoteStyle *qstyle_classify (struct QuoteStyle **quote_list, const char *qptr, size_t length, bool *force_redraw, int *q_level);

--- a/color/regex.c
+++ b/color/regex.c
@@ -39,7 +39,6 @@
 #include "attr.h"
 #include "color.h"
 #include "command2.h"
-#include "curses2.h"
 #include "debug.h"
 #include "notify2.h"
 #include "regex4.h"
@@ -225,9 +224,7 @@ struct RegexColorList *regex_colors_get_list(enum ColorId cid)
  * @param rcl       List of existing colours
  * @param s         String to match
  * @param sensitive true if the pattern case-sensitive
- * @param fg        Foreground colour
- * @param bg        Background colour
- * @param attrs     Attributes, e.g. A_UNDERLINE
+ * @param ac_val    Colour value to use
  * @param err       Buffer for error messages
  * @param is_index  true of this is for the index
  * @param match     Number of regex subexpression to match (0 for entire pattern)
@@ -237,7 +234,7 @@ struct RegexColorList *regex_colors_get_list(enum ColorId cid)
  * called from mutt_parse_color()
  */
 static enum CommandResult add_pattern(struct RegexColorList *rcl, const char *s,
-                                      bool sensitive, color_t fg, color_t bg, int attrs,
+                                      bool sensitive, struct AttrColor *ac_val,
                                       struct Buffer *err, bool is_index, int match)
 {
   struct RegexColor *rcol = NULL;
@@ -254,21 +251,7 @@ static enum CommandResult add_pattern(struct RegexColorList *rcl, const char *s,
   if (rcol) // found a matching regex
   {
     struct AttrColor *ac = &rcol->attr_color;
-    struct CursesColor *cc = ac->curses_color;
-
-    // different colours
-    if (!cc || (cc->fg != fg) || (cc->bg != bg))
-    {
-      cc = curses_color_new(fg, bg);
-      if (cc)
-      {
-        attr_color_clear(&rcol->attr_color);
-        cc->fg = fg;
-        cc->bg = bg;
-      }
-      ac->curses_color = cc;
-    }
-    ac->attrs = attrs;
+    attr_color_overwrite(ac, ac_val);
   }
   else
   {
@@ -307,10 +290,11 @@ static enum CommandResult add_pattern(struct RegexColorList *rcl, const char *s,
     }
     rcol->pattern = mutt_str_dup(s);
     rcol->match = match;
-    struct CursesColor *cc = curses_color_new(fg, bg);
+
     struct AttrColor *ac = &rcol->attr_color;
-    ac->curses_color = cc;
-    ac->attrs = attrs;
+
+    attr_color_overwrite(ac, ac_val);
+
     STAILQ_INSERT_TAIL(rcl, rcol, entries);
   }
 
@@ -328,17 +312,15 @@ static enum CommandResult add_pattern(struct RegexColorList *rcl, const char *s,
  * regex_colors_parse_color_list - Parse a Regex 'color' command
  * @param cid     Colour Id, should be #MT_COLOR_QUOTED
  * @param pat     Regex pattern
- * @param fg      Foreground colour
- * @param bg      Background colour
- * @param attrs   Attributes, e.g. A_UNDERLINE
+ * @param ac      Colour value to use
  * @param rc      Return code, e.g. #MUTT_CMD_SUCCESS
  * @param err     Buffer for error messages
  * @retval true Colour was parsed
  *
  * Parse a Regex 'color' command, e.g. "color index green default pattern"
  */
-bool regex_colors_parse_color_list(enum ColorId cid, const char *pat, color_t fg,
-                                   color_t bg, int attrs, int *rc, struct Buffer *err)
+bool regex_colors_parse_color_list(enum ColorId cid, const char *pat,
+                                   struct AttrColor *ac, int *rc, struct Buffer *err)
 
 {
   if (cid == MT_COLOR_STATUS)
@@ -379,7 +361,7 @@ bool regex_colors_parse_color_list(enum ColorId cid, const char *pat, color_t fg
       return false;
   }
 
-  *rc = add_pattern(rcl, pat, sensitive, fg, bg, attrs, err, is_index, 0);
+  *rc = add_pattern(rcl, pat, sensitive, ac, err, is_index, 0);
 
   struct Buffer *buf = buf_pool_get();
   get_colorid_name(cid, buf);
@@ -400,20 +382,18 @@ bool regex_colors_parse_color_list(enum ColorId cid, const char *pat, color_t fg
  * regex_colors_parse_status_list - Parse a Regex 'color status' command
  * @param cid     Colour ID, should be #MT_COLOR_QUOTED
  * @param pat     Regex pattern
- * @param fg      Foreground colour
- * @param bg      Background colour
- * @param attrs   Attributes, e.g. A_UNDERLINE
+ * @param ac      Colour value to use
  * @param match   Use the nth regex submatch
  * @param err     Buffer for error messages
  * @retval #CommandResult Result e.g. #MUTT_CMD_SUCCESS
  */
-int regex_colors_parse_status_list(enum ColorId cid, const char *pat, color_t fg,
-                                   color_t bg, int attrs, int match, struct Buffer *err)
+int regex_colors_parse_status_list(enum ColorId cid, const char *pat,
+                                   struct AttrColor *ac, int match, struct Buffer *err)
 {
   if (cid != MT_COLOR_STATUS)
     return MUTT_CMD_ERROR;
 
-  int rc = add_pattern(&StatusList, pat, true, fg, bg, attrs, err, false, match);
+  int rc = add_pattern(&StatusList, pat, true, ac, err, false, match);
   if (rc != MUTT_CMD_SUCCESS)
     return rc;
 

--- a/color/regex4.h
+++ b/color/regex4.h
@@ -28,7 +28,6 @@
 #include "mutt/lib.h"
 #include "attr.h"
 #include "color.h"
-#include "curses2.h"
 
 /**
  * struct RegexColor - A regular expression and a color to highlight a line
@@ -57,8 +56,8 @@ void                   regex_colors_init(void);
 
 void                   regex_color_list_clear(struct RegexColorList *rcl);
 
-bool regex_colors_parse_color_list (enum ColorId cid, const char *pat, color_t fg, color_t bg, int attrs, int *rc,   struct Buffer *err);
-int  regex_colors_parse_status_list(enum ColorId cid, const char *pat, color_t fg, color_t bg, int attrs, int match, struct Buffer *err);
+bool regex_colors_parse_color_list (enum ColorId cid, const char *pat, struct AttrColor *ac, int *rc, struct Buffer *err);
+int  regex_colors_parse_status_list(enum ColorId cid, const char *pat, struct AttrColor *ac, int match, struct Buffer *err);
 bool regex_colors_parse_uncolor    (enum ColorId cid, const char *pat, bool uncolor);
 
 #endif /* MUTT_COLOR_REGEX4_H */

--- a/color/simple.c
+++ b/color/simple.c
@@ -35,7 +35,6 @@
 #include "attr.h"
 #include "color.h"
 #include "command2.h"
-#include "curses2.h"
 #include "debug.h"
 #include "notify2.h"
 #include "simple2.h"
@@ -47,6 +46,12 @@ struct AttrColor SimpleColors[MT_COLOR_MAX]; ///< Array of Simple colours
  */
 void simple_colors_init(void)
 {
+  for (int i = 0; i < MT_COLOR_MAX; i++)
+  {
+    SimpleColors[i].fg.color = COLOR_DEFAULT;
+    SimpleColors[i].bg.color = COLOR_DEFAULT;
+  }
+
   // Set some defaults
   color_debug(LL_DEBUG5, "init indicator, markers, etc\n");
   SimpleColors[MT_COLOR_INDICATOR].attrs = A_REVERSE;
@@ -116,22 +121,17 @@ bool simple_color_is_header(enum ColorId cid)
 
 /**
  * simple_color_set - Set the colour of a simple object
- * @param cid   Colour Id, e.g. #MT_COLOR_SEARCH
- * @param fg    Foreground colour
- * @param bg    Background colour
- * @param attrs Attributes, e.g. A_UNDERLINE
+ * @param cid    Colour Id, e.g. #MT_COLOR_SEARCH
+ * @param ac_val Colour value to use
  * @retval ptr Colour
  */
-struct AttrColor *simple_color_set(enum ColorId cid, color_t fg, color_t bg, int attrs)
+struct AttrColor *simple_color_set(enum ColorId cid, struct AttrColor *ac_val)
 {
   struct AttrColor *ac = simple_color_get(cid);
   if (!ac)
     return NULL;
 
-  struct CursesColor *cc = curses_color_new(fg, bg);
-  curses_color_free(&ac->curses_color);
-  ac->curses_color = cc;
-  ac->attrs = attrs;
+  attr_color_overwrite(ac, ac_val);
 
   struct Buffer *buf = buf_pool_get();
   get_colorid_name(cid, buf);

--- a/color/simple2.h
+++ b/color/simple2.h
@@ -27,7 +27,6 @@
 #include <stdbool.h>
 #include "attr.h"
 #include "color.h"
-#include "curses2.h"
 
 extern struct AttrColor SimpleColors[];
 
@@ -35,7 +34,7 @@ struct AttrColor *simple_color_get      (enum ColorId cid);
 bool              simple_color_is_header(enum ColorId cid);
 bool              simple_color_is_set   (enum ColorId cid);
 void              simple_color_reset    (enum ColorId cid);
-struct AttrColor *simple_color_set      (enum ColorId cid, color_t fg, color_t bg, int attrs);
+struct AttrColor *simple_color_set      (enum ColorId cid, struct AttrColor *ac_val);
 
 void              simple_colors_cleanup(void);
 void              simple_colors_init(void);

--- a/pager/display.c
+++ b/pager/display.c
@@ -126,7 +126,7 @@ static void resolve_color(struct MuttWindow *win, struct Line *lines, int line_n
   if (cnt == 0)
   {
     last_color.curses_color = NULL;
-    last_color.attrs = 0;
+    last_color.attrs = A_NORMAL;
   }
 
   if (lines[line_num].cont_line)
@@ -923,7 +923,7 @@ static int format_line(struct MuttWindow *win, struct Line **lines, int line_num
     }
 
     if (ansi && ((flags & (MUTT_SHOWCOLOR | MUTT_SEARCH | MUTT_PAGER_MARKER)) ||
-                 special || last_special || ansi->attrs))
+                 special || last_special || (ansi->attrs != A_NORMAL)))
     {
       resolve_color(win, *lines, line_num, vch, flags, special, ansi);
       last_special = special;
@@ -1027,7 +1027,7 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
   const struct AttrColor *def_color = NULL;
   int m;
   int rc = -1;
-  struct AnsiColor ansi = { NULL, 0, COLOR_DEFAULT, COLOR_DEFAULT };
+  struct AnsiColor ansi = { { COLOR_DEFAULT, 0, 0 }, { COLOR_DEFAULT, 0, 0 }, 0, NULL };
   regmatch_t pmatch[1];
 
   if (line_num == *lines_used)


### PR DESCRIPTION
This is a **Work-In-Progress**.
It works, but I still need to make sure it's robust and degrades correctly if true-colour isn't enabled.

Refactor the colour parsing.


- d75aacfd3 color: introduce ColorElement
  Keep track of the _type_ of colour being used, e.g. palette
- 8c627cd7c color: change parse_color() to use an AttrColor
  Use a temporary object to track the fg, bg, attrs
- 30fd6d697 color: move business logic out of parsers
  Simplify the parsers to just check the **syntax**.
  `parse_color()` will check whether the colours are allowed.

<img src="https://flatcap.org/mutt/colour/parse_color4.svg">

Source: [graphviz](https://flatcap.org/mutt/colour/parse_color4.gv)