### PR TITLE
fix file auto-completion

### DIFF
--- a/alias/alias.c
+++ b/alias/alias.c
@@ -498,7 +498,7 @@ retry_name:
 
   struct FileCompletionData cdata = { false, NULL, NULL, NULL };
   if (mw_get_field(_("Save to file: "), buf, MUTT_COMP_CLEAR, HC_FILE,
-                   &CompleteMailboxOps, &cdata) != 0)
+                   &CompleteFileOps, &cdata) != 0)
   {
     goto done;
   }

--- a/attach/recvattach.c
+++ b/attach/recvattach.c
@@ -303,7 +303,7 @@ static int query_save_attachment(FILE *fp, struct Body *body, struct Email *e, c
   while (prompt)
   {
     struct FileCompletionData cdata = { false, NULL, NULL, NULL };
-    if ((mw_get_field(prompt, buf, MUTT_COMP_CLEAR, HC_FILE, &CompleteMailboxOps, &cdata) != 0) ||
+    if ((mw_get_field(prompt, buf, MUTT_COMP_CLEAR, HC_FILE, &CompleteFileOps, &cdata) != 0) ||
         buf_is_empty(buf))
     {
       goto cleanup;
@@ -485,7 +485,7 @@ void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
 
           struct FileCompletionData cdata = { false, NULL, NULL, NULL };
           if ((mw_get_field(_("Save to file: "), buf, MUTT_COMP_CLEAR, HC_FILE,
-                            &CompleteMailboxOps, &cdata) != 0) ||
+                            &CompleteFileOps, &cdata) != 0) ||
               buf_is_empty(buf))
           {
             goto cleanup;

--- a/browser/complete.c
+++ b/browser/complete.c
@@ -127,7 +127,7 @@ int complete_file_simple(struct EnterWindowData *wdata, int op)
               (wdata->state->lastchar - i) * sizeof(wchar_t)) == 0))
   {
     dlg_browser(wdata->buffer, MUTT_SEL_NO_FLAGS, NULL, NULL, NULL);
-    if (buf_is_empty(wdata->buffer))
+    if (!buf_is_empty(wdata->buffer))
       replace_part(wdata->state, i, buf_string(wdata->buffer));
     return FR_CONTINUE;
   }

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1457,7 +1457,7 @@ static int op_attachment_new_mime(struct ComposeSharedData *shared, int op)
 
   struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
   if ((mw_get_field(_("New file: "), fname, MUTT_COMP_NO_FLAGS, HC_FILE,
-                    &CompleteMailboxOps, &cdata) != 0) ||
+                    &CompleteFileOps, &cdata) != 0) ||
       buf_is_empty(fname))
   {
     goto done;
@@ -1569,7 +1569,7 @@ static int op_attachment_rename_attachment(struct ComposeSharedData *shared, int
   buf_strcpy(fname, mutt_path_basename(NONULL(src)));
   struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
   int rc = mw_get_field(_("Send attachment with name: "), fname,
-                        MUTT_COMP_NO_FLAGS, HC_FILE, &CompleteMailboxOps, &cdata);
+                        MUTT_COMP_NO_FLAGS, HC_FILE, &CompleteFileOps, &cdata);
   if (rc == 0)
   {
     // It's valid to set an empty string here, to erase what was set
@@ -1902,7 +1902,7 @@ static int op_compose_rename_file(struct ComposeSharedData *shared, int op)
   buf_pretty_mailbox(fname);
   struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
   if ((mw_get_field(_("Rename to: "), fname, MUTT_COMP_NO_FLAGS, HC_FILE,
-                    &CompleteMailboxOps, &cdata) == 0) &&
+                    &CompleteFileOps, &cdata) == 0) &&
       !buf_is_empty(fname))
   {
     struct stat st = { 0 };

--- a/muttlib.c
+++ b/muttlib.c
@@ -625,7 +625,7 @@ int mutt_check_overwrite(const char *attname, const char *path, struct Buffer *f
     buf_strcpy(tmp, mutt_path_basename(NONULL(attname)));
     struct FileCompletionData cdata = { false, NULL, NULL, NULL };
     if ((mw_get_field(_("File under directory: "), tmp, MUTT_COMP_CLEAR,
-                      HC_FILE, &CompleteMailboxOps, &cdata) != 0) ||
+                      HC_FILE, &CompleteFileOps, &cdata) != 0) ||
         buf_is_empty(tmp))
     {
       buf_pool_release(&tmp);


### PR DESCRIPTION
- Fix file auto-completion
  The selected file was being lost

- Use `CompleteFileOps` where possible rather than `CompleteMailboxOps`
  e.g. Save file