### PR TITLE
Simplify the API of smtp_code()

### DIFF
--- a/send/smtp.c
+++ b/send/smtp.c
@@ -438,22 +438,18 @@ static int smtp_helo(struct SmtpAccountData *adata, bool esmtp)
 #ifdef USE_SASL_GNU
 /**
  * smtp_code - Extract an SMTP return code from a string
- * @param[in]  str String to parse
- * @param[in]  len Length of string
+ * @param[in]  buf Buffer containing the string to parse
  * @param[out] n   SMTP return code result
  * @retval true Success
- *
- * Note: the 'len' parameter is actually the number of bytes, as
- * returned by mutt_socket_readln().  If all callers are converted to
- * mutt_socket_buffer_readln() we can pass in the actual len, or
- * perhaps the buffer itself.
  */
-static int smtp_code(const char *str, size_t len, int *n)
+static int smtp_code(const struct Buffer *buf, int *n)
 {
-  char code[4];
-
-  if (len < 4)
+  if (buf_len(buf) < 3)
     return false;
+
+  char code[4];
+  const char *str = buf_string(buf);
+
   code[0] = str[0];
   code[1] = str[1];
   code[2] = str[2];
@@ -484,7 +480,7 @@ static int smtp_get_auth_response(struct Connection *conn, struct Buffer *input_
   {
     if (mutt_socket_buffer_readln(input_buf, conn) < 0)
       return -1;
-    if (!smtp_code(buf_string(input_buf), buf_len(input_buf) + 1 /* number of bytes */, smtp_rc))
+    if (!smtp_code(input_buf, smtp_rc))
     {
       return -1;
     }


### PR DESCRIPTION
* **What does this PR do?**

There's only 1 call to this function, so we can simplify by passing the entire buffer, instead of extracting the string before the call.

$ grep -rn '\<smtp_code\>' *
send/smtp.c:440: * smtp_code - Extract an SMTP return code from a string send/smtp.c:445:static int smtp_code(const struct Buffer *buf, int *n)
send/smtp.c:484:    if (!smtp_code(input_buf, smtp_rc))

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

N/A

   - All builds and tests are passing

I can't build from source successfully without the patch, so didn't try with the patch.

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

N/A

   - Code follows the [style guide](https://neomutt.org/dev/code)

Except for a small thing: alignment of local variable declaractions.  It's a small suggestion I'm trying (a habit from nginx).

* **What are the relevant issue numbers?**

N/A
