### PR TITLE
logging: minor fixes / improvements

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -276,7 +276,7 @@ int source_rc(const char *rcfile_path, struct Buffer *err)
     line_rc = parse_rc_buffer(linebuf, token, err);
     if (line_rc == MUTT_CMD_ERROR)
     {
-      mutt_error(_("Error in %s, line %d: %s"), rcfile, lineno, buf_string(err));
+      mutt_error("%s:%d: %s", rcfile, lineno, buf_string(err));
       if (--rc < -MAX_ERRS)
       {
         if (conv)
@@ -287,7 +287,7 @@ int source_rc(const char *rcfile_path, struct Buffer *err)
     else if (line_rc == MUTT_CMD_WARNING)
     {
       /* Warning */
-      mutt_warning(_("Warning in %s, line %d: %s"), rcfile, lineno, buf_string(err));
+      mutt_warning("%s:%d: %s", rcfile, lineno, buf_string(err));
       warnings++;
     }
     else if (line_rc == MUTT_CMD_FINISH)

--- a/init.c
+++ b/init.c
@@ -324,7 +324,7 @@ void mutt_opts_cleanup(void)
 int mutt_init(struct ConfigSet *cs, const char *dlevel, const char *dfile,
               bool skip_sys_rc, struct ListHead *commands)
 {
-  int need_pause = 0;
+  bool need_pause = false;
   int rc = 1;
   struct Buffer err = buf_make(256);
   struct Buffer buf = buf_make(256);
@@ -535,7 +535,7 @@ int mutt_init(struct ConfigSet *cs, const char *dlevel, const char *dfile,
       if (source_rc(buf_string(&buf), &err) != 0)
       {
         mutt_error("%s", err.data);
-        need_pause = 1; // TEST11: neomutt (error in /etc/neomuttrc)
+        need_pause = true; // TEST11: neomutt (error in /etc/neomuttrc)
       }
     }
   }
@@ -549,13 +549,13 @@ int mutt_init(struct ConfigSet *cs, const char *dlevel, const char *dfile,
       if (source_rc(np->data, &err) != 0)
       {
         mutt_error("%s", err.data);
-        need_pause = 1; // TEST12: neomutt (error in ~/.neomuttrc)
+        need_pause = true; // TEST12: neomutt (error in ~/.neomuttrc)
       }
     }
   }
 
   if (execute_commands(commands) != 0)
-    need_pause = 1; // TEST13: neomutt -e broken
+    need_pause = true; // TEST13: neomutt -e broken
 
   if (!get_hostname(cs))
     goto done;

--- a/init.h
+++ b/init.h
@@ -30,7 +30,7 @@ struct ConfigSet;
 struct ListHead;
 
 void init_config         (struct ConfigSet *cs);
-int  mutt_init           (struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands);
+int  mutt_init           (struct ConfigSet *cs, const char *dlevel, const char *dfile, bool skip_sys_rc, struct ListHead *commands);
 void mutt_opts_cleanup   (void);
 int  mutt_query_variables(struct ListHead *queries, bool show_docs);
 

--- a/main.c
+++ b/main.c
@@ -786,23 +786,11 @@ main
   }
 
   /* set defaults and read init files */
-  int rc2 = mutt_init(cs, flags & MUTT_CLI_NOSYSRC, &commands);
+  int rc2 = mutt_init(cs, dlevel, dfile, flags & MUTT_CLI_NOSYSRC, &commands);
   if (rc2 != 0)
     goto main_curses;
 
   mutt_init_abort_key();
-
-  /* The command line overrides the config */
-  if (dlevel)
-    cs_str_reset(cs, "debug_level", NULL);
-  if (dfile)
-    cs_str_reset(cs, "debug_file", NULL);
-
-  if (mutt_log_start() < 0)
-  {
-    mutt_perror("log file");
-    goto main_exit;
-  }
 
 #ifdef USE_NNTP
   {
@@ -1455,7 +1443,6 @@ main_exit:
   neomutt_free(&NeoMutt);
   cs_free(&cs);
   log_queue_flush(log_disp_terminal);
-  log_queue_empty();
   mutt_log_stop();
   return rc;
 }


### PR DESCRIPTION
- 1c69ae782 fix logging on error
  Some debugging messages were lost if there was an error in the config file

- 9c8613ba6 boolify: need_pause

- 49967ec49 log: vim-style
  Change the form of the error message to: `file:line_num: message`