### PR TITLE
color: refactor/upgrade debugging

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -181,7 +181,7 @@ $(PWD)/browser:
 # libcolor
 LIBCOLOR=	libcolor.a
 LIBCOLOROBJS=	color/ansi.o color/attr.o color/color.o color/command.o \
-		color/curses.o color/merged.o color/notify.o \
+		color/curses.o color/dump.o color/merged.o color/notify.o \
 		color/parse_ansi.o color/parse_color.o color/quoted.o \
 		color/regex.o color/simple.o
 @if USE_DEBUG_COLOR

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -952,6 +952,7 @@ coverage: all test
 	$(RM) mutt/exit.gc??
 	lcov --test-name "test" --output-file coverage.info --capture \
 	  --directory address \
+	  --directory color \
 	  --directory compress \
 	  --directory config \
 	  --directory core \

--- a/color/ansi.c
+++ b/color/ansi.c
@@ -34,7 +34,6 @@
 #include "attr.h"
 #include "color.h"
 #include "curses2.h"
-#include "debug.h"
 #include "parse_ansi.h"
 #include "simple2.h"
 
@@ -101,7 +100,7 @@ static void ansi_color_list_add(struct AttrColorList *acl, struct AnsiColor *ans
   ansi->attr_color = ac;
 
   TAILQ_INSERT_TAIL(acl, ac, entries);
-  attr_color_list_dump(acl, "AnsiColors");
+  //QWQ attr_color_list_dump(acl, "AnsiColors");
 }
 
 /**

--- a/color/command.c
+++ b/color/command.c
@@ -40,6 +40,7 @@
 #include "color.h"
 #include "command2.h"
 #include "debug.h"
+#include "dump.h"
 #include "globals.h"
 #include "notify2.h"
 #include "parse_color.h"
@@ -302,8 +303,8 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
 
   } while (MoreArgs(s));
 
-  if (changes)
-    regex_colors_dump_all();
+  //QWQ if (changes)
+  //QWQ   regex_colors_dump(buf);
 
   return MUTT_CMD_SUCCESS;
 }
@@ -491,7 +492,7 @@ enum CommandResult mutt_parse_uncolor(struct Buffer *buf, struct Buffer *s,
 
   color_debug(LL_DEBUG5, "parse: %s\n", buf_string(buf));
   enum CommandResult rc = parse_uncolor(buf, s, err, true);
-  curses_colors_dump();
+  curses_colors_dump(buf);
   return rc;
 }
 
@@ -523,7 +524,7 @@ enum CommandResult mutt_parse_color(struct Buffer *buf, struct Buffer *s,
 
   color_debug(LL_DEBUG5, "parse: %s\n", buf_string(buf));
   enum CommandResult rc = parse_color(buf, s, err, parse_color_pair, true);
-  curses_colors_dump();
+  curses_colors_dump(buf);
   return rc;
 }
 
@@ -545,6 +546,6 @@ enum CommandResult mutt_parse_mono(struct Buffer *buf, struct Buffer *s,
 
   color_debug(LL_DEBUG5, "parse: %s\n", buf_string(buf));
   enum CommandResult rc = parse_color(buf, s, err, parse_attr_spec, false);
-  curses_colors_dump();
+  curses_colors_dump(buf);
   return rc;
 }

--- a/color/curses.c
+++ b/color/curses.c
@@ -122,15 +122,16 @@ void curses_color_free(struct CursesColor **ptr)
     return;
 
   struct CursesColor *cc = *ptr;
-  if (cc->ref_count > 1)
+
+  cc->ref_count--;
+  if (cc->ref_count > 0)
   {
-    cc->ref_count--;
-    curses_color_dump(cc, "CursesColor rc--: ");
+    curses_color_dump(cc, "curses rc--");
     *ptr = NULL;
     return;
   }
 
-  curses_color_dump(cc, "free: ");
+  curses_color_dump(cc, "curses free");
   TAILQ_REMOVE(&CursesColors, cc, entries);
   NumCursesColors--;
   color_debug(LL_DEBUG5, "CursesColors: %d\n", NumCursesColors);
@@ -159,7 +160,7 @@ struct CursesColor *curses_color_new(color_t fg, color_t bg)
   if (cc)
   {
     cc->ref_count++;
-    curses_color_dump(cc, "rc++: ");
+    curses_color_dump(cc, "curses rc++");
     return cc;
   }
 
@@ -191,7 +192,7 @@ struct CursesColor *curses_color_new(color_t fg, color_t bg)
   color_debug(LL_DEBUG5, "tail\n");
 
 done:
-  curses_color_dump(cc_new, "CursesColor new: ");
+  curses_color_dump(cc_new, "curses new");
   color_debug(LL_DEBUG5, "CursesColors: %d\n", NumCursesColors);
   return cc_new;
 }

--- a/color/debug.c
+++ b/color/debug.c
@@ -27,134 +27,28 @@
  */
 
 #include "config.h"
-#include <stdbool.h>
 #include <stdio.h>
 #include "mutt/lib.h"
-#include "core/lib.h"
 #include "gui/lib.h"
 #include "debug.h"
 #include "pager/lib.h"
 #include "attr.h"
-#include "color.h"
 #include "curses2.h"
+#include "dump.h"
 #include "pager/private_data.h" // IWYU pragma: keep
-#include "parse_color.h"
-#include "quoted.h"
-#include "regex4.h"
-#include "simple2.h"
 
 extern struct AttrColorList MergedColors;
 extern struct CursesColorList CursesColors;
-extern int NumCursesColors;
-
-extern struct RegexColorList AttachList;
-extern struct RegexColorList BodyList;
-extern struct RegexColorList HeaderList;
-extern struct RegexColorList IndexAuthorList;
-extern struct RegexColorList IndexCollapsedList;
-extern struct RegexColorList IndexDateList;
-extern struct RegexColorList IndexFlagsList;
-extern struct RegexColorList IndexLabelList;
-extern struct RegexColorList IndexList;
-extern struct RegexColorList IndexNumberList;
-extern struct RegexColorList IndexSizeList;
-extern struct RegexColorList IndexSubjectList;
-extern struct RegexColorList IndexTagList;
-extern struct RegexColorList IndexTagsList;
-extern struct RegexColorList StatusList;
 
 /**
- * color_debug_log_color_attrs - Get a colourful string to represent a colour in the log
- * @param ac     Colour
- * @param swatch Buffer for swatch
- *
- * @note Do not free the returned string
- */
-void color_debug_log_color_attrs(struct AttrColor *ac, struct Buffer *swatch)
-{
-  buf_reset(swatch);
-
-  if (ac->attrs & A_BLINK)
-    buf_add_printf(swatch, "\033[5m");
-  if (ac->attrs & A_BOLD)
-    buf_add_printf(swatch, "\033[1m");
-  if (ac->attrs & A_ITALIC)
-    buf_add_printf(swatch, "\033[3m");
-  if (ac->attrs & A_NORMAL)
-    buf_add_printf(swatch, "\033[0m");
-  if (ac->attrs & A_REVERSE)
-    buf_add_printf(swatch, "\033[7m");
-  if (ac->attrs & A_STANDOUT)
-    buf_add_printf(swatch, "\033[1m");
-  if (ac->attrs & A_UNDERLINE)
-    buf_add_printf(swatch, "\033[4m");
-
-  if (ac->fg.color >= 0)
-  {
-    switch (ac->fg.type)
-    {
-      case CT_SIMPLE:
-      {
-        buf_add_printf(swatch, "\033[%dm", 30 + ac->fg.color);
-        break;
-      }
-
-      case CT_PALETTE:
-      {
-        buf_add_printf(swatch, "\033[38;5;%dm", ac->fg.color);
-        break;
-      }
-
-      case CT_RGB:
-      {
-        int r = (ac->fg.color >> 16) & 0xff;
-        int g = (ac->fg.color >> 8) & 0xff;
-        int b = (ac->fg.color >> 0) & 0xff;
-        buf_add_printf(swatch, "\033[38;2;%d;%d;%dm", r, g, b);
-        break;
-      }
-    }
-  }
-
-  if (ac->bg.color >= 0)
-  {
-    switch (ac->bg.type)
-    {
-      case CT_SIMPLE:
-      {
-        buf_add_printf(swatch, "\033[%dm", 40 + ac->bg.color);
-        break;
-      }
-
-      case CT_PALETTE:
-      {
-        buf_add_printf(swatch, "\033[48;5;%dm", ac->bg.color);
-        break;
-      }
-
-      case CT_RGB:
-      {
-        int r = (ac->bg.color >> 16) & 0xff;
-        int g = (ac->bg.color >> 8) & 0xff;
-        int b = (ac->bg.color >> 0) & 0xff;
-        buf_add_printf(swatch, "\033[48;2;%d;%d;%dm", r, g, b);
-        break;
-      }
-    }
-  }
-
-  buf_addstr(swatch, "XXXXXX\033[0m");
-}
-
-/**
- * color_debug_log_color - Get a colourful string to represent a colour in the log
+ * color_log_color - Get a colourful string to represent a colour in the log
  * @param fg Foreground colour
  * @param bg Background colour
  * @retval ptr Generated string
  *
  * @note Do not free the returned string
  */
-const char *color_debug_log_color(color_t fg, color_t bg)
+const char *color_log_color(color_t fg, color_t bg)
 {
   static char text[64];
   size_t pos = 0;
@@ -184,248 +78,40 @@ const char *color_debug_log_color(color_t fg, color_t bg)
 }
 
 /**
- * color_debug_log_attrcolor - XXX
- *
- * @note Do not free the returned string
+ * ansi_colors_dump - Dump all the ANSI colours
+ * @param buf   Buffer for result
  */
-void color_debug_log_attrcolor(struct AttrColor *ac, struct Buffer *buf)
+void ansi_colors_dump(struct Buffer *buf)
 {
-  if (ac->fg.color != -1)
-  {
-    switch (ac->fg.type)
-    {
-      case CT_SIMPLE:
-      {
-        buf_add_printf(buf, "\033[%dm", 30 + ac->fg.color);
-        break;
-      }
-
-      case CT_PALETTE:
-      {
-        buf_add_printf(buf, "\033[38;5;%dm", ac->fg.color);
-        break;
-      }
-
-      case CT_RGB:
-      {
-        const int r = (ac->fg.color >> 16) & 0xff;
-        const int g = (ac->fg.color >> 8) & 0xff;
-        const int b = (ac->fg.color >> 0) & 0xff;
-
-        buf_add_printf(buf, "\033[38;2;%d;%d;%dm", r, g, b);
-        break;
-      }
-    }
-  }
-
-  if (ac->bg.color != -1)
-  {
-    switch (ac->bg.type)
-    {
-      case CT_SIMPLE:
-      {
-        buf_add_printf(buf, "\033[%dm", 40 + ac->bg.color);
-        break;
-      }
-
-      case CT_PALETTE:
-      {
-        buf_add_printf(buf, "\033[48;5;%dm", ac->bg.color);
-        break;
-      }
-
-      case CT_RGB:
-      {
-        const int r = (ac->bg.color >> 16) & 0xff;
-        const int g = (ac->bg.color >> 8) & 0xff;
-        const int b = (ac->bg.color >> 0) & 0xff;
-
-        buf_add_printf(buf, "\033[48;2;%d;%d;%dm", r, g, b);
-        break;
-      }
-    }
-  }
-
-  buf_addstr(buf, "XXXXXX\033[0m");
-}
-
-/**
- * color_debug_log_attrs - Get a string to represent some attributes in the log
- * @param attrs Attributes, e.g. A_UNDERLINE
- * @retval ptr Generated string
- *
- * @note Do not free the returned string
- */
-const char *color_debug_log_attrs(int attrs)
-{
-  static char text[64];
-  struct Mapping attr_names[] = {
-    { "\033[5mBLI\033[0m", A_BLINK },
-    { "\033[1mBLD\033[0m", A_BOLD },
-    { "\033[0mNOR\033[0m", A_NORMAL },
-    { "\033[7mREV\033[0m", A_REVERSE },
-    { "\033[1mSTD\033[0m", A_STANDOUT },
-    { "\033[4mUND\033[0m", A_UNDERLINE },
-    { NULL, 0 },
-  };
-
-  int offset = 0;
-  text[0] = '\0';
-  for (int i = 0; attr_names[i].name; i++)
-  {
-    if (attrs & attr_names[i].value)
-    {
-      offset += snprintf(text + offset, sizeof(text) - offset, "%s ",
-                         attr_names[i].name);
-    }
-  }
-  return text;
-}
-
-/**
- * color_debug_log_attrs_list - Get a string to represent some attributes in the log
- * @param attrs Attributes, e.g. A_UNDERLINE
- * @retval ptr Generated string
- *
- * @note Do not free the returned string
- */
-const char *color_debug_log_attrs_list(int attrs)
-{
-  static char text[64];
-
-  text[0] = '\0';
-  int pos = 0;
-  if (attrs & A_BLINK)
-    pos += snprintf(text + pos, sizeof(text) - pos, "blink ");
-  if (attrs & A_BOLD)
-    pos += snprintf(text + pos, sizeof(text) - pos, "bold ");
-  if (attrs & A_ITALIC)
-    pos += snprintf(text + pos, sizeof(text) - pos, "italic ");
-  if (attrs & A_NORMAL)
-    pos += snprintf(text + pos, sizeof(text) - pos, "normal ");
-  if (attrs & A_REVERSE)
-    pos += snprintf(text + pos, sizeof(text) - pos, "reverse ");
-  if (attrs & A_STANDOUT)
-    pos += snprintf(text + pos, sizeof(text) - pos, "standout ");
-  if (attrs & A_UNDERLINE)
-    pos += snprintf(text + pos, sizeof(text) - pos, "underline ");
-
-  return text;
-}
-
-/**
- * color_debug_log_name - Get a string to represent a colour name
- * @param buf    Buffer for the result
- * @param buflen Length of the Buffer
- * @param elem   Colour to use
- * @retval ptr Generated string
- */
-const char *color_debug_log_name(char *buf, int buflen, struct ColorElement *elem)
-{
-  if (elem->color < 0)
-    return "default";
-
-  switch (elem->type)
-  {
-    case CT_SIMPLE:
-    {
-      const char *prefix = NULL;
-      switch (elem->prefix)
-      {
-        case COLOR_PREFIX_ALERT:
-          prefix = "alert";
-          break;
-        case COLOR_PREFIX_BRIGHT:
-          prefix = "bright";
-          break;
-        case COLOR_PREFIX_LIGHT:
-          prefix = "light";
-          break;
-        default:
-          prefix = "";
-          break;
-      }
-
-      const char *name = mutt_map_get_name(elem->color, ColorNames);
-      snprintf(buf, buflen, "%s%s", prefix, name);
-      break;
-    }
-
-    case CT_PALETTE:
-    {
-      if (elem->color < 256)
-        snprintf(buf, buflen, "color%d", elem->color);
-      else
-        snprintf(buf, buflen, "BAD:%d", elem->color);
-      break;
-    }
-
-    case CT_RGB:
-    {
-      int r = (elem->color >> 16) & 0xff;
-      int g = (elem->color >> 8) & 0xff;
-      int b = (elem->color >> 0) & 0xff;
-      snprintf(buf, buflen, "#%02x%02x%02x", r, g, b);
-      break;
-    }
-  }
-
-  return buf;
-}
-
-/**
- * attr_color_dump - Dump an Attr Colour to the log
- * @param ac     AttrColor to dump
- * @param prefix prefix for the log block
- */
-void attr_color_dump(struct AttrColor *ac, const char *prefix)
-{
-  if (!ac)
+  struct MuttWindow *win = window_get_focus();
+  if (!win || (win->type != WT_CUSTOM) || !win->parent || (win->parent->type != WT_PAGER))
     return;
 
-  int index = ac->curses_color ? ac->curses_color->index : -1;
-
-  color_t fg = COLOR_DEFAULT;
-  color_t bg = COLOR_DEFAULT;
-  struct CursesColor *cc = ac->curses_color;
-  if (cc)
-  {
-    fg = cc->fg;
-    bg = cc->bg;
-  }
-  const char *color = color_debug_log_color(fg, bg);
-  const char *attrs = color_debug_log_attrs(ac->attrs);
-  color_debug(LL_DEBUG5, "%s| %5d | %s | 0x%08x | %s\n", NONULL(prefix), index,
-              color, ac->attrs, attrs);
-}
-
-/**
- * attr_color_list_dump - Dump all the Attr Colours to the log
- * @param acl   List of Attr colours
- * @param title Title for the log block
- */
-void attr_color_list_dump(struct AttrColorList *acl, const char *title)
-{
-  if (!acl)
+  struct PagerPrivateData *priv = win->parent->wdata;
+  if (!priv || TAILQ_EMPTY(&priv->ansi_list))
     return;
 
-  int count = 0;
+  struct Buffer *swatch = buf_pool_get();
+  char color_fg[64] = { 0 };
+  char color_bg[64] = { 0 };
+
+  buf_addstr(buf, "# Ansi Colors\n");
   struct AttrColor *ac = NULL;
-  TAILQ_FOREACH(ac, acl, entries)
+  TAILQ_FOREACH(ac, &priv->ansi_list, entries)
   {
-    count++;
+    struct CursesColor *cc = ac->curses_color;
+    if (!cc)
+      continue;
+
+    color_log_color_attrs(ac, swatch);
+    buf_add_printf(buf, "# %-30s %-16s %-16s # %s\n", color_log_attrs_list(ac->attrs),
+                   color_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                   color_log_name(color_bg, sizeof(color_bg), &ac->bg),
+                   buf_string(swatch));
   }
 
-  color_debug(LL_DEBUG5, "\033[1;32m%s:\033[0m (%d)\n", title, count);
-  if (count == 0)
-    return;
-
-  color_debug(LL_DEBUG5, "    | Index | Colour | Attrs      | Attrs\n");
-
-  TAILQ_FOREACH(ac, acl, entries)
-  {
-    attr_color_dump(ac, "    ");
-  }
+  buf_addstr(buf, "\n");
+  buf_pool_release(&swatch);
 }
 
 /**
@@ -446,372 +132,71 @@ void curses_color_dump(struct CursesColor *cc, const char *prefix)
   if (cc->bg != -1)
     snprintf(bg, sizeof(bg), "#%06x", cc->bg);
 
-  const char *color = color_debug_log_color(cc->fg, cc->bg);
-  color_debug(LL_DEBUG5, "%s| %5d | %-7s %-7s | %s | %2d |\n", NONULL(prefix),
+  const char *color = color_log_color(cc->fg, cc->bg);
+  color_debug(LL_DEBUG5, "%s index %d, %s %s %s rc %d\n", NONULL(prefix),
               cc->index, fg, bg, color, cc->ref_count);
 }
 
 /**
- * curses_colors_dump - Log all the Curses colours
+ * curses_colors_dump - Dump all the Curses colours
+ * @param buf   Buffer for result
  */
-void curses_colors_dump(void)
+void curses_colors_dump(struct Buffer *buf)
 {
-  color_debug(LL_DEBUG5, "\033[1;32mCursesColors:\033[0m (%d)\n", NumCursesColors);
   if (TAILQ_EMPTY(&CursesColors))
     return;
 
-  color_debug(LL_DEBUG5, "    | Index | fg      bg      | Colour | rc |\n");
+  struct Buffer *swatch = buf_pool_get();
+
+  buf_addstr(buf, "# Curses Colors\n");
+  buf_add_printf(buf, "# Index fg      bg      Color  rc\n");
 
   struct CursesColor *cc = NULL;
   TAILQ_FOREACH(cc, &CursesColors, entries)
   {
-    curses_color_dump(cc, "    ");
+    char fg[16] = "-";
+    char bg[16] = "-";
+
+    if (cc->fg != -1)
+      snprintf(fg, sizeof(fg), "#%06x", cc->fg);
+    if (cc->bg != -1)
+      snprintf(bg, sizeof(bg), "#%06x", cc->bg);
+
+    const char *color = color_log_color(cc->fg, cc->bg);
+    buf_add_printf(buf, "# %5d %-7s %-7s %s %2d\n", cc->index, fg, bg, color, cc->ref_count);
   }
+
+  buf_addstr(buf, "\n");
+  buf_pool_release(&swatch);
 }
 
 /**
- * quoted_color_dump - Log a Quoted colour
- * @param ac      Quoted colour
- * @param q_level Quote level
- * @param prefix  Prefix for the log line
+ * merged_colors_dump - Dump all the Merged colours
  */
-void quoted_color_dump(struct AttrColor *ac, int q_level, const char *prefix)
+void merged_colors_dump(struct Buffer *buf)
 {
-  if (!ac)
+  if (TAILQ_EMPTY(&MergedColors))
     return;
-
-  int index = ac->curses_color ? ac->curses_color->index : -1;
-
-  if ((index >= 0) || (ac->attrs != 0))
-  {
-    struct Buffer *color_str = buf_pool_get();
-    color_debug_log_attrcolor(ac, color_str);
-
-    const char *attrs = color_debug_log_attrs(ac->attrs);
-    color_debug(LL_DEBUG5, "%s| quoted%d | %5d | %s | 0x%08x | %s\n", prefix,
-                q_level, index, buf_string(color_str), ac->attrs, attrs);
-
-    buf_pool_release(&color_str);
-  }
-  else
-  {
-    color_debug(LL_DEBUG5, "%s| quoted%d | %5d |        |            |\n",
-                prefix, q_level, index);
-  }
-}
-
-/**
- * quoted_color_list_dump - Log all the Quoted colours
- */
-void quoted_color_list_dump(void)
-{
-  color_debug(LL_DEBUG5, "\033[1;32mQuotedColors:\033[0m (%d)\n", NumQuotedColors);
-  color_debug(LL_DEBUG5, "    | Name    | Index | Colour | Attrs      | Attrs\n");
-  for (size_t i = 0; i < COLOR_QUOTES_MAX; i++)
-  {
-    quoted_color_dump(&QuotedColors[i], i, "    ");
-  }
-}
-
-/**
- * regex_color_dump - Dump a Regex colour to the log
- * @param rcol   Regex to dump
- * @param prefix Prefix for the log line
- */
-void regex_color_dump(struct RegexColor *rcol, const char *prefix)
-{
-  if (!rcol)
-    return;
-
-  struct AttrColor *ac = &rcol->attr_color;
-  int index = ac->curses_color ? ac->curses_color->index : -1;
-
-  struct Buffer *color_str = buf_pool_get();
-  color_debug_log_attrcolor(ac, color_str);
-
-  const char *attrs = color_debug_log_attrs(ac->attrs);
-  color_debug(LL_DEBUG5, "%s| %5d | %s | 0x%08x | %-8s | %s\n", NONULL(prefix),
-              index, buf_string(color_str), ac->attrs, attrs, rcol->pattern);
-
-  buf_pool_release(&color_str);
-}
-
-/**
- * regex_color_list_dump - Dump one Regex's colours to the log
- * @param name Name of the Regex
- * @param rcl  RegexColorList to dump
- */
-void regex_color_list_dump(const char *name, struct RegexColorList *rcl)
-{
-  if (!name || !rcl)
-    return;
-
-  int count = 0;
-  struct RegexColor *rcol = NULL;
-  STAILQ_FOREACH(rcol, rcl, entries)
-  {
-    count++;
-  }
-
-  color_debug(LL_DEBUG5, "\033[1;32mRegexColorList %s\033[0m (%d)\n", name, count);
-  if (count == 0)
-    return;
-
-  color_debug(LL_DEBUG5, "    | Index | Colour | Attrs      | Attrs    | Pattern\n");
-  STAILQ_FOREACH(rcol, rcl, entries)
-  {
-    regex_color_dump(rcol, "    ");
-  }
-}
-
-/**
- * regex_colors_dump_all - Dump all the Regex colours to the log
- */
-void regex_colors_dump_all(void)
-{
-  regex_color_list_dump("AttachList", &AttachList);
-  regex_color_list_dump("BodyList", &BodyList);
-  regex_color_list_dump("HeaderList", &HeaderList);
-  regex_color_list_dump("IndexAuthorList", &IndexAuthorList);
-  regex_color_list_dump("IndexCollapsedList", &IndexCollapsedList);
-  regex_color_list_dump("IndexDateList", &IndexDateList);
-  regex_color_list_dump("IndexFlagsList", &IndexFlagsList);
-  regex_color_list_dump("IndexLabelList", &IndexLabelList);
-  regex_color_list_dump("IndexList", &IndexList);
-  regex_color_list_dump("IndexNumberList", &IndexNumberList);
-  regex_color_list_dump("IndexSizeList", &IndexSizeList);
-  regex_color_list_dump("IndexSubjectList", &IndexSubjectList);
-  regex_color_list_dump("IndexTagList", &IndexTagList);
-  regex_color_list_dump("IndexTagsList", &IndexTagsList);
-  regex_color_list_dump("StatusList", &StatusList);
-}
-
-/**
- * simple_color_dump - Dump a Simple colour to the log
- * @param cid    Colour Id, e.g. #MT_COLOR_UNDERLINE
- * @param prefix Prefix for the log line
- */
-void simple_color_dump(enum ColorId cid, const char *prefix)
-{
-  struct AttrColor *ac = &SimpleColors[cid];
-  int index = ac->curses_color ? ac->curses_color->index : -1;
-  const char *name = NULL;
-  const char *compose = "";
-
-  name = mutt_map_get_name(cid, ColorFields);
-  if (!name)
-  {
-    name = mutt_map_get_name(cid, ComposeColorFields);
-    if (name)
-    {
-      compose = "compose ";
-    }
-  }
-
-  struct Buffer *color_str = buf_pool_get();
-  color_debug_log_attrcolor(ac, color_str);
-
-  const char *attrs_str = color_debug_log_attrs(ac->attrs);
-  color_debug(LL_DEBUG5, "%s| %s%-19s | %5d | %s | 0x%08x | %s\n", prefix,
-              compose, name, index, buf_string(color_str), ac->attrs, attrs_str);
-
-  buf_pool_release(&color_str);
-}
-
-/**
- * simple_colors_dump - Dump all the Simple colours to the log
- * @param force If true, list unset colours
- */
-void simple_colors_dump(bool force)
-{
-  color_debug(LL_DEBUG5, "\033[1;32mSimpleColors:\033[0m\n");
-  color_debug(LL_DEBUG5, "    | Name                | Index | Colour | Attrs      | Attrs\n");
-  for (enum ColorId cid = MT_COLOR_NONE; cid < MT_COLOR_MAX; cid++)
-  {
-    struct AttrColor *ac = &SimpleColors[cid];
-    if (!force && !attr_color_is_set(ac))
-      continue;
-
-    simple_color_dump(cid, "    ");
-  }
-}
-
-/**
- * merged_colors_dump - Dump all the Merged colours to the log
- */
-void merged_colors_dump(void)
-{
-  attr_color_list_dump(&MergedColors, "MergedColors");
-}
-
-/**
- * color_dump - Display all the colours in the Pager
- */
-void color_dump(void)
-{
-  struct Buffer *tmp_file = buf_pool_get();
-
-  buf_mktemp(tmp_file);
-  FILE *fp = mutt_file_fopen(buf_string(tmp_file), "w");
-  if (!fp)
-  {
-    // L10N: '%s' is the file name of the temporary file
-    mutt_error(_("Could not create temporary file %s"), buf_string(tmp_file));
-    buf_pool_release(&tmp_file);
-    return;
-  }
 
   struct Buffer *swatch = buf_pool_get();
   char color_fg[64] = { 0 };
   char color_bg[64] = { 0 };
 
-  fputs("# All Colours\n\n", fp);
-  fputs("# Simple Colours\n", fp);
-  for (enum ColorId cid = MT_COLOR_NONE + 1; cid < MT_COLOR_MAX; cid++)
+  buf_addstr(buf, "# Merged Colors\n");
+  struct AttrColor *ac = NULL;
+  TAILQ_FOREACH(ac, &MergedColors, entries)
   {
-    struct AttrColor *ac = simple_color_get(cid);
-    if (!ac)
-      continue;
-
     struct CursesColor *cc = ac->curses_color;
-    if (!cc && (ac->attrs == 0))
+    if (!cc)
       continue;
 
-    const char *name = mutt_map_get_name(cid, ColorFields);
-    if (!name)
-      continue;
-
-    color_debug_log_color_attrs(ac, swatch);
-    fprintf(fp, "color %-18s %-30s %-16s %-16s # %s\n", name,
-            color_debug_log_attrs_list(ac->attrs),
-            color_debug_log_name(color_fg, sizeof(color_fg), &ac->fg),
-            color_debug_log_name(color_bg, sizeof(color_bg), &ac->bg), buf_string(swatch));
+    color_log_color_attrs(ac, swatch);
+    buf_add_printf(buf, "# %-30s %-16s %-16s # %s\n", color_log_attrs_list(ac->attrs),
+                   color_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                   color_log_name(color_bg, sizeof(color_bg), &ac->bg),
+                   buf_string(swatch));
   }
 
-  if (NumQuotedColors > 0)
-  {
-    fputs("\n# Quoted Colours\n", fp);
-    for (int i = 0; i < NumQuotedColors; i++)
-    {
-      struct AttrColor *ac = quoted_colors_get(i);
-      if (!ac)
-        continue;
-
-      // struct CursesColor *cc = ac->curses_color;
-      // if (!cc)
-      //   continue;
-
-      color_debug_log_color_attrs(ac, swatch);
-      fprintf(fp, "color quoted%d %-30s %-16s %-16s # %s\n", i,
-              color_debug_log_attrs_list(ac->attrs),
-              color_debug_log_name(color_fg, sizeof(color_fg), &ac->fg),
-              color_debug_log_name(color_bg, sizeof(color_bg), &ac->bg), buf_string(swatch));
-    }
-  }
-
-  int rl_count = 0;
-  for (enum ColorId id = MT_COLOR_NONE; id != MT_COLOR_MAX; id++)
-  {
-    if (!mutt_color_has_pattern(id))
-    {
-      continue;
-    }
-
-    struct RegexColorList *rcl = regex_colors_get_list(id);
-    if (!STAILQ_EMPTY(rcl))
-      rl_count++;
-  }
-
-  if (rl_count > 0)
-  {
-    for (enum ColorId id = MT_COLOR_NONE; id != MT_COLOR_MAX; id++)
-    {
-      if (!mutt_color_has_pattern(id))
-      {
-        continue;
-      }
-
-      struct RegexColorList *rcl = regex_colors_get_list(id);
-      if (STAILQ_EMPTY(rcl))
-        continue;
-
-      const char *name = mutt_map_get_name(id, ColorFields);
-      if (!name)
-        continue;
-
-      fprintf(fp, "\n# Regex Colour %s\n", name);
-
-      struct RegexColor *rc = NULL;
-      STAILQ_FOREACH(rc, rcl, entries)
-      {
-        struct AttrColor *ac = &rc->attr_color;
-        struct CursesColor *cc = ac->curses_color;
-        if (!cc)
-          continue;
-
-        color_debug_log_color_attrs(ac, swatch);
-        fprintf(fp, "color %-14s %-30s %-16s %-16s %-30s # %s\n", name,
-                color_debug_log_attrs_list(ac->attrs),
-                color_debug_log_name(color_fg, sizeof(color_fg), &ac->fg),
-                color_debug_log_name(color_bg, sizeof(color_bg), &ac->bg),
-                rc->pattern, buf_string(swatch));
-      }
-    }
-  }
-
-  if (!TAILQ_EMPTY(&MergedColors))
-  {
-    fputs("\n# Merged Colours\n", fp);
-    struct AttrColor *ac = NULL;
-    TAILQ_FOREACH(ac, &MergedColors, entries)
-    {
-      struct CursesColor *cc = ac->curses_color;
-      if (!cc)
-        continue;
-
-      color_debug_log_color_attrs(ac, swatch);
-      fprintf(fp, "# %-30s %-16s %-16s # %s\n", color_debug_log_attrs_list(ac->attrs),
-              color_debug_log_name(color_fg, sizeof(color_fg), &ac->fg),
-              color_debug_log_name(color_bg, sizeof(color_bg), &ac->bg),
-              buf_string(swatch));
-    }
-  }
-
-  struct MuttWindow *win = window_get_focus();
-  if (win && (win->type == WT_CUSTOM) && win->parent && (win->parent->type == WT_PAGER))
-  {
-    struct PagerPrivateData *priv = win->parent->wdata;
-    if (priv && !TAILQ_EMPTY(&priv->ansi_list))
-    {
-      fputs("\n# Ansi Colours\n", fp);
-      struct AttrColor *ac = NULL;
-      TAILQ_FOREACH(ac, &priv->ansi_list, entries)
-      {
-        struct CursesColor *cc = ac->curses_color;
-        if (!cc)
-          continue;
-
-        color_debug_log_color_attrs(ac, swatch);
-        fprintf(fp, "# %-30s %-16s %-16s # %s\n", color_debug_log_attrs_list(ac->attrs),
-                color_debug_log_name(color_fg, sizeof(color_fg), &ac->fg),
-                color_debug_log_name(color_bg, sizeof(color_bg), &ac->bg),
-                buf_string(swatch));
-      }
-    }
-  }
-
-  mutt_file_fclose(&fp);
-
-  struct PagerData pdata = { 0 };
-  struct PagerView pview = { &pdata };
-
-  pdata.fname = buf_string(tmp_file);
-
-  pview.banner = "color";
-  pview.flags = MUTT_SHOWCOLOR;
-  pview.mode = PAGER_MODE_OTHER;
-
-  mutt_do_pager(&pview, NULL);
-  buf_pool_release(&tmp_file);
+  buf_addstr(buf, "\n");
   buf_pool_release(&swatch);
 }

--- a/color/debug.c
+++ b/color/debug.c
@@ -38,6 +38,7 @@
 #include "color.h"
 #include "curses2.h"
 #include "pager/private_data.h" // IWYU pragma: keep
+#include "parse_color.h"
 #include "quoted.h"
 #include "regex4.h"
 #include "simple2.h"
@@ -64,34 +65,83 @@ extern struct RegexColorList StatusList;
 
 /**
  * color_debug_log_color_attrs - Get a colourful string to represent a colour in the log
- * @param fg     Foreground colour
- * @param bg     Background colour
- * @param attrs  Attributes, e.g. A_UNDERLINE
+ * @param ac     Colour
  * @param swatch Buffer for swatch
  *
  * @note Do not free the returned string
  */
-void color_debug_log_color_attrs(color_t fg, color_t bg, int attrs, struct Buffer *swatch)
+void color_debug_log_color_attrs(struct AttrColor *ac, struct Buffer *swatch)
 {
   buf_reset(swatch);
 
-  if (attrs & A_BLINK)
+  if (ac->attrs & A_BLINK)
     buf_add_printf(swatch, "\033[5m");
-  if (attrs & A_BOLD)
+  if (ac->attrs & A_BOLD)
     buf_add_printf(swatch, "\033[1m");
-  if (attrs & A_NORMAL)
+  if (ac->attrs & A_ITALIC)
+    buf_add_printf(swatch, "\033[3m");
+  if (ac->attrs & A_NORMAL)
     buf_add_printf(swatch, "\033[0m");
-  if (attrs & A_REVERSE)
+  if (ac->attrs & A_REVERSE)
     buf_add_printf(swatch, "\033[7m");
-  if (attrs & A_STANDOUT)
+  if (ac->attrs & A_STANDOUT)
     buf_add_printf(swatch, "\033[1m");
-  if (attrs & A_UNDERLINE)
+  if (ac->attrs & A_UNDERLINE)
     buf_add_printf(swatch, "\033[4m");
 
-  if (fg >= 0)
-    buf_add_printf(swatch, "\033[38;5;%dm", fg);
-  if (bg >= 0)
-    buf_add_printf(swatch, "\033[48;5;%dm", bg);
+  if (ac->fg.color >= 0)
+  {
+    switch (ac->fg.type)
+    {
+      case CT_SIMPLE:
+      {
+        buf_add_printf(swatch, "\033[%dm", 30 + ac->fg.color);
+        break;
+      }
+
+      case CT_PALETTE:
+      {
+        buf_add_printf(swatch, "\033[38;5;%dm", ac->fg.color);
+        break;
+      }
+
+      case CT_RGB:
+      {
+        int r = (ac->fg.color >> 16) & 0xff;
+        int g = (ac->fg.color >> 8) & 0xff;
+        int b = (ac->fg.color >> 0) & 0xff;
+        buf_add_printf(swatch, "\033[38;2;%d;%d;%dm", r, g, b);
+        break;
+      }
+    }
+  }
+
+  if (ac->bg.color >= 0)
+  {
+    switch (ac->bg.type)
+    {
+      case CT_SIMPLE:
+      {
+        buf_add_printf(swatch, "\033[%dm", 40 + ac->bg.color);
+        break;
+      }
+
+      case CT_PALETTE:
+      {
+        buf_add_printf(swatch, "\033[48;5;%dm", ac->bg.color);
+        break;
+      }
+
+      case CT_RGB:
+      {
+        int r = (ac->bg.color >> 16) & 0xff;
+        int g = (ac->bg.color >> 8) & 0xff;
+        int b = (ac->bg.color >> 0) & 0xff;
+        buf_add_printf(swatch, "\033[48;2;%d;%d;%dm", r, g, b);
+        break;
+      }
+    }
+  }
 
   buf_addstr(swatch, "XXXXXX\033[0m");
 }
@@ -107,8 +157,96 @@ void color_debug_log_color_attrs(color_t fg, color_t bg, int attrs, struct Buffe
 const char *color_debug_log_color(color_t fg, color_t bg)
 {
   static char text[64];
-  snprintf(text, sizeof(text), "\033[38;5;%dm\033[48;5;%dmXXXXXX\033[0m", fg, bg);
+  size_t pos = 0;
+  // snprintf(text, sizeof(text), "\033[38;5;%dm\033[48;5;%dmXXXXXX\033[0m", fg, bg);
+
+  if (fg != -1)
+  {
+    int r = (fg >> 16) & 0xff;
+    int g = (fg >> 8) & 0xff;
+    int b = (fg >> 0) & 0xff;
+
+    pos += snprintf(text + pos, sizeof(text) - pos, "\033[38;2;%d;%d;%dm", r, g, b);
+  }
+
+  if (bg != -1)
+  {
+    int r = (bg >> 16) & 0xff;
+    int g = (bg >> 8) & 0xff;
+    int b = (bg >> 0) & 0xff;
+
+    pos += snprintf(text + pos, sizeof(text) - pos, "\033[48;2;%d;%d;%dm", r, g, b);
+  }
+
+  pos += snprintf(text + pos, sizeof(text) - pos, "XXXXXX\033[0m");
+
   return text;
+}
+
+/**
+ * color_debug_log_attrcolor - XXX
+ *
+ * @note Do not free the returned string
+ */
+void color_debug_log_attrcolor(struct AttrColor *ac, struct Buffer *buf)
+{
+  if (ac->fg.color != -1)
+  {
+    switch (ac->fg.type)
+    {
+      case CT_SIMPLE:
+      {
+        buf_add_printf(buf, "\033[%dm", 30 + ac->fg.color);
+        break;
+      }
+
+      case CT_PALETTE:
+      {
+        buf_add_printf(buf, "\033[38;5;%dm", ac->fg.color);
+        break;
+      }
+
+      case CT_RGB:
+      {
+        const int r = (ac->fg.color >> 16) & 0xff;
+        const int g = (ac->fg.color >> 8) & 0xff;
+        const int b = (ac->fg.color >> 0) & 0xff;
+
+        buf_add_printf(buf, "\033[38;2;%d;%d;%dm", r, g, b);
+        break;
+      }
+    }
+  }
+
+  if (ac->bg.color != -1)
+  {
+    switch (ac->bg.type)
+    {
+      case CT_SIMPLE:
+      {
+        buf_add_printf(buf, "\033[%dm", 40 + ac->bg.color);
+        break;
+      }
+
+      case CT_PALETTE:
+      {
+        buf_add_printf(buf, "\033[48;5;%dm", ac->bg.color);
+        break;
+      }
+
+      case CT_RGB:
+      {
+        const int r = (ac->bg.color >> 16) & 0xff;
+        const int g = (ac->bg.color >> 8) & 0xff;
+        const int b = (ac->bg.color >> 0) & 0xff;
+
+        buf_add_printf(buf, "\033[48;2;%d;%d;%dm", r, g, b);
+        break;
+      }
+    }
+  }
+
+  buf_addstr(buf, "XXXXXX\033[0m");
 }
 
 /**
@@ -179,18 +317,58 @@ const char *color_debug_log_attrs_list(int attrs)
  * color_debug_log_name - Get a string to represent a colour name
  * @param buf    Buffer for the result
  * @param buflen Length of the Buffer
- * @param color  Palette colour number
+ * @param elem   Colour to use
  * @retval ptr Generated string
  */
-const char *color_debug_log_name(char *buf, int buflen, int color)
+const char *color_debug_log_name(char *buf, int buflen, struct ColorElement *elem)
 {
-  if (color < 0)
+  if (elem->color < 0)
     return "default";
 
-  if (color < 256)
-    snprintf(buf, buflen, "color%d", color);
-  else
-    snprintf(buf, buflen, "BAD:%d", color);
+  switch (elem->type)
+  {
+    case CT_SIMPLE:
+    {
+      const char *prefix = NULL;
+      switch (elem->prefix)
+      {
+        case COLOR_PREFIX_ALERT:
+          prefix = "alert";
+          break;
+        case COLOR_PREFIX_BRIGHT:
+          prefix = "bright";
+          break;
+        case COLOR_PREFIX_LIGHT:
+          prefix = "light";
+          break;
+        default:
+          prefix = "";
+          break;
+      }
+
+      const char *name = mutt_map_get_name(elem->color, ColorNames);
+      snprintf(buf, buflen, "%s%s", prefix, name);
+      break;
+    }
+
+    case CT_PALETTE:
+    {
+      if (elem->color < 256)
+        snprintf(buf, buflen, "color%d", elem->color);
+      else
+        snprintf(buf, buflen, "BAD:%d", elem->color);
+      break;
+    }
+
+    case CT_RGB:
+    {
+      int r = (elem->color >> 16) & 0xff;
+      int g = (elem->color >> 8) & 0xff;
+      int b = (elem->color >> 0) & 0xff;
+      snprintf(buf, buflen, "#%02x%02x%02x", r, g, b);
+      break;
+    }
+  }
 
   return buf;
 }
@@ -260,9 +438,17 @@ void curses_color_dump(struct CursesColor *cc, const char *prefix)
   if (!cc)
     return;
 
+  char fg[16] = "-";
+  char bg[16] = "-";
+
+  if (cc->fg != -1)
+    snprintf(fg, sizeof(fg), "#%06x", cc->fg);
+  if (cc->bg != -1)
+    snprintf(bg, sizeof(bg), "#%06x", cc->bg);
+
   const char *color = color_debug_log_color(cc->fg, cc->bg);
-  color_debug(LL_DEBUG5, "%s| %5d | %3d %3d | %s | %2d |\n", NONULL(prefix),
-              cc->index, cc->fg, cc->bg, color, cc->ref_count);
+  color_debug(LL_DEBUG5, "%s| %5d | %-7s %-7s | %s | %2d |\n", NONULL(prefix),
+              cc->index, fg, bg, color, cc->ref_count);
 }
 
 /**
@@ -274,7 +460,7 @@ void curses_colors_dump(void)
   if (TAILQ_EMPTY(&CursesColors))
     return;
 
-  color_debug(LL_DEBUG5, "    | index |  fg  bg | colour | rc |\n");
+  color_debug(LL_DEBUG5, "    | Index | fg      bg      | Colour | rc |\n");
 
   struct CursesColor *cc = NULL;
   TAILQ_FOREACH(cc, &CursesColors, entries)
@@ -296,18 +482,22 @@ void quoted_color_dump(struct AttrColor *ac, int q_level, const char *prefix)
 
   int index = ac->curses_color ? ac->curses_color->index : -1;
 
-  color_t fg = COLOR_DEFAULT;
-  color_t bg = COLOR_DEFAULT;
-  struct CursesColor *cc = ac->curses_color;
-  if (cc)
+  if ((index >= 0) || (ac->attrs != 0))
   {
-    fg = cc->fg;
-    bg = cc->bg;
+    struct Buffer *color_str = buf_pool_get();
+    color_debug_log_attrcolor(ac, color_str);
+
+    const char *attrs = color_debug_log_attrs(ac->attrs);
+    color_debug(LL_DEBUG5, "%s| quoted%d | %5d | %s | 0x%08x | %s\n", prefix,
+                q_level, index, buf_string(color_str), ac->attrs, attrs);
+
+    buf_pool_release(&color_str);
   }
-  const char *color = color_debug_log_color(fg, bg);
-  const char *attrs = color_debug_log_attrs(ac->attrs);
-  color_debug(LL_DEBUG5, "%s| quoted%d | %5d | %s | 0x%08x | %s\n", prefix,
-              q_level, index, color, ac->attrs, attrs);
+  else
+  {
+    color_debug(LL_DEBUG5, "%s| quoted%d | %5d |        |            |\n",
+                prefix, q_level, index);
+  }
 }
 
 /**
@@ -336,18 +526,14 @@ void regex_color_dump(struct RegexColor *rcol, const char *prefix)
   struct AttrColor *ac = &rcol->attr_color;
   int index = ac->curses_color ? ac->curses_color->index : -1;
 
-  color_t fg = COLOR_DEFAULT;
-  color_t bg = COLOR_DEFAULT;
-  struct CursesColor *cc = ac->curses_color;
-  if (cc)
-  {
-    fg = cc->fg;
-    bg = cc->bg;
-  }
-  const char *color = color_debug_log_color(fg, bg);
+  struct Buffer *color_str = buf_pool_get();
+  color_debug_log_attrcolor(ac, color_str);
+
   const char *attrs = color_debug_log_attrs(ac->attrs);
   color_debug(LL_DEBUG5, "%s| %5d | %s | 0x%08x | %-8s | %s\n", NONULL(prefix),
-              index, color, ac->attrs, attrs, rcol->pattern);
+              index, buf_string(color_str), ac->attrs, attrs, rcol->pattern);
+
+  buf_pool_release(&color_str);
 }
 
 /**
@@ -422,18 +608,14 @@ void simple_color_dump(enum ColorId cid, const char *prefix)
     }
   }
 
-  color_t fg = COLOR_DEFAULT;
-  color_t bg = COLOR_DEFAULT;
-  struct CursesColor *cc = ac->curses_color;
-  if (cc)
-  {
-    fg = cc->fg;
-    bg = cc->bg;
-  }
-  const char *color_str = color_debug_log_color(fg, bg);
+  struct Buffer *color_str = buf_pool_get();
+  color_debug_log_attrcolor(ac, color_str);
+
   const char *attrs_str = color_debug_log_attrs(ac->attrs);
-  color_debug(LL_DEBUG5, "%s| %s%-17s | %5d | %s | 0x%08x | %s\n", prefix,
-              compose, name, index, color_str, ac->attrs, attrs_str);
+  color_debug(LL_DEBUG5, "%s| %s%-19s | %5d | %s | 0x%08x | %s\n", prefix,
+              compose, name, index, buf_string(color_str), ac->attrs, attrs_str);
+
+  buf_pool_release(&color_str);
 }
 
 /**
@@ -443,7 +625,7 @@ void simple_color_dump(enum ColorId cid, const char *prefix)
 void simple_colors_dump(bool force)
 {
   color_debug(LL_DEBUG5, "\033[1;32mSimpleColors:\033[0m\n");
-  color_debug(LL_DEBUG5, "    | Name              | Index | Colour | Attrs      | Attrs\n");
+  color_debug(LL_DEBUG5, "    | Name                | Index | Colour | Attrs      | Attrs\n");
   for (enum ColorId cid = MT_COLOR_NONE; cid < MT_COLOR_MAX; cid++)
   {
     struct AttrColor *ac = &SimpleColors[cid];
@@ -480,8 +662,8 @@ void color_dump(void)
   }
 
   struct Buffer *swatch = buf_pool_get();
-  char color_fg[32] = { 0 };
-  char color_bg[32] = { 0 };
+  char color_fg[64] = { 0 };
+  char color_bg[64] = { 0 };
 
   fputs("# All Colours\n\n", fp);
   fputs("# Simple Colours\n", fp);
@@ -492,18 +674,18 @@ void color_dump(void)
       continue;
 
     struct CursesColor *cc = ac->curses_color;
-    if (!cc)
+    if (!cc && (ac->attrs == 0))
       continue;
 
     const char *name = mutt_map_get_name(cid, ColorFields);
     if (!name)
       continue;
 
-    color_debug_log_color_attrs(cc->fg, cc->bg, ac->attrs, swatch);
-    fprintf(fp, "color %-18s %-30s %-8s %-8s # %s\n", name,
+    color_debug_log_color_attrs(ac, swatch);
+    fprintf(fp, "color %-18s %-30s %-16s %-16s # %s\n", name,
             color_debug_log_attrs_list(ac->attrs),
-            color_debug_log_name(color_fg, sizeof(color_fg), cc->fg),
-            color_debug_log_name(color_bg, sizeof(color_bg), cc->bg), buf_string(swatch));
+            color_debug_log_name(color_fg, sizeof(color_fg), &ac->fg),
+            color_debug_log_name(color_bg, sizeof(color_bg), &ac->bg), buf_string(swatch));
   }
 
   if (NumQuotedColors > 0)
@@ -515,16 +697,15 @@ void color_dump(void)
       if (!ac)
         continue;
 
-      struct CursesColor *cc = ac->curses_color;
-      if (!cc)
-        continue;
+      // struct CursesColor *cc = ac->curses_color;
+      // if (!cc)
+      //   continue;
 
-      color_debug_log_color_attrs(cc->fg, cc->bg, ac->attrs, swatch);
-      fprintf(fp, "color quoted%d %-30s %-8s %-8s # %s\n", i,
+      color_debug_log_color_attrs(ac, swatch);
+      fprintf(fp, "color quoted%d %-30s %-16s %-16s # %s\n", i,
               color_debug_log_attrs_list(ac->attrs),
-              color_debug_log_name(color_fg, sizeof(color_fg), cc->fg),
-              color_debug_log_name(color_bg, sizeof(color_bg), cc->bg),
-              buf_string(swatch));
+              color_debug_log_name(color_fg, sizeof(color_fg), &ac->fg),
+              color_debug_log_name(color_bg, sizeof(color_bg), &ac->bg), buf_string(swatch));
     }
   }
 
@@ -568,11 +749,11 @@ void color_dump(void)
         if (!cc)
           continue;
 
-        color_debug_log_color_attrs(cc->fg, cc->bg, ac->attrs, swatch);
-        fprintf(fp, "color %-14s %-30s %-8s %-8s %-30s # %s\n", name,
+        color_debug_log_color_attrs(ac, swatch);
+        fprintf(fp, "color %-14s %-30s %-16s %-16s %-30s # %s\n", name,
                 color_debug_log_attrs_list(ac->attrs),
-                color_debug_log_name(color_fg, sizeof(color_fg), cc->fg),
-                color_debug_log_name(color_bg, sizeof(color_bg), cc->bg),
+                color_debug_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                color_debug_log_name(color_bg, sizeof(color_bg), &ac->bg),
                 rc->pattern, buf_string(swatch));
       }
     }
@@ -588,10 +769,10 @@ void color_dump(void)
       if (!cc)
         continue;
 
-      color_debug_log_color_attrs(cc->fg, cc->bg, ac->attrs, swatch);
-      fprintf(fp, "# %-30s %-8s %-8s # %s\n", color_debug_log_attrs_list(ac->attrs),
-              color_debug_log_name(color_fg, sizeof(color_fg), cc->fg),
-              color_debug_log_name(color_bg, sizeof(color_bg), cc->bg),
+      color_debug_log_color_attrs(ac, swatch);
+      fprintf(fp, "# %-30s %-16s %-16s # %s\n", color_debug_log_attrs_list(ac->attrs),
+              color_debug_log_name(color_fg, sizeof(color_fg), &ac->fg),
+              color_debug_log_name(color_bg, sizeof(color_bg), &ac->bg),
               buf_string(swatch));
     }
   }
@@ -610,10 +791,10 @@ void color_dump(void)
         if (!cc)
           continue;
 
-        color_debug_log_color_attrs(cc->fg, cc->bg, ac->attrs, swatch);
-        fprintf(fp, "# %-30s %-8s %-8s # %s\n", color_debug_log_attrs_list(ac->attrs),
-                color_debug_log_name(color_fg, sizeof(color_fg), cc->fg),
-                color_debug_log_name(color_bg, sizeof(color_bg), cc->bg),
+        color_debug_log_color_attrs(ac, swatch);
+        fprintf(fp, "# %-30s %-16s %-16s # %s\n", color_debug_log_attrs_list(ac->attrs),
+                color_debug_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                color_debug_log_name(color_bg, sizeof(color_bg), &ac->bg),
                 buf_string(swatch));
       }
     }

--- a/color/debug.h
+++ b/color/debug.h
@@ -24,66 +24,31 @@
 #define MUTT_COLOR_DEBUG_H
 
 #include "config.h"
-#include <stdbool.h>
-#include "color.h"
 #include "curses2.h"
 
-struct AttrColor;
-struct AttrColorList;
-struct RegexColor;
-struct RegexColorList;
+struct Buffer;
 
 #ifdef USE_DEBUG_COLOR
 
-void color_dump(void);
+const char *color_log_color(color_t fg, color_t bg);
 
-const char *color_debug_log_attrs(int attrs);
-const char *color_debug_log_color(color_t fg, color_t bg);
+void curses_color_dump(struct CursesColor *cc, const char *prefix);
 
-void attr_color_dump       (struct AttrColor *ac, const char *prefix);
-void attr_color_list_dump  (struct AttrColorList *acl, const char *title);
-
-void curses_color_dump     (struct CursesColor *cc, const char *prefix);
-void curses_colors_dump    (void);
-
-void merged_colors_dump    (void);
-
-void quoted_color_dump     (struct AttrColor *ac, int q_level, const char *prefix);
-void quoted_color_list_dump(void);
-
-void regex_color_dump      (struct RegexColor *rcol, const char *prefix);
-void regex_color_list_dump (const char *name, struct RegexColorList *rcl);
-void regex_colors_dump_all (void);
-
-void simple_color_dump     (enum ColorId cid, const char *prefix);
-void simple_colors_dump    (bool force);
+void ansi_colors_dump  (struct Buffer *buf);
+void curses_colors_dump(struct Buffer *buf);
+void merged_colors_dump(struct Buffer *buf);
 
 #define color_debug(LEVEL, ...) MuttLogger(0, __FILE__, __LINE__, __func__, LEVEL, __VA_ARGS__) ///< @ingroup logging_api
 
 #else
 
-static inline void color_dump(void) {}
+static inline const char *color_log_color(color_t fg, color_t bg) { return ""; }
 
-static inline const char *color_debug_log_attrs(int attrs) { return ""; }
-static inline const char *color_debug_log_color(color_t fg, color_t bg) { return ""; }
+static inline void curses_color_dump(struct CursesColor *cc, const char *prefix) {}
 
-static inline void attr_color_dump       (struct AttrColor *ac, const char *prefix) {}
-static inline void attr_color_list_dump  (struct AttrColorList *acl, const char *title) {}
-
-static inline void curses_color_dump     (struct CursesColor *cc, const char *prefix) {}
-static inline void curses_colors_dump    (void) {}
-
-static inline void merged_colors_dump    (void) {}
-
-static inline void quoted_color_dump     (struct AttrColor *ac, int q_level, const char *prefix) {}
-static inline void quoted_color_list_dump(void) {}
-
-static inline void regex_color_dump      (struct RegexColor *rcol, const char *prefix) {}
-static inline void regex_color_list_dump (const char *name, struct RegexColorList *rcl) {}
-static inline void regex_colors_dump_all (void) {}
-
-static inline void simple_color_dump     (enum ColorId cid, const char *prefix) {}
-static inline void simple_colors_dump    (bool force) {}
+static inline void ansi_colors_dump  (struct Buffer *buf) {}
+static inline void curses_colors_dump(struct Buffer *buf) {}
+static inline void merged_colors_dump(struct Buffer *buf) {}
 
 static inline int color_debug(enum LogLevel level, const char *format, ...) { return 0; }
 

--- a/color/dump.c
+++ b/color/dump.c
@@ -336,10 +336,10 @@ void simple_colors_dump(struct Buffer *buf)
 
       color_log_color_attrs(ac, swatch);
       buf_add_printf(buf, "color %-18s %-20s %-16s %-16s # %s\n", name,
-                    color_log_attrs_list(ac->attrs),
-                    color_log_name(color_fg, sizeof(color_fg), &ac->fg),
-                    color_log_name(color_bg, sizeof(color_bg), &ac->bg),
-                    buf_string(swatch));
+                     color_log_attrs_list(ac->attrs),
+                     color_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                     color_log_name(color_bg, sizeof(color_bg), &ac->bg),
+                     buf_string(swatch));
     }
     buf_addstr(buf, "\n");
   }
@@ -368,10 +368,10 @@ void simple_colors_dump(struct Buffer *buf)
 
       color_log_color_attrs(ac, swatch);
       buf_add_printf(buf, "color compose %-18s %-20s %-16s %-16s # %s\n", name,
-                    color_log_attrs_list(ac->attrs),
-                    color_log_name(color_fg, sizeof(color_fg), &ac->fg),
-                    color_log_name(color_bg, sizeof(color_bg), &ac->bg),
-                    buf_string(swatch));
+                     color_log_attrs_list(ac->attrs),
+                     color_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                     color_log_name(color_bg, sizeof(color_bg), &ac->bg),
+                     buf_string(swatch));
     }
     buf_addstr(buf, "\n");
   }
@@ -407,10 +407,10 @@ void status_colors_dump(struct Buffer *buf)
 
     color_log_color_attrs(ac, swatch);
     buf_add_printf(buf, "color status %-20s %-16s %-16s                                # %s\n",
-                  color_log_attrs_list(ac->attrs),
-                  color_log_name(color_fg, sizeof(color_fg), &ac->fg),
-                  color_log_name(color_bg, sizeof(color_bg), &ac->bg),
-                  buf_string(swatch));
+                   color_log_attrs_list(ac->attrs),
+                   color_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                   color_log_name(color_bg, sizeof(color_bg), &ac->bg),
+                   buf_string(swatch));
 
     struct RegexColor *rc = NULL;
     STAILQ_FOREACH(rc, rcl, entries)
@@ -423,18 +423,18 @@ void status_colors_dump(struct Buffer *buf)
       if (rc->match == 0)
       {
         buf_add_printf(buf, "color status %-20s %-16s %-16s %-30s # %s\n",
-                      color_log_attrs_list(ac->attrs),
-                      color_log_name(color_fg, sizeof(color_fg), &ac->fg),
-                      color_log_name(color_bg, sizeof(color_bg), &ac->bg),
-                      buf_string(pattern), buf_string(swatch));
+                       color_log_attrs_list(ac->attrs),
+                       color_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                       color_log_name(color_bg, sizeof(color_bg), &ac->bg),
+                       buf_string(pattern), buf_string(swatch));
       }
       else
       {
         buf_add_printf(buf, "color status %-20s %-16s %-16s %-28s %d # %s\n",
-                      color_log_attrs_list(ac->attrs),
-                      color_log_name(color_fg, sizeof(color_fg), &ac->fg),
-                      color_log_name(color_bg, sizeof(color_bg), &ac->bg),
-                      buf_string(pattern), rc->match, buf_string(swatch));
+                       color_log_attrs_list(ac->attrs),
+                       color_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                       color_log_name(color_bg, sizeof(color_bg), &ac->bg),
+                       buf_string(pattern), rc->match, buf_string(swatch));
       }
     }
     buf_addstr(buf, "\n");

--- a/color/dump.c
+++ b/color/dump.c
@@ -1,0 +1,493 @@
+/**
+ * @file
+ * Colour Dump Command
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page color_dump Colour Dump Command
+ *
+ * Colour Dump Command
+ */
+
+#include "config.h"
+#include <stdio.h>
+#include "mutt/lib.h"
+#include "config/lib.h"
+#include "core/lib.h"
+#include "gui/lib.h"
+#include "pager/lib.h"
+#include "attr.h"
+#include "color.h"
+#include "debug.h"
+#include "parse_color.h"
+#include "quoted.h"
+#include "regex4.h"
+#include "simple2.h"
+
+/**
+ * color_log_color_attrs - Get a colourful string to represent a colour in the log
+ * @param ac     Colour
+ * @param swatch Buffer for swatch
+ *
+ * @note Do not free the returned string
+ */
+void color_log_color_attrs(struct AttrColor *ac, struct Buffer *swatch)
+{
+  buf_reset(swatch);
+
+  if (ac->attrs & A_BLINK)
+    buf_add_printf(swatch, "\033[5m");
+  if (ac->attrs & A_BOLD)
+    buf_add_printf(swatch, "\033[1m");
+  if (ac->attrs & A_ITALIC)
+    buf_add_printf(swatch, "\033[3m");
+  if (ac->attrs & A_NORMAL)
+    buf_add_printf(swatch, "\033[0m");
+  if (ac->attrs & A_REVERSE)
+    buf_add_printf(swatch, "\033[7m");
+  if (ac->attrs & A_STANDOUT)
+    buf_add_printf(swatch, "\033[1m");
+  if (ac->attrs & A_UNDERLINE)
+    buf_add_printf(swatch, "\033[4m");
+
+  if (ac->fg.color >= 0)
+  {
+    switch (ac->fg.type)
+    {
+      case CT_SIMPLE:
+      {
+        buf_add_printf(swatch, "\033[%dm", 30 + ac->fg.color);
+        break;
+      }
+
+      case CT_PALETTE:
+      {
+        buf_add_printf(swatch, "\033[38;5;%dm", ac->fg.color);
+        break;
+      }
+
+      case CT_RGB:
+      {
+        int r = (ac->fg.color >> 16) & 0xff;
+        int g = (ac->fg.color >> 8) & 0xff;
+        int b = (ac->fg.color >> 0) & 0xff;
+        buf_add_printf(swatch, "\033[38;2;%d;%d;%dm", r, g, b);
+        break;
+      }
+    }
+  }
+
+  if (ac->bg.color >= 0)
+  {
+    switch (ac->bg.type)
+    {
+      case CT_SIMPLE:
+      {
+        buf_add_printf(swatch, "\033[%dm", 40 + ac->bg.color);
+        break;
+      }
+
+      case CT_PALETTE:
+      {
+        buf_add_printf(swatch, "\033[48;5;%dm", ac->bg.color);
+        break;
+      }
+
+      case CT_RGB:
+      {
+        int r = (ac->bg.color >> 16) & 0xff;
+        int g = (ac->bg.color >> 8) & 0xff;
+        int b = (ac->bg.color >> 0) & 0xff;
+        buf_add_printf(swatch, "\033[48;2;%d;%d;%dm", r, g, b);
+        break;
+      }
+    }
+  }
+
+  buf_addstr(swatch, "XXXXXX\033[0m");
+}
+
+/**
+ * color_log_attrs_list - Get a string to represent some attributes in the log
+ * @param attrs Attributes, e.g. A_UNDERLINE
+ * @retval ptr Generated string
+ *
+ * @note Do not free the returned string
+ */
+const char *color_log_attrs_list(int attrs)
+{
+  static char text[64];
+
+  text[0] = '\0';
+  int pos = 0;
+  if (attrs & A_BLINK)
+    pos += snprintf(text + pos, sizeof(text) - pos, "blink ");
+  if (attrs & A_BOLD)
+    pos += snprintf(text + pos, sizeof(text) - pos, "bold ");
+  if (attrs & A_ITALIC)
+    pos += snprintf(text + pos, sizeof(text) - pos, "italic ");
+  if (attrs & A_NORMAL)
+    pos += snprintf(text + pos, sizeof(text) - pos, "normal ");
+  if (attrs & A_REVERSE)
+    pos += snprintf(text + pos, sizeof(text) - pos, "reverse ");
+  if (attrs & A_STANDOUT)
+    pos += snprintf(text + pos, sizeof(text) - pos, "standout ");
+  if (attrs & A_UNDERLINE)
+    pos += snprintf(text + pos, sizeof(text) - pos, "underline ");
+
+  return text;
+}
+
+/**
+ * color_log_name - Get a string to represent a colour name
+ * @param buf    Buffer for the result
+ * @param buflen Length of the Buffer
+ * @param elem   Colour to use
+ * @retval ptr Generated string
+ */
+const char *color_log_name(char *buf, int buflen, struct ColorElement *elem)
+{
+  if (elem->color < 0)
+    return "default";
+
+  switch (elem->type)
+  {
+    case CT_SIMPLE:
+    {
+      const char *prefix = NULL;
+      switch (elem->prefix)
+      {
+        case COLOR_PREFIX_ALERT:
+          prefix = "alert";
+          break;
+        case COLOR_PREFIX_BRIGHT:
+          prefix = "bright";
+          break;
+        case COLOR_PREFIX_LIGHT:
+          prefix = "light";
+          break;
+        default:
+          prefix = "";
+          break;
+      }
+
+      const char *name = mutt_map_get_name(elem->color, ColorNames);
+      snprintf(buf, buflen, "%s%s", prefix, name);
+      break;
+    }
+
+    case CT_PALETTE:
+    {
+      if (elem->color < 256)
+        snprintf(buf, buflen, "color%d", elem->color);
+      else
+        snprintf(buf, buflen, "BAD:%d", elem->color);
+      break;
+    }
+
+    case CT_RGB:
+    {
+      int r = (elem->color >> 16) & 0xff;
+      int g = (elem->color >> 8) & 0xff;
+      int b = (elem->color >> 0) & 0xff;
+      snprintf(buf, buflen, "#%02x%02x%02x", r, g, b);
+      break;
+    }
+  }
+
+  return buf;
+}
+
+/**
+ * quoted_colors_dump - Dump all the Quoted colours
+ * @param buf Buffer for result
+ */
+void quoted_colors_dump(struct Buffer *buf)
+{
+  if (NumQuotedColors == 0)
+    return;
+
+  struct Buffer *swatch = buf_pool_get();
+  char color_fg[64] = { 0 };
+  char color_bg[64] = { 0 };
+
+  buf_addstr(buf, _("# Quoted Colors\n"));
+  for (int i = 0; i < NumQuotedColors; i++)
+  {
+    struct AttrColor *ac = quoted_colors_get(i);
+    if (!ac)
+      continue;
+
+    color_log_color_attrs(ac, swatch);
+    buf_add_printf(buf, "color quoted%d %-20s %-16s %-16s # %s\n", i,
+                   color_log_attrs_list(ac->attrs),
+                   color_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                   color_log_name(color_bg, sizeof(color_bg), &ac->bg),
+                   buf_string(swatch));
+  }
+
+  buf_addstr(buf, "\n");
+  buf_pool_release(&swatch);
+}
+
+/**
+ * regex_colors_dump - Dump all the Regex colours
+ * @param buf   Buffer for result
+ */
+void regex_colors_dump(struct Buffer *buf)
+{
+  struct Buffer *swatch = buf_pool_get();
+  struct Buffer *pattern = buf_pool_get();
+  char color_fg[64] = { 0 };
+  char color_bg[64] = { 0 };
+
+  for (enum ColorId cid = MT_COLOR_NONE; cid != MT_COLOR_MAX; cid++)
+  {
+    if (cid == MT_COLOR_STATUS)
+      continue;
+
+    if (!mutt_color_has_pattern(cid))
+      continue;
+
+    struct RegexColorList *rcl = regex_colors_get_list(cid);
+    if (STAILQ_EMPTY(rcl))
+      continue;
+
+    const char *name = mutt_map_get_name(cid, ColorFields);
+    if (!name)
+      continue;
+
+    buf_add_printf(buf, _("# Regex Color %s\n"), name);
+
+    struct RegexColor *rc = NULL;
+    STAILQ_FOREACH(rc, rcl, entries)
+    {
+      struct AttrColor *ac = &rc->attr_color;
+
+      buf_reset(pattern);
+      pretty_var(rc->pattern, pattern);
+      color_log_color_attrs(ac, swatch);
+      buf_add_printf(buf, "color %-16s %-20s %-16s %-16s %-30s # %s\n", name,
+                     color_log_attrs_list(ac->attrs),
+                     color_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                     color_log_name(color_bg, sizeof(color_bg), &ac->bg),
+                     buf_string(pattern), buf_string(swatch));
+    }
+    buf_addstr(buf, "\n");
+  }
+
+  buf_pool_release(&swatch);
+  buf_pool_release(&pattern);
+}
+
+/**
+ * simple_colors_dump - Dump all the Simple colours
+ * @param buf   Buffer for result
+ */
+void simple_colors_dump(struct Buffer *buf)
+{
+  struct Buffer *swatch = buf_pool_get();
+  char color_fg[64] = { 0 };
+  char color_bg[64] = { 0 };
+
+  int count = 0;
+  for (enum ColorId cid = MT_COLOR_NONE + 1; cid < MT_COLOR_MAX; cid++)
+  {
+    if ((cid == MT_COLOR_QUOTED) || (cid == MT_COLOR_STATUS))
+      continue;
+
+    struct AttrColor *ac = simple_color_get(cid);
+    if (attr_color_is_set(ac))
+      count++;
+  }
+
+  if (count > 0)
+  {
+    buf_addstr(buf, _("# Simple Colors\n"));
+    for (enum ColorId cid = MT_COLOR_NONE + 1; cid < MT_COLOR_MAX; cid++)
+    {
+      if ((cid == MT_COLOR_QUOTED) || (cid == MT_COLOR_STATUS))
+        continue;
+
+      struct AttrColor *ac = simple_color_get(cid);
+      if (!attr_color_is_set(ac))
+        continue;
+
+      const char *name = mutt_map_get_name(cid, ColorFields);
+      if (!name)
+        continue;
+
+      color_log_color_attrs(ac, swatch);
+      buf_add_printf(buf, "color %-18s %-20s %-16s %-16s # %s\n", name,
+                    color_log_attrs_list(ac->attrs),
+                    color_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                    color_log_name(color_bg, sizeof(color_bg), &ac->bg),
+                    buf_string(swatch));
+    }
+    buf_addstr(buf, "\n");
+  }
+
+  count = 0;
+  for (int i = 0; ComposeColorFields[i].name; i++)
+  {
+    enum ColorId cid = ComposeColorFields[i].value;
+
+    struct AttrColor *ac = simple_color_get(cid);
+    if (attr_color_is_set(ac))
+      count++;
+  }
+
+  if (count > 0)
+  {
+    buf_addstr(buf, _("# Compose Colors\n"));
+    for (int i = 0; ComposeColorFields[i].name; i++)
+    {
+      const char *name = ComposeColorFields[i].name;
+      enum ColorId cid = ComposeColorFields[i].value;
+
+      struct AttrColor *ac = simple_color_get(cid);
+      if (!attr_color_is_set(ac))
+        continue;
+
+      color_log_color_attrs(ac, swatch);
+      buf_add_printf(buf, "color compose %-18s %-20s %-16s %-16s # %s\n", name,
+                    color_log_attrs_list(ac->attrs),
+                    color_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                    color_log_name(color_bg, sizeof(color_bg), &ac->bg),
+                    buf_string(swatch));
+    }
+    buf_addstr(buf, "\n");
+  }
+
+  buf_pool_release(&swatch);
+}
+
+/**
+ * status_colors_dump - Dump all the Status colours
+ * @param buf   Buffer for result
+ */
+void status_colors_dump(struct Buffer *buf)
+{
+  struct Buffer *swatch = buf_pool_get();
+  struct Buffer *pattern = buf_pool_get();
+  char color_fg[64] = { 0 };
+  char color_bg[64] = { 0 };
+
+  bool set = false;
+
+  const enum ColorId cid = MT_COLOR_STATUS;
+  struct AttrColor *ac = simple_color_get(cid);
+  if (attr_color_is_set(ac))
+    set = true;
+
+  struct RegexColorList *rcl = regex_colors_get_list(cid);
+  if (!STAILQ_EMPTY(rcl))
+    set = true;
+
+  if (set)
+  {
+    buf_addstr(buf, _("# Status Colors\n"));
+
+    color_log_color_attrs(ac, swatch);
+    buf_add_printf(buf, "color status %-20s %-16s %-16s                                # %s\n",
+                  color_log_attrs_list(ac->attrs),
+                  color_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                  color_log_name(color_bg, sizeof(color_bg), &ac->bg),
+                  buf_string(swatch));
+
+    struct RegexColor *rc = NULL;
+    STAILQ_FOREACH(rc, rcl, entries)
+    {
+      ac = &rc->attr_color;
+
+      buf_reset(pattern);
+      pretty_var(rc->pattern, pattern);
+      color_log_color_attrs(ac, swatch);
+      if (rc->match == 0)
+      {
+        buf_add_printf(buf, "color status %-20s %-16s %-16s %-30s # %s\n",
+                      color_log_attrs_list(ac->attrs),
+                      color_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                      color_log_name(color_bg, sizeof(color_bg), &ac->bg),
+                      buf_string(pattern), buf_string(swatch));
+      }
+      else
+      {
+        buf_add_printf(buf, "color status %-20s %-16s %-16s %-28s %d # %s\n",
+                      color_log_attrs_list(ac->attrs),
+                      color_log_name(color_fg, sizeof(color_fg), &ac->fg),
+                      color_log_name(color_bg, sizeof(color_bg), &ac->bg),
+                      buf_string(pattern), rc->match, buf_string(swatch));
+      }
+    }
+    buf_addstr(buf, "\n");
+  }
+
+  buf_pool_release(&swatch);
+  buf_pool_release(&pattern);
+}
+
+/**
+ * color_dump - Display all the colours in the Pager
+ */
+void color_dump(void)
+{
+  struct Buffer *tmp_file = buf_pool_get();
+
+  buf_mktemp(tmp_file);
+  FILE *fp = mutt_file_fopen(buf_string(tmp_file), "w");
+  if (!fp)
+  {
+    // L10N: '%s' is the file name of the temporary file
+    mutt_error(_("Could not create temporary file %s"), buf_string(tmp_file));
+    buf_pool_release(&tmp_file);
+    return;
+  }
+
+  struct Buffer *buf = buf_pool_get();
+
+  simple_colors_dump(buf);
+  quoted_colors_dump(buf);
+  status_colors_dump(buf);
+  regex_colors_dump(buf);
+
+#ifdef USE_DEBUG_COLOR
+  merged_colors_dump(buf);
+  ansi_colors_dump(buf);
+  curses_colors_dump(buf);
+  log_multiline(LL_DEBUG1, buf_string(buf));
+#endif
+
+  mutt_file_save_str(fp, buf_string(buf));
+  buf_pool_release(&buf);
+  mutt_file_fclose(&fp);
+
+  struct PagerData pdata = { 0 };
+  struct PagerView pview = { &pdata };
+
+  pdata.fname = buf_string(tmp_file);
+
+  pview.banner = "color";
+  pview.flags = MUTT_SHOWCOLOR;
+  pview.mode = PAGER_MODE_OTHER;
+
+  mutt_do_pager(&pview, NULL);
+  buf_pool_release(&tmp_file);
+}

--- a/color/dump.h
+++ b/color/dump.h
@@ -1,0 +1,37 @@
+/**
+ * @file
+ * Colour Dump Command
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_COLOR_DUMP_H
+#define MUTT_COLOR_DUMP_H
+
+struct AttrColor;
+struct Buffer;
+struct ColorElement;
+
+void color_dump(void);
+
+const char *color_log_attrs_list (int attrs);
+void        color_log_color_attrs(struct AttrColor *ac, struct Buffer *swatch);
+const char *color_log_name       (char *buf, int buflen, struct ColorElement *elem);
+
+#endif /* MUTT_COLOR_DUMP_H */
+

--- a/color/lib.h
+++ b/color/lib.h
@@ -33,6 +33,7 @@
  * | color/command.c     | @subpage color_command     |
  * | color/curses.c      | @subpage color_curses      |
  * | color/debug.c       | @subpage color_debug       |
+ * | color/dump.c        | @subpage color_dump        |
  * | color/merged.c      | @subpage color_merge       |
  * | color/notify.c      | @subpage color_notify      |
  * | color/parse_ansi.c  | @subpage color_parse_ansi  |
@@ -52,6 +53,7 @@
 #include "command2.h"
 #include "curses2.h"
 #include "debug.h"
+#include "dump.h"
 #include "merged.h"
 #include "notify2.h"
 #include "parse_ansi.h"

--- a/color/merged.c
+++ b/color/merged.c
@@ -35,7 +35,6 @@
 #include "attr.h"
 #include "color.h"
 #include "curses2.h"
-#include "debug.h"
 
 struct AttrColorList MergedColors; ///< Array of user colours
 
@@ -145,7 +144,7 @@ const struct AttrColor *merged_color_overlay(const struct AttrColor *base,
   ac->fg = (base->fg.color == COLOR_DEFAULT) ? over->fg : base->fg;
   ac->bg = (base->bg.color == COLOR_DEFAULT) ? over->bg : base->bg;
   TAILQ_INSERT_TAIL(&MergedColors, ac, entries);
-  merged_colors_dump();
+  //QWQ merged_colors_dump(buf);
 
   return ac;
 }

--- a/color/parse_color.h
+++ b/color/parse_color.h
@@ -24,9 +24,11 @@
 #define MUTT_COLOR_PARSE_COLOR_H
 
 #include "core/lib.h"
+#include "mutt/lib.h"
 
 struct AttrColor;
-struct Buffer;
+
+extern const struct Mapping ColorNames[];
 
 enum CommandResult parse_attr_spec (struct Buffer *buf, struct Buffer *s, struct AttrColor *ac, struct Buffer *err);
 enum CommandResult parse_color_pair(struct Buffer *buf, struct Buffer *s, struct AttrColor *ac, struct Buffer *err);

--- a/color/quoted.c
+++ b/color/quoted.c
@@ -131,7 +131,7 @@ bool quoted_colors_parse_color(enum ColorId cid, struct AttrColor *ac_val,
     NumQuotedColors = q_level + 1;
 
   struct AttrColor *ac = &QuotedColors[q_level];
-  const bool was_set = ((ac->attrs != 0) || ac->curses_color);
+  //QWQ const bool was_set = ((ac->attrs != 0) || ac->curses_color);
 
   attr_color_overwrite(ac, ac_val);
 
@@ -139,10 +139,10 @@ bool quoted_colors_parse_color(enum ColorId cid, struct AttrColor *ac_val,
   if (!cc)
     NumQuotedColors = find_highest_used();
 
-  if (was_set)
-    quoted_color_dump(ac, q_level, "QuotedColors changed: ");
-  else
-    quoted_color_dump(ac, q_level, "QuotedColors new: ");
+  //QWQ if (was_set)
+  //QWQ   quoted_color_dump(ac, q_level, "QuotedColors changed: ");
+  //QWQ else
+  //QWQ   quoted_color_dump(ac, q_level, "QuotedColors new: ");
 
   struct Buffer *buf = buf_pool_get();
   get_colorid_name(cid, buf);
@@ -153,17 +153,21 @@ bool quoted_colors_parse_color(enum ColorId cid, struct AttrColor *ac_val,
   {
     // Copy the colour into the SimpleColors
     struct AttrColor *ac_quoted = simple_color_get(MT_COLOR_QUOTED);
+    curses_color_free(&ac_quoted->curses_color);
     *ac_quoted = *ac;
     ac_quoted->ref_count = 1;
     if (ac_quoted->curses_color)
+    {
       ac_quoted->curses_color->ref_count++;
+      curses_color_dump(cc, "curses rc++");
+    }
   }
 
   struct EventColor ev_c = { cid, ac };
   notify_send(ColorsNotify, NT_COLOR, NT_COLOR_SET, &ev_c);
 
-  curses_colors_dump();
-  quoted_color_list_dump();
+  curses_colors_dump(buf);
+  //QWQ quoted_colors_dump(buf);
 
   *rc = MUTT_CMD_SUCCESS;
   return true;
@@ -183,10 +187,10 @@ enum CommandResult quoted_colors_parse_uncolor(enum ColorId cid, int q_level,
 
   struct AttrColor *ac = &QuotedColors[q_level];
   attr_color_clear(ac);
-  quoted_color_dump(ac, q_level, "QuotedColors clear: ");
+  //QWQ quoted_color_dump(ac, q_level, "QuotedColors clear: ");
 
-  curses_colors_dump();
-  quoted_color_list_dump();
+  //QWQ curses_colors_dump(buf);
+  //QWQ quoted_colors_dump(buf);
 
   NumQuotedColors = find_highest_used();
 
@@ -633,7 +637,7 @@ void qstyle_recolor(struct QuoteStyle *quote_list)
   int num = quoted_colors_num_used();
   int cur = 0;
 
-  quoted_color_list_dump();
+  //QWQ quoted_color_list_dump();
   qstyle_recurse(quote_list, num, &cur);
-  quoted_color_list_dump();
+  //QWQ quoted_color_list_dump();
 }

--- a/color/regex.c
+++ b/color/regex.c
@@ -374,7 +374,7 @@ bool regex_colors_parse_color_list(enum ColorId cid, const char *pat,
     notify_send(ColorsNotify, NT_COLOR, NT_COLOR_SET, &ev_c);
   }
 
-  regex_colors_dump_all();
+  //QWQ regex_colors_dump(buf);
   return true;
 }
 
@@ -405,7 +405,7 @@ int regex_colors_parse_status_list(enum ColorId cid, const char *pat,
   struct EventColor ev_c = { cid, NULL };
   notify_send(ColorsNotify, NT_COLOR, NT_COLOR_SET, &ev_c);
 
-  regex_colors_dump_all();
+  //QWQ regex_colors_dump();
   return rc;
 }
 

--- a/debug/pager.c
+++ b/debug/pager.c
@@ -49,7 +49,7 @@ void dump_text_syntax(struct TextSyntax *ts, int num)
     if (cc)
     {
       index = cc->index;
-      swatch = color_debug_log_color(cc->fg, cc->bg);
+      swatch = color_log_color(cc->fg, cc->bg);
     }
     mutt_debug(LL_DEBUG1, "\t\t%3d %4d %4d %s\n", index, ts[i].first, ts[i].last, swatch);
   }
@@ -69,7 +69,7 @@ void dump_line(int i, struct Line *line)
     if (ac && ac->curses_color)
     {
       struct CursesColor *cc = ac->curses_color;
-      swatch = color_debug_log_color(cc->fg, cc->bg);
+      swatch = color_log_color(cc->fg, cc->bg);
     }
 
     mutt_debug(LL_DEBUG1, "\tcolor: %d %s (%s)\n", line->cid, swatch, buf_string(buf));

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -1710,3 +1710,21 @@ void mutt_file_resolve_symlink(struct Buffer *buf)
     }
   }
 }
+
+/**
+ * mutt_file_save_str - Save a string to a file
+ * @param fp  Open file to save to
+ * @param str String to save
+ * @retval num Bytes written to file
+ */
+size_t mutt_file_save_str(FILE *fp, const char *str)
+{
+  if (!fp)
+    return 0;
+
+  size_t len = mutt_str_len(str);
+  if (len == 0)
+    return 0;
+
+  return fwrite(str, 1, len, fp);
+}

--- a/mutt/file.h
+++ b/mutt/file.h
@@ -129,6 +129,7 @@ const char *mutt_file_rotate(const char *path, int num);
 int         mutt_file_safe_rename(const char *src, const char *target);
 void        mutt_file_sanitize_filename(char *path, bool slash);
 int         mutt_file_sanitize_regex(struct Buffer *dest, const char *src);
+size_t      mutt_file_save_str(FILE *fp, const char *str);
 bool        mutt_file_seek(FILE *fp, LOFF_T offset, int whence);
 void        mutt_file_set_mtime(const char *from, const char *to);
 int         mutt_file_stat_compare(struct stat *st1, enum MuttStatType st1_type, struct stat *st2, enum MuttStatType st2_type);

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -114,6 +114,20 @@ CHARSET_OBJS	= test/charset/mutt_ch_canonical_charset.o \
 		  test/charset/mutt_ch_lookup_remove.o \
 		  test/charset/mutt_ch_set_charset.o
 
+COLOR_OBJS	= test/color/ansi_color_parse_single.o \
+		  test/color/attr.o \
+		  test/color/curses.o \
+		  test/color/merged.o \
+		  test/color/parse_attr_spec.o \
+		  test/color/quoted.o \
+		  test/color/simple.o \
+		  test/color/parse_color_colornnn.o \
+		  test/color/parse_color_name.o \
+		  test/color/parse_color_namedcolor.o \
+		  test/color/parse_color_pair.o \
+		  test/color/parse_color_prefix.o \
+		  test/color/parse_color_rrggbb.o
+
 @if USE_LZ4 || USE_ZLIB || USE_ZSTD
 COMPRESS_OBJS	+= test/compress/common.o
 @endif
@@ -613,22 +627,22 @@ URL_OBJS	= test/url/url_check_scheme.o \
 BUILD_DIRS	= $(PWD)/test/account $(PWD)/test/address $(PWD)/test/array \
 		  $(PWD)/test/atoi $(PWD)/test/attach $(PWD)/test/base64 \
 		  $(PWD)/test/body $(PWD)/test/buffer $(PWD)/test/charset \
-		  $(PWD)/test/compress $(PWD)/test/config $(PWD)/test/convert \
-		  $(PWD)/test/core $(PWD)/test/date $(PWD)/test/editor \
-		  $(PWD)/test/email $(PWD)/test/envelope $(PWD)/test/envlist \
-		  $(PWD)/test/eqi $(PWD)/test/file $(PWD)/test/filter \
-		  $(PWD)/test/from $(PWD)/test/group $(PWD)/test/gui \
-		  $(PWD)/test/hash $(PWD)/test/history $(PWD)/test/idna \
-		  $(PWD)/test/imap $(PWD)/test/list $(PWD)/test/logging \
-		  $(PWD)/test/mailbox $(PWD)/test/mapping $(PWD)/test/mbyte \
-		  $(PWD)/test/md5 $(PWD)/test/memory $(PWD)/test/neo \
-		  $(PWD)/test/notify $(PWD)/test/notmuch $(PWD)/test/parameter \
-		  $(PWD)/test/parse $(PWD)/test/path $(PWD)/test/pattern \
-		  $(PWD)/test/pool $(PWD)/test/prex $(PWD)/test/random \
-		  $(PWD)/test/regex $(PWD)/test/rfc2047 $(PWD)/test/rfc2231 \
-		  $(PWD)/test/signal $(PWD)/test/slist $(PWD)/test/sort \
-		  $(PWD)/test/store $(PWD)/test/string $(PWD)/test/tags \
-		  $(PWD)/test/thread $(PWD)/test/url
+		  $(PWD)/test/color $(PWD)/test/compress $(PWD)/test/config \
+		  $(PWD)/test/convert $(PWD)/test/core $(PWD)/test/date \
+		  $(PWD)/test/editor $(PWD)/test/email $(PWD)/test/envelope \
+		  $(PWD)/test/envlist $(PWD)/test/eqi $(PWD)/test/file \
+		  $(PWD)/test/filter $(PWD)/test/from $(PWD)/test/group \
+		  $(PWD)/test/gui $(PWD)/test/hash $(PWD)/test/history \
+		  $(PWD)/test/idna $(PWD)/test/imap $(PWD)/test/list \
+		  $(PWD)/test/logging $(PWD)/test/mailbox $(PWD)/test/mapping \
+		  $(PWD)/test/mbyte $(PWD)/test/md5 $(PWD)/test/memory \
+		  $(PWD)/test/neo $(PWD)/test/notify $(PWD)/test/notmuch \
+		  $(PWD)/test/parameter $(PWD)/test/parse $(PWD)/test/path \
+		  $(PWD)/test/pattern $(PWD)/test/pool $(PWD)/test/prex \
+		  $(PWD)/test/random $(PWD)/test/regex $(PWD)/test/rfc2047 \
+		  $(PWD)/test/rfc2231 $(PWD)/test/signal $(PWD)/test/slist \
+		  $(PWD)/test/sort $(PWD)/test/store $(PWD)/test/string \
+		  $(PWD)/test/tags $(PWD)/test/thread $(PWD)/test/url
 
 TEST_OBJS	= test/common.o test/main.o \
 		  $(ACCOUNT_OBJS) \
@@ -640,6 +654,7 @@ TEST_OBJS	= test/common.o test/main.o \
 		  $(BODY_OBJS) \
 		  $(BUFFER_OBJS) \
 		  $(CHARSET_OBJS) \
+		  $(COLOR_OBJS) \
 		  $(COMPRESS_OBJS) \
 		  $(CONFIG_OBJS) \
 		  $(CONVERT_OBJS) \

--- a/test/color/ansi_color_parse_single.c
+++ b/test/color/ansi_color_parse_single.c
@@ -1,0 +1,166 @@
+/**
+ * @file
+ * Test code for Colour Parsing
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "gui/lib.h"
+#include "color/lib.h"
+
+struct AnsiTest
+{
+  const char *str;
+  int len;
+  int attrs;
+};
+
+void test_ansi_color_parse_single(void)
+{
+  // int ansi_color_parse_single(const char *buf, struct AnsiColor *ansi, bool dry_run);
+
+  // Degenerate tests
+  {
+    struct AnsiColor ansi = { 0 };
+    const char *str = "\033[31m";
+    int len;
+
+    len = ansi_color_parse_single(NULL, &ansi, false);
+    TEST_CHECK(len == 0);
+
+    len = ansi_color_parse_single(str, NULL, false);
+    TEST_CHECK(len == 5);
+
+    len = ansi_color_parse_single("", &ansi, false);
+    TEST_CHECK(len == 0);
+
+    len = ansi_color_parse_single(str, &ansi, true);
+    TEST_CHECK(len == 5);
+  }
+
+  // Attributes
+  {
+    static const struct AnsiTest tests[] = {
+      // clang-format off
+      { "\033[m",  3, A_NORMAL    },
+      { "\033[0m", 4, A_NORMAL    },
+      { "\033[1m", 4, A_BOLD      },
+      { "\033[3m", 4, A_ITALIC    },
+      { "\033[4m", 4, A_UNDERLINE },
+      { "\033[5m", 4, A_BLINK     },
+      { "\033[7m", 4, A_REVERSE   },
+      { NULL, 0 },
+      // clang-format on
+    };
+
+    int len;
+    for (int i = 0; tests[i].str; i++)
+    {
+      TEST_CASE_("<esc>%s", tests[i].str + 1);
+
+      struct AnsiColor ansi = { 0 };
+      len = ansi_color_parse_single(tests[i].str, &ansi, false);
+      TEST_CHECK(len == tests[i].len);
+      TEST_MSG("len: Expected %d, Got %d", tests[i].len, len);
+      TEST_CHECK(ansi.attrs == tests[i].attrs);
+      TEST_MSG("attrs: Expected %d, Got %d", tests[i].attrs, ansi.attrs);
+    }
+  }
+
+  // Simple Colours - Foregrounds and Backgrounds
+  {
+    char str[32];
+    int len;
+    for (int i = 30; i < 41; i += 10)
+    {
+      for (int j = 0; j < 8; j++)
+      {
+        snprintf(str, sizeof(str), "\033[%dm", i + j);
+        TEST_CASE_("<esc>%s", str + 1);
+
+        struct AnsiColor ansi = { 0 };
+        len = ansi_color_parse_single(str, &ansi, false);
+        TEST_CHECK(len == 5);
+        TEST_MSG("len: Expected 5, Got %d", len);
+      }
+    }
+  }
+
+  // Palette Colours - Foregrounds and Backgrounds
+  {
+    char str[32];
+    for (int i = 38; i < 49; i += 10)
+    {
+      for (int j = 0; j < 255; j++)
+      {
+        snprintf(str, sizeof(str), "\033[%d;5;%dm", i, j);
+        TEST_CASE_("<esc>%s", str + 1);
+
+        struct AnsiColor ansi = { 0 };
+        int len = ansi_color_parse_single(str, &ansi, false);
+        int expected = 9 + ((j > 9) ? 1 : 0) + ((j > 99) ? 1 : 0);
+        TEST_CHECK(len == expected);
+        TEST_MSG("len: Expected %d, Got %d", expected, len);
+      }
+    }
+  }
+
+  // RGB Colours - Foregrounds and Backgrounds
+  {
+    static const int red[] = { 0,   1,   67,  189, 31,  103, 121, 162,
+                               142, 174, 100, 87,  254, 255, -1 };
+    static const int green[] = { 0,  1,  86,  214, 142, 29,  87, 89,
+                                 75, 28, 170, 97,  254, 255, -1 };
+    static const int blue[] = { 0,   1,   200, 142, 239, 107, 125, 179,
+                                198, 190, 189, 246, 254, 255, -1 };
+
+    char str[32];
+    for (int i = 38; i < 49; i += 10)
+    {
+      for (int r = 0; red[r] >= 0; r++)
+      {
+        for (int g = 0; green[g] >= 0; g++)
+        {
+          for (int b = 0; blue[b] >= 0; b++)
+          {
+            int val_r = red[r];
+            int val_g = green[g];
+            int val_b = blue[b];
+            snprintf(str, sizeof(str), "\033[%d;2;%d;%d;%dm", i, val_r, val_g, val_b);
+            TEST_CASE_("<esc>%s", str + 1);
+
+            struct AnsiColor ansi = { 0 };
+            int len = ansi_color_parse_single(str, &ansi, false);
+            int expected = 13 + ((val_r > 9) ? 1 : 0) + ((val_r > 99) ? 1 : 0) +
+                           ((val_g > 9) ? 1 : 0) + ((val_g > 99) ? 1 : 0) +
+                           ((val_b > 9) ? 1 : 0) + ((val_b > 99) ? 1 : 0);
+            TEST_CHECK(len == expected);
+            TEST_MSG("len: Expected %d, Got %d", expected, len);
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/color/attr.c
+++ b/test/color/attr.c
@@ -1,0 +1,248 @@
+/**
+ * @file
+ * Test code for Attr Colours
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include "mutt/lib.h"
+#include "config/lib.h"
+#include "core/lib.h"
+#include "gui/lib.h"
+#include "color/lib.h"
+#include "test_common.h"
+
+color_t color_xterm256_to_24bit(const color_t color);
+void modify_color_by_prefix(enum ColorPrefix prefix, bool is_fg, color_t *col, int *attrs);
+
+static struct ConfigDef Vars[] = {
+  // clang-format off
+  { "color_directcolor", DT_BOOL, true, 0, NULL, },
+  { NULL },
+  // clang-format on
+};
+
+struct ModifyTest
+{
+  enum ColorPrefix prefix;
+  bool is_fg;
+  color_t col_before;
+  int attrs_before;
+  color_t col_after;
+  int attrs_after;
+};
+
+void test_attr_colors(void)
+{
+  COLOR_PAIRS = 32;
+  curses_colors_init();
+  TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
+
+  {
+    attr_color_free(NULL);
+  }
+
+  {
+    struct AttrColor *ac = attr_color_new();
+    TEST_CHECK(ac != NULL);
+    attr_color_free(&ac);
+  }
+
+  {
+    struct AttrColor *ac = attr_color_new();
+    TEST_CHECK(ac != NULL);
+
+    struct AttrColor *ac_copy = ac;
+    ac_copy->ref_count++;
+
+    attr_color_free(&ac_copy);
+    attr_color_free(&ac);
+  }
+
+  {
+    attr_color_clear(NULL);
+  }
+
+  {
+    color_t fg = rand() % (1 << 24); // Make up some arbitrary colours
+    color_t bg = rand() % (1 << 24);
+
+    struct CursesColor *cc = curses_color_new(fg, bg);
+    struct AttrColor ac = { 0 };
+    ac.attrs = A_BOLD;
+    ac.curses_color = cc;
+
+    TEST_CHECK(attr_color_is_set(NULL) == false);
+    TEST_CHECK(attr_color_is_set(&ac) == true);
+
+    struct AttrColor ac_copy = attr_color_copy(&ac);
+
+    TEST_CHECK(memcmp(&ac, &ac_copy, sizeof(ac_copy)) == 0);
+
+    attr_color_clear(&ac);
+  }
+
+  {
+    attr_color_list_clear(NULL);
+
+    struct AttrColorList acl = TAILQ_HEAD_INITIALIZER(acl);
+
+    struct AttrColor *ac = attr_color_list_find(&acl, COLOR_RED, COLOR_RED, A_BOLD);
+    TEST_CHECK(ac == NULL);
+
+    color_t fg_find = COLOR_DEFAULT;
+    color_t bg_find = COLOR_DEFAULT;
+    int attrs_find = A_UNDERLINE;
+
+    for (int i = 0; i < 10; i++)
+    {
+      color_t fg = rand(); // Make up some arbitrary colours
+      color_t bg = rand();
+
+      struct CursesColor *cc = NULL;
+      if (i != 3)
+        cc = curses_color_new(fg, bg);
+
+      ac = attr_color_new();
+      ac->curses_color = cc;
+      ac->attrs = A_BOLD | A_ITALIC;
+
+      if (i == 3)
+        ac->attrs = attrs_find;
+
+      if (i == 7)
+      {
+        fg_find = fg;
+        bg_find = bg;
+        ac->attrs = attrs_find;
+      }
+
+      TAILQ_INSERT_TAIL(&acl, ac, entries);
+    }
+
+    ac = attr_color_list_find(NULL, fg_find, bg_find, attrs_find);
+    TEST_CHECK(ac == NULL);
+
+    ac = attr_color_list_find(&acl, fg_find, bg_find, attrs_find);
+    TEST_CHECK(ac != NULL);
+    TEST_CHECK(ac->attrs == attrs_find);
+    TEST_CHECK(ac->curses_color->fg == fg_find);
+    TEST_CHECK(ac->curses_color->bg == bg_find);
+
+    attr_color_list_clear(&acl);
+  }
+
+  {
+    COLORS = 256;
+
+    struct ModifyTest Tests[] = {
+      // clang-format off
+      { COLOR_PREFIX_NONE,   true,  COLOR_RED, A_NORMAL, COLOR_RED,     A_NORMAL         },
+      { COLOR_PREFIX_ALERT,  true,  COLOR_RED, A_NORMAL, COLOR_RED,     A_BOLD | A_BLINK },
+      { COLOR_PREFIX_LIGHT,  true,  COLOR_RED, A_NORMAL, COLOR_RED + 8, A_NORMAL         },
+      { COLOR_PREFIX_LIGHT,  true,  123,       A_NORMAL, 123,           A_NORMAL         },
+      { COLOR_PREFIX_BRIGHT, true,  COLOR_RED, A_NORMAL, COLOR_RED,     A_BOLD           },
+      { COLOR_PREFIX_LIGHT,  false, COLOR_RED, A_NORMAL, COLOR_RED + 8, A_NORMAL         },
+      { COLOR_PREFIX_LIGHT,  false, 123,       A_NORMAL, 123,           A_NORMAL         },
+      // clang-format on
+    };
+
+    for (int i = 0; i < mutt_array_size(Tests); i++)
+    {
+      color_t col = Tests[i].col_before;
+      int attrs = Tests[i].attrs_before;
+
+      modify_color_by_prefix(Tests[i].prefix, Tests[i].is_fg, &col, &attrs);
+
+      TEST_CHECK(col == Tests[i].col_after);
+      TEST_MSG("[%d] Color Expected: 0x%06x, Got: 0x%06x", i, Tests[i].col_after, col);
+
+      TEST_CHECK(attrs == Tests[i].attrs_after);
+      TEST_MSG("[%d] Attrs Expected: 0x%06x, Got: 0x%06x", i, Tests[i].attrs_after, attrs);
+    }
+  }
+
+  {
+    COLORS = 8;
+
+    struct ModifyTest Tests[] = {
+      // clang-format off
+      { COLOR_PREFIX_LIGHT,  true,  COLOR_RED, A_NORMAL, COLOR_RED, A_BOLD   },
+      { COLOR_PREFIX_LIGHT,  true,  123,       A_NORMAL, 123,       A_BOLD   },
+      { COLOR_PREFIX_BRIGHT, true,  COLOR_RED, A_NORMAL, COLOR_RED, A_BOLD   },
+      { COLOR_PREFIX_LIGHT,  false, COLOR_RED, A_NORMAL, COLOR_RED, A_NORMAL },
+      { COLOR_PREFIX_LIGHT,  false, 123,       A_NORMAL, 123,       A_NORMAL },
+      // clang-format on
+    };
+
+    for (int i = 0; i < mutt_array_size(Tests); i++)
+    {
+      color_t col = Tests[i].col_before;
+      int attrs = Tests[i].attrs_before;
+
+      modify_color_by_prefix(Tests[i].prefix, Tests[i].is_fg, &col, &attrs);
+
+      TEST_CHECK(col == Tests[i].col_after);
+      TEST_MSG("[%d] Color Expected: 0x%06x, Got: 0x%06x", i, Tests[i].col_after, col);
+
+      TEST_CHECK(attrs == Tests[i].attrs_after);
+      TEST_MSG("[%d] Attrs Expected: 0x%06x, Got: 0x%06x", i, Tests[i].attrs_after, attrs);
+    }
+  }
+
+  {
+    color_t Colors[][2] = {
+      // clang-format off
+      { COLOR_DEFAULT, COLOR_DEFAULT },
+      {   0, 0x000000 }, // Basic Colours
+      {   1, 0x800000 },
+      {  14, 0x00ffff },
+      {  15, 0xffffff },
+      {  16, 0x000000 }, // Palette Colours
+      {  17, 0x00005f },
+      { 230, 0xffffd7 },
+      { 231, 0xffffff },
+      { 232, 0x080808 }, // Greyscale Colours
+      { 233, 0x121212 },
+      { 254, 0xe4e4e4 },
+      { 255, 0xeeeeee },
+      // clang-format on
+    };
+
+    for (int i = 0; i < mutt_array_size(Colors); i++)
+    {
+      color_t col = color_xterm256_to_24bit(Colors[i][0]);
+      TEST_CHECK(col == Colors[i][1]);
+      TEST_MSG("[%d] %d", i, Colors[i][0]);
+      TEST_MSG("Expected: 0x%06x, Got: 0x%06x", Colors[i][1], col);
+    }
+  }
+
+  {
+    cs_str_native_set(NeoMutt->sub->cs, "color_directcolor", false, NULL);
+    color_t col = color_xterm256_to_24bit(123);
+    TEST_CHECK(col == 123);
+  }
+}

--- a/test/color/curses.c
+++ b/test/color/curses.c
@@ -1,0 +1,129 @@
+/**
+ * @file
+ * Test code for Curses Colours
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "gui/lib.h"
+#include "color/lib.h"
+
+ARRAY_HEAD(CursesColorArray, struct CursesColor *);
+
+void test_curses_colors(void)
+{
+  MuttLogger = log_disp_null;
+
+  COLOR_PAIRS = 32;
+  curses_colors_init();
+
+  {
+    // Degnerate test -- no colour
+    struct CursesColor *cc = curses_color_new(COLOR_DEFAULT, COLOR_DEFAULT);
+    TEST_CHECK(cc == NULL);
+  }
+
+  {
+    // Create too many colours
+    struct CursesColorArray cca = ARRAY_HEAD_INITIALIZER;
+
+    for (int i = 0; i < 50; i++)
+    {
+      color_t fg = rand() % (1 << 24); // Make up some arbitrary colours
+      color_t bg = rand() % (1 << 24);
+
+      struct CursesColor *cc = curses_color_new(fg, bg);
+      if (!cc)
+        continue;
+
+      ARRAY_ADD(&cca, cc);
+    }
+
+    TEST_CHECK(ARRAY_SIZE(&cca) == 16);
+
+    struct CursesColor **ccp = NULL;
+    ARRAY_FOREACH(ccp, &cca)
+    {
+      struct CursesColor *cc = *ccp;
+      curses_color_free(&cc);
+    }
+    ARRAY_FREE(&cca);
+  }
+
+  {
+    // Create and find colours
+    struct CursesColor *cc = NULL;
+    color_t fg = 0x800000;
+    color_t bg = 0x008000;
+
+    cc = curses_color_new(fg, bg);
+    TEST_CHECK(cc != NULL);
+
+    struct CursesColor *cc_copy = NULL;
+    cc_copy = curses_color_new(fg, bg);
+    TEST_CHECK(cc == cc_copy);
+
+    struct CursesColor *cc_find = NULL;
+    cc_find = curses_colors_find(bg, fg);
+    TEST_CHECK(cc_find == NULL);
+
+    cc_find = curses_colors_find(fg, bg);
+    TEST_CHECK(cc_find == cc);
+
+    curses_color_free(&cc_copy);
+    curses_color_free(&cc);
+  }
+
+  {
+    // Check the insertion / freeing of colours
+    struct CursesColor *cc1 = curses_color_new(1, 1);
+    struct CursesColor *cc2 = curses_color_new(2, 2);
+    struct CursesColor *cc3 = curses_color_new(3, 3);
+    struct CursesColor *cc4 = curses_color_new(4, 4);
+    struct CursesColor *cc5 = curses_color_new(5, 5);
+
+    TEST_CHECK(cc1 != NULL);
+    TEST_CHECK(cc2 != NULL);
+    TEST_CHECK(cc3 != NULL);
+    TEST_CHECK(cc4 != NULL);
+    TEST_CHECK(cc5 != NULL);
+
+    curses_color_free(&cc2);
+    curses_color_free(&cc4);
+
+    cc2 = curses_color_new(22, 22);
+    cc4 = curses_color_new(44, 44);
+
+    TEST_CHECK(cc2 != NULL);
+    TEST_CHECK(cc4 != NULL);
+
+    curses_color_free(&cc1);
+    curses_color_free(&cc2);
+    curses_color_free(&cc3);
+    curses_color_free(&cc4);
+    curses_color_free(&cc5);
+  }
+}

--- a/test/color/merged.c
+++ b/test/color/merged.c
@@ -1,0 +1,35 @@
+/**
+ * @file
+ * Test code for Merged Colours
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "gui/lib.h"
+#include "color/lib.h"
+
+void test_merged_colors(void)
+{
+}

--- a/test/color/parse_attr_spec.c
+++ b/test/color/parse_attr_spec.c
@@ -1,0 +1,132 @@
+/**
+ * @file
+ * Test code for Colour Parsing
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "gui/lib.h"
+#include "color/lib.h"
+
+struct AttrTest
+{
+  const char *str;
+  int value;
+};
+
+void test_parse_attr_spec(void)
+{
+  // enum CommandResult parse_attr_spec (struct Buffer *buf, struct Buffer *s, struct AttrColor *ac, struct Buffer *err);
+
+  {
+    struct Buffer *buf = buf_pool_get();
+    struct Buffer *s = buf_pool_get();
+    struct Buffer *err = buf_pool_get();
+    enum CommandResult rc;
+
+    struct AttrColor *ac = attr_color_new();
+
+    buf_addstr(s, "underline");
+    buf_seek(s, 0);
+
+    rc = parse_attr_spec(NULL, s, ac, err);
+    TEST_CHECK(rc == MUTT_CMD_ERROR);
+
+    rc = parse_attr_spec(buf, NULL, ac, err);
+    TEST_CHECK(rc == MUTT_CMD_ERROR);
+
+    rc = parse_attr_spec(buf, s, NULL, err);
+    TEST_CHECK(rc == MUTT_CMD_ERROR);
+
+    attr_color_free(&ac);
+
+    buf_pool_release(&buf);
+    buf_pool_release(&s);
+    buf_pool_release(&err);
+  }
+
+  {
+    struct Buffer *buf = buf_pool_get();
+    struct Buffer *s = buf_pool_get();
+    struct Buffer *err = buf_pool_get();
+
+    struct AttrColor *ac = attr_color_new();
+
+    struct AttrTest tests[] = {
+      // clang-format off
+      { "bold",      A_BOLD      },
+      { "italic",    A_ITALIC    },
+      { "NONE",      A_NORMAL    },
+      { "normal",    A_NORMAL    },
+      { "REVERSE",   A_REVERSE   },
+      { "standout",  A_STANDOUT  },
+      { "UnDeRlInE", A_UNDERLINE },
+      { NULL, 0 },
+      // clang-format on
+    };
+
+    for (int i = 0; tests[i].str; i++)
+    {
+      buf_strcpy(s, tests[i].str);
+      buf_seek(s, 0);
+
+      enum CommandResult rc = parse_attr_spec(buf, s, ac, err);
+      TEST_CHECK(rc == MUTT_CMD_SUCCESS);
+      TEST_MSG("rc: Expected %d, Got %d", MUTT_CMD_SUCCESS, rc);
+      TEST_MSG("err: %s", buf_string(err));
+    }
+
+    attr_color_free(&ac);
+
+    buf_pool_release(&buf);
+    buf_pool_release(&s);
+    buf_pool_release(&err);
+  }
+
+  {
+    struct Buffer *buf = buf_pool_get();
+    struct Buffer *s = buf_pool_get();
+    struct Buffer *err = buf_pool_get();
+
+    struct AttrColor *ac = attr_color_new();
+
+    const char *tests[] = { "", "reversed", NULL };
+
+    for (int i = 0; tests[i]; i++)
+    {
+      buf_addstr(s, tests[i]);
+      buf_seek(s, 0);
+
+      enum CommandResult rc = parse_attr_spec(buf, s, ac, err);
+      TEST_CHECK(rc == MUTT_CMD_WARNING);
+    }
+
+    attr_color_free(&ac);
+
+    buf_pool_release(&buf);
+    buf_pool_release(&s);
+    buf_pool_release(&err);
+  }
+}

--- a/test/color/parse_color_colornnn.c
+++ b/test/color/parse_color_colornnn.c
@@ -1,0 +1,115 @@
+/**
+ * @file
+ * Test code for Colour Parsing
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "color/lib.h"
+
+enum CommandResult parse_color_colornnn(const char *s, struct ColorElement *elem,
+                                        struct Buffer *err);
+
+void test_parse_color_colornnn(void)
+{
+  // enum CommandResult parse_color_colornnn(const char *s, struct ColorElement *elem, struct Buffer *err);
+
+  {
+    enum CommandResult rc;
+    const char *str = "color123";
+    struct ColorElement elem = { 0 };
+    struct Buffer *err = buf_pool_get();
+
+    rc = parse_color_colornnn(NULL, &elem, err);
+    TEST_CHECK(rc == MUTT_CMD_ERROR);
+
+    rc = parse_color_colornnn(str, NULL, err);
+    TEST_CHECK(rc == MUTT_CMD_ERROR);
+
+    buf_pool_release(&err);
+  }
+
+  {
+    enum CommandResult rc;
+    struct Buffer *err = buf_pool_get();
+
+    for (int i = 0; i < 256; i++)
+    {
+      char str[32] = { 0 };
+      struct ColorElement elem = { 0 };
+
+      snprintf(str, sizeof(str), "color%d", i);
+
+      rc = parse_color_colornnn(str, &elem, err);
+      TEST_CHECK(rc == MUTT_CMD_SUCCESS);
+
+      TEST_CHECK(elem.type == CT_PALETTE);
+      TEST_CHECK(elem.color == i);
+      TEST_CHECK(elem.prefix == COLOR_PREFIX_NONE);
+    }
+
+    buf_pool_release(&err);
+  }
+
+  {
+    enum CommandResult rc;
+    struct Buffer *err = buf_pool_get();
+
+    for (int i = 0; i < 256; i++)
+    {
+      char str[32] = { 0 };
+      struct ColorElement elem = { 0 };
+
+      snprintf(str, sizeof(str), "brightCOLOR%d", i);
+
+      rc = parse_color_colornnn(str, &elem, err);
+      TEST_CHECK(rc == MUTT_CMD_SUCCESS);
+
+      TEST_CHECK(elem.type == CT_PALETTE);
+      TEST_CHECK(elem.color == i);
+      TEST_CHECK(elem.prefix == COLOR_PREFIX_BRIGHT);
+    }
+
+    buf_pool_release(&err);
+  }
+
+  {
+    enum CommandResult rc;
+    struct Buffer *err = buf_pool_get();
+    const char *tests[] = { "red",       "color",    "colour123", "color-1",
+                            "colorblue", "color256", "color1000", NULL };
+
+    for (int i = 0; tests[i]; i++)
+    {
+      struct ColorElement elem = { 0 };
+
+      rc = parse_color_colornnn(tests[i], &elem, err);
+      TEST_CHECK(rc < 0);
+      TEST_MSG("Case: %s", tests[i]);
+    }
+
+    buf_pool_release(&err);
+  }
+}

--- a/test/color/parse_color_name.c
+++ b/test/color/parse_color_name.c
@@ -1,0 +1,55 @@
+/**
+ * @file
+ * Test code for Colour Parsing
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "color/lib.h"
+
+enum CommandResult parse_color_name(const char *s, struct ColorElement *elem,
+                                    struct Buffer *err);
+
+void test_parse_color_name(void)
+{
+  // enum CommandResult parse_color_name(const char *s, struct ColorElement *elem, struct Buffer *err);
+
+  struct Buffer *err = buf_pool_get();
+  struct ColorElement elem = { 0 };
+  enum CommandResult rc;
+
+  const char *tests[] = { "#11AAFF", "color123", "brightred", NULL };
+
+  for (int i = 0; tests[i]; i++)
+  {
+    rc = parse_color_name(tests[i], &elem, err);
+    TEST_CHECK(rc == MUTT_CMD_SUCCESS);
+  }
+
+  rc = parse_color_name("junk", &elem, err);
+  TEST_CHECK(rc == MUTT_CMD_WARNING);
+
+  buf_pool_release(&err);
+}

--- a/test/color/parse_color_namedcolor.c
+++ b/test/color/parse_color_namedcolor.c
@@ -1,0 +1,157 @@
+/**
+ * @file
+ * Test code for Colour Parsing
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "color/lib.h"
+
+enum CommandResult parse_color_namedcolor(const char *s, struct ColorElement *elem,
+                                          struct Buffer *err);
+
+struct NamedTest
+{
+  const char *str;
+  int cid;
+};
+
+void test_parse_color_namedcolor(void)
+{
+  // enum CommandResult parse_color_namedcolor(const char *s, struct ColorElement *elem, struct Buffer *err);
+
+  {
+    enum CommandResult rc;
+    const char *str = "red";
+    struct ColorElement elem = { 0 };
+    struct Buffer *err = buf_pool_get();
+
+    rc = parse_color_namedcolor(NULL, &elem, err);
+    TEST_CHECK(rc == MUTT_CMD_ERROR);
+
+    rc = parse_color_namedcolor(str, NULL, err);
+    TEST_CHECK(rc == MUTT_CMD_ERROR);
+
+    buf_pool_release(&err);
+  }
+
+  {
+    struct NamedTest tests[] = {
+      // clang-format off
+      { "default", -1 },
+      { "black",    0 },
+      { "blue",     4 },
+      { "cyan",     6 },
+      { "green",    2 },
+      { "magenta",  5 },
+      { "red",      1 },
+      { "white",    7 },
+      { "yellow",   3 },
+      { NULL,       0 },
+      // clang-format on
+    };
+
+    struct Buffer *err = buf_pool_get();
+
+    for (int i = 0; tests[i].str; i++)
+    {
+      enum CommandResult rc;
+      struct ColorElement elem = { 0 };
+
+      TEST_CASE(tests[i].str);
+      rc = parse_color_namedcolor(tests[i].str, &elem, err);
+      TEST_CHECK(rc == MUTT_CMD_SUCCESS);
+      TEST_MSG("%s", buf_string(err));
+      TEST_MSG("rc: Expected %d, Got %d\n", MUTT_CMD_SUCCESS, rc);
+
+      TEST_CHECK(elem.color == tests[i].cid);
+      TEST_MSG("cid: Expected %d, Got %d\n", tests[i].cid, elem.color);
+
+      TEST_CHECK(elem.type == CT_SIMPLE);
+      TEST_MSG("type: Expected %d, Got %d\n", CT_SIMPLE, elem.type);
+
+      TEST_CHECK(elem.prefix == COLOR_PREFIX_NONE);
+      TEST_MSG("prefix: Expected %d, Got %d\n", COLOR_PREFIX_NONE, elem.prefix);
+    }
+
+    buf_pool_release(&err);
+  }
+
+  {
+    struct NamedTest tests[] = {
+      // clang-format off
+      { "lightblack",    0 },
+      { "lightblue",     4 },
+      { "lightcyan",     6 },
+      { "lightgreen",    2 },
+      { "lightmagenta",  5 },
+      { "lightred",      1 },
+      { "lightwhite",    7 },
+      { "lightyellow",   3 },
+      { NULL,       0 },
+      // clang-format on
+    };
+
+    struct Buffer *err = buf_pool_get();
+
+    for (int i = 0; tests[i].str; i++)
+    {
+      enum CommandResult rc;
+      struct ColorElement elem = { 0 };
+
+      TEST_CASE(tests[i].str);
+      rc = parse_color_namedcolor(tests[i].str, &elem, err);
+      TEST_CHECK(rc == MUTT_CMD_SUCCESS);
+      TEST_MSG("%s", buf_string(err));
+      TEST_MSG("rc: Expected %d, Got %d\n", MUTT_CMD_SUCCESS, rc);
+
+      TEST_CHECK(elem.color == tests[i].cid);
+      TEST_MSG("cid: Expected %d, Got %d\n", tests[i].cid, elem.color);
+
+      TEST_CHECK(elem.type == CT_SIMPLE);
+      TEST_MSG("type: Expected %d, Got %d\n", CT_SIMPLE, elem.type);
+
+      TEST_CHECK(elem.prefix == COLOR_PREFIX_LIGHT);
+      TEST_MSG("prefix: Expected %d, Got %d\n", COLOR_PREFIX_LIGHT, elem.prefix);
+    }
+
+    buf_pool_release(&err);
+  }
+
+  {
+    const char *tests[] = { "blacklight", "brown", "blac", "lightdefault", NULL };
+
+    enum CommandResult rc;
+    struct ColorElement elem = { 0 };
+
+    for (int i = 0; tests[i]; i++)
+    {
+      TEST_CASE(tests[i]);
+      rc = parse_color_namedcolor(tests[i], &elem, NULL);
+      TEST_CHECK(rc == MUTT_CMD_WARNING);
+      TEST_MSG("rc: Expected %d, Got %d\n", MUTT_CMD_WARNING, rc);
+    }
+  }
+}

--- a/test/color/parse_color_pair.c
+++ b/test/color/parse_color_pair.c
@@ -1,0 +1,77 @@
+/**
+ * @file
+ * Test code for Colour Parsing
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "color/lib.h"
+
+void test_parse_color_pair(void)
+{
+  // enum CommandResult parse_color_pair(struct Buffer *buf, struct Buffer *s, struct AttrColor *ac, struct Buffer *err);
+
+  struct Buffer *buf = buf_pool_get();
+  struct Buffer *s = buf_pool_get();
+  struct Buffer *err = buf_pool_get();
+
+  struct AttrColor *ac = attr_color_new();
+
+  const char *first[] = { "blue", "color86", "#BB2288", NULL };
+  const char *second[] = { "brightyellow", "alertcolor86", "#4F8E3A", NULL };
+
+  for (int i = 0; first[i]; i++)
+  {
+    for (int j = 0; second[j]; j++)
+    {
+      buf_printf(s, "%s %s", first[i], second[j]);
+      buf_seek(s, 0);
+
+      enum CommandResult rc = parse_color_pair(buf, s, ac, err);
+      TEST_CHECK(rc == MUTT_CMD_SUCCESS);
+      TEST_MSG("%s\n", buf_string(err));
+    }
+  }
+
+  const char *tests[] = {
+    "", "red", "underline red", "normal yellow", "bold junk", "'' red", NULL
+  };
+
+  for (int i = 0; tests[i]; i++)
+  {
+    buf_strcpy(s, tests[i]);
+    buf_seek(s, 0);
+
+    enum CommandResult rc = parse_color_pair(buf, s, ac, err);
+    TEST_CHECK(rc < 0);
+    TEST_MSG("%s\n", buf_string(err));
+  }
+
+  attr_color_free(&ac);
+
+  buf_pool_release(&buf);
+  buf_pool_release(&s);
+  buf_pool_release(&err);
+}

--- a/test/color/parse_color_prefix.c
+++ b/test/color/parse_color_prefix.c
@@ -1,0 +1,93 @@
+/**
+ * @file
+ * Test code for Colour Parsing
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "color/lib.h"
+
+int parse_color_prefix(const char *s, enum ColorPrefix *prefix);
+
+struct PrefixTest
+{
+  const char *str;
+  int len;
+  enum ColorPrefix prefix;
+};
+
+void test_parse_color_prefix(void)
+{
+  // int parse_color_prefix(const char *s, enum ColorPrefix *prefix);
+
+  {
+    enum ColorPrefix prefix = COLOR_PREFIX_NONE;
+    const char *test = "brightred";
+    int len;
+
+    len = parse_color_prefix(test, NULL);
+    TEST_CHECK(len == 0);
+
+    len = parse_color_prefix(NULL, &prefix);
+    TEST_CHECK(len == 0);
+  }
+
+  {
+    struct PrefixTest tests[] = {
+      // clang-format off
+      { "red",       0, COLOR_PREFIX_NONE   },
+      { "brightred", 6, COLOR_PREFIX_BRIGHT },
+      { "alertred",  5, COLOR_PREFIX_ALERT  },
+      { "lightred",  5, COLOR_PREFIX_LIGHT  },
+      { "bright",    6, COLOR_PREFIX_BRIGHT },
+      { "alert",     5, COLOR_PREFIX_ALERT  },
+      { "light",     5, COLOR_PREFIX_LIGHT  },
+      { "BriGHtred", 6, COLOR_PREFIX_BRIGHT },
+      { "AleRTred",  5, COLOR_PREFIX_ALERT  },
+      { "LigHTred",  5, COLOR_PREFIX_LIGHT  },
+      { "BriGHt",    6, COLOR_PREFIX_BRIGHT },
+      { "AleRT",     5, COLOR_PREFIX_ALERT  },
+      { "LigHT",     5, COLOR_PREFIX_LIGHT  },
+      { "brigh",     0, COLOR_PREFIX_NONE   },
+      { "aler",      0, COLOR_PREFIX_NONE   },
+      { "ligh",      0, COLOR_PREFIX_NONE   },
+      { NULL, 0 },
+      // clang-format on
+    };
+
+    for (int i = 0; tests[i].str; i++)
+    {
+      TEST_CASE(tests[i].str);
+      enum ColorPrefix prefix = COLOR_PREFIX_NONE;
+      int len = parse_color_prefix(tests[i].str, &prefix);
+
+      TEST_CHECK(len == tests[i].len);
+      TEST_MSG("\tlen:    Expected %d, Got %d\n", tests[i].len, len);
+
+      TEST_CHECK(prefix == tests[i].prefix);
+      TEST_MSG("\tprefix: Expected %d, Got %d\n", tests[i].prefix, prefix);
+    }
+  }
+}

--- a/test/color/parse_color_rrggbb.c
+++ b/test/color/parse_color_rrggbb.c
@@ -1,0 +1,118 @@
+/**
+ * @file
+ * Test code for Colour Parsing
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "color/lib.h"
+
+enum CommandResult parse_color_rrggbb(const char *s, struct ColorElement *elem,
+                                      struct Buffer *err);
+
+struct RgbTest
+{
+  const char *str;
+  long color;
+};
+
+void test_parse_color_rrggbb(void)
+{
+  // enum CommandResult parse_color_rrggbb(const char *s, struct ColorElement *elem, struct Buffer *err);
+
+  {
+    struct Buffer *err = buf_pool_get();
+    enum CommandResult rc;
+    const char *str = "#12AB89";
+    struct ColorElement elem = { 0 };
+
+    rc = parse_color_rrggbb(NULL, &elem, err);
+    TEST_CHECK(rc == MUTT_CMD_ERROR);
+
+    rc = parse_color_rrggbb(str, NULL, err);
+    TEST_CHECK(rc == MUTT_CMD_ERROR);
+
+    buf_pool_release(&err);
+  }
+
+  {
+    struct RgbTest tests[] = {
+      // clang-format off
+      // Start
+      { "#000000", 0x000000 }, { "#000001", 0x000001 }, { "#000002", 0x000002 }, { "#000003", 0x000003 }, { "#000004", 0x000004 }, { "#000005", 0x000005 }, { "#000006", 0x000006 }, { "#000007", 0x000007 }, { "#000008", 0x000008 }, { "#000009", 0x000009 }, { "#00000a", 0x00000a }, { "#00000b", 0x00000b }, { "#00000c", 0x00000c }, { "#00000d", 0x00000d }, { "#00000e", 0x00000e }, { "#00000f", 0x00000f },
+
+      // Random
+      { "#CF4144", 0xcf4144 }, { "#19F5EA", 0x19f5ea }, { "#A01642", 0xa01642 }, { "#A8FF5E", 0xa8ff5e }, { "#11A708", 0x11a708 }, { "#87F1DA", 0x87f1da }, { "#19D732", 0x19d732 }, { "#284FC1", 0x284fc1 }, { "#9C6277", 0x9c6277 }, { "#CFC961", 0xcfc961 }, { "#F437D8", 0xf437d8 }, { "#90CE8E", 0x90ce8e }, { "#D98D81", 0xd98d81 }, { "#6EB3DA", 0x6eb3da }, { "#B09F00", 0xb09f00 }, { "#DA9F7A", 0xda9f7a },
+      { "#0D267A", 0x0d267a }, { "#F0F240", 0xf0f240 }, { "#0385CC", 0x0385cc }, { "#93200F", 0x93200f }, { "#F26296", 0xf26296 }, { "#8C5896", 0x8c5896 }, { "#323BE6", 0x323be6 }, { "#C4F73A", 0xc4f73a }, { "#42E907", 0x42e907 }, { "#ED732A", 0xed732a }, { "#A88888", 0xa88888 }, { "#1FEA37", 0x1fea37 }, { "#62341D", 0x62341d }, { "#939E63", 0x939e63 }, { "#7914E4", 0x7914e4 }, { "#CDF98E", 0xcdf98e },
+      { "#2C314C", 0x2c314c }, { "#59BE9E", 0x59be9e }, { "#925F21", 0x925f21 }, { "#33F620", 0x33f620 }, { "#B8D8BC", 0xb8d8bc }, { "#706513", 0x706513 }, { "#F32758", 0xf32758 }, { "#AFF6A6", 0xaff6a6 }, { "#C4A243", 0xc4a243 }, { "#669B53", 0x669b53 }, { "#C516CA", 0xc516ca }, { "#CB0014", 0xcb0014 }, { "#25DD14", 0x25dd14 }, { "#A64784", 0xa64784 }, { "#34925D", 0x34925d }, { "#735267", 0x735267 },
+      { "#25203B", 0x25203b }, { "#09D7CD", 0x09d7cd }, { "#79F705", 0x79f705 }, { "#6C9E18", 0x6c9e18 }, { "#9FAD47", 0x9fad47 }, { "#915A05", 0x915a05 }, { "#C138AD", 0xc138ad }, { "#A699EF", 0xa699ef }, { "#934667", 0x934667 }, { "#8686ED", 0x8686ed }, { "#C9F464", 0xc9f464 }, { "#879860", 0x879860 }, { "#72369A", 0x72369a }, { "#9B20ED", 0x9b20ed }, { "#7767B1", 0x7767b1 }, { "#9B8942", 0x9b8942 },
+
+      // End
+      { "#fffff0", 0xfffff0 }, { "#fffff1", 0xfffff1 }, { "#fffff2", 0xfffff2 }, { "#fffff3", 0xfffff3 }, { "#fffff4", 0xfffff4 }, { "#fffff5", 0xfffff5 }, { "#fffff6", 0xfffff6 }, { "#fffff7", 0xfffff7 }, { "#fffff8", 0xfffff8 }, { "#fffff9", 0xfffff9 }, { "#fffffa", 0xfffffa }, { "#fffffb", 0xfffffb }, { "#fffffc", 0xfffffc }, { "#fffffd", 0xfffffd }, { "#fffffe", 0xfffffe }, { "#ffffff", 0xffffff },
+      { NULL, 0 },
+      // clang-format on
+    };
+
+    struct Buffer *err = buf_pool_get();
+    enum CommandResult rc;
+
+    for (int i = 0; tests[i].str; i++)
+    {
+      struct ColorElement elem = { 0 };
+
+      rc = parse_color_rrggbb(tests[i].str, &elem, err);
+      TEST_CHECK(rc == MUTT_CMD_SUCCESS);
+      TEST_MSG("rc: Expected %d, Got %d", MUTT_CMD_SUCCESS, rc);
+
+      TEST_CHECK(elem.color == tests[i].color);
+      TEST_MSG("color: Expected %d, Got %d", tests[i].color, elem.color);
+
+      TEST_CHECK(elem.type == CT_RGB);
+      TEST_CHECK(elem.prefix == COLOR_PREFIX_NONE);
+    }
+
+    buf_pool_release(&err);
+  }
+
+  {
+    struct Buffer *err = buf_pool_get();
+    enum CommandResult rc;
+    const char *tests[] = { "1234",      "#",          "#1",      "#12",
+                            "#123",      "#1234",      "#12345",  "#1234567",
+                            "#12345678", "#123456789", "#abcdeg", "#red",
+                            NULL };
+
+    for (int i = 0; tests[i]; i++)
+    {
+      struct ColorElement elem = { 0 };
+
+      rc = parse_color_rrggbb(tests[i], &elem, err);
+      TEST_CHECK(rc < 0);
+      TEST_MSG("Case: %s", tests[i]);
+    }
+
+    buf_pool_release(&err);
+  }
+}

--- a/test/color/quoted.c
+++ b/test/color/quoted.c
@@ -1,0 +1,35 @@
+/**
+ * @file
+ * Test code for Quoted Colours
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "gui/lib.h"
+#include "color/lib.h"
+
+void test_quoted_colors(void)
+{
+}

--- a/test/color/simple.c
+++ b/test/color/simple.c
@@ -1,0 +1,62 @@
+/**
+ * @file
+ * Test code for Simple Colours
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "gui/lib.h"
+#include "color/lib.h"
+
+void test_simple_colors(void)
+{
+  MuttLogger = log_disp_null;
+
+  simple_colors_init();
+
+  struct AttrColor *ac = NULL;
+
+  ac = simple_color_get(MT_COLOR_NONE - 10);
+  TEST_CHECK(ac == NULL);
+
+  ac = simple_color_get(MT_COLOR_PROMPT);
+  TEST_CHECK(ac != NULL);
+
+  bool set = simple_color_is_set(MT_COLOR_PROMPT);
+  TEST_CHECK(!set);
+
+  ac = simple_color_get(MT_COLOR_MAX + 10);
+  TEST_CHECK(ac == NULL);
+
+  TEST_CHECK(simple_color_is_header(MT_COLOR_HEADER));
+  TEST_CHECK(!simple_color_is_header(MT_COLOR_QUOTED));
+
+  simple_colors_cleanup();
+}
+
+#if 0
+struct AttrColor *simple_color_set(enum ColorId cid, struct AttrColor *ac_val);
+void              simple_color_reset    (enum ColorId cid);
+#endif

--- a/test/main.c
+++ b/test/main.c
@@ -152,6 +152,21 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_mutt_ch_lookup_remove)                                \
   NEOMUTT_TEST_ITEM(test_mutt_ch_set_charset)                                  \
                                                                                \
+  /* color */                                                                  \
+  NEOMUTT_TEST_ITEM(test_ansi_color_parse_single)                              \
+  NEOMUTT_TEST_ITEM(test_attr_colors)                                          \
+  NEOMUTT_TEST_ITEM(test_curses_colors)                                        \
+  NEOMUTT_TEST_ITEM(test_merged_colors)                                        \
+  NEOMUTT_TEST_ITEM(test_parse_attr_spec)                                      \
+  NEOMUTT_TEST_ITEM(test_parse_color_colornnn)                                 \
+  NEOMUTT_TEST_ITEM(test_parse_color_name)                                     \
+  NEOMUTT_TEST_ITEM(test_parse_color_namedcolor)                               \
+  NEOMUTT_TEST_ITEM(test_parse_color_pair)                                     \
+  NEOMUTT_TEST_ITEM(test_parse_color_prefix)                                   \
+  NEOMUTT_TEST_ITEM(test_parse_color_rrggbb)                                   \
+  NEOMUTT_TEST_ITEM(test_quoted_colors)                                        \
+  NEOMUTT_TEST_ITEM(test_simple_colors)                                        \
+                                                                               \
   /* config */                                                                 \
   NEOMUTT_TEST_ITEM(test_config_account)                                       \
   NEOMUTT_TEST_ITEM(test_config_bool)                                          \


### PR DESCRIPTION
WIP

- Refactor / tidy the colour debugging code
- Add a `:color` command to dump the colours

<img src="https://flatcap.org/mutt/colour/parse_color4.svg">

Source: [graphviz](https://flatcap.org/mutt/colour/parse_color4.gv)