### PR TITLE
hcache: fix key handling

### DIFF
--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -292,12 +292,13 @@ static struct RealKey *realkey(struct HeaderCache *hc, const char *key, size_t k
 #ifdef USE_HCACHE_COMPRESSION
   if (hc->compr_ops)
   {
-    rk.len = snprintf(rk.key, sizeof(rk.key), "%s-%s", key, hc->compr_ops->name);
+    rk.len = snprintf(rk.key, sizeof(rk.key), "%.*s-%s", (int) keylen, key,
+                      hc->compr_ops->name);
   }
   else
 #endif
   {
-    memcpy(rk.key, key, keylen + 1); // Including NUL byte
+    mutt_strn_copy(rk.key, key, keylen, sizeof(rk.key));
     rk.len = keylen;
   }
   return &rk;

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -75,6 +75,16 @@ struct Progress;
 #define MMC_CUR_DIR (1 << 1) ///< 'cur' directory changed
 
 /**
+ * maildir_hcache_key - Get the header cache key for an Email
+ * @param e Email
+ * @retval str Header cache key string
+ */
+static inline const char *maildir_hcache_key(struct Email *e)
+{
+  return e->path + 4;
+}
+
+/**
  * maildir_email_new - Create a Maildir Email
  * @retval ptr Newly created Email
  *
@@ -637,7 +647,7 @@ static void maildir_delayed_parsing(struct Mailbox *m, struct MdEmailArray *mda,
     struct stat st_lastchanged = { 0 };
     int rc = 0;
 
-    const char *key = md->email->path + 3;
+    const char *key = maildir_hcache_key(md->email);
     size_t keylen = maildir_hcache_keylen(key);
     struct HCacheEntry hce = { 0 };
 
@@ -668,7 +678,7 @@ static void maildir_delayed_parsing(struct Mailbox *m, struct MdEmailArray *mda,
       {
         md->header_parsed = true;
 #ifdef USE_HCACHE
-        key = md->email->path + 3;
+        key = maildir_hcache_key(md->email);
         keylen = maildir_hcache_keylen(key);
         hcache_store(hc, key, keylen, md->email, 0);
 #endif
@@ -987,7 +997,7 @@ bool maildir_sync_mailbox_message(struct Mailbox *m, struct Email *e, struct Hea
 #ifdef USE_HCACHE
     if (hc)
     {
-      const char *key = e->path + 3;
+      const char *key = maildir_hcache_key(e);
       size_t keylen = maildir_hcache_keylen(key);
       hcache_delete_record(hc, key, keylen);
     }
@@ -1004,7 +1014,7 @@ bool maildir_sync_mailbox_message(struct Mailbox *m, struct Email *e, struct Hea
 #ifdef USE_HCACHE
   if (hc && e->changed)
   {
-    const char *key = e->path + 3;
+    const char *key = maildir_hcache_key(e);
     size_t keylen = maildir_hcache_keylen(key);
     hcache_store(hc, key, keylen, e, 0);
   }
@@ -1610,7 +1620,7 @@ static int maildir_msg_save_hcache(struct Mailbox *m, struct Email *e)
 #ifdef USE_HCACHE
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
   struct HeaderCache *hc = hcache_open(c_header_cache, mailbox_path(m), NULL);
-  char *key = e->path + 3;
+  const char *key = maildir_hcache_key(e);
   int keylen = maildir_hcache_keylen(key);
   rc = hcache_store(hc, key, keylen, e, 0);
   hcache_close(&hc);


### PR DESCRIPTION
Fix a couple of bugs in the header cache key handling.

- maildir: factor out key location
- realkey(): honour key length

Given an Email with path, **`cur/1462463620.M306996P28816.flatcap.org,S=4057,W=4147:2,RS`**
Maildir was adding 3 to the start, which meant that the **`/`** was included.
This has been changed to 4, so that the **filename** is the base of the key.

In the Header Cache, `realkey()` performs a transform on the key depending on whether compression is enabled.
Unfortunately, both branches were producing the wrong output.
When compression was enabled, the entire filename was used -- this includes the flags: **`:2,RS`**
When compression wasn't enabled, the `memcpy()` assumed the string was `NUL`-terminated at keylen.
This lead to a stray **`:`**  being included.

The fixes mean that for path, **`cur/1462463620.M306996P28816.flatcap.org,S=4057,W=4147:2,RS`**
the key is either:
- `1462463620.M306996P28816.flatcap.org,S=4057,W=4147`
- `1462463620.M306996P28816.flatcap.org,S=4057,W=4147-zstd`

---

**Note**:  This will caused the invalidation of all cached maildir headers.