### PR TITLE
fix new mail in limited view

### DIFF
--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -553,6 +553,7 @@ void update_index(struct Menu *menu, struct MailboxView *mv, enum MxStatus check
   else
     update_index_unthreaded(mv, check);
 
+  menu->max = m->vcount;
   const int old_index = menu_get_index(menu);
   int index = -1;
   if (oldcount)


### PR DESCRIPTION
If new mail arrives that doesn't match the current limit, the Menu loses its selection leading to errors:  "no visible messages".

Fixes: #4072

---

When new mail arrives, `Mailbox->emails[]` is updated and the view (`Mailbox->v2r`) must be recalculated.
During this process, `Mailbox->vcount` gets set to `0`, which leads to `Menu->max` being set to `0`.
Unfortunately, `Menu->max` wasn't being reset afterwards, so the Menu thought it was empty.

The fix resets `Menu->max` as soon as possible after the updates, in time for the selection to be restored.