### PR TITLE
config: add DT_ON_STARTUP

### DIFF
--- a/config/bool.c
+++ b/config/bool.c
@@ -81,6 +81,9 @@ static int bool_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
     if (num == (*(bool *) var))
       return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+    if (startup_only(cdef, err))
+      return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
     if (cdef->validator)
     {
       int rc = cdef->validator(cs, cdef, (intptr_t) num, err);
@@ -134,6 +137,9 @@ static int bool_native_set(const struct ConfigSet *cs, void *var,
   if (value == (*(bool *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   if (cdef->validator)
   {
     int rc = cdef->validator(cs, cdef, value, err);
@@ -163,6 +169,9 @@ static int bool_reset(const struct ConfigSet *cs, void *var,
 {
   if (cdef->initial == (*(bool *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
+
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
 
   if (cdef->validator)
   {

--- a/config/enum.c
+++ b/config/enum.c
@@ -64,6 +64,9 @@ static int enum_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
     if (num == (*(unsigned char *) var))
       return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+    if (startup_only(cdef, err))
+      return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
     if (cdef->validator)
     {
       int rc = cdef->validator(cs, cdef, (intptr_t) num, err);
@@ -136,6 +139,9 @@ static int enum_native_set(const struct ConfigSet *cs, void *var,
   if (value == (*(unsigned char *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   if (cdef->validator)
   {
     int rc = cdef->validator(cs, cdef, value, err);
@@ -171,6 +177,9 @@ static int enum_reset(const struct ConfigSet *cs, void *var,
 
   if (cdef->initial == (*(unsigned char *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
+
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
 
   if (cdef->validator)
   {

--- a/config/long.c
+++ b/config/long.c
@@ -67,6 +67,9 @@ static int long_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
     if (num == (*(long *) var))
       return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+    if (startup_only(cdef, err))
+      return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
     if (cdef->validator)
     {
       int rc = cdef->validator(cs, cdef, (intptr_t) num, err);
@@ -117,6 +120,9 @@ static int long_native_set(const struct ConfigSet *cs, void *var,
   if (value == (*(long *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   if (cdef->validator)
   {
     int rc = cdef->validator(cs, cdef, value, err);
@@ -162,6 +168,9 @@ static int long_string_plus_equals(const struct ConfigSet *cs, void *var,
   if (result == (*(long *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   if (cdef->validator)
   {
     int rc = cdef->validator(cs, cdef, (intptr_t) result, err);
@@ -198,6 +207,9 @@ static int long_string_minus_equals(const struct ConfigSet *cs, void *var,
   if (result == (*(long *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   if (cdef->validator)
   {
     int rc = cdef->validator(cs, cdef, (intptr_t) result, err);
@@ -218,6 +230,9 @@ static int long_reset(const struct ConfigSet *cs, void *var,
 {
   if (cdef->initial == (*(long *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
+
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
 
   if (cdef->validator)
   {

--- a/config/mbtable.c
+++ b/config/mbtable.c
@@ -135,6 +135,9 @@ static int mbtable_string_set(const struct ConfigSet *cs, void *var, struct Conf
     if (curval && mutt_str_equal(value, curval->orig_str))
       return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+    if (startup_only(cdef, err))
+      return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
     table = mbtable_parse(value);
 
     if (cdef->validator)
@@ -218,6 +221,9 @@ static int mbtable_native_set(const struct ConfigSet *cs, void *var,
   if (mbtable_compare(*(struct MbTable **) var, (struct MbTable *) value))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   if (cdef->validator)
   {
     rc = cdef->validator(cs, cdef, value, err);
@@ -267,6 +273,9 @@ static int mbtable_reset(const struct ConfigSet *cs, void *var,
 
   if (mutt_str_equal(initial, curval))
     return rc | CSR_SUC_NO_CHANGE;
+
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
 
   if (initial)
     table = mbtable_parse(initial);

--- a/config/mbtable.c
+++ b/config/mbtable.c
@@ -42,6 +42,22 @@
 #include "types.h"
 
 /**
+ * mbtable_compare - Compare two MbTables
+ * @param a First MbTable
+ * @param b Second MbTable
+ * @retval true They are identical
+ */
+bool mbtable_compare(const struct MbTable *a, const struct MbTable *b)
+{
+  if (!a && !b) /* both empty */
+    return true;
+  if (!a ^ !b) /* one is empty, but not the other */
+    return false;
+
+  return mutt_str_equal(a->orig_str, b->orig_str);
+}
+
+/**
  * mbtable_parse - Parse a multibyte string into a table
  * @param s String of multibyte characters
  * @retval ptr New MbTable object
@@ -198,6 +214,9 @@ static int mbtable_native_set(const struct ConfigSet *cs, void *var,
                               struct Buffer *err)
 {
   int rc;
+
+  if (mbtable_compare(*(struct MbTable **) var, (struct MbTable *) value))
+    return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
   if (cdef->validator)
   {

--- a/config/mbtable.h
+++ b/config/mbtable.h
@@ -23,6 +23,8 @@
 #ifndef MUTT_CONFIG_MBTABLE_H
 #define MUTT_CONFIG_MBTABLE_H
 
+#include <stdbool.h>
+
 /**
  * struct MbTable - Multibyte character table
  *
@@ -38,8 +40,9 @@ struct MbTable
   char *segmented_str; ///< Each chars entry points inside this string
 };
 
-void            mbtable_free (struct MbTable **ptr);
+bool            mbtable_compare      (const struct MbTable *a, const struct MbTable *b);
+void            mbtable_free         (struct MbTable **ptr);
 const char *    mbtable_get_nth_wchar(const struct MbTable *table, int index);
-struct MbTable *mbtable_parse(const char *str);
+struct MbTable *mbtable_parse        (const char *str);
 
 #endif /* MUTT_CONFIG_MBTABLE_H */

--- a/config/number.c
+++ b/config/number.c
@@ -82,6 +82,9 @@ static int number_string_set(const struct ConfigSet *cs, void *var, struct Confi
         return rc | CSR_INV_VALIDATOR;
     }
 
+    if (startup_only(cdef, err))
+      return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
     *(short *) var = num;
   }
   else
@@ -139,6 +142,9 @@ static int number_native_set(const struct ConfigSet *cs, void *var,
       return rc | CSR_INV_VALIDATOR;
   }
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   *(short *) var = value;
   return CSR_SUCCESS;
 }
@@ -187,6 +193,9 @@ static int number_string_plus_equals(const struct ConfigSet *cs, void *var,
       return rc | CSR_INV_VALIDATOR;
   }
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   *(short *) var = result;
   return CSR_SUCCESS;
 }
@@ -226,6 +235,9 @@ static int number_string_minus_equals(const struct ConfigSet *cs, void *var,
       return rc | CSR_INV_VALIDATOR;
   }
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   *(short *) var = result;
   return CSR_SUCCESS;
 }
@@ -246,6 +258,9 @@ static int number_reset(const struct ConfigSet *cs, void *var,
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
   }
+
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
 
   *(short *) var = cdef->initial;
   return CSR_SUCCESS;

--- a/config/path.c
+++ b/config/path.c
@@ -104,6 +104,9 @@ static int path_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
     if (mutt_str_equal(value, (*(char **) var)))
       return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+    if (startup_only(cdef, err))
+      return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
     if (cdef->validator)
     {
       rc = cdef->validator(cs, cdef, (intptr_t) value, err);
@@ -175,6 +178,9 @@ static int path_native_set(const struct ConfigSet *cs, void *var,
 
   int rc;
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   if (cdef->validator)
   {
     rc = cdef->validator(cs, cdef, value, err);
@@ -221,6 +227,12 @@ static int path_reset(const struct ConfigSet *cs, void *var,
   {
     FREE(&str);
     return rc | CSR_SUC_NO_CHANGE;
+  }
+
+  if (startup_only(cdef, err))
+  {
+    FREE(&str);
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
   }
 
   if (cdef->validator)

--- a/config/quad.c
+++ b/config/quad.c
@@ -80,6 +80,9 @@ static int quad_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
     if (num == (*(char *) var))
       return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+    if (startup_only(cdef, err))
+      return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
     if (cdef->validator)
     {
       int rc = cdef->validator(cs, cdef, (intptr_t) num, err);
@@ -136,6 +139,9 @@ static int quad_native_set(const struct ConfigSet *cs, void *var,
   if (value == (*(char *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   if (cdef->validator)
   {
     int rc = cdef->validator(cs, cdef, value, err);
@@ -165,6 +171,9 @@ static int quad_reset(const struct ConfigSet *cs, void *var,
 {
   if (cdef->initial == (*(char *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
+
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
 
   if (cdef->validator)
   {

--- a/config/regex.c
+++ b/config/regex.c
@@ -42,6 +42,24 @@
 #include "types.h"
 
 /**
+ * regex_compare - Compare two regexes
+ * @param a First regex
+ * @param b Second regex
+ * @retval true They are identical
+ */
+bool regex_compare(const struct Regex *a, const struct Regex *b)
+{
+  if (!a && !b) /* both empty */
+    return true;
+  if (!a ^ !b) /* one is empty, but not the other */
+    return false;
+  if (a->pat_not != b->pat_not)
+    return false;
+
+  return mutt_str_equal(a->pattern, b->pattern);
+}
+
+/**
  * regex_free - Free a Regex object
  * @param[out] ptr Regex to free
  */
@@ -206,6 +224,9 @@ static int regex_native_set(const struct ConfigSet *cs, void *var,
                             const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
 {
   int rc;
+
+  if (regex_compare(*(struct Regex **) var, (struct Regex *) value))
+    return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
   if (cdef->validator)
   {

--- a/config/regex.c
+++ b/config/regex.c
@@ -154,6 +154,9 @@ static int regex_string_set(const struct ConfigSet *cs, void *var, struct Config
     if (curval && mutt_str_equal(value, curval->pattern))
       return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+    if (startup_only(cdef, err))
+      return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
     if (value)
     {
       r = regex_new(value, cdef->type, err);
@@ -228,6 +231,9 @@ static int regex_native_set(const struct ConfigSet *cs, void *var,
   if (regex_compare(*(struct Regex **) var, (struct Regex *) value))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   if (cdef->validator)
   {
     rc = cdef->validator(cs, cdef, value, err);
@@ -290,6 +296,9 @@ static int regex_reset(const struct ConfigSet *cs, void *var,
 
   if (mutt_str_equal(initial, curval))
     return rc | CSR_SUC_NO_CHANGE;
+
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
 
   if (initial)
   {

--- a/config/regex2.h
+++ b/config/regex2.h
@@ -28,7 +28,8 @@
 struct Buffer;
 struct Regex;
 
-void          regex_free(struct Regex **ptr);
-struct Regex *regex_new (const char *str, uint32_t flags, struct Buffer *err);
+bool          regex_compare(const struct Regex *a, const struct Regex *b);
+void          regex_free   (struct Regex **ptr);
+struct Regex *regex_new    (const char *str, uint32_t flags, struct Buffer *err);
 
 #endif /* MUTT_CONFIG_REGEX2_H */

--- a/config/set.h
+++ b/config/set.h
@@ -26,10 +26,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include "mutt/lib.h"
+#include "types.h"
 
-struct Buffer;
 struct ConfigSet;
-struct HashElem;
 
 /* Config Set Results */
 #define CSR_SUCCESS       0 ///< Action completed successfully
@@ -289,5 +289,24 @@ int      cs_str_string_minus_equals(const struct ConfigSet *cs, const char *name
 int      cs_str_string_plus_equals (const struct ConfigSet *cs, const char *name,    const char *value, struct Buffer *err);
 int      cs_str_string_set         (const struct ConfigSet *cs, const char *name,    const char *value, struct Buffer *err);
 int      cs_str_delete             (const struct ConfigSet *cs, const char *name,                       struct Buffer *err);
+
+extern bool StartupComplete;
+
+/**
+ * startup_only - Validator function for DT_ON_STARTUP
+ * @param cdef Variable definition
+ * @param err  Buffer for error messages
+ * @retval true Variable may only be set at startup
+ */
+static inline bool startup_only(const struct ConfigDef *cdef, struct Buffer *err)
+{
+  if ((cdef->type & DT_ON_STARTUP) && StartupComplete)
+  {
+    buf_printf(err, _("Option %s may only be set at startup"), cdef->name);
+    return true;
+  }
+
+  return false;
+}
 
 #endif /* MUTT_CONFIG_SET_H */

--- a/config/slist.c
+++ b/config/slist.c
@@ -76,6 +76,12 @@ static int slist_string_set(const struct ConfigSet *cs, void *var, struct Config
   {
     list = slist_parse(value, cdef->type);
 
+    if (slist_compare(list, *(struct Slist **) var))
+    {
+      slist_free(&list);
+      return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
+    }
+
     if (cdef->validator)
     {
       rc = cdef->validator(cs, cdef, (intptr_t) list, err);
@@ -146,6 +152,9 @@ static int slist_native_set(const struct ConfigSet *cs, void *var,
 
   int rc;
 
+  if (slist_compare((struct Slist *) value, *(struct Slist **) var))
+    return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
+
   if (cdef->validator)
   {
     rc = cdef->validator(cs, cdef, value, err);
@@ -194,6 +203,9 @@ static int slist_string_plus_equals(const struct ConfigSet *cs, void *var,
 
   /* Store empty strings as NULL */
   if (value && (value[0] == '\0'))
+    value = NULL;
+
+  if (!value)
     return rc | CSR_SUC_NO_CHANGE;
 
   struct Slist *orig = *(struct Slist **) var;
@@ -236,6 +248,9 @@ static int slist_string_minus_equals(const struct ConfigSet *cs, void *var,
 
   /* Store empty strings as NULL */
   if (value && (value[0] == '\0'))
+    value = NULL;
+
+  if (!value)
     return rc | CSR_SUC_NO_CHANGE;
 
   struct Slist *orig = *(struct Slist **) var;
@@ -275,6 +290,12 @@ static int slist_reset(const struct ConfigSet *cs, void *var,
 
   if (initial)
     list = slist_parse(initial, cdef->type);
+
+  if (slist_compare(list, *(struct Slist **) var))
+  {
+    slist_free(&list);
+    return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
+  }
 
   int rc = CSR_SUCCESS;
 

--- a/config/slist.c
+++ b/config/slist.c
@@ -82,6 +82,12 @@ static int slist_string_set(const struct ConfigSet *cs, void *var, struct Config
       return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
     }
 
+    if (startup_only(cdef, err))
+    {
+      slist_free(&list);
+      return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+    }
+
     if (cdef->validator)
     {
       rc = cdef->validator(cs, cdef, (intptr_t) list, err);
@@ -155,6 +161,9 @@ static int slist_native_set(const struct ConfigSet *cs, void *var,
   if (slist_compare((struct Slist *) value, *(struct Slist **) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   if (cdef->validator)
   {
     rc = cdef->validator(cs, cdef, value, err);
@@ -208,6 +217,9 @@ static int slist_string_plus_equals(const struct ConfigSet *cs, void *var,
   if (!value)
     return rc | CSR_SUC_NO_CHANGE;
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   struct Slist *orig = *(struct Slist **) var;
   if (slist_is_member(orig, value))
     return rc | CSR_SUC_NO_CHANGE;
@@ -253,6 +265,9 @@ static int slist_string_minus_equals(const struct ConfigSet *cs, void *var,
   if (!value)
     return rc | CSR_SUC_NO_CHANGE;
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   struct Slist *orig = *(struct Slist **) var;
   if (!slist_is_member(orig, value))
     return rc | CSR_SUC_NO_CHANGE;
@@ -295,6 +310,12 @@ static int slist_reset(const struct ConfigSet *cs, void *var,
   {
     slist_free(&list);
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
+  }
+
+  if (startup_only(cdef, err))
+  {
+    slist_free(&list);
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
   }
 
   int rc = CSR_SUCCESS;

--- a/config/sort.c
+++ b/config/sort.c
@@ -93,6 +93,9 @@ static int sort_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
     if (id == (*(short *) var))
       return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+    if (startup_only(cdef, err))
+      return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
     if (cdef->validator)
     {
       int rc = cdef->validator(cs, cdef, (intptr_t) id, err);
@@ -165,6 +168,9 @@ static int sort_native_set(const struct ConfigSet *cs, void *var,
   if (value == (*(short *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   if (cdef->validator)
   {
     int rc = cdef->validator(cs, cdef, value, err);
@@ -194,6 +200,9 @@ static int sort_reset(const struct ConfigSet *cs, void *var,
 {
   if (cdef->initial == (*(short *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
+
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
 
   if (cdef->validator)
   {

--- a/config/string.c
+++ b/config/string.c
@@ -74,6 +74,9 @@ static int string_string_set(const struct ConfigSet *cs, void *var, struct Confi
     if (mutt_str_equal(value, (*(char **) var)))
       return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
+    if (startup_only(cdef, err))
+      return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
     if (cdef->validator)
     {
       rc = cdef->validator(cs, cdef, (intptr_t) value, err);
@@ -146,6 +149,9 @@ static int string_native_set(const struct ConfigSet *cs, void *var,
 
   int rc;
 
+  if (startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+
   if (cdef->validator)
   {
     rc = cdef->validator(cs, cdef, value, err);
@@ -186,6 +192,9 @@ static int string_string_plus_equals(const struct ConfigSet *cs, void *var,
   /* Skip if the value is missing or empty string*/
   if (!value || (value[0] == '\0'))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
+
+  if (value && startup_only(cdef, err))
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
 
   int rc = CSR_SUCCESS;
 
@@ -230,6 +239,12 @@ static int string_reset(const struct ConfigSet *cs, void *var,
   {
     FREE(&str);
     return rc | CSR_SUC_NO_CHANGE;
+  }
+
+  if (startup_only(cdef, err))
+  {
+    FREE(&str);
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
   }
 
   if (cdef->validator)

--- a/config/types.h
+++ b/config/types.h
@@ -46,22 +46,23 @@
 
 #define DT_NO_FLAGS            0   ///< No flags are set
 
-#define DT_NOT_EMPTY     (1 << 6)  ///< Empty strings are not allowed
-#define DT_NOT_NEGATIVE  (1 << 7)  ///< Negative numbers are not allowed
-#define DT_MAILBOX       (1 << 8)  ///< Don't perform path expansions
-#define DT_SENSITIVE     (1 << 9)  ///< Contains sensitive value, e.g. password
-#define DT_COMMAND       (1 << 10) ///< A command
-#define DT_INHERIT_ACC   (1 << 11) ///< Config item can be Account-specific
-#define DT_INHERIT_MBOX  (1 << 12) ///< Config item can be Mailbox-specific
-#define DT_PATH_DIR      (1 << 13) ///< Path is a directory
-#define DT_PATH_FILE     (1 << 14) ///< Path is a file
+#define DT_ON_STARTUP    (1 << 6)  ///< May only be set at startup
+#define DT_NOT_EMPTY     (1 << 7)  ///< Empty strings are not allowed
+#define DT_NOT_NEGATIVE  (1 << 8)  ///< Negative numbers are not allowed
+#define DT_MAILBOX       (1 << 9)  ///< Don't perform path expansions
+#define DT_SENSITIVE     (1 << 10) ///< Contains sensitive value, e.g. password
+#define DT_COMMAND       (1 << 11) ///< A command
+#define DT_INHERIT_ACC   (1 << 12) ///< Config item can be Account-specific
+#define DT_INHERIT_MBOX  (1 << 13) ///< Config item can be Mailbox-specific
+#define DT_PATH_DIR      (1 << 14) ///< Path is a directory
+#define DT_PATH_FILE     (1 << 15) ///< Path is a file
 
 #define IS_SENSITIVE(type) (((type) & DT_SENSITIVE) == DT_SENSITIVE)
 #define IS_MAILBOX(type)   (((type) & (DT_STRING | DT_MAILBOX)) == (DT_STRING | DT_MAILBOX))
 #define IS_COMMAND(type)   (((type) & (DT_STRING | DT_COMMAND)) == (DT_STRING | DT_COMMAND))
 
 /* subtypes for... */
-#define DT_SUBTYPE_MASK  0x7FC0  ///< Mask for the Data Subtype
+#define DT_SUBTYPE_MASK  0xFFC0  ///< Mask for the Data Subtype
 
 typedef uint32_t ConfigRedrawFlags; ///< Flags for redraw/resort, e.g. #R_INDEX
 #define R_REDRAW_NO_FLAGS        0  ///< No refresh/resort flags

--- a/maildir/config.c
+++ b/maildir/config.c
@@ -60,19 +60,6 @@ static int maildir_field_delimiter_validator(const struct ConfigSet *cs,
     return CSR_ERR_INVALID;
   }
 
-  static bool maildir_field_delimiter_changed = false;
-  if (maildir_field_delimiter_changed)
-  {
-    // L10N: maildir_field_delimiter is a config variable and shouldn't be translated
-    buf_printf(err, _("maildir_field_delimiter can only be set once"));
-    return CSR_ERR_INVALID;
-  }
-
-  if (*delim != *(const char *) cdef->initial)
-  {
-    maildir_field_delimiter_changed = true;
-  }
-
   return CSR_SUCCESS;
 }
 
@@ -87,7 +74,7 @@ static struct ConfigDef MaildirVars[] = {
   { "maildir_check_cur", DT_BOOL, false, 0, NULL,
     "Check both 'new' and 'cur' directories for new mail"
   },
-  { "maildir_field_delimiter", DT_STRING|DT_NOT_EMPTY, IP ":", 0, maildir_field_delimiter_validator,
+  { "maildir_field_delimiter", DT_STRING|DT_NOT_EMPTY|DT_ON_STARTUP, IP ":", 0, maildir_field_delimiter_validator,
     "Field delimiter to be used for maildir email files (default is colon, recommended alternative is semi-colon)"
   },
   { "maildir_trash", DT_BOOL, false, 0, NULL,

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -117,7 +117,7 @@ static struct ConfigDef MainVars[] = {
   { "abort_backspace", DT_BOOL, true, 0, NULL,
     "Hitting backspace against an empty prompt aborts the prompt"
   },
-  { "abort_key", DT_STRING|DT_NOT_EMPTY, IP "\007", 0, NULL,
+  { "abort_key", DT_STRING|DT_NOT_EMPTY|DT_ON_STARTUP, IP "\007", 0, NULL,
     "String representation of key to abort prompts"
   },
   { "arrow_cursor", DT_BOOL, false, 0, NULL,
@@ -177,7 +177,7 @@ static struct ConfigDef MainVars[] = {
   { "collapse_unread", DT_BOOL, true, 0, NULL,
     "Prevent the collapse of threads with unread emails"
   },
-  { "color_directcolor", DT_BOOL, false, 0, NULL,
+  { "color_directcolor", DT_BOOL|DT_ON_STARTUP, false, 0, NULL,
     "Use 24bit colors (aka truecolor aka directcolor)"
   },
   { "config_charset", DT_STRING, 0, 0, charset_validator,

--- a/ncrypt/config.c
+++ b/ncrypt/config.c
@@ -155,7 +155,7 @@ static struct ConfigDef NcryptVars[] = {
  */
 static struct ConfigDef NcryptVarsGpgme[] = {
   // clang-format off
-  { "crypt_use_gpgme", DT_BOOL, true, 0, NULL,
+  { "crypt_use_gpgme", DT_BOOL|DT_ON_STARTUP, true, 0, NULL,
     "Use GPGME crypto backend"
   },
   { "crypt_use_pka", DT_BOOL, false, 0, NULL,

--- a/test/config/enum.c
+++ b/test/config/enum.c
@@ -81,6 +81,7 @@ static struct ConfigDef Vars[] = {
   { "Mango",      DT_ENUM, ANIMAL_ANTELOPE, IP &AnimalDef, validator_warn,    },
   { "Nectarine",  DT_ENUM, ANIMAL_ANTELOPE, IP &AnimalDef, validator_fail,    },
   { "Olive",      DT_ENUM, ANIMAL_ANTELOPE, IP &AnimalDef, NULL,              }, /* test_inherit */
+  { "Papaya",     DT_ENUM | DT_ON_STARTUP, ANIMAL_ANTELOPE, IP &AnimalDef, NULL, }, /* startup */
   { NULL },
 };
 // clang-format on
@@ -251,6 +252,13 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
+  name = "Papaya";
+  rc = cs_str_string_set(cs, name, "Antelope", err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  rc = cs_str_string_set(cs, name, "Badger", err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -377,6 +385,13 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
+  name = "Papaya";
+  rc = cs_str_native_set(cs, name, ANIMAL_ANTELOPE, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  rc = cs_str_native_set(cs, name, ANIMAL_BADGER, err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -472,6 +487,18 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
     TEST_MSG("%s", buf_string(err));
     return false;
   }
+
+  name = "Papaya";
+  rc = cs_str_reset(cs, name, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  StartupComplete = false;
+  rc = cs_str_native_set(cs, name, ANIMAL_BADGER, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+  StartupComplete = true;
+
+  rc = cs_str_reset(cs, name, err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
 
   log_line(__func__);
   return true;
@@ -671,8 +698,10 @@ void test_config_enum(void)
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
+  StartupComplete = false;
   if (!TEST_CHECK(cs_register_variables(cs, Vars, DT_NO_FLAGS)))
     return;
+  StartupComplete = true;
 
   notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 

--- a/test/config/long.c
+++ b/test/config/long.c
@@ -50,6 +50,7 @@ static struct ConfigDef Vars[] = {
   { "Mango",      DT_LONG,                 0,   0, validator_warn,    },
   { "Nectarine",  DT_LONG,                 0,   0, validator_fail,    },
   { "Olive",      DT_LONG,                 0,   0, NULL,              }, /* test_inherit */
+  { "Papaya",     DT_LONG | DT_ON_STARTUP, 1,   0, NULL,              }, /* startup */
   { NULL },
 };
 // clang-format on
@@ -220,6 +221,13 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
+  name = "Papaya";
+  rc = cs_str_string_set(cs, name, "1", err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  rc = cs_str_string_set(cs, name, "0", err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -333,6 +341,10 @@ static bool test_string_plus_equals(struct ConfigSubset *sub, struct Buffer *err
     return false;
   }
 
+  name = "Papaya";
+  rc = cs_str_string_plus_equals(cs, name, "1", err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -414,6 +426,10 @@ static bool test_string_minus_equals(struct ConfigSubset *sub, struct Buffer *er
     return false;
   }
 
+  name = "Papaya";
+  rc = cs_str_string_minus_equals(cs, name, "1", err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -471,6 +487,13 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
     TEST_MSG("This test should have failed");
     return false;
   }
+
+  name = "Papaya";
+  rc = cs_str_native_set(cs, name, 1, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  rc = cs_str_native_set(cs, name, 0, err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
 
   log_line(__func__);
   return true;
@@ -556,6 +579,18 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   TEST_MSG("Reset: %s = %ld", name, VarKumquat);
+
+  name = "Papaya";
+  rc = cs_str_reset(cs, name, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  StartupComplete = false;
+  rc = cs_str_native_set(cs, name, 0, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+  StartupComplete = true;
+
+  rc = cs_str_reset(cs, name, err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
 
   log_line(__func__);
   return true;
@@ -831,10 +866,12 @@ void test_config_long(void)
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
+  StartupComplete = false;
   dont_fail = true;
   if (!TEST_CHECK(cs_register_variables(cs, Vars, DT_NO_FLAGS)))
     return;
   dont_fail = false;
+  StartupComplete = true;
 
   notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 

--- a/test/config/number.c
+++ b/test/config/number.c
@@ -50,6 +50,7 @@ static struct ConfigDef Vars[] = {
   { "Mango",      DT_NUMBER,                 0,   0, validator_warn,    },
   { "Nectarine",  DT_NUMBER,                 0,   0, validator_fail,    },
   { "Olive",      DT_NUMBER,                 0,   0, NULL,              }, /* test_inherit */
+  { "Papaya",     DT_NUMBER | DT_ON_STARTUP, 1,   0, NULL,              }, /* startup */
   { NULL },
 };
 // clang-format on
@@ -220,6 +221,13 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
+  name = "Papaya";
+  rc = cs_str_string_set(cs, name, "1", err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  rc = cs_str_string_set(cs, name, "0", err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -331,6 +339,13 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
     }
   }
 
+  name = "Papaya";
+  rc = cs_str_native_set(cs, name, 1, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  rc = cs_str_native_set(cs, name, 0, err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -432,6 +447,10 @@ static bool test_string_plus_equals(struct ConfigSubset *sub, struct Buffer *err
     return false;
   }
 
+  name = "Papaya";
+  rc = cs_str_string_plus_equals(cs, name, "1", err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -513,6 +532,10 @@ static bool test_string_minus_equals(struct ConfigSubset *sub, struct Buffer *er
     return false;
   }
 
+  name = "Papaya";
+  rc = cs_str_string_minus_equals(cs, name, "1", err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -576,7 +599,19 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  TEST_MSG("Reset: %s = %d", name, VarKumquat);
+  TEST_MSG("Reset: %s = %ld", name, VarKumquat);
+
+  name = "Papaya";
+  rc = cs_str_reset(cs, name, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  StartupComplete = false;
+  rc = cs_str_native_set(cs, name, 0, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+  StartupComplete = true;
+
+  rc = cs_str_reset(cs, name, err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
 
   log_line(__func__);
   return true;
@@ -916,10 +951,12 @@ void test_config_number(void)
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
+  StartupComplete = false;
   dont_fail = true;
   if (!TEST_CHECK(cs_register_variables(cs, Vars, DT_NO_FLAGS)))
     return;
   dont_fail = false;
+  StartupComplete = true;
 
   notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 

--- a/test/config/quad.c
+++ b/test/config/quad.c
@@ -50,6 +50,7 @@ static struct ConfigDef Vars[] = {
   { "Mango",      DT_QUAD, 0, 0, NULL,              }, /* test_inherit */
   { "Nectarine",  DT_QUAD, 0, 0, NULL,              }, /* test_toggle */
   { "Olive",      DT_BOOL, 0, 0, NULL,              },
+  { "Papaya",     DT_QUAD | DT_ON_STARTUP, 3, 0, NULL, }, /* startup */
   { NULL },
 };
 // clang-format on
@@ -221,6 +222,13 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
     short_line();
   }
 
+  name = "Papaya";
+  rc = cs_str_string_set(cs, name, "ask-yes", err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  rc = cs_str_string_set(cs, name, "ask-no", err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -326,6 +334,13 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
     }
   }
 
+  name = "Papaya";
+  rc = cs_str_native_set(cs, name, MUTT_ASKYES, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  rc = cs_str_native_set(cs, name, MUTT_ASKNO, err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -411,6 +426,18 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   TEST_MSG("Reset: %s = %d", name, VarIlama);
+
+  name = "Papaya";
+  rc = cs_str_reset(cs, name, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  StartupComplete = false;
+  rc = cs_str_native_set(cs, name, MUTT_NO, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+  StartupComplete = true;
+
+  rc = cs_str_reset(cs, name, err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
 
   log_line(__func__);
   return true;
@@ -727,10 +754,12 @@ void test_config_quad(void)
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
+  StartupComplete = false;
   dont_fail = true;
   if (!TEST_CHECK(cs_register_variables(cs, Vars, DT_NO_FLAGS)))
     return;
   dont_fail = false;
+  StartupComplete = true;
 
   notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 

--- a/test/config/sort.c
+++ b/test/config/sort.c
@@ -72,6 +72,7 @@ static struct ConfigDef Vars[] = {
   { "Papaya",     DT_SORT,                              1,  IP SortTestMethods, validator_warn,    },
   { "Quince",     DT_SORT,                              1,  IP SortTestMethods, validator_fail,    },
   { "Strawberry", DT_SORT,                              1,  IP SortTestMethods, NULL,              }, /* test_inherit */
+  { "Tangerine",  DT_SORT | DT_ON_STARTUP,              1,  IP SortTestMethods, NULL,              }, /* startup */
   { NULL },
 };
 
@@ -269,6 +270,13 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
+  name = "Tangerine";
+  rc = cs_str_string_set(cs, name, "date", err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  rc = cs_str_string_set(cs, name, "size", err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -445,6 +453,13 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
+  name = "Tangerine";
+  rc = cs_str_native_set(cs, name, SORT_DATE, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  rc = cs_str_native_set(cs, name, SORT_SIZE, err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -533,6 +548,18 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   TEST_MSG("Reset: %s = %d", name, VarNectarine);
+
+  name = "Tangerine";
+  rc = cs_str_reset(cs, name, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  StartupComplete = false;
+  rc = cs_str_native_set(cs, name, SORT_SIZE, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+  StartupComplete = true;
+
+  rc = cs_str_reset(cs, name, err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
 
   log_line(__func__);
   return true;
@@ -758,10 +785,12 @@ void test_config_sort(void)
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
+  StartupComplete = false;
   dont_fail = true;
   if (!TEST_CHECK(cs_register_variables(cs, Vars, DT_NO_FLAGS)))
     return;
   dont_fail = false;
+  StartupComplete = true;
 
   notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 

--- a/test/config/string.c
+++ b/test/config/string.c
@@ -56,6 +56,7 @@ static struct ConfigDef Vars[] = {
   { "Tangerine",  DT_STRING,              0,               0, NULL,              }, /* test_plus_equals */
   { "Ugli",       DT_STRING|DT_CHARSET_SINGLE, 0,          0, charset_validator, },
   { "Vanilla",    DT_STRING|DT_CHARSET_STRICT, 0,          0, charset_validator, },
+  { "Wolfberry",  DT_STRING|DT_ON_STARTUP, IP "wolfberry", 0, NULL,              }, /* startup */
   { NULL },
 };
 // clang-format on
@@ -235,6 +236,13 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
     TEST_MSG("%s = '%s', set by '%s'", name, NONULL(VarElderberry), NONULL(valid[i]));
   }
 
+  name = "Wolfberry";
+  rc = cs_str_string_set(cs, name, "wolfberry", err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  rc = cs_str_string_set(cs, name, "apple", err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -360,6 +368,13 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
     TEST_MSG("%s = '%s', set by '%s'", name, NONULL(VarKumquat), NONULL(valid[i]));
   }
 
+  name = "Wolfberry";
+  rc = cs_str_native_set(cs, name, (intptr_t) "wolfberry", err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  rc = cs_str_native_set(cs, name, (intptr_t) "apple", err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -438,6 +453,10 @@ static bool test_string_plus_equals(struct ConfigSubset *sub, struct Buffer *err
       return false;
   }
 
+  name = "Wolfberry";
+  rc = cs_str_string_plus_equals(cs, name, "apple", err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
   log_line(__func__);
   return true;
 }
@@ -513,6 +532,18 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   TEST_MSG("Reset: %s = '%s'", name, VarOlive);
+
+  name = "Wolfberry";
+  rc = cs_str_reset(cs, name, err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+
+  StartupComplete = false;
+  rc = cs_str_native_set(cs, name, (intptr_t) "apple", err);
+  TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
+  StartupComplete = true;
+
+  rc = cs_str_reset(cs, name, err);
+  TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
 
   log_line(__func__);
   return true;
@@ -762,10 +793,12 @@ void test_config_string(void)
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
+  StartupComplete = false;
   dont_fail = true;
   if (!TEST_CHECK(cs_register_variables(cs, Vars, DT_NO_FLAGS)))
     return;
   dont_fail = false;
+  StartupComplete = true;
 
   notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 


### PR DESCRIPTION
Some config variables may only be set at startup.
This can be either in a system/user config file or using the `-e` command line. 

- 95ff7c418 config: add more sameness checks
- 466a3fac0 config: create a new flag, `DT_ON_STARTUP`
- 6f95fdb79 config: add tests for DT_ON_STARTUP
- 4b66a50ba config: apply DT_ON_STARTUP
  - `$abort_key`
  - `$color_directcolor`
  - `$crypt_use_gpgme`
  - `$maildir_field_delimiter`