### PR TITLE
strip non-conditionals

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -803,7 +803,6 @@ $(PWD)/send:
 
 ###############################################################################
 # libsidebar
-@if USE_SIDEBAR
 LIBSIDEBAR=	libsidebar.a
 LIBSIDEBAROBJS=	sidebar/commands.o sidebar/config.o sidebar/functions.o \
 		sidebar/observer.o sidebar/sidebar.o sidebar/sort.o \
@@ -816,7 +815,6 @@ $(LIBSIDEBAR): $(PWD)/sidebar $(LIBSIDEBAROBJS)
 	$(RANLIB) $@
 $(PWD)/sidebar:
 	$(MKDIR_P) $(PWD)/sidebar
-@endif
 
 ###############################################################################
 # libstore

--- a/attach/functions.c
+++ b/attach/functions.c
@@ -70,14 +70,10 @@ const struct MenuFuncOp OpAttachment[] = { /* map: attachment */
   { "edit-type",                     OP_ATTACHMENT_EDIT_TYPE },
   { "exit",                          OP_EXIT },
   { "extract-keys",                  OP_EXTRACT_KEYS },
-#ifdef USE_NNTP
   { "followup-message",              OP_FOLLOWUP },
-#endif
   { "forget-passphrase",             OP_FORGET_PASSPHRASE },
   { "forward-message",               OP_FORWARD_MESSAGE },
-#ifdef USE_NNTP
   { "forward-to-group",              OP_FORWARD_TO_GROUP },
-#endif
   { "group-chat-reply",              OP_GROUP_CHAT_REPLY },
   { "group-reply",                   OP_GROUP_REPLY },
   { "list-reply",                    OP_LIST_REPLY },
@@ -274,23 +270,19 @@ static int op_attachment_delete(struct AttachPrivateData *priv, int op)
   if (check_readonly(priv->mailbox))
     return FR_ERROR;
 
-#ifdef USE_POP
   if (priv->mailbox->type == MUTT_POP)
   {
     mutt_flushinp();
     mutt_error(_("Can't delete attachment from POP server"));
     return FR_ERROR;
   }
-#endif
 
-#ifdef USE_NNTP
   if (priv->mailbox->type == MUTT_NNTP)
   {
     mutt_flushinp();
     mutt_error(_("Can't delete attachment from news server"));
     return FR_ERROR;
   }
-#endif
 
   if ((WithCrypto != 0) && (priv->actx->email->security & SEC_ENCRYPT))
   {
@@ -638,7 +630,6 @@ static int op_resend(struct AttachPrivateData *priv, int op)
 
 // -----------------------------------------------------------------------------
 
-#ifdef USE_NNTP
 /**
  * op_followup - followup to newsgroup - Implements ::attach_function_t - @ingroup attach_function_api
  */
@@ -675,7 +666,6 @@ static int op_forward_to_group(struct AttachPrivateData *priv, int op)
   menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
   return FR_SUCCESS;
 }
-#endif
 
 // -----------------------------------------------------------------------------
 
@@ -701,14 +691,10 @@ static const struct AttachFunction AttachFunctions[] = {
   { OP_DISPLAY_HEADERS,             op_attachment_view },
   { OP_EXIT,                        op_exit },
   { OP_EXTRACT_KEYS,                op_extract_keys },
-#ifdef USE_NNTP
   { OP_FOLLOWUP,                    op_followup },
-#endif
   { OP_FORGET_PASSPHRASE,           op_forget_passphrase },
   { OP_FORWARD_MESSAGE,             op_forward_message },
-#ifdef USE_NNTP
   { OP_FORWARD_TO_GROUP,            op_forward_to_group },
-#endif
   { OP_GROUP_CHAT_REPLY,            op_reply },
   { OP_GROUP_REPLY,                 op_reply },
   { OP_LIST_REPLY,                  op_reply },

--- a/attach/mutt_attach.c
+++ b/attach/mutt_attach.c
@@ -43,6 +43,7 @@
 #include "gui/lib.h"
 #include "mutt_attach.h"
 #include "lib.h"
+#include "imap/lib.h"
 #include "ncrypt/lib.h"
 #include "pager/lib.h"
 #include "question/lib.h"
@@ -57,9 +58,6 @@
 #include "mx.h"
 #include "protos.h"
 #include "rfc3676.h"
-#ifdef USE_IMAP
-#include "imap/lib.h"
-#endif
 
 /**
  * mutt_get_tmp_attachment - Get a temporary copy of an attachment
@@ -389,11 +387,7 @@ static int wait_interactive_filter(pid_t pid)
 {
   int rc;
 
-#ifdef USE_IMAP
   rc = imap_wait_keep_alive(pid);
-#else
-  waitpid(pid, &rc, 0);
-#endif
   mutt_sig_unblock_system(true);
   rc = WIFEXITED(rc) ? WEXITSTATUS(rc) : -1;
 

--- a/auto.def
+++ b/auto.def
@@ -437,14 +437,6 @@ if {1} {
 
 ###############################################################################
 # Various unconditional defines
-define USE_COMP_MBOX
-define USE_IMAP
-define USE_NNTP
-define USE_POP
-define USE_SIDEBAR
-define USE_SOCKET
-define USE_SMTP
-define SUN_ATTACHMENT
 define TEST_CASE_MAXSIZE 1024
 ###############################################################################
 
@@ -1197,7 +1189,6 @@ set auto_rep {
   PKGDOCDIR
   QUEUE_*
   SENDMAIL
-  SUN_ATTACHMENT
   SYSCONFDIR
   TEST_CASE_MAXSIZE
   TMPDIR

--- a/browser/dlg_browser.c
+++ b/browser/dlg_browser.c
@@ -85,8 +85,10 @@
 #include "conn/lib.h"
 #include "gui/lib.h"
 #include "lib.h"
+#include "imap/lib.h"
 #include "key/lib.h"
 #include "menu/lib.h"
+#include "nntp/lib.h"
 #include "format_flags.h"
 #include "functions.h"
 #include "globals.h"
@@ -94,15 +96,9 @@
 #include "mutt_mailbox.h"
 #include "muttlib.h"
 #include "mx.h"
-#include "private_data.h"
-#ifdef USE_IMAP
-#include "imap/lib.h"
-#endif
-#ifdef USE_NNTP
-#include "nntp/lib.h"
 #include "nntp/adata.h"
 #include "nntp/mdata.h"
-#endif
+#include "private_data.h"
 
 /// Help Bar for the File/Dir/Mailbox browser dialog
 static const struct Mapping FolderHelp[] = {
@@ -116,7 +112,6 @@ static const struct Mapping FolderHelp[] = {
   // clang-format on
 };
 
-#ifdef USE_NNTP
 /// Help Bar for the NNTP Mailbox browser dialog
 static const struct Mapping FolderNewsHelp[] = {
   // clang-format off
@@ -130,7 +125,6 @@ static const struct Mapping FolderNewsHelp[] = {
   { NULL, 0 },
   // clang-format on
 };
-#endif
 
 /// Browser: previous selected directory
 struct Buffer LastDir = { 0 };
@@ -382,7 +376,6 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
                                                        '-');
         mutt_format_s(buf, buflen, prec, permission);
       }
-#ifdef USE_IMAP
       else if (folder->ff->imap)
       {
         char permission[11] = { 0 };
@@ -391,9 +384,10 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
                  (folder->ff->inferiors && folder->ff->selectable) ? '+' : ' ');
         mutt_format_s(buf, buflen, prec, permission);
       }
-#endif
       else
+      {
         mutt_format_s(buf, buflen, prec, "");
+      }
       break;
     }
 
@@ -614,13 +608,9 @@ void browser_add_folder(const struct Menu *menu, struct BrowserState *state,
 
   ff.name = mutt_str_dup(name);
   ff.desc = mutt_str_dup(desc ? desc : name);
-#ifdef USE_IMAP
   ff.imap = false;
-#endif
-#ifdef USE_NNTP
   if (OptNews)
     ff.nd = data;
-#endif
 
   ARRAY_ADD(&state->entry, ff);
 }
@@ -634,9 +624,8 @@ void init_state(struct BrowserState *state, struct Menu *menu)
 {
   ARRAY_INIT(&state->entry);
   ARRAY_RESERVE(&state->entry, 256);
-#ifdef USE_IMAP
   state->imap_browse = false;
-#endif
+
   if (menu)
   {
     menu->mdata = &state->entry;
@@ -659,7 +648,6 @@ int examine_directory(struct Mailbox *m, struct Menu *menu, struct BrowserState 
 {
   int rc = -1;
   struct Buffer *buf = buf_pool_get();
-#ifdef USE_NNTP
   if (OptNews)
   {
     struct NntpAccountData *adata = CurrentNewsSrv;
@@ -682,7 +670,6 @@ int examine_directory(struct Mailbox *m, struct Menu *menu, struct BrowserState 
     }
   }
   else
-#endif /* USE_NNTP */
   {
     struct stat st = { 0 };
     DIR *dir = NULL;
@@ -789,7 +776,6 @@ int examine_mailboxes(struct Mailbox *m, struct Menu *menu, struct BrowserState 
   struct Buffer *md = NULL;
   struct Buffer *mailbox = NULL;
 
-#ifdef USE_NNTP
   if (OptNews)
   {
     struct NntpAccountData *adata = CurrentNewsSrv;
@@ -808,7 +794,6 @@ int examine_mailboxes(struct Mailbox *m, struct Menu *menu, struct BrowserState 
     }
   }
   else
-#endif
   {
     init_state(state, menu);
 
@@ -893,10 +878,8 @@ int examine_mailboxes(struct Mailbox *m, struct Menu *menu, struct BrowserState 
 static int select_file_search(struct Menu *menu, regex_t *rx, int line)
 {
   struct BrowserEntryArray *entry = menu->mdata;
-#ifdef USE_NNTP
   if (OptNews)
     return regexec(rx, ARRAY_GET(entry, line)->desc, 0, NULL, 0);
-#endif
   struct FolderFile *ff = ARRAY_GET(entry, line);
   char *search_on = ff->desc ? ff->desc : ff->name;
 
@@ -917,7 +900,6 @@ static void folder_make_entry(struct Menu *menu, char *buf, size_t buflen, int l
     .num = line,
   };
 
-#ifdef USE_NNTP
   if (OptNews)
   {
     const char *const c_group_index_format = cs_subset_string(NeoMutt->sub, "group_index_format");
@@ -925,9 +907,7 @@ static void folder_make_entry(struct Menu *menu, char *buf, size_t buflen, int l
                         NONULL(c_group_index_format), group_index_format_str,
                         (intptr_t) &folder, MUTT_FORMAT_ARROWCURSOR);
   }
-  else
-#endif
-      if (bstate->is_mailbox_list)
+  else if (bstate->is_mailbox_list)
   {
     const char *const c_mailbox_folder_format = cs_subset_string(NeoMutt->sub, "mailbox_folder_format");
     mutt_expando_format(buf, buflen, 0, menu->win->state.cols,
@@ -992,7 +972,6 @@ void init_menu(struct BrowserState *state, struct Menu *menu, struct Mailbox *m,
 
   menu->num_tagged = 0;
 
-#ifdef USE_NNTP
   if (OptNews)
   {
     if (state->is_mailbox_list)
@@ -1006,7 +985,6 @@ void init_menu(struct BrowserState *state, struct Menu *menu, struct Mailbox *m,
     }
   }
   else
-#endif
   {
     if (state->is_mailbox_list)
     {
@@ -1019,7 +997,6 @@ void init_menu(struct BrowserState *state, struct Menu *menu, struct Mailbox *m,
       buf_copy(path, &LastDir);
       buf_pretty_mailbox(path);
       const struct Regex *c_mask = cs_subset_regex(NeoMutt->sub, "mask");
-#ifdef USE_IMAP
       const bool c_imap_list_subscribed = cs_subset_bool(NeoMutt->sub, "imap_list_subscribed");
       if (state->imap_browse && c_imap_list_subscribed)
       {
@@ -1027,7 +1004,6 @@ void init_menu(struct BrowserState *state, struct Menu *menu, struct Mailbox *m,
                  buf_string(path), NONULL(c_mask ? c_mask->pattern : NULL));
       }
       else
-#endif
       {
         snprintf(title, sizeof(title), _("Directory [%s], File mask: %s"),
                  buf_string(path), NONULL(c_mask ? c_mask->pattern : NULL));
@@ -1045,7 +1021,6 @@ void init_menu(struct BrowserState *state, struct Menu *menu, struct Mailbox *m,
   {
     char target_dir[PATH_MAX] = { 0 };
 
-#ifdef USE_IMAP
     /* Check what kind of dir LastDirBackup is. */
     if (imap_path_probe(buf_string(&LastDirBackup), NULL) == MUTT_IMAP)
     {
@@ -1053,9 +1028,10 @@ void init_menu(struct BrowserState *state, struct Menu *menu, struct Mailbox *m,
       imap_clean_path(target_dir, sizeof(target_dir));
     }
     else
-#endif
+    {
       mutt_str_copy(target_dir, strrchr(buf_string(&LastDirBackup), '/') + 1,
                     sizeof(target_dir));
+    }
 
     /* If we get here, it means that LastDir is the parent directory of
      * LastDirBackup.  I.e., we're returning from a subdirectory, and we want
@@ -1264,7 +1240,6 @@ void dlg_browser(struct Buffer *file, SelectFileFlags flags, struct Mailbox *m,
 
   init_lastdir();
 
-#ifdef USE_NNTP
   if (OptNews)
   {
     if (buf_is_empty(file))
@@ -1288,12 +1263,9 @@ void dlg_browser(struct Buffer *file, SelectFileFlags flags, struct Mailbox *m,
       buf_copy(priv->prefix, file);
     }
   }
-  else
-#endif
-      if (!buf_is_empty(file))
+  else if (!buf_is_empty(file))
   {
     buf_expand_path(file);
-#ifdef USE_IMAP
     if (imap_path_probe(buf_string(file), NULL) == MUTT_IMAP)
     {
       init_state(&priv->state, NULL);
@@ -1306,7 +1278,6 @@ void dlg_browser(struct Buffer *file, SelectFileFlags flags, struct Mailbox *m,
     }
     else
     {
-#endif
       int i;
       for (i = buf_len(file) - 1; (i > 0) && ((buf_string(file))[i] != '/'); i--)
       {
@@ -1339,9 +1310,7 @@ void dlg_browser(struct Buffer *file, SelectFileFlags flags, struct Mailbox *m,
       else
         buf_strcpy(priv->prefix, buf_string(file) + i + 1);
       priv->kill_prefix = true;
-#ifdef USE_IMAP
     }
-#endif
   }
   else
   {
@@ -1418,7 +1387,6 @@ void dlg_browser(struct Buffer *file, SelectFileFlags flags, struct Mailbox *m,
       mutt_path_getcwd(&LastDir);
     }
 
-#ifdef USE_IMAP
     if (!priv->state.is_mailbox_list &&
         (imap_path_probe(buf_string(&LastDir), NULL) == MUTT_IMAP))
     {
@@ -1428,7 +1396,6 @@ void dlg_browser(struct Buffer *file, SelectFileFlags flags, struct Mailbox *m,
       browser_sort(&priv->state);
     }
     else
-#endif
     {
       size_t i = buf_len(&LastDir);
       while ((i > 0) && (buf_string(&LastDir)[--i] == '/'))
@@ -1442,11 +1409,10 @@ void dlg_browser(struct Buffer *file, SelectFileFlags flags, struct Mailbox *m,
   buf_reset(file);
 
   const struct Mapping *help_data = NULL;
-#ifdef USE_NNTP
+
   if (OptNews)
     help_data = FolderNewsHelp;
   else
-#endif
     help_data = FolderHelp;
 
   dlg = simple_dialog_new(MENU_FOLDER, WT_DLG_BROWSER, help_data);
@@ -1474,10 +1440,7 @@ void dlg_browser(struct Buffer *file, SelectFileFlags flags, struct Mailbox *m,
   {
     examine_mailboxes(m, NULL, &priv->state);
   }
-  else
-#ifdef USE_IMAP
-      if (!priv->state.imap_browse)
-#endif
+  else if (!priv->state.imap_browse)
   {
     // examine_directory() calls browser_add_folder() which needs the menu
     if (examine_directory(m, priv->menu, &priv->state, buf_string(&LastDir),

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -44,8 +44,10 @@
 #include "attach/lib.h"
 #include "editor/lib.h"
 #include "history/lib.h"
+#include "imap/lib.h"
 #include "key/lib.h"
 #include "menu/lib.h"
+#include "nntp/lib.h"
 #include "pattern/lib.h"
 #include "question/lib.h"
 #include "send/lib.h"
@@ -54,15 +56,9 @@
 #include "mutt_mailbox.h"
 #include "muttlib.h"
 #include "mx.h"
-#include "private_data.h"
-#ifdef USE_IMAP
-#include "imap/lib.h"
-#endif
-#ifdef USE_NNTP
-#include "nntp/lib.h"
 #include "nntp/adata.h"
 #include "nntp/mdata.h"
-#endif
+#include "private_data.h"
 #endif
 
 /// Error message for unavailable functions
@@ -75,15 +71,11 @@ static int op_subscribe_pattern(struct BrowserPrivateData *priv, int op);
  * OpBrowser - Functions for the file Browser Menu
  */
 const struct MenuFuncOp OpBrowser[] = { /* map: browser */
-#ifdef USE_NNTP
   { "catchup",                       OP_CATCHUP },
-#endif
   { "change-dir",                    OP_CHANGE_DIRECTORY },
   { "check-new",                     OP_CHECK_NEW },
-#ifdef USE_IMAP
   { "create-mailbox",                OP_CREATE_MAILBOX },
   { "delete-mailbox",                OP_DELETE_MAILBOX },
-#endif
   { "descend-directory",             OP_DESCEND_DIRECTORY },
   { "display-filename",              OP_BROWSER_TELL },
   { "enter-mask",                    OP_ENTER_MASK },
@@ -91,34 +83,18 @@ const struct MenuFuncOp OpBrowser[] = { /* map: browser */
   { "goto-folder",                   OP_BROWSER_GOTO_FOLDER },
   { "goto-parent",                   OP_GOTO_PARENT },
   { "mailbox-list",                  OP_MAILBOX_LIST },
-#ifdef USE_NNTP
   { "reload-active",                 OP_LOAD_ACTIVE },
-#endif
-#ifdef USE_IMAP
   { "rename-mailbox",                OP_RENAME_MAILBOX },
-#endif
   { "select-new",                    OP_BROWSER_NEW_FILE },
   { "sort",                          OP_SORT },
   { "sort-reverse",                  OP_SORT_REVERSE },
-#if defined(USE_IMAP) || defined(USE_NNTP)
   { "subscribe",                     OP_BROWSER_SUBSCRIBE },
-#endif
-#ifdef USE_NNTP
   { "subscribe-pattern",             OP_SUBSCRIBE_PATTERN },
-#endif
   { "toggle-mailboxes",              OP_TOGGLE_MAILBOXES },
-#ifdef USE_IMAP
   { "toggle-subscribed",             OP_BROWSER_TOGGLE_LSUB },
-#endif
-#ifdef USE_NNTP
   { "uncatchup",                     OP_UNCATCHUP },
-#endif
-#if defined(USE_IMAP) || defined(USE_NNTP)
   { "unsubscribe",                   OP_BROWSER_UNSUBSCRIBE },
-#endif
-#ifdef USE_NNTP
   { "unsubscribe-pattern",           OP_UNSUBSCRIBE_PATTERN },
-#endif
   { "view-file",                     OP_BROWSER_VIEW_FILE },
   // Deprecated
   { "buffy-list",                    OP_MAILBOX_LIST },
@@ -131,31 +107,19 @@ const struct MenuFuncOp OpBrowser[] = { /* map: browser */
 const struct MenuOpSeq BrowserDefaultBindings[] = { /* map: browser */
   { OP_BROWSER_GOTO_FOLDER,                "=" },
   { OP_BROWSER_NEW_FILE,                   "N" },
-#if defined(USE_IMAP) || defined(USE_NNTP)
   { OP_BROWSER_SUBSCRIBE,                  "s" },
-#endif
   { OP_BROWSER_TELL,                       "@" },
-#ifdef USE_IMAP
   { OP_BROWSER_TOGGLE_LSUB,                "T" },
-#endif
-#if defined(USE_IMAP) || defined(USE_NNTP)
   { OP_BROWSER_UNSUBSCRIBE,                "u" },
-#endif
   { OP_BROWSER_VIEW_FILE,                  " " },              // <Space>
   { OP_CHANGE_DIRECTORY,                   "c" },
-#ifdef USE_IMAP
   { OP_CREATE_MAILBOX,                     "C" },
   { OP_DELETE_MAILBOX,                     "d" },
-#endif
   { OP_ENTER_MASK,                         "m" },
   { OP_EXIT,                               "q" },
   { OP_GOTO_PARENT,                        "p" },
-#ifdef USE_NNTP
-#endif
   { OP_MAILBOX_LIST,                       "." },
-#ifdef USE_IMAP
   { OP_RENAME_MAILBOX,                     "r" },
-#endif
   { OP_SORT,                               "o" },
   { OP_SORT_REVERSE,                       "O" },
   { OP_TOGGLE_MAILBOXES,                   "\t" },             // <Tab>
@@ -178,10 +142,7 @@ void destroy_state(struct BrowserState *state)
     FREE(&ff->desc);
   }
   ARRAY_FREE(&state->entry);
-
-#ifdef USE_IMAP
   FREE(&state->folder);
-#endif
 }
 
 // -----------------------------------------------------------------------------
@@ -209,7 +170,6 @@ static int op_browser_new_file(struct BrowserPrivateData *priv, int op)
   return FR_DONE;
 }
 
-#if defined(USE_IMAP) || defined(USE_NNTP)
 /**
  * op_browser_subscribe - Subscribe to current mbox (IMAP/NNTP only) - Implements ::browser_function_t - @ingroup browser_function_api
  *
@@ -248,7 +208,6 @@ static int op_browser_subscribe(struct BrowserPrivateData *priv, int op)
     nntp_clear_cache(adata);
     nntp_newsrc_close(adata);
   }
-#ifdef USE_IMAP
   else
   {
     if (ARRAY_EMPTY(&priv->state.entry))
@@ -264,10 +223,8 @@ static int op_browser_subscribe(struct BrowserPrivateData *priv, int op)
     mutt_expand_path(tmp2, sizeof(tmp2));
     imap_subscribe(tmp2, (op == OP_BROWSER_SUBSCRIBE));
   }
-#endif
   return FR_SUCCESS;
 }
-#endif
 
 /**
  * op_browser_tell - Display the currently selected file's name - Implements ::browser_function_t - @ingroup browser_function_api
@@ -282,7 +239,6 @@ static int op_browser_tell(struct BrowserPrivateData *priv, int op)
   return FR_SUCCESS;
 }
 
-#ifdef USE_IMAP
 /**
  * op_browser_toggle_lsub - Toggle view all/subscribed mailboxes (IMAP only) - Implements ::browser_function_t - @ingroup browser_function_api
  */
@@ -293,7 +249,6 @@ static int op_browser_toggle_lsub(struct BrowserPrivateData *priv, int op)
   mutt_unget_op(OP_CHECK_NEW);
   return FR_SUCCESS;
 }
-#endif
 
 /**
  * op_browser_view_file - View file - Implements ::browser_function_t - @ingroup browser_function_api
@@ -308,17 +263,14 @@ static int op_browser_view_file(struct BrowserPrivateData *priv, int op)
 
   int index = menu_get_index(priv->menu);
   struct FolderFile *ff = ARRAY_GET(&priv->state.entry, index);
-#ifdef USE_IMAP
   if (ff->selectable)
   {
     buf_strcpy(priv->file, ff->name);
     priv->done = true;
     return FR_DONE;
   }
-  else
-#endif
-      if (S_ISDIR(ff->mode) ||
-          (S_ISLNK(ff->mode) && link_is_dir(buf_string(&LastDir), ff->name)))
+  else if (S_ISDIR(ff->mode) ||
+           (S_ISLNK(ff->mode) && link_is_dir(buf_string(&LastDir), ff->name)))
   {
     mutt_error(_("Can't view a directory"));
     return FR_ERROR;
@@ -343,7 +295,6 @@ static int op_browser_view_file(struct BrowserPrivateData *priv, int op)
   return FR_ERROR;
 }
 
-#ifdef USE_NNTP
 /**
  * op_catchup - Mark all articles in newsgroup as read - Implements ::browser_function_t - @ingroup browser_function_api
  */
@@ -379,7 +330,6 @@ static int op_catchup(struct BrowserPrivateData *priv, int op)
   nntp_newsrc_close(CurrentNewsSrv);
   return FR_ERROR;
 }
-#endif
 
 /**
  * op_change_directory - Change directories - Implements ::browser_function_t - @ingroup browser_function_api
@@ -390,16 +340,12 @@ static int op_catchup(struct BrowserPrivateData *priv, int op)
  */
 static int op_change_directory(struct BrowserPrivateData *priv, int op)
 {
-#ifdef USE_NNTP
   if (OptNews)
     return FR_NOT_IMPL;
-#endif
 
   struct Buffer *buf = buf_pool_get();
   buf_copy(buf, &LastDir);
-#ifdef USE_IMAP
   if (!priv->state.imap_browse)
-#endif
   {
     /* add '/' at the end of the directory name if not already there */
     size_t len = buf_len(buf);
@@ -427,7 +373,6 @@ static int op_change_directory(struct BrowserPrivateData *priv, int op)
   {
     priv->state.is_mailbox_list = false;
     buf_expand_path(buf);
-#ifdef USE_IMAP
     if (imap_path_probe(buf_string(buf), NULL) == MUTT_IMAP)
     {
       buf_copy(&LastDir, buf);
@@ -442,7 +387,6 @@ static int op_change_directory(struct BrowserPrivateData *priv, int op)
       init_menu(&priv->state, priv->menu, priv->mailbox, priv->sbar);
     }
     else
-#endif
     {
       if (buf_string(buf)[0] != '/')
       {
@@ -501,7 +445,6 @@ static int op_change_directory(struct BrowserPrivateData *priv, int op)
   return FR_ERROR;
 }
 
-#ifdef USE_IMAP
 /**
  * op_create_mailbox - Create a new mailbox (IMAP only) - Implements ::browser_function_t - @ingroup browser_function_api
  */
@@ -530,9 +473,7 @@ static int op_create_mailbox(struct BrowserPrivateData *priv, int op)
 
   return FR_SUCCESS;
 }
-#endif
 
-#ifdef USE_IMAP
 /**
  * op_delete_mailbox - Delete the current mailbox (IMAP only) - Implements ::browser_function_t - @ingroup browser_function_api
  */
@@ -580,7 +521,6 @@ static int op_delete_mailbox(struct BrowserPrivateData *priv, int op)
 
   return FR_SUCCESS;
 }
-#endif
 
 /**
  * op_enter_mask - Enter a file mask - Implements ::browser_function_t - @ingroup browser_function_api
@@ -618,7 +558,6 @@ static int op_enter_mask(struct BrowserPrivateData *priv, int op)
   buf_pool_release(&errmsg);
 
   destroy_state(&priv->state);
-#ifdef USE_IMAP
   if (priv->state.imap_browse)
   {
     init_state(&priv->state, NULL);
@@ -629,10 +568,8 @@ static int op_enter_mask(struct BrowserPrivateData *priv, int op)
     priv->menu->mdata_free = NULL; // Menu doesn't own the data
     init_menu(&priv->state, priv->menu, priv->mailbox, priv->sbar);
   }
-  else
-#endif
-      if (examine_directory(priv->mailbox, priv->menu, &priv->state,
-                            buf_string(&LastDir), NULL) == 0)
+  else if (examine_directory(priv->mailbox, priv->menu, &priv->state,
+                             buf_string(&LastDir), NULL) == 0)
   {
     init_menu(&priv->state, priv->menu, priv->mailbox, priv->sbar);
   }
@@ -711,11 +648,7 @@ static int op_generic_select_entry(struct BrowserPrivateData *priv, int op)
   int index = menu_get_index(priv->menu);
   struct FolderFile *ff = ARRAY_GET(&priv->state.entry, index);
   if (S_ISDIR(ff->mode) ||
-      (S_ISLNK(ff->mode) && link_is_dir(buf_string(&LastDir), ff->name))
-#ifdef USE_IMAP
-      || ff->inferiors
-#endif
-  )
+      (S_ISLNK(ff->mode) && link_is_dir(buf_string(&LastDir), ff->name)) || ff->inferiors)
   {
     /* make sure this isn't a MH or maildir mailbox */
     struct Buffer *buf = buf_pool_get();
@@ -724,12 +657,10 @@ static int op_generic_select_entry(struct BrowserPrivateData *priv, int op)
       buf_strcpy(buf, ff->name);
       buf_expand_path(buf);
     }
-#ifdef USE_IMAP
     else if (priv->state.imap_browse)
     {
       buf_strcpy(buf, ff->name);
     }
-#endif
     else
     {
       buf_concat_path(buf, buf_string(&LastDir), ff->name);
@@ -738,11 +669,8 @@ static int op_generic_select_entry(struct BrowserPrivateData *priv, int op)
     enum MailboxType type = mx_path_probe(buf_string(buf));
     buf_pool_release(&buf);
 
-    if ((op == OP_DESCEND_DIRECTORY) || (type == MUTT_MAILBOX_ERROR) || (type == MUTT_UNKNOWN)
-#ifdef USE_IMAP
-        || ff->inferiors
-#endif
-    )
+    if ((op == OP_DESCEND_DIRECTORY) || (type == MUTT_MAILBOX_ERROR) ||
+        (type == MUTT_UNKNOWN) || ff->inferiors)
     {
       /* save the old directory */
       buf_copy(priv->OldLastDir, &LastDir);
@@ -779,7 +707,6 @@ static int op_generic_select_entry(struct BrowserPrivateData *priv, int op)
         buf_strcpy(&LastDir, ff->name);
         buf_expand_path(&LastDir);
       }
-#ifdef USE_IMAP
       else if (priv->state.imap_browse)
       {
         buf_strcpy(&LastDir, ff->name);
@@ -793,7 +720,6 @@ static int op_generic_select_entry(struct BrowserPrivateData *priv, int op)
         }
         url_free(&url);
       }
-#endif
       else
       {
         struct Buffer *tmp = buf_pool_get();
@@ -809,7 +735,6 @@ static int op_generic_select_entry(struct BrowserPrivateData *priv, int op)
         priv->kill_prefix = false;
       }
       priv->state.is_mailbox_list = false;
-#ifdef USE_IMAP
       if (priv->state.imap_browse)
       {
         init_state(&priv->state, NULL);
@@ -820,7 +745,6 @@ static int op_generic_select_entry(struct BrowserPrivateData *priv, int op)
         priv->menu->mdata_free = NULL; // Menu doesn't own the data
       }
       else
-#endif
       {
         if (examine_directory(priv->mailbox, priv->menu, &priv->state,
                               buf_string(&LastDir), buf_string(priv->prefix)) == -1)
@@ -852,15 +776,15 @@ static int op_generic_select_entry(struct BrowserPrivateData *priv, int op)
     return FR_ERROR;
   }
 
-  if (priv->state.is_mailbox_list || OptNews) /* USE_NNTP */
+  if (priv->state.is_mailbox_list || OptNews)
   {
     buf_strcpy(priv->file, ff->name);
     buf_expand_path(priv->file);
   }
-#ifdef USE_IMAP
   else if (priv->state.imap_browse)
+  {
     buf_strcpy(priv->file, ff->name);
-#endif
+  }
   else
   {
     buf_concat_path(priv->file, buf_string(&LastDir), ff->name);
@@ -869,7 +793,6 @@ static int op_generic_select_entry(struct BrowserPrivateData *priv, int op)
   return op_exit(priv, op);
 }
 
-#ifdef USE_NNTP
 /**
  * op_load_active - Load list of all newsgroups from NNTP server - Implements ::browser_function_t - @ingroup browser_function_api
  */
@@ -906,7 +829,6 @@ static int op_load_active(struct BrowserPrivateData *priv, int op)
   init_menu(&priv->state, priv->menu, priv->mailbox, priv->sbar);
   return FR_SUCCESS;
 }
-#endif
 
 /**
  * op_mailbox_list - List mailboxes with new mail - Implements ::browser_function_t - @ingroup browser_function_api
@@ -917,7 +839,6 @@ static int op_mailbox_list(struct BrowserPrivateData *priv, int op)
   return FR_SUCCESS;
 }
 
-#ifdef USE_IMAP
 /**
  * op_rename_mailbox - Rename the current mailbox (IMAP only) - Implements ::browser_function_t - @ingroup browser_function_api
  */
@@ -946,7 +867,6 @@ static int op_rename_mailbox(struct BrowserPrivateData *priv, int op)
 
   return FR_SUCCESS;
 }
-#endif
 
 /**
  * op_sort - Sort messages - Implements ::browser_function_t - @ingroup browser_function_api
@@ -1013,7 +933,6 @@ static int op_sort(struct BrowserPrivateData *priv, int op)
   return FR_SUCCESS;
 }
 
-#ifdef USE_NNTP
 /**
  * op_subscribe_pattern - Subscribe to newsgroups matching a pattern - Implements ::browser_function_t - @ingroup browser_function_api
  *
@@ -1098,7 +1017,6 @@ static int op_subscribe_pattern(struct BrowserPrivateData *priv, int op)
   regfree(&rx);
   return FR_SUCCESS;
 }
-#endif
 
 /**
  * op_toggle_mailboxes - Toggle whether to browse mailboxes or all files - Implements ::browser_function_t - @ingroup browser_function_api
@@ -1153,7 +1071,6 @@ static int op_toggle_mailboxes(struct BrowserPrivateData *priv, int op)
   {
     examine_mailboxes(priv->mailbox, priv->menu, &priv->state);
   }
-#ifdef USE_IMAP
   else if (imap_path_probe(buf_string(&LastDir), NULL) == MUTT_IMAP)
   {
     init_state(&priv->state, NULL);
@@ -1163,7 +1080,6 @@ static int op_toggle_mailboxes(struct BrowserPrivateData *priv, int op)
     priv->menu->mdata = &priv->state.entry;
     priv->menu->mdata_free = NULL; // Menu doesn't own the data
   }
-#endif
   else if (examine_directory(priv->mailbox, priv->menu, &priv->state,
                              buf_string(&LastDir), buf_string(priv->prefix)) == -1)
   {
@@ -1185,48 +1101,30 @@ static const struct BrowserFunction BrowserFunctions[] = {
   // clang-format off
   { OP_BROWSER_GOTO_FOLDER,  op_toggle_mailboxes },
   { OP_BROWSER_NEW_FILE,     op_browser_new_file },
-#if defined(USE_IMAP) || defined(USE_NNTP)
   { OP_BROWSER_SUBSCRIBE,    op_browser_subscribe },
-#endif
   { OP_BROWSER_TELL,         op_browser_tell },
-#ifdef USE_IMAP
   { OP_BROWSER_TOGGLE_LSUB,  op_browser_toggle_lsub },
-#endif
-#if defined(USE_IMAP) || defined(USE_NNTP)
   { OP_BROWSER_UNSUBSCRIBE,  op_browser_subscribe },
-#endif
   { OP_BROWSER_VIEW_FILE,    op_browser_view_file },
-#ifdef USE_NNTP
   { OP_CATCHUP,              op_catchup },
-#endif
   { OP_CHANGE_DIRECTORY,     op_change_directory },
   { OP_CHECK_NEW,            op_toggle_mailboxes },
-#ifdef USE_IMAP
   { OP_CREATE_MAILBOX,       op_create_mailbox },
   { OP_DELETE_MAILBOX,       op_delete_mailbox },
-#endif
   { OP_DESCEND_DIRECTORY,    op_generic_select_entry },
   { OP_ENTER_MASK,           op_enter_mask },
   { OP_EXIT,                 op_exit },
   { OP_GENERIC_SELECT_ENTRY, op_generic_select_entry },
   { OP_GOTO_PARENT,          op_change_directory },
-#ifdef USE_NNTP
   { OP_LOAD_ACTIVE,          op_load_active },
-#endif
   { OP_MAILBOX_LIST,         op_mailbox_list },
-#ifdef USE_IMAP
   { OP_RENAME_MAILBOX,       op_rename_mailbox },
-#endif
   { OP_SORT,                 op_sort },
   { OP_SORT_REVERSE,         op_sort },
-#ifdef USE_NNTP
   { OP_SUBSCRIBE_PATTERN,    op_subscribe_pattern },
-#endif
   { OP_TOGGLE_MAILBOXES,     op_toggle_mailboxes },
-#ifdef USE_NNTP
   { OP_UNCATCHUP,            op_catchup },
   { OP_UNSUBSCRIBE_PATTERN,  op_subscribe_pattern },
-#endif
   { 0, NULL },
   // clang-format on
 };

--- a/browser/lib.h
+++ b/browser/lib.h
@@ -90,21 +90,17 @@ struct FolderFile
   int msg_count;           ///< total number of messages
   int msg_unread;          ///< number of unread messages
 
-#ifdef USE_IMAP
   char delim;              ///< Path delimiter
 
   bool imap          : 1;  ///< This is an IMAP folder
   bool selectable    : 1;  ///< Folder can be selected
   bool inferiors     : 1;  ///< Folder has children
-#endif
   bool has_mailbox   : 1;  ///< This is a mailbox
   bool local         : 1;  ///< Folder is on local filesystem
   bool notify_user   : 1;  ///< User will be notified of new mail
   bool poll_new_mail : 1;  ///< Check mailbox for new mail
   bool tagged        : 1;  ///< Folder is tagged
-#ifdef USE_NNTP
   struct NntpMboxData *nd; ///< Extra NNTP data
-#endif
 
   int gen;                 ///< Unique id, used for (un)sorting
 };
@@ -117,10 +113,8 @@ ARRAY_HEAD(BrowserEntryArray, struct FolderFile);
 struct BrowserState
 {
   struct BrowserEntryArray entry; ///< Array of files / dirs / mailboxes
-#ifdef USE_IMAP
   bool imap_browse; ///< IMAP folder
   char *folder;     ///< Folder name
-#endif
   bool is_mailbox_list; ///< Viewing mailboxes
 };
 

--- a/browser/sort.c
+++ b/browser/sort.c
@@ -187,13 +187,11 @@ void browser_sort(struct BrowserState *state)
   const enum SortType c_sort_browser = cs_subset_sort(NeoMutt->sub, "sort_browser");
   switch (c_sort_browser & SORT_MASK)
   {
-#ifdef USE_NNTP
     case SORT_SIZE:
     case SORT_DATE:
       if (OptNews)
         return;
       FALLTHROUGH;
-#endif
     default:
       break;
   }

--- a/color/color.h
+++ b/color/color.h
@@ -61,7 +61,6 @@ enum ColorId
   MT_COLOR_PROMPT,                   ///< Question/user input
   MT_COLOR_QUOTED,                   ///< Pager: quoted text
   MT_COLOR_SEARCH,                   ///< Pager: search matches
-#ifdef USE_SIDEBAR
   MT_COLOR_SIDEBAR_BACKGROUND,       ///< Background colour for the Sidebar
   MT_COLOR_SIDEBAR_DIVIDER,          ///< Line dividing sidebar from the index/pager
   MT_COLOR_SIDEBAR_FLAGGED,          ///< Mailbox with flagged messages
@@ -71,7 +70,6 @@ enum ColorId
   MT_COLOR_SIDEBAR_ORDINARY,         ///< Mailbox with no new or flagged messages
   MT_COLOR_SIDEBAR_SPOOLFILE,        ///< $spool_file (Spool mailbox)
   MT_COLOR_SIDEBAR_UNREAD,           ///< Mailbox with unread mail
-#endif
   MT_COLOR_SIGNATURE,                ///< Pager: signature lines
   MT_COLOR_STATUS,                   ///< Status bar (takes a pattern)
   MT_COLOR_STRIPE_EVEN,              ///< Stripes: even lines of the Help Page

--- a/color/command.c
+++ b/color/command.c
@@ -81,7 +81,6 @@ const struct Mapping ColorFields[] = {
   { "prompt",            MT_COLOR_PROMPT },
   { "quoted",            MT_COLOR_QUOTED },
   { "search",            MT_COLOR_SEARCH },
-#ifdef USE_SIDEBAR
   { "sidebar_background", MT_COLOR_SIDEBAR_BACKGROUND },
   { "sidebar_divider",   MT_COLOR_SIDEBAR_DIVIDER },
   { "sidebar_flagged",   MT_COLOR_SIDEBAR_FLAGGED },
@@ -92,7 +91,6 @@ const struct Mapping ColorFields[] = {
   { "sidebar_spool_file", MT_COLOR_SIDEBAR_SPOOLFILE },
   { "sidebar_spoolfile", MT_COLOR_SIDEBAR_SPOOLFILE }, // This will be deprecated
   { "sidebar_unread",    MT_COLOR_SIDEBAR_UNREAD },
-#endif
   { "signature",         MT_COLOR_SIGNATURE },
   { "status",            MT_COLOR_STATUS },
   { "stripe_even",       MT_COLOR_STRIPE_EVEN},

--- a/color/simple.c
+++ b/color/simple.c
@@ -59,9 +59,7 @@ void simple_colors_init(void)
   SimpleColors[MT_COLOR_ITALIC].attrs = A_ITALIC;
   SimpleColors[MT_COLOR_MARKERS].attrs = A_REVERSE;
   SimpleColors[MT_COLOR_SEARCH].attrs = A_REVERSE;
-#ifdef USE_SIDEBAR
   SimpleColors[MT_COLOR_SIDEBAR_HIGHLIGHT].attrs = A_UNDERLINE;
-#endif
   SimpleColors[MT_COLOR_STATUS].attrs = A_REVERSE;
   SimpleColors[MT_COLOR_STRIPE_EVEN].attrs = A_BOLD;
   SimpleColors[MT_COLOR_UNDERLINE].attrs = A_UNDERLINE;

--- a/commands.c
+++ b/commands.c
@@ -1194,7 +1194,6 @@ bail:
   return MUTT_CMD_ERROR;
 }
 
-#ifdef USE_IMAP
 /**
  * parse_subscribe_to - Parse the 'subscribe-to' command - Implements Command::parse() - @ingroup command_parse
  *
@@ -1240,7 +1239,6 @@ enum CommandResult parse_subscribe_to(struct Buffer *buf, struct Buffer *s,
   buf_addstr(err, _("No folder specified"));
   return MUTT_CMD_WARNING;
 }
-#endif
 
 /**
  * parse_tag_formats - Parse the 'tag-formats' command - Implements Command::parse() - @ingroup command_parse
@@ -1533,7 +1531,6 @@ static enum CommandResult parse_unsubscribe(struct Buffer *buf, struct Buffer *s
   return MUTT_CMD_SUCCESS;
 }
 
-#ifdef USE_IMAP
 /**
  * parse_unsubscribe_from - Parse the 'unsubscribe-from' command - Implements Command::parse() - @ingroup command_parse
  *
@@ -1577,7 +1574,6 @@ enum CommandResult parse_unsubscribe_from(struct Buffer *buf, struct Buffer *s,
   buf_addstr(err, _("No folder specified"));
   return MUTT_CMD_WARNING;
 }
-#endif
 
 /**
  * parse_version - Parse the 'version' command - Implements Command::parse() - @ingroup command_parse

--- a/commands.h
+++ b/commands.h
@@ -38,15 +38,11 @@ struct GroupList;
 enum CommandResult parse_mailboxes       (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult parse_my_hdr          (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult parse_subjectrx_list  (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
-#ifdef USE_IMAP
 enum CommandResult parse_subscribe_to    (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
-#endif
 enum CommandResult parse_unalternates    (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult parse_unmailboxes     (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult parse_unsubjectrx_list(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
-#ifdef USE_IMAP
 enum CommandResult parse_unsubscribe_from(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
-#endif
 
 enum CommandResult parse_rc_line_cwd(const char *line, char *cwd, struct Buffer *err);
 char *mutt_get_sourced_cwd(void);

--- a/complete/complete.c
+++ b/complete/complete.c
@@ -35,14 +35,10 @@
 #include "config/lib.h"
 #include "core/lib.h"
 #include "lib.h"
+#include "imap/lib.h"
+#include "nntp/lib.h"
 #include "globals.h"
 #include "muttlib.h"
-#ifdef USE_IMAP
-#include "imap/lib.h"
-#endif
-#ifdef USE_NNTP
-#include "nntp/lib.h"
-#endif
 
 struct CompletionData;
 
@@ -67,21 +63,17 @@ int mutt_complete(struct CompletionData *cd, struct Buffer *buf)
   struct Buffer *exp_dirpart = NULL;
   struct Buffer *filepart = NULL;
   struct Buffer *tmp = NULL;
-#ifdef USE_IMAP
   struct Buffer *imap_path = NULL;
   int rc;
-#endif
 
   mutt_debug(LL_DEBUG2, "completing %s\n", buf_string(buf));
 
-#ifdef USE_NNTP
   if (OptNews)
     return nntp_complete(buf);
-#endif
 
   const char *const c_spool_file = cs_subset_string(NeoMutt->sub, "spool_file");
   const char *const c_folder = cs_subset_string(NeoMutt->sub, "folder");
-#ifdef USE_IMAP
+
   imap_path = buf_pool_get();
   /* we can use '/' as a delimiter, imap_complete rewrites it */
   char ch = buf_at(buf, 0);
@@ -107,7 +99,6 @@ int mutt_complete(struct CompletionData *cd, struct Buffer *buf)
   }
 
   buf_pool_release(&imap_path);
-#endif
 
   dirpart = buf_pool_get();
   exp_dirpart = buf_pool_get();

--- a/compose/dlg_compose.c
+++ b/compose/dlg_compose.c
@@ -107,7 +107,6 @@ static const struct Mapping ComposeHelp[] = {
   // clang-format on
 };
 
-#ifdef USE_NNTP
 /// Help Bar for the News Compose dialog
 static const struct Mapping ComposeNewsHelp[] = {
   // clang-format off
@@ -121,7 +120,6 @@ static const struct Mapping ComposeNewsHelp[] = {
   { NULL, 0 },
   // clang-format on
 };
-#endif
 
 /**
  * compose_config_observer - Notification that a Config Variable has changed - Implements ::observer_t - @ingroup observer_api
@@ -322,11 +320,9 @@ int dlg_compose(struct Email *e, struct Buffer *fcc, uint8_t flags, struct Confi
   notify_observer_add(e->notify, NT_ALL, compose_email_observer, shared);
   notify_observer_add(dlg->notify, NT_WINDOW, compose_window_observer, dlg);
 
-#ifdef USE_NNTP
   if (OptNewsSend)
     dlg->help_data = ComposeNewsHelp;
   else
-#endif
     dlg->help_data = ComposeHelp;
   dlg->help_menu = MENU_COMPOSE;
 
@@ -344,9 +340,7 @@ int dlg_compose(struct Email *e, struct Buffer *fcc, uint8_t flags, struct Confi
   int op = OP_NULL;
   do
   {
-#ifdef USE_NNTP
     OptNews = false; /* for any case */
-#endif
     menu_tagging_dispatcher(menu->win, op);
     window_redraw(NULL);
 

--- a/compose/shared_data.h
+++ b/compose/shared_data.h
@@ -43,9 +43,7 @@ struct ComposeSharedData
   int flags;                         ///< Flags, e.g. #MUTT_COMPOSE_NOFREEHEADER
   bool fcc_set;                      ///< User has edited the Fcc: field
   int rc;                            ///< Return code to leave compose
-#ifdef USE_NNTP
   bool news;                         ///< Email is a news article
-#endif
 };
 
 void compose_shared_data_free(struct MuttWindow *win, void **ptr);

--- a/core/mailbox.h
+++ b/core/mailbox.h
@@ -117,9 +117,7 @@ struct Mailbox
 
   AclFlags rights;                    ///< ACL bits, see #AclFlags
 
-#ifdef USE_COMP_MBOX
   void *compress_info;                ///< Compressed mbox module private data
-#endif
 
   struct HashTable *id_hash;          ///< Hash Table: "message-id" -> Email
   struct HashTable *subj_hash;        ///< Hash Table: "subject" -> Email

--- a/debug/email.c
+++ b/debug/email.c
@@ -122,12 +122,10 @@ void dump_envelope(const struct Envelope *env)
   OPT_STRING(date);
   OPT_STRING(x_label);
   OPT_STRING(organization);
-#ifdef USE_NNTP
   OPT_STRING(newsgroups);
   OPT_STRING(xref);
   OPT_STRING(followup_to);
   OPT_STRING(x_comment_to);
-#endif
 #undef OPT_STRING
 
   dump_list_head(&env->references, "references");

--- a/docs/config.c
+++ b/docs/config.c
@@ -188,7 +188,6 @@
 ** editing the body of an outgoing message.
 */
 
-#ifdef USE_NNTP
 { "ask_followup_to", DT_BOOL, false },
 /*
 ** .pp
@@ -202,7 +201,6 @@
 ** If set, NeoMutt will prompt you for x-comment-to field before editing
 ** the body of an outgoing message.
 */
-#endif
 
 { "assumed_charset", DT_SLIST, 0 },
 /*
@@ -476,14 +474,19 @@
 ** desirable to \fIunset\fP this variable.
 */
 
-#ifdef USE_NNTP
+{ "browser_sort_dirs_first", DT_BOOL, false },
+/*
+** .pp
+** If this variable is \fIset\fP, the browser will group directories before
+** files.
+*/
+
 { "catchup_newsgroup", DT_QUAD, MUTT_ASKYES },
 /*
 ** .pp
 ** If this variable is \fIset\fP, NeoMutt will mark all articles in newsgroup
 ** as read when you quit the newsgroup (catchup newsgroup).
 */
-#endif
 
 #ifdef USE_SSL
 { "certificate_file", DT_PATH, "~/.mutt_certificates" },
@@ -1362,7 +1365,6 @@
 ** of the same email for you.
 */
 
-#ifdef USE_NNTP
 { "followup_to_poster", DT_QUAD, MUTT_ASKYES },
 /*
 ** .pp
@@ -1371,7 +1373,6 @@
 ** permitted.  The message will be mailed to the submitter of the
 ** message via mail.
 */
-#endif
 
 { "force_name", DT_BOOL, false },
 /*
@@ -1529,7 +1530,6 @@
 ** .de
 */
 
-#ifdef USE_NNTP
 { "group_index_format", DT_STRING, "%4C %M%N %5s  %-45.45f %d" },
 /*
 ** .pp
@@ -1548,7 +1548,6 @@
 ** .dt %|X .dd Pad to the end of the line with character "X"
 ** .de
 */
-#endif
 
 { "hdrs", DT_BOOL, true },
 /*
@@ -1795,7 +1794,6 @@
 ** list.
 */
 
-#ifdef USE_IMAP
 { "imap_authenticators", DT_SLIST, 0 },
 /*
 ** .pp
@@ -2006,6 +2004,14 @@
 ** https://github.com/neomutt/neomutt/issues/1689
 */
 
+{ "imap_send_id", DT_BOOL, false },
+/*
+** .pp
+** When \fIset\fP, NeoMutt will send an IMAP ID command (RFC2971) to the
+** server when logging in if advertised by the server. This command provides
+** information about the IMAP client, such as "NeoMutt" and the current version.
+*/
+
 { "imap_server_noise", DT_BOOL, true },
 /*
 ** .pp
@@ -2024,15 +2030,6 @@
 ** .pp
 ** This variable defaults to your user name on the local machine.
 */
-
-{ "imap_send_id", DT_BOOL, false },
-/*
-** .pp
-** When \fIset\fP, NeoMutt will send an IMAP ID command (RFC2971) to the
-** server when logging in if advertised by the server. This command provides
-** information about the IMAP client, such as "NeoMutt" and the current version.
-*/
-#endif
 
 { "implicit_auto_view", DT_BOOL, false },
 /*
@@ -2201,7 +2198,6 @@
 ** "$save-hook", "$fcc-hook" and "$fcc-save-hook", too.
 */
 
-#ifdef USE_NNTP
 { "inews", DT_COMMAND, 0 },
 /*
 ** .pp
@@ -2222,7 +2218,6 @@
 ** set inews="/usr/local/bin/inews -hS"
 ** .te
 */
-#endif
 
 { "ispell", DT_COMMAND, ISPELL },
 /*
@@ -2447,7 +2442,6 @@
 ** (useful for slow links to avoid many redraws).
 */
 
-#if defined(USE_IMAP) || defined(USE_POP)
 { "message_cache_clean", DT_BOOL, false },
 /*
 ** .pp
@@ -2470,7 +2464,6 @@
 ** .pp
 ** Also see the $$message_cache_clean variable.
 */
-#endif
 
 { "message_format", DT_STRING, "%s" },
 /*
@@ -2624,7 +2617,6 @@
 ** deeper threads to fit on the screen.
 */
 
-#ifdef USE_SOCKET
 { "net_inc", DT_NUMBER, 10 },
 /*
 ** .pp
@@ -2634,7 +2626,6 @@
 ** .pp
 ** See also $$read_inc, $$write_inc and $$net_inc.
 */
-#endif
 
 { "new_mail_command", DT_COMMAND, 0 },
 /*
@@ -2644,7 +2635,6 @@
 ** into this command.
 */
 
-#ifdef USE_NNTP
 { "news_cache_dir", DT_PATH, "~/.neomutt" },
 /*
 ** .pp
@@ -2688,7 +2678,6 @@
 ** .dt %u .dd Username          .dd \fCusername\fP
 ** .de
 */
-#endif
 
 #ifdef USE_NOTMUCH
 { "nm_config_file", DT_PATH, "auto" },
@@ -2825,7 +2814,6 @@
 */
 #endif
 
-#ifdef USE_NNTP
 { "nntp_authenticators", DT_STRING, 0 },
 /*
 ** .pp
@@ -2893,7 +2881,6 @@
 ** authentication, NeoMutt will prompt you for your account name when you
 ** connect to news server.
 */
-#endif
 
 { "pager", DT_COMMAND, "builtin" },
 /*
@@ -3485,7 +3472,6 @@
 ** and the $$pipe_sep separator is added after each message.
 */
 
-#ifdef USE_POP
 { "pop_auth_try_all", DT_BOOL, true },
 /*
 ** .pp
@@ -3581,9 +3567,7 @@
 ** .pp
 ** This variable defaults to your user name on the local machine.
 */
-#endif
 
-#ifdef USE_NNTP
 { "post_moderated", DT_QUAD, MUTT_ASKYES },
 /*
 ** .pp
@@ -3592,7 +3576,6 @@
 ** does not support posting to that newsgroup or totally read-only, that
 ** posting will not have an effect.
 */
-#endif
 
 { "postpone", DT_QUAD, MUTT_ASKYES },
 /*
@@ -3634,7 +3617,6 @@
 ** Also see the $$postpone variable.
 */
 
-#ifdef USE_SOCKET
 { "preconnect", DT_STRING, 0 },
 /*
 ** .pp
@@ -3653,7 +3635,6 @@
 ** Note: For this example to work, you must be able to log in to the
 ** remote machine without having to enter a password.
 */
-#endif
 
 { "preferred_languages", DT_SLIST, 0 },
 /*
@@ -4085,14 +4066,12 @@
 ** Also see the $$force_name variable.
 */
 
-#ifdef USE_NNTP
 { "save_unsubscribed", DT_BOOL, false },
 /*
 ** .pp
 ** When \fIset\fP, info about unsubscribed newsgroups will be saved into
 ** "newsrc" file and into cache.
 */
-#endif
 
 { "score", DT_BOOL, true },
 /*
@@ -4195,7 +4174,6 @@
 ** When not set, the default behavior is to show only the chosen alternative.
 */
 
-#ifdef USE_NNTP
 { "show_new_news", DT_BOOL, true },
 /*
 ** .pp
@@ -4211,9 +4189,7 @@
 ** If \fIset\fP, only subscribed newsgroups that contain unread articles
 ** will be displayed in browser.
 */
-#endif
 
-#ifdef USE_SIDEBAR
 { "sidebar_component_depth", DT_NUMBER, 0 },
 /*
 ** .pp
@@ -4400,7 +4376,6 @@
 ** For example: sidebar_width=20 could display 20 ASCII characters, or 10
 ** Chinese characters.
 */
-#endif
 
 { "sig_dashes", DT_BOOL, true },
 /*
@@ -4763,7 +4738,6 @@
 */
 #endif
 
-#ifdef USE_SMTP
 { "smtp_authenticators", DT_SLIST, 0 },
 /*
 ** .pp
@@ -4827,7 +4801,6 @@
 ** .pp
 ** This variable defaults to your user name on the local machine.
 */
-#endif
 
 { "socket_timeout", DT_NUMBER, 30 },
 /*
@@ -4944,13 +4917,6 @@
 ** order (example: "\fCset sort_browser=reverse-date\fP").
 ** .pp
 ** The "unread" value is a synonym for "new".
-*/
-
-{ "browser_sort_dirs_first", DT_BOOL, false },
-/*
-** .pp
-** If this variable is \fIset\fP, the browser will group directories before
-** files.
 */
 
 { "sort_re", DT_BOOL, true },
@@ -5440,7 +5406,6 @@
 ** formatting to the one used by "$$status_format".
 */
 
-#ifdef USE_SOCKET
 { "tunnel", DT_COMMAND, 0 },
 /*
 ** .pp
@@ -5473,7 +5438,6 @@
 ** This setting is appropriate if $$tunnel does not provide security and
 ** could be tampered with by attackers.
 */
-#endif
 
 { "uncollapse_jump", DT_BOOL, false },
 /*
@@ -5676,13 +5640,11 @@
 ** "$tuning" section of the manual for performance considerations.
 */
 
-#ifdef USE_NNTP
 { "x_comment_to", DT_BOOL, false },
 /*
 ** .pp
 ** If \fIset\fP, NeoMutt will add "X-Comment-To:" field (that contains full
 ** name of original article author) to article that followuped to newsgroup.
 */
-#endif
 // clang-format on
 /*--*/

--- a/docs/makedoc_defs.h
+++ b/docs/makedoc_defs.h
@@ -66,17 +66,11 @@
 #ifndef USE_AUTOCRYPT
 #define USE_AUTOCRYPT
 #endif
-#ifndef USE_COMP_MBOX
-#define USE_COMP_MBOX
-#endif
 #ifndef USE_HCACHE
 #define USE_HCACHE
 #endif
 #ifndef USE_HCACHE_COMPRESSION
 #define USE_HCACHE_COMPRESSION
-#endif
-#ifndef USE_IMAP
-#define USE_IMAP
 #endif
 #ifndef USE_LUA
 #define USE_LUA
@@ -84,20 +78,8 @@
 #ifndef USE_NOTMUCH
 #define USE_NOTMUCH
 #endif
-#ifndef USE_POP
-#define USE_POP
-#endif
 #ifndef USE_SASL
 #define USE_SASL
-#endif
-#ifndef USE_SIDEBAR
-#define USE_SIDEBAR
-#endif
-#ifndef USE_SMTP
-#define USE_SMTP
-#endif
-#ifndef USE_SOCKET
-#define USE_SOCKET
 #endif
 #ifndef USE_SSL
 #define USE_SSL

--- a/email/envelope.c
+++ b/email/envelope.c
@@ -122,12 +122,10 @@ void mutt_env_free(struct Envelope **ptr)
   FREE(&env->date);
   FREE(&env->x_label);
   FREE(&env->organization);
-#ifdef USE_NNTP
   FREE(&env->newsgroups);
   FREE(&env->xref);
   FREE(&env->followup_to);
   FREE(&env->x_comment_to);
-#endif
 
   buf_dealloc(&env->spam);
 

--- a/email/envelope.h
+++ b/email/envelope.h
@@ -75,12 +75,10 @@ struct Envelope
   char *date;                          ///< Sent date
   char *x_label;                       ///< X-Label
   char *organization;                  ///< Organisation header
-#ifdef USE_NNTP
   char *newsgroups;                    ///< List of newsgroups
   char *xref;                          ///< List of cross-references
   char *followup_to;                   ///< List of 'followup-to' fields
   char *x_comment_to;                  ///< List of 'X-comment-to' fields
-#endif
   struct Buffer spam;                  ///< Spam header
   struct ListHead references;          ///< message references (in reverse order)
   struct ListHead in_reply_to;         ///< in-reply-to header content

--- a/envelope/functions.c
+++ b/envelope/functions.c
@@ -191,10 +191,8 @@ void update_crypt_info(struct EnvelopeWindowData *wdata)
  */
 static int op_envelope_edit_bcc(struct EnvelopeWindowData *wdata, int op)
 {
-#ifdef USE_NNTP
   if (wdata->is_news)
     return FR_NO_ACTION;
-#endif
   if (!edit_address_list(HDR_BCC, &wdata->email->env->bcc))
     return FR_NO_ACTION;
 
@@ -208,10 +206,8 @@ static int op_envelope_edit_bcc(struct EnvelopeWindowData *wdata, int op)
  */
 static int op_envelope_edit_cc(struct EnvelopeWindowData *wdata, int op)
 {
-#ifdef USE_NNTP
   if (wdata->is_news)
     return FR_NO_ACTION;
-#endif
   if (!edit_address_list(HDR_CC, &wdata->email->env->cc))
     return FR_NO_ACTION;
 
@@ -305,10 +301,8 @@ done:
  */
 static int op_envelope_edit_to(struct EnvelopeWindowData *wdata, int op)
 {
-#ifdef USE_NNTP
   if (wdata->is_news)
     return FR_NO_ACTION;
-#endif
   if (!edit_address_list(HDR_TO, &wdata->email->env->to))
     return FR_NO_ACTION;
 
@@ -433,7 +427,6 @@ static int op_compose_autocrypt_menu(struct EnvelopeWindowData *wdata, int op)
 
 // -----------------------------------------------------------------------------
 
-#ifdef USE_NNTP
 /**
  * op_envelope_edit_followup_to - Edit the Followup-To field - Implements ::envelope_function_t - @ingroup envelope_function_api
  */
@@ -503,7 +496,6 @@ static int op_envelope_edit_x_comment_to(struct EnvelopeWindowData *wdata, int o
   buf_pool_release(&buf);
   return rc;
 }
-#endif
 
 #ifdef MIXMASTER
 /**
@@ -536,19 +528,13 @@ static const struct EnvelopeFunction EnvelopeFunctions[] = {
   { OP_ENVELOPE_EDIT_BCC,                 op_envelope_edit_bcc },
   { OP_ENVELOPE_EDIT_CC,                  op_envelope_edit_cc },
   { OP_ENVELOPE_EDIT_FCC,                 op_envelope_edit_fcc },
-#ifdef USE_NNTP
   { OP_ENVELOPE_EDIT_FOLLOWUP_TO,         op_envelope_edit_followup_to },
-#endif
   { OP_ENVELOPE_EDIT_FROM,                op_envelope_edit_from },
-#ifdef USE_NNTP
   { OP_ENVELOPE_EDIT_NEWSGROUPS,          op_envelope_edit_newsgroups },
-#endif
   { OP_ENVELOPE_EDIT_REPLY_TO,            op_envelope_edit_reply_to },
   { OP_ENVELOPE_EDIT_SUBJECT,             op_envelope_edit_subject },
   { OP_ENVELOPE_EDIT_TO,                  op_envelope_edit_to },
-#ifdef USE_NNTP
   { OP_ENVELOPE_EDIT_X_COMMENT_TO,        op_envelope_edit_x_comment_to },
-#endif
   { 0, NULL },
   // clang-format on
 };

--- a/envelope/private.h
+++ b/envelope/private.h
@@ -47,11 +47,9 @@ enum HeaderField
 #ifdef USE_AUTOCRYPT
   HDR_AUTOCRYPT, ///< "Autocrypt:" and "Recommendation:" fields
 #endif
-#ifdef USE_NNTP
   HDR_NEWSGROUPS, ///< "Newsgroups:" field
   HDR_FOLLOWUPTO, ///< "Followup-To:" field
   HDR_XCOMMENTTO, ///< "X-Comment-To:" field
-#endif
   HDR_CUSTOM_HEADERS, ///< "Headers:" field
   HDR_ATTACH_TITLE,   ///< The "-- Attachments" line
 };

--- a/envelope/wdata.h
+++ b/envelope/wdata.h
@@ -45,9 +45,7 @@ struct EnvelopeWindowData
   short bcc_rows;                  ///< Number of rows used by the 'Bcc:' field
   short sec_rows;                  ///< Number of rows used by the security fields
 
-#ifdef USE_NNTP
   bool is_news;                    ///< Email is a news article
-#endif
 #ifdef USE_AUTOCRYPT
   enum AutocryptRec autocrypt_rec; ///< Autocrypt recommendation
 #endif

--- a/envelope/window.c
+++ b/envelope/window.c
@@ -120,14 +120,12 @@ const char *const Prompts[] = {
   // L10N: The compose menu autocrypt line
   N_("Autocrypt: "),
 #endif
-#ifdef USE_NNTP
   /* L10N: Compose menu field.  May not want to translate. */
   N_("Newsgroups: "),
   /* L10N: Compose menu field.  May not want to translate. */
   N_("Followup-To: "),
   /* L10N: Compose menu field.  May not want to translate. */
   N_("X-Comment-To: "),
-#endif
   N_("Headers: "),
 };
 
@@ -317,7 +315,6 @@ static int calc_envelope(struct MuttWindow *win, struct EnvelopeWindowData *wdat
   struct Envelope *env = e->env;
   const int cols = win->state.cols - MaxHeaderWidth;
 
-#ifdef USE_NNTP
   if (wdata->is_news)
   {
     rows += 2; // 'Newsgroups:' and 'Followup-To:'
@@ -326,7 +323,6 @@ static int calc_envelope(struct MuttWindow *win, struct EnvelopeWindowData *wdat
       rows++;
   }
   else
-#endif
   {
     rows += calc_address(&env->to, cols, &wdata->to_rows);
     rows += calc_address(&env->cc, cols, &wdata->cc_rows);
@@ -724,7 +720,6 @@ static void draw_envelope(struct MuttWindow *win, struct EnvelopeWindowData *wda
   mutt_window_clear(win);
   int row = draw_envelope_addr(HDR_FROM, &e->env->from, win, 0, 1);
 
-#ifdef USE_NNTP
   if (wdata->is_news)
   {
     draw_header(win, row++, HDR_NEWSGROUPS);
@@ -741,7 +736,6 @@ static void draw_envelope(struct MuttWindow *win, struct EnvelopeWindowData *wda
     }
   }
   else
-#endif
   {
     row += draw_envelope_addr(HDR_TO, &e->env->to, win, row, wdata->to_rows);
     row += draw_envelope_addr(HDR_CC, &e->env->cc, win, row, wdata->cc_rows);

--- a/external.c
+++ b/external.c
@@ -49,6 +49,7 @@
 #include "complete/lib.h"
 #include "editor/lib.h"
 #include "history/lib.h"
+#include "imap/lib.h"
 #include "ncrypt/lib.h"
 #include "parse/lib.h"
 #include "progress/lib.h"
@@ -63,9 +64,6 @@
 #include "muttlib.h"
 #include "mx.h"
 #include "protos.h"
-#ifdef USE_IMAP
-#include "imap/lib.h"
-#endif
 #ifdef USE_NOTMUCH
 #include "notmuch/lib.h"
 #endif
@@ -881,7 +879,6 @@ int mutt_save_message(struct Mailbox *m, struct EmailArray *ea,
 
   mutt_message(_("Copying to %s..."), buf_string(buf));
 
-#ifdef USE_IMAP
   enum MailboxType mailbox_type = imap_path_probe(buf_string(buf), NULL);
   if ((m->type == MUTT_IMAP) && (transform_opt == TRANSFORM_NONE) && (mailbox_type == MUTT_IMAP))
   {
@@ -913,7 +910,6 @@ int mutt_save_message(struct Mailbox *m, struct EmailArray *ea,
         goto errcleanup;
     }
   }
-#endif
 
   mutt_file_resolve_symlink(buf);
   m_save = mx_path_resolve(buf_string(buf));
@@ -931,7 +927,6 @@ int mutt_save_message(struct Mailbox *m, struct EmailArray *ea,
   }
   m_save->append = true;
 
-#ifdef USE_COMP_MBOX
   /* If we're saving to a compressed mailbox, the stats won't be updated
    * until the next open.  Until then, improvise. */
   struct Mailbox *m_comp = NULL;
@@ -942,7 +937,7 @@ int mutt_save_message(struct Mailbox *m, struct EmailArray *ea,
   /* We probably haven't been opened yet */
   if (m_comp && (m_comp->msg_count == 0))
     m_comp = NULL;
-#endif
+
   if (msg_count == 1)
   {
     rc = mutt_save_message_mbox(m, e_cur, save_opt, transform_opt, m_save);
@@ -952,7 +947,7 @@ int mutt_save_message(struct Mailbox *m, struct EmailArray *ea,
       m_save->append = old_append;
       goto errcleanup;
     }
-#ifdef USE_COMP_MBOX
+
     if (m_comp)
     {
       m_comp->msg_count++;
@@ -965,7 +960,6 @@ int mutt_save_message(struct Mailbox *m, struct EmailArray *ea,
       if (e_cur->flagged)
         m_comp->msg_flagged++;
     }
-#endif
   }
   else
   {
@@ -985,7 +979,7 @@ int mutt_save_message(struct Mailbox *m, struct EmailArray *ea,
       rc = mutt_save_message_mbox(m, e, save_opt, transform_opt, m_save);
       if (rc != 0)
         break;
-#ifdef USE_COMP_MBOX
+
       if (m_comp)
       {
         struct Email *e2 = e;
@@ -999,7 +993,6 @@ int mutt_save_message(struct Mailbox *m, struct EmailArray *ea,
         if (e2->flagged)
           m_comp->msg_flagged++;
       }
-#endif
     }
     progress_free(&progress);
 

--- a/flags.c
+++ b/flags.c
@@ -81,7 +81,6 @@ void mutt_set_flag(struct Mailbox *m, struct Email *e, enum MessageType flag,
           update = true;
           if (upd_mbox)
             m->msg_deleted++;
-#ifdef USE_IMAP
           /* deleted messages aren't treated as changed elsewhere so that the
            * purge-on-sync option works correctly. This isn't applicable here */
           if (m->type == MUTT_IMAP)
@@ -90,7 +89,6 @@ void mutt_set_flag(struct Mailbox *m, struct Email *e, enum MessageType flag,
             if (upd_mbox)
               m->changed = true;
           }
-#endif
         }
       }
       else if (e->deleted)
@@ -99,7 +97,6 @@ void mutt_set_flag(struct Mailbox *m, struct Email *e, enum MessageType flag,
         update = true;
         if (upd_mbox)
           m->msg_deleted--;
-#ifdef USE_IMAP
         /* see my comment above */
         if (m->type == MUTT_IMAP)
         {
@@ -107,7 +104,6 @@ void mutt_set_flag(struct Mailbox *m, struct Email *e, enum MessageType flag,
           if (upd_mbox)
             m->changed = true;
         }
-#endif
         /* If the user undeletes a message which is marked as
          * "trash" in the maildir folder on disk, the folder has
          * been changed, and is marked accordingly.  However, we do

--- a/globals.c
+++ b/globals.c
@@ -72,10 +72,8 @@ bool OptKeepQuiet;          ///< (pseudo) shut up the message and refresh functi
 bool OptMsgErr;             ///< (pseudo) used by mutt_error/mutt_message
 bool OptNeedRescore;        ///< (pseudo) set when the 'score' command is used
 bool OptNeedResort;         ///< (pseudo) used to force a re-sort
-#ifdef USE_NNTP
 bool OptNews;               ///< (pseudo) used to change reader mode
 bool OptNewsSend;           ///< (pseudo) used to change behavior when posting
-#endif
 bool OptNoCurses;           ///< (pseudo) when sending in batch mode
 bool OptPgpCheckTrust;      ///< (pseudo) used by dlg_pgp()
 bool OptResortInit;         ///< (pseudo) used to force the next resort to be from scratch

--- a/globals.h
+++ b/globals.h
@@ -67,10 +67,8 @@ extern bool OptKeepQuiet;           ///< (pseudo) shut up the message and refres
 extern bool OptMsgErr;              ///< (pseudo) used by mutt_error/mutt_message
 extern bool OptNeedRescore;         ///< (pseudo) set when the 'score' command is used
 extern bool OptNeedResort;          ///< (pseudo) used to force a re-sort
-#ifdef USE_NNTP
 extern bool OptNews;                ///< (pseudo) used to change reader mode
 extern bool OptNewsSend;            ///< (pseudo) used to change behavior when posting
-#endif
 extern bool OptNoCurses;            ///< (pseudo) when sending in batch mode
 extern bool OptPgpCheckTrust;       ///< (pseudo) used by dlg_pgp()
 extern bool OptResortInit;          ///< (pseudo) used to force the next resort to be from scratch

--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -616,11 +616,9 @@ unsigned char *serial_dump_envelope(const struct Envelope *env,
   d = serial_dump_stailq(&env->in_reply_to, d, off, false);
   d = serial_dump_stailq(&env->userhdrs, d, off, convert);
 
-#ifdef USE_NNTP
   d = serial_dump_char(env->xref, d, off, false);
   d = serial_dump_char(env->followup_to, d, off, false);
   d = serial_dump_char(env->x_comment_to, d, off, convert);
-#endif
 
   return d;
 }
@@ -674,11 +672,9 @@ void serial_restore_envelope(struct Envelope *env, const unsigned char *d, int *
   serial_restore_stailq(&env->in_reply_to, d, off, false);
   serial_restore_stailq(&env->userhdrs, d, off, convert);
 
-#ifdef USE_NNTP
   serial_restore_char(&env->xref, d, off, false);
   serial_restore_char(&env->followup_to, d, off, false);
   serial_restore_char(&env->x_comment_to, d, off, convert);
-#endif
 }
 
 /**

--- a/hdrline.c
+++ b/hdrline.c
@@ -980,11 +980,9 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       mutt_str_copy(buf, hfi->pager_progress, buflen);
       break;
 
-#ifdef USE_NNTP
     case 'q':
       mutt_format_s(buf, buflen, prec, e->env->newsgroups ? e->env->newsgroups : "");
       break;
-#endif
 
     case 'r':
     {
@@ -1139,7 +1137,6 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       }
       break;
 
-#ifdef USE_NNTP
     case 'x':
       if (!optional)
       {
@@ -1150,7 +1147,6 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         optional = false;
       }
       break;
-#endif
 
     case 'X':
     {

--- a/hook.c
+++ b/hook.c
@@ -41,6 +41,7 @@
 #include "alias/lib.h"
 #include "hook.h"
 #include "attach/lib.h"
+#include "compmbox/lib.h"
 #include "index/lib.h"
 #include "ncrypt/lib.h"
 #include "parse/lib.h"
@@ -51,9 +52,6 @@
 #include "hdrline.h"
 #include "muttlib.h"
 #include "mx.h"
-#ifdef USE_COMP_MBOX
-#include "compmbox/lib.h"
-#endif
 
 /**
  * struct Hook - A list of user hooks
@@ -254,7 +252,6 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
     }
     buf_pool_release(&tmp);
   }
-#ifdef USE_COMP_MBOX
   else if (data & (MUTT_APPEND_HOOK | MUTT_OPEN_HOOK | MUTT_CLOSE_HOOK))
   {
     if (mutt_comp_valid_command(buf_string(cmd)) == 0)
@@ -263,7 +260,6 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
       goto cleanup;
     }
   }
-#endif
   else if (c_default_hook && (~data & MUTT_GLOBAL_HOOK) &&
            !(data & (MUTT_ACCOUNT_HOOK)) && (!WithCrypto || !(data & MUTT_CRYPT_HOOK)))
   {

--- a/hook.h
+++ b/hook.h
@@ -46,11 +46,9 @@ typedef uint32_t HookFlags;          ///< Flags for mutt_parse_hook(), e.g. #MUT
 #define MUTT_ACCOUNT_HOOK  (1 << 9)  ///< account-hook: when changing between accounts
 #define MUTT_REPLY_HOOK    (1 << 10) ///< reply-hook: when replying to an email
 #define MUTT_SEND2_HOOK    (1 << 11) ///< send2-hook: when changing fields in the compose menu
-#ifdef USE_COMP_MBOX
 #define MUTT_OPEN_HOOK     (1 << 12) ///< open-hook: to read a compressed mailbox
 #define MUTT_APPEND_HOOK   (1 << 13) ///< append-hook: append to a compressed mailbox
 #define MUTT_CLOSE_HOOK    (1 << 14) ///< close-hook: write to a compressed mailbox
-#endif
 #define MUTT_IDXFMTHOOK    (1 << 15) ///< index-format-hook: customise the format of the index
 #define MUTT_TIMEOUT_HOOK  (1 << 16) ///< timeout-hook: run a command periodically
 #define MUTT_STARTUP_HOOK  (1 << 17) ///< startup-hook: run when starting NeoMutt

--- a/index/functions.c
+++ b/index/functions.c
@@ -46,11 +46,14 @@
 #include "browser/lib.h"
 #include "editor/lib.h"
 #include "history/lib.h"
+#include "imap/lib.h"
 #include "key/lib.h"
 #include "menu/lib.h"
 #include "ncrypt/lib.h"
+#include "nntp/lib.h"
 #include "pager/lib.h"
 #include "pattern/lib.h"
+#include "pop/lib.h"
 #include "progress/lib.h"
 #include "question/lib.h"
 #include "send/lib.h"
@@ -64,6 +67,7 @@
 #include "muttlib.h"
 #include "mview.h"
 #include "mx.h"
+#include "nntp/mdata.h"
 #include "private_data.h"
 #include "protos.h"
 #include "shared_data.h"
@@ -73,16 +77,6 @@
 #endif
 #ifdef USE_NOTMUCH
 #include "notmuch/lib.h"
-#endif
-#ifdef USE_IMAP
-#include "imap/lib.h"
-#endif
-#ifdef USE_NNTP
-#include "nntp/lib.h"
-#include "nntp/mdata.h"
-#endif
-#ifdef USE_POP
-#include "pop/lib.h"
 #endif
 #ifdef ENABLE_NLS
 #include <libintl.h>
@@ -103,15 +97,11 @@ const struct MenuFuncOp OpIndex[] = { /* map: index */
 #endif
   { "bounce-message",                OP_BOUNCE_MESSAGE },
   { "break-thread",                  OP_MAIN_BREAK_THREAD },
-#ifdef USE_NNTP
   { "catchup",                       OP_CATCHUP },
-#endif
   { "change-folder",                 OP_MAIN_CHANGE_FOLDER },
   { "change-folder-readonly",        OP_MAIN_CHANGE_FOLDER_READONLY },
-#ifdef USE_NNTP
   { "change-newsgroup",              OP_MAIN_CHANGE_GROUP },
   { "change-newsgroup-readonly",     OP_MAIN_CHANGE_GROUP_READONLY },
-#endif
 #ifdef USE_NOTMUCH
   { "change-vfolder",                OP_MAIN_CHANGE_VFOLDER },
 #endif
@@ -143,27 +133,19 @@ const struct MenuFuncOp OpIndex[] = { /* map: index */
 #endif
   { "exit",                          OP_EXIT },
   { "extract-keys",                  OP_EXTRACT_KEYS },
-#ifdef USE_POP
   { "fetch-mail",                    OP_MAIN_FETCH_MAIL },
-#endif
   { "flag-message",                  OP_FLAG_MESSAGE },
-#ifdef USE_NNTP
   { "followup-message",              OP_FOLLOWUP },
-#endif
   { "forget-passphrase",             OP_FORGET_PASSPHRASE },
   { "forward-message",               OP_FORWARD_MESSAGE },
-#ifdef USE_NNTP
   { "forward-to-group",              OP_FORWARD_TO_GROUP },
   { "get-children",                  OP_GET_CHILDREN },
   { "get-message",                   OP_GET_MESSAGE },
   { "get-parent",                    OP_GET_PARENT },
-#endif
   { "group-chat-reply",              OP_GROUP_CHAT_REPLY },
   { "group-reply",                   OP_GROUP_REPLY },
-#ifdef USE_IMAP
   { "imap-fetch-mail",               OP_MAIN_IMAP_FETCH },
   { "imap-logout-all",               OP_MAIN_IMAP_LOGOUT_ALL },
-#endif
   { "limit",                         OP_MAIN_LIMIT },
   { "limit-current-thread",          OP_LIMIT_CURRENT_THREAD },
   { "link-threads",                  OP_MAIN_LINK_THREADS },
@@ -188,9 +170,7 @@ const struct MenuFuncOp OpIndex[] = { /* map: index */
   { "parent-message",                OP_MAIN_PARENT_MESSAGE },
   { "pipe-entry",                    OP_PIPE },
   { "pipe-message",                  OP_PIPE },
-#ifdef USE_NNTP
   { "post-message",                  OP_POST },
-#endif
   { "previous-new",                  OP_MAIN_PREV_NEW },
   { "previous-new-then-unread",      OP_MAIN_PREV_NEW_THEN_UNREAD },
   { "previous-subthread",            OP_MAIN_PREV_SUBTHREAD },
@@ -206,16 +186,13 @@ const struct MenuFuncOp OpIndex[] = { /* map: index */
   { "read-subthread",                OP_MAIN_READ_SUBTHREAD },
   { "read-thread",                   OP_MAIN_READ_THREAD },
   { "recall-message",                OP_RECALL_MESSAGE },
-#ifdef USE_NNTP
   { "reconstruct-thread",            OP_RECONSTRUCT_THREAD },
-#endif
   { "reply",                         OP_REPLY },
   { "resend-message",                OP_RESEND },
   { "root-message",                  OP_MAIN_ROOT_MESSAGE },
   { "save-message",                  OP_SAVE },
   { "set-flag",                      OP_MAIN_SET_FLAG },
   { "show-limit",                    OP_MAIN_SHOW_LIMIT },
-#ifdef USE_SIDEBAR
   { "sidebar-first",                 OP_SIDEBAR_FIRST },
   { "sidebar-last",                  OP_SIDEBAR_LAST },
   { "sidebar-next",                  OP_SIDEBAR_NEXT },
@@ -227,7 +204,6 @@ const struct MenuFuncOp OpIndex[] = { /* map: index */
   { "sidebar-prev-new",              OP_SIDEBAR_PREV_NEW },
   { "sidebar-toggle-virtual",        OP_SIDEBAR_TOGGLE_VIRTUAL },
   { "sidebar-toggle-visible",        OP_SIDEBAR_TOGGLE_VISIBLE },
-#endif
   { "sort-mailbox",                  OP_SORT },
   { "sort-reverse",                  OP_SORT_REVERSE },
   { "sync-mailbox",                  OP_MAIN_SYNC_FOLDER },
@@ -294,17 +270,13 @@ const struct MenuOpSeq IndexDefaultBindings[] = { /* map: index */
   { OP_MAIN_BREAK_THREAD,                  "#" },
   { OP_MAIN_CHANGE_FOLDER,                 "c" },
   { OP_MAIN_CHANGE_FOLDER_READONLY,        "\033c" },          // <Alt-c>
-#ifdef USE_NNTP
   { OP_MAIN_CHANGE_GROUP,                  "i" },
   { OP_MAIN_CHANGE_GROUP_READONLY,         "\033i" },          // <Alt-i>
-#endif
   { OP_MAIN_CLEAR_FLAG,                    "W" },
   { OP_MAIN_COLLAPSE_ALL,                  "\033V" },          // <Alt-V>
   { OP_MAIN_COLLAPSE_THREAD,               "\033v" },          // <Alt-v>
   { OP_MAIN_DELETE_PATTERN,                "D" },
-#ifdef USE_POP
   { OP_MAIN_FETCH_MAIL,                    "G" },
-#endif
   { OP_MAIN_LIMIT,                         "l" },
   { OP_MAIN_LINK_THREADS,                  "&" },
   { OP_MAIN_NEXT_NEW_THEN_UNREAD,          "\t" },             // <Tab>
@@ -2068,7 +2040,6 @@ static int op_pipe(struct IndexSharedData *shared, struct IndexPrivateData *priv
   mutt_pipe_message(shared->mailbox, &ea);
   ARRAY_FREE(&ea);
 
-#ifdef USE_IMAP
   /* in an IMAP folder index with imap_peek=no, piping could change
    * new or old messages status to read. Redraw what's needed.  */
   const bool c_imap_peek = cs_subset_bool(shared->sub, "imap_peek");
@@ -2076,7 +2047,6 @@ static int op_pipe(struct IndexSharedData *shared, struct IndexPrivateData *priv
   {
     menu_queue_redraw(priv->menu, (priv->tag_prefix ? MENU_REDRAW_INDEX : MENU_REDRAW_CURRENT));
   }
-#endif
 
   return FR_SUCCESS;
 }
@@ -2107,7 +2077,6 @@ static int op_print(struct IndexSharedData *shared, struct IndexPrivateData *pri
   mutt_print_message(shared->mailbox, &ea);
   ARRAY_FREE(&ea);
 
-#ifdef USE_IMAP
   /* in an IMAP folder index with imap_peek=no, printing could change
    * new or old messages status to read. Redraw what's needed.  */
   const bool c_imap_peek = cs_subset_bool(shared->sub, "imap_peek");
@@ -2115,7 +2084,6 @@ static int op_print(struct IndexSharedData *shared, struct IndexPrivateData *pri
   {
     menu_queue_redraw(priv->menu, (priv->tag_prefix ? MENU_REDRAW_INDEX : MENU_REDRAW_CURRENT));
   }
-#endif
 
   return FR_SUCCESS;
 }
@@ -2546,7 +2514,6 @@ static int op_autocrypt_acct_menu(struct IndexSharedData *shared,
 }
 #endif
 
-#ifdef USE_IMAP
 /**
  * op_main_imap_fetch - Force retrieval of mail from IMAP server - Implements ::index_function_t - @ingroup index_function_api
  */
@@ -2591,9 +2558,7 @@ static int op_main_imap_logout_all(struct IndexSharedData *shared,
 
   return FR_SUCCESS;
 }
-#endif
 
-#ifdef USE_NNTP
 /**
  * op_catchup - Mark all articles in newsgroup as read - Implements ::index_function_t - @ingroup index_function_api
  */
@@ -2910,7 +2875,6 @@ static int op_post(struct IndexSharedData *shared, struct IndexPrivateData *priv
 
   return op_reply(shared, priv, OP_REPLY);
 }
-#endif
 
 #ifdef USE_NOTMUCH
 /**
@@ -3073,7 +3037,6 @@ static int op_main_windowed_vfolder(struct IndexSharedData *shared,
 }
 #endif
 
-#ifdef USE_POP
 /**
  * op_main_fetch_mail - Retrieve mail from POP server - Implements ::index_function_t - @ingroup index_function_api
  */
@@ -3084,7 +3047,6 @@ static int op_main_fetch_mail(struct IndexSharedData *shared,
   menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
   return FR_SUCCESS;
 }
-#endif
 
 // -----------------------------------------------------------------------------
 
@@ -3149,6 +3111,7 @@ static const struct IndexFunction IndexFunctions[] = {
   { OP_ALIAS_DIALOG,                        op_alias_dialog,                      CHECK_NO_FLAGS },
   { OP_ATTACHMENT_EDIT_TYPE,                op_attachment_edit_type,              CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_BOUNCE_MESSAGE,                      op_bounce_message,                    CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
+  { OP_CATCHUP,                             op_catchup,                           CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY },
   { OP_CHECK_TRADITIONAL,                   op_check_traditional,                 CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_COMPOSE_TO_SENDER,                   op_compose_to_sender,                 CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_COPY_MESSAGE,                        op_save,                              CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
@@ -3170,8 +3133,13 @@ static const struct IndexFunction IndexFunctions[] = {
   { OP_EXIT,                                op_exit,                              CHECK_NO_FLAGS },
   { OP_EXTRACT_KEYS,                        op_extract_keys,                      CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_FLAG_MESSAGE,                        op_flag_message,                      CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_VISIBLE },
+  { OP_FOLLOWUP,                            op_post,                              CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_FORGET_PASSPHRASE,                   op_forget_passphrase,                 CHECK_NO_FLAGS },
   { OP_FORWARD_MESSAGE,                     op_forward_message,                   CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
+  { OP_FORWARD_TO_GROUP,                    op_post,                              CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
+  { OP_GET_CHILDREN,                        op_get_children,                      CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_VISIBLE },
+  { OP_GET_MESSAGE,                         op_get_message,                       CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_READONLY },
+  { OP_GET_PARENT,                          op_get_message,                       CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_GROUP_CHAT_REPLY,                    op_group_reply,                       CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_GROUP_REPLY,                         op_group_reply,                       CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_JUMP,                                op_jump,                              CHECK_IN_MAILBOX },
@@ -3194,10 +3162,15 @@ static const struct IndexFunction IndexFunctions[] = {
   { OP_MAIN_BREAK_THREAD,                   op_main_break_thread,                 CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_VISIBLE },
   { OP_MAIN_CHANGE_FOLDER,                  op_main_change_folder,                CHECK_NO_FLAGS },
   { OP_MAIN_CHANGE_FOLDER_READONLY,         op_main_change_folder,                CHECK_NO_FLAGS },
+  { OP_MAIN_CHANGE_GROUP,                   op_main_change_group,                 CHECK_NO_FLAGS },
+  { OP_MAIN_CHANGE_GROUP_READONLY,          op_main_change_group,                 CHECK_NO_FLAGS },
   { OP_MAIN_CLEAR_FLAG,                     op_main_set_flag,                     CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_VISIBLE },
   { OP_MAIN_COLLAPSE_ALL,                   op_main_collapse_all,                 CHECK_IN_MAILBOX },
   { OP_MAIN_COLLAPSE_THREAD,                op_main_collapse_thread,              CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_MAIN_DELETE_PATTERN,                 op_main_delete_pattern,               CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_READONLY },
+  { OP_MAIN_FETCH_MAIL,                     op_main_fetch_mail,                   CHECK_ATTACH },
+  { OP_MAIN_IMAP_FETCH,                     op_main_imap_fetch,                   CHECK_NO_FLAGS },
+  { OP_MAIN_IMAP_LOGOUT_ALL,                op_main_imap_logout_all,              CHECK_NO_FLAGS },
   { OP_MAIN_LIMIT,                          op_main_limit,                        CHECK_IN_MAILBOX },
   { OP_MAIN_LINK_THREADS,                   op_main_link_threads,                 CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_VISIBLE },
   { OP_MAIN_MODIFY_TAGS,                    op_main_modify_tags,                  CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_VISIBLE },
@@ -3229,6 +3202,7 @@ static const struct IndexFunction IndexFunctions[] = {
   { OP_MARK_MSG,                            op_mark_msg,                          CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_NEXT_ENTRY,                          op_next_entry,                        CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_PIPE,                                op_pipe,                              CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
+  { OP_POST,                                op_post,                              CHECK_ATTACH | CHECK_IN_MAILBOX },
   { OP_PREV_ENTRY,                          op_prev_entry,                        CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_PRINT,                               op_print,                             CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_PURGE_MESSAGE,                       op_delete,                            CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_VISIBLE },
@@ -3236,6 +3210,7 @@ static const struct IndexFunction IndexFunctions[] = {
   { OP_QUERY,                               op_query,                             CHECK_ATTACH },
   { OP_QUIT,                                op_quit,                              CHECK_NO_FLAGS },
   { OP_RECALL_MESSAGE,                      op_recall_message,                    CHECK_ATTACH },
+  { OP_RECONSTRUCT_THREAD,                  op_get_children,                      CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_VISIBLE },
   { OP_REPLY,                               op_reply,                             CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_RESEND,                              op_resend,                            CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_SAVE,                                op_save,                              CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
@@ -3259,22 +3234,6 @@ static const struct IndexFunction IndexFunctions[] = {
 #ifdef USE_AUTOCRYPT
   { OP_AUTOCRYPT_ACCT_MENU,                 op_autocrypt_acct_menu,               CHECK_NO_FLAGS },
 #endif
-#ifdef USE_IMAP
-  { OP_MAIN_IMAP_FETCH,                     op_main_imap_fetch,                   CHECK_NO_FLAGS },
-  { OP_MAIN_IMAP_LOGOUT_ALL,                op_main_imap_logout_all,              CHECK_NO_FLAGS },
-#endif
-#ifdef USE_NNTP
-  { OP_CATCHUP,                             op_catchup,                           CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY },
-  { OP_FOLLOWUP,                            op_post,                              CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
-  { OP_FORWARD_TO_GROUP,                    op_post,                              CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
-  { OP_GET_CHILDREN,                        op_get_children,                      CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_VISIBLE },
-  { OP_GET_MESSAGE,                         op_get_message,                       CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_READONLY },
-  { OP_GET_PARENT,                          op_get_message,                       CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
-  { OP_MAIN_CHANGE_GROUP,                   op_main_change_group,                 CHECK_NO_FLAGS },
-  { OP_MAIN_CHANGE_GROUP_READONLY,          op_main_change_group,                 CHECK_NO_FLAGS },
-  { OP_POST,                                op_post,                              CHECK_ATTACH | CHECK_IN_MAILBOX },
-  { OP_RECONSTRUCT_THREAD,                  op_get_children,                      CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_VISIBLE },
-#endif
 #ifdef USE_NOTMUCH
   { OP_MAIN_CHANGE_VFOLDER,                 op_main_change_folder,                CHECK_NO_FLAGS },
   { OP_MAIN_ENTIRE_THREAD,                  op_main_entire_thread,                CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
@@ -3283,9 +3242,6 @@ static const struct IndexFunction IndexFunctions[] = {
   { OP_MAIN_WINDOWED_VFOLDER_BACKWARD,      op_main_windowed_vfolder,             CHECK_IN_MAILBOX },
   { OP_MAIN_WINDOWED_VFOLDER_FORWARD,       op_main_windowed_vfolder,             CHECK_IN_MAILBOX },
   { OP_MAIN_WINDOWED_VFOLDER_RESET,         op_main_windowed_vfolder,             CHECK_IN_MAILBOX },
-#endif
-#ifdef USE_POP
-  { OP_MAIN_FETCH_MAIL,                     op_main_fetch_mail,                   CHECK_ATTACH },
 #endif
   { 0, NULL, CHECK_NO_FLAGS },
   // clang-format on

--- a/init.c
+++ b/init.c
@@ -45,31 +45,25 @@
 #include "gui/lib.h"
 #include "init.h"
 #include "color/lib.h"
+#include "compmbox/lib.h"
 #include "history/lib.h"
+#include "imap/lib.h"
 #include "key/lib.h"
+#include "menu/lib.h"
 #include "notmuch/lib.h"
 #include "parse/lib.h"
+#include "sidebar/lib.h"
 #include "commands.h"
 #include "globals.h"
 #include "hook.h"
 #include "mutt_logging.h"
+#include "muttlib.h"
+#include "protos.h"
 #ifndef DOMAIN
 #include "conn/lib.h"
 #endif
 #ifdef USE_LUA
 #include "mutt_lua.h"
-#endif
-#include "menu/lib.h"
-#include "muttlib.h"
-#include "protos.h"
-#ifdef USE_SIDEBAR
-#include "sidebar/lib.h"
-#endif
-#ifdef USE_COMP_MBOX
-#include "compmbox/lib.h"
-#endif
-#ifdef USE_IMAP
-#include "imap/lib.h"
 #endif
 
 /**
@@ -268,9 +262,7 @@ void mutt_opts_cleanup(void)
   source_stack_cleanup();
 
   alias_cleanup();
-#ifdef USE_SIDEBAR
   sb_cleanup();
-#endif
 
   mutt_regexlist_free(&MailLists);
   mutt_regexlist_free(&NoSpamList);
@@ -333,21 +325,15 @@ int mutt_init(struct ConfigSet *cs, const char *dlevel, const char *dfile,
   alias_init();
   commands_init();
   hooks_init();
-#ifdef USE_COMP_MBOX
   mutt_comp_init();
-#endif
-#ifdef USE_IMAP
   imap_init();
-#endif
 #ifdef USE_LUA
   mutt_lua_init();
 #endif
   driver_tags_init();
 
   menu_init();
-#ifdef USE_SIDEBAR
   sb_init();
-#endif
 #ifdef USE_NOTMUCH
   nm_init();
 #endif

--- a/mutt_account.c
+++ b/mutt_account.c
@@ -84,7 +84,6 @@ void mutt_account_tourl(struct ConnAccount *cac, struct Url *url)
   url->port = 0;
   url->path = NULL;
 
-#ifdef USE_IMAP
   if (cac->type == MUTT_ACCT_TYPE_IMAP)
   {
     if (cac->flags & MUTT_ACCT_SSL)
@@ -92,9 +91,7 @@ void mutt_account_tourl(struct ConnAccount *cac, struct Url *url)
     else
       url->scheme = U_IMAP;
   }
-#endif
 
-#ifdef USE_POP
   if (cac->type == MUTT_ACCT_TYPE_POP)
   {
     if (cac->flags & MUTT_ACCT_SSL)
@@ -102,9 +99,7 @@ void mutt_account_tourl(struct ConnAccount *cac, struct Url *url)
     else
       url->scheme = U_POP;
   }
-#endif
 
-#ifdef USE_SMTP
   if (cac->type == MUTT_ACCT_TYPE_SMTP)
   {
     if (cac->flags & MUTT_ACCT_SSL)
@@ -112,9 +107,7 @@ void mutt_account_tourl(struct ConnAccount *cac, struct Url *url)
     else
       url->scheme = U_SMTP;
   }
-#endif
 
-#ifdef USE_NNTP
   if (cac->type == MUTT_ACCT_TYPE_NNTP)
   {
     if (cac->flags & MUTT_ACCT_SSL)
@@ -122,7 +115,6 @@ void mutt_account_tourl(struct ConnAccount *cac, struct Url *url)
     else
       url->scheme = U_NNTP;
   }
-#endif
 
   url->host = cac->host;
   if (cac->flags & MUTT_ACCT_PORT)

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -696,30 +696,22 @@ static void init_variables(struct ConfigSet *cs)
 #endif
   CONFIG_INIT_VARS(cs, helpbar);
   CONFIG_INIT_VARS(cs, history);
-#if defined(USE_IMAP)
   CONFIG_INIT_VARS(cs, imap);
-#endif
   CONFIG_INIT_VARS(cs, index);
   CONFIG_INIT_VARS(cs, maildir);
   CONFIG_INIT_VARS(cs, mh);
   CONFIG_INIT_VARS(cs, mbox);
   CONFIG_INIT_VARS(cs, menu);
   CONFIG_INIT_VARS(cs, ncrypt);
-#if defined(USE_NNTP)
   CONFIG_INIT_VARS(cs, nntp);
-#endif
 #if defined(USE_NOTMUCH)
   CONFIG_INIT_VARS(cs, notmuch);
 #endif
   CONFIG_INIT_VARS(cs, pager);
   CONFIG_INIT_VARS(cs, pattern);
-#if defined(USE_POP)
   CONFIG_INIT_VARS(cs, pop);
-#endif
   CONFIG_INIT_VARS(cs, send);
-#if defined(USE_SIDEBAR)
   CONFIG_INIT_VARS(cs, sidebar);
-#endif
 }
 
 /**

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -264,9 +264,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *e,
    * $edit_headers set, we remove References: as they're likely invalid;
    * we can simply compare strings as we don't generate References for
    * multiple Message-Ids in IRT anyways */
-#ifdef USE_NNTP
   if (!OptNewsSend)
-#endif
   {
     if (!STAILQ_EMPTY(&e->env->in_reply_to) &&
         (STAILQ_EMPTY(&env_new->in_reply_to) ||

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -168,10 +168,8 @@ int mutt_mailbox_check(struct Mailbox *m_cur, CheckStatsFlags flags)
   if (TAILQ_EMPTY(&NeoMutt->accounts)) // fast return if there are no mailboxes
     return 0;
 
-#ifdef USE_IMAP
   if (flags & MUTT_MAILBOX_CHECK_FORCE)
     mutt_update_num_postponed();
-#endif
 
   const short c_mail_check = cs_subset_number(NeoMutt->sub, "mail_check");
   const bool c_mail_check_stats = cs_subset_bool(NeoMutt->sub, "mail_check_stats");
@@ -194,11 +192,8 @@ int mutt_mailbox_check(struct Mailbox *m_cur, CheckStatsFlags flags)
 
   /* check device ID and serial number instead of comparing paths */
   struct stat st_cur = { 0 };
-  if (!m_cur || (m_cur->type == MUTT_IMAP) || (m_cur->type == MUTT_POP)
-#ifdef USE_NNTP
-      || (m_cur->type == MUTT_NNTP)
-#endif
-      || stat(mailbox_path(m_cur), &st_cur) != 0)
+  if (!m_cur || (m_cur->type == MUTT_IMAP) || (m_cur->type == MUTT_POP) ||
+      (m_cur->type == MUTT_NNTP) || stat(mailbox_path(m_cur), &st_cur) != 0)
   {
     st_cur.st_dev = 0;
     st_cur.st_ino = 0;

--- a/muttlib.c
+++ b/muttlib.c
@@ -52,6 +52,7 @@
 #include "browser/lib.h"
 #include "editor/lib.h"
 #include "history/lib.h"
+#include "imap/lib.h"
 #include "ncrypt/lib.h"
 #include "parse/lib.h"
 #include "question/lib.h"
@@ -60,9 +61,6 @@
 #include "hook.h"
 #include "mx.h"
 #include "protos.h"
-#ifdef USE_IMAP
-#include "imap/lib.h"
-#endif
 
 /// Accepted XDG environment variables
 static const char *XdgEnvVars[] = {
@@ -316,12 +314,10 @@ void buf_expand_path_regex(struct Buffer *buf, bool regex)
   buf_pool_release(&q);
   buf_pool_release(&tmp);
 
-#ifdef USE_IMAP
   /* Rewrite IMAP path in canonical form - aids in string comparisons of
    * folders. May possibly fail, in which case buf should be the same. */
   if (imap_path_probe(buf_string(buf), NULL) == MUTT_IMAP)
     imap_expand_path(buf);
-#endif
 }
 
 /**
@@ -1328,13 +1324,11 @@ int mutt_save_confirm(const char *s, struct stat *st)
 
   enum MailboxType type = mx_path_probe(s);
 
-#ifdef USE_POP
   if (type == MUTT_POP)
   {
     mutt_error(_("Can't save message to POP mailbox"));
     return 1;
   }
-#endif
 
   if ((type != MUTT_MAILBOX_ERROR) && (type != MUTT_UNKNOWN) && (mx_access(s, W_OK) == 0))
   {
@@ -1353,13 +1347,11 @@ int mutt_save_confirm(const char *s, struct stat *st)
     }
   }
 
-#ifdef USE_NNTP
   if (type == MUTT_NNTP)
   {
     mutt_error(_("Can't save message to news server"));
     return 0;
   }
-#endif
 
   if (stat(s, st) != -1)
   {

--- a/mview.c
+++ b/mview.c
@@ -308,10 +308,8 @@ static void update_tables(struct MailboxView *mv)
         mutt_hash_delete(m->id_hash, m->emails[i]->env->message_id, m->emails[i]);
       mutt_label_hash_remove(m, m->emails[i]);
 
-#ifdef USE_IMAP
       if (m->type == MUTT_IMAP)
         imap_notify_delete_email(m, m->emails[i]);
-#endif
 
       mailbox_gc_add(m->emails[i]);
       m->emails[i] = NULL;

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -51,6 +51,7 @@
 #include "key/lib.h"
 #include "menu/lib.h"
 #include "pattern/lib.h"
+#include "sidebar/lib.h"
 #include "display.h"
 #include "functions.h"
 #include "globals.h"
@@ -61,9 +62,6 @@
 #include "private_data.h"
 #include "protos.h"
 #include "status.h"
-#ifdef USE_SIDEBAR
-#include "sidebar/lib.h"
-#endif
 
 /// Braille display: row to leave the cursor
 int BrailleRow = -1;
@@ -106,7 +104,6 @@ static const struct Mapping PagerNormalHelp[] = {
   // clang-format on
 };
 
-#ifdef USE_NNTP
 /// Help Bar for the Pager of an NNTP Mailbox
 static const struct Mapping PagerNewsHelp[] = {
   // clang-format off
@@ -121,7 +118,6 @@ static const struct Mapping PagerNewsHelp[] = {
   { NULL, 0 },
   // clang-format on
 };
-#endif
 
 /**
  * pager_queue_redraw - Queue a request for a redraw
@@ -541,10 +537,8 @@ int dlg_pager(struct PagerView *pview)
     {
       if ((rc == FR_UNKNOWN) && priv->pview->win_index)
         rc = index_function_dispatcher(priv->pview->win_index, op);
-#ifdef USE_SIDEBAR
       if (rc == FR_UNKNOWN)
         rc = sb_function_dispatcher(win_sidebar, op);
-#endif
     }
     if (rc == FR_UNKNOWN)
       rc = global_function_dispatcher(NULL, op);

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -74,10 +74,8 @@ const struct MenuFuncOp OpPager[] = { /* map: pager */
   { "break-thread",                  OP_MAIN_BREAK_THREAD },
   { "change-folder",                 OP_MAIN_CHANGE_FOLDER },
   { "change-folder-readonly",        OP_MAIN_CHANGE_FOLDER_READONLY },
-#ifdef USE_NNTP
   { "change-newsgroup",              OP_MAIN_CHANGE_GROUP },
   { "change-newsgroup-readonly",     OP_MAIN_CHANGE_GROUP_READONLY },
-#endif
 #ifdef USE_NOTMUCH
   { "change-vfolder",                OP_MAIN_CHANGE_VFOLDER },
 #endif
@@ -108,23 +106,17 @@ const struct MenuFuncOp OpPager[] = { /* map: pager */
   { "exit",                          OP_EXIT },
   { "extract-keys",                  OP_EXTRACT_KEYS },
   { "flag-message",                  OP_FLAG_MESSAGE },
-#ifdef USE_NNTP
   { "followup-message",              OP_FOLLOWUP },
-#endif
   { "forget-passphrase",             OP_FORGET_PASSPHRASE },
   { "forward-message",               OP_FORWARD_MESSAGE },
-#ifdef USE_NNTP
   { "forward-to-group",              OP_FORWARD_TO_GROUP },
-#endif
   { "group-chat-reply",              OP_GROUP_CHAT_REPLY },
   { "group-reply",                   OP_GROUP_REPLY },
   { "half-down",                     OP_HALF_DOWN },
   { "half-up",                       OP_HALF_UP },
   { "help",                          OP_HELP },
-#ifdef USE_IMAP
   { "imap-fetch-mail",               OP_MAIN_IMAP_FETCH },
   { "imap-logout-all",               OP_MAIN_IMAP_LOGOUT_ALL },
-#endif
   { "jump",                          OP_JUMP },
   { "jump",                          OP_JUMP_1 },
   { "jump",                          OP_JUMP_2 },
@@ -160,9 +152,7 @@ const struct MenuFuncOp OpPager[] = { /* map: pager */
   { "parent-message",                OP_MAIN_PARENT_MESSAGE },
   { "pipe-entry",                    OP_PIPE },
   { "pipe-message",                  OP_PIPE },
-#ifdef USE_NNTP
   { "post-message",                  OP_POST },
-#endif
   { "previous-entry",                OP_PREV_ENTRY },
   { "previous-line",                 OP_PREV_LINE },
   { "previous-new",                  OP_MAIN_PREV_NEW },
@@ -181,9 +171,7 @@ const struct MenuFuncOp OpPager[] = { /* map: pager */
   { "read-subthread",                OP_MAIN_READ_SUBTHREAD },
   { "read-thread",                   OP_MAIN_READ_THREAD },
   { "recall-message",                OP_RECALL_MESSAGE },
-#ifdef USE_NNTP
   { "reconstruct-thread",            OP_RECONSTRUCT_THREAD },
-#endif
   { "redraw-screen",                 OP_REDRAW },
   { "reply",                         OP_REPLY },
   { "resend-message",                OP_RESEND },
@@ -199,7 +187,6 @@ const struct MenuFuncOp OpPager[] = { /* map: pager */
   { "shell-escape",                  OP_SHELL_ESCAPE },
   { "show-log-messages",             OP_SHOW_LOG_MESSAGES },
   { "show-version",                  OP_VERSION },
-#ifdef USE_SIDEBAR
   { "sidebar-first",                 OP_SIDEBAR_FIRST },
   { "sidebar-last",                  OP_SIDEBAR_LAST },
   { "sidebar-next",                  OP_SIDEBAR_NEXT },
@@ -211,7 +198,6 @@ const struct MenuFuncOp OpPager[] = { /* map: pager */
   { "sidebar-prev-new",              OP_SIDEBAR_PREV_NEW },
   { "sidebar-toggle-virtual",        OP_SIDEBAR_TOGGLE_VIRTUAL },
   { "sidebar-toggle-visible",        OP_SIDEBAR_TOGGLE_VISIBLE },
-#endif
   { "skip-headers",                  OP_PAGER_SKIP_HEADERS },
   { "skip-quoted",                   OP_PAGER_SKIP_QUOTED },
   { "sort-mailbox",                  OP_SORT },

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -784,11 +784,7 @@ static bool pattern_needs_msg(const struct Mailbox *m, const struct Pattern *pat
 
   if ((pat->op == MUTT_PAT_WHOLE_MSG) || (pat->op == MUTT_PAT_BODY) || (pat->op == MUTT_PAT_HEADER))
   {
-#ifdef USE_IMAP
     return !((m->type == MUTT_IMAP) && pat->string_match);
-#else
-    return true;
-#endif
   }
 
   if ((pat->op == MUTT_PAT_AND) || (pat->op == MUTT_PAT_OR))
@@ -884,21 +880,17 @@ static bool pattern_exec(struct Pattern *pat, PatternExecFlags flags,
        * This is also the case when message scoring.  */
       if (!m)
         return false;
-#ifdef USE_IMAP
       /* IMAP search sets e->matched at search compile time */
       if ((m->type == MUTT_IMAP) && pat->string_match)
         return e->matched;
-#endif
       return pat->pat_not ^ msg_search(pat, e, msg);
     case MUTT_PAT_SERVERSEARCH:
-#ifdef USE_IMAP
       if (!m)
         return false;
       if (m->type == MUTT_IMAP)
       {
         return (pat->string_match) ? e->matched : false;
       }
-#endif
       mutt_error(_("error: server custom search only supported with IMAP"));
       return false;
     case MUTT_PAT_SENDER:
@@ -1109,12 +1101,10 @@ static bool pattern_exec(struct Pattern *pat, PatternExecFlags flags,
       return pat->pat_not ^ (e->thread && !e->thread->child);
     case MUTT_PAT_BROKEN:
       return pat->pat_not ^ (e->thread && e->thread->fake_thread);
-#ifdef USE_NNTP
     case MUTT_PAT_NEWSGROUPS:
       if (!e->env)
         return false;
       return pat->pat_not ^ (e->env->newsgroups && patmatch(pat, e->env->newsgroups));
-#endif
   }
   mutt_error(_("error: unknown op %d (report this error)"), pat->op);
   return false;

--- a/pattern/flags.c
+++ b/pattern/flags.c
@@ -156,11 +156,9 @@ const struct PatternFlags Flags[] = {
   { 'V', MUTT_PAT_CRYPT_VERIFIED, 0, EAT_NONE,
     // L10N: Pattern Completion Menu description for ~V
     N_("cryptographically verified messages") },
-#ifdef USE_NNTP
   { 'w', MUTT_PAT_NEWSGROUPS, 0, EAT_REGEX,
     // L10N: Pattern Completion Menu description for ~w
     N_("newsgroups matching EXPR") },
-#endif
   { 'x', MUTT_PAT_REFERENCE, 0, EAT_REGEX,
     // L10N: Pattern Completion Menu description for ~x
     N_("messages whose References header matches EXPR") },

--- a/pattern/lib.h
+++ b/pattern/lib.h
@@ -176,9 +176,7 @@ enum PatternType
   MUTT_PAT_DRIVER_TAGS,       ///< Pattern matches message tags
   MUTT_PAT_MIMEATTACH,        ///< Pattern matches number of attachments
   MUTT_PAT_MIMETYPE,          ///< Pattern matches MIME type
-#ifdef USE_NNTP
   MUTT_PAT_NEWSGROUPS,        ///< Pattern matches newsgroup
-#endif
   MUTT_PAT_MAX,
 };
 

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -43,6 +43,7 @@
 #include "lib.h"
 #include "editor/lib.h"
 #include "history/lib.h"
+#include "imap/lib.h"
 #include "menu/lib.h"
 #include "progress/lib.h"
 #include "globals.h"
@@ -53,9 +54,6 @@
 #include "search_state.h"
 #ifndef USE_FMEMOPEN
 #include <sys/stat.h>
-#endif
-#ifdef USE_IMAP
-#include "imap/lib.h"
 #endif
 
 /**
@@ -328,10 +326,8 @@ int mutt_pattern_func(struct MailboxView *mv, int op, char *prompt)
     goto bail;
   }
 
-#ifdef USE_IMAP
   if ((m->type == MUTT_IMAP) && (!imap_search(m, pat)))
     goto bail;
-#endif
 
   progress = progress_new(_("Executing command on matching messages..."), MUTT_PROGRESS_READ,
                           (op == MUTT_LIMIT) ? m->msg_count : m->vcount);
@@ -497,10 +493,8 @@ int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
   {
     for (int i = 0; i < m->msg_count; i++)
       m->emails[i]->searched = false;
-#ifdef USE_IMAP
     if ((m->type == MUTT_IMAP) && (!imap_search(m, state->pattern)))
       return -1;
-#endif
   }
 
   int incr = state->reverse ? -1 : 1;

--- a/postpone/postpone.c
+++ b/postpone/postpone.c
@@ -40,6 +40,7 @@
 #include "core/lib.h"
 #include "mutt.h"
 #include "lib.h"
+#include "imap/lib.h"
 #include "ncrypt/lib.h"
 #include "send/lib.h"
 #include "globals.h"
@@ -50,9 +51,6 @@
 #include "mx.h"
 #include "protos.h"
 #include "rfc3676.h"
-#ifdef USE_IMAP
-#include "imap/lib.h"
-#endif
 
 /// Number of postponed (draft) emails
 short PostCount = 0;
@@ -99,7 +97,6 @@ int mutt_num_postponed(struct Mailbox *m, bool force)
     return PostCount;
   }
 
-#ifdef USE_IMAP
   /* LastModify is useless for IMAP */
   if (imap_path_probe(c_postponed, NULL) == MUTT_IMAP)
   {
@@ -120,7 +117,6 @@ int mutt_num_postponed(struct Mailbox *m, bool force)
     }
     return PostCount;
   }
-#endif
 
   if (stat(c_postponed, &st) == -1)
   {
@@ -147,17 +143,13 @@ int mutt_num_postponed(struct Mailbox *m, bool force)
 
   if (LastModify < st.st_mtime)
   {
-#ifdef USE_NNTP
     int optnews = OptNews;
-#endif
     LastModify = st.st_mtime;
 
     if (access(c_postponed, R_OK | F_OK) != 0)
       return PostCount = 0;
-#ifdef USE_NNTP
     if (optnews)
       OptNews = false;
-#endif
     struct Mailbox *m_post = mx_path_resolve(c_postponed);
     if (mx_mbox_open(m_post, MUTT_NOSORT | MUTT_QUIET))
     {
@@ -170,10 +162,8 @@ int mutt_num_postponed(struct Mailbox *m, bool force)
     }
     mailbox_free(&m_post);
 
-#ifdef USE_NNTP
     if (optnews)
       OptNews = true;
-#endif
   }
 
   return PostCount;

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -847,7 +847,6 @@ static int attach_reply_envelope_defaults(struct Envelope *env, struct AttachCtx
     return -1;
   }
 
-#ifdef USE_NNTP
   if ((flags & SEND_NEWS))
   {
     /* in case followup set Newsgroups: with Followup-To: if it present */
@@ -857,7 +856,6 @@ static int attach_reply_envelope_defaults(struct Envelope *env, struct AttachCtx
     }
   }
   else
-#endif
   {
     if (parent)
     {
@@ -958,12 +956,10 @@ void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
 
   char prefix[128] = { 0 };
 
-#ifdef USE_NNTP
   if (flags & SEND_NEWS)
     OptNewsSend = true;
   else
     OptNewsSend = false;
-#endif
 
   if (!check_all_msg(actx, b, false))
   {

--- a/send/header.c
+++ b/send/header.c
@@ -603,20 +603,20 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *b,
     mutt_addrlist_write_file(&env->to, fp, "To");
   }
   else if (mode == MUTT_WRITE_HEADER_EDITHDRS)
-#ifdef USE_NNTP
+  {
     if (!OptNewsSend)
-#endif
       fputs("To:\n", fp);
+  }
 
   if (!TAILQ_EMPTY(&env->cc))
   {
     mutt_addrlist_write_file(&env->cc, fp, "Cc");
   }
   else if (mode == MUTT_WRITE_HEADER_EDITHDRS)
-#ifdef USE_NNTP
+  {
     if (!OptNewsSend)
-#endif
       fputs("Cc:\n", fp);
+  }
 
   if (!TAILQ_EMPTY(&env->bcc))
   {
@@ -630,12 +630,11 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *b,
     }
   }
   else if (mode == MUTT_WRITE_HEADER_EDITHDRS)
-#ifdef USE_NNTP
+  {
     if (!OptNewsSend)
-#endif
       fputs("Bcc:\n", fp);
+  }
 
-#ifdef USE_NNTP
   if (env->newsgroups)
     fprintf(fp, "Newsgroups: %s\n", env->newsgroups);
   else if ((mode == MUTT_WRITE_HEADER_EDITHDRS) && OptNewsSend)
@@ -651,7 +650,6 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *b,
     fprintf(fp, "X-Comment-To: %s\n", env->x_comment_to);
   else if ((mode == MUTT_WRITE_HEADER_EDITHDRS) && OptNewsSend && c_x_comment_to)
     fputs("X-Comment-To:\n", fp);
-#endif
 
   if (env->subject)
   {
@@ -688,9 +686,7 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *b,
 
   if (!TAILQ_EMPTY(&env->mail_followup_to))
   {
-#ifdef USE_NNTP
     if (!OptNewsSend)
-#endif
     {
       mutt_addrlist_write_file(&env->mail_followup_to, fp, "Mail-Followup-To");
     }

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -885,7 +885,6 @@ static int bounce_message(FILE *fp, struct Mailbox *m, struct Email *e,
       unlink(buf_string(tempfile));
       return -1;
     }
-#ifdef USE_SMTP
     const char *const c_smtp_url = cs_subset_string(sub, "smtp_url");
     if (c_smtp_url)
     {
@@ -893,7 +892,6 @@ static int bounce_message(FILE *fp, struct Mailbox *m, struct Email *e,
                           (e->body->encoding == ENC_8BIT), sub);
     }
     else
-#endif
     {
       rc = mutt_invoke_sendmail(m, env_from, to, NULL, NULL, buf_string(tempfile),
                                 (e->body->encoding == ENC_8BIT), sub);
@@ -952,9 +950,7 @@ int mutt_bounce_message(FILE *fp, struct Mailbox *m, struct Email *e,
   struct Buffer *resent_from = buf_pool_get();
   mutt_addrlist_write(&from_list, resent_from, false);
 
-#ifdef USE_NNTP
   OptNewsSend = false;
-#endif
 
   /* prepare recipient list. idna conversion appears to happen before this
    * function is called, since the user receives confirmation of the address

--- a/send/sendmail.c
+++ b/send/sendmail.c
@@ -43,13 +43,11 @@
 #include "core/lib.h"
 #include "gui/lib.h"
 #include "sendmail.h"
+#include "nntp/lib.h"
 #include "pager/lib.h"
 #include "format_flags.h"
 #include "globals.h"
 #include "muttlib.h"
-#ifdef USE_NNTP
-#include "nntp/lib.h"
-#endif
 #ifdef HAVE_SYSEXITS_H
 #include <sysexits.h>
 #else
@@ -304,7 +302,6 @@ int mutt_invoke_sendmail(struct Mailbox *m, struct AddressList *from,
   struct SendmailArgArray extra_args = ARRAY_HEAD_INITIALIZER;
   int i;
 
-#ifdef USE_NNTP
   if (OptNewsSend)
   {
     char cmd[1024] = { 0 };
@@ -322,7 +319,6 @@ int mutt_invoke_sendmail(struct Mailbox *m, struct AddressList *from,
     s = mutt_str_dup(cmd);
   }
   else
-#endif
   {
     const char *const c_sendmail = cs_subset_string(sub, "sendmail");
     s = mutt_str_dup(c_sendmail);
@@ -358,10 +354,8 @@ int mutt_invoke_sendmail(struct Mailbox *m, struct AddressList *from,
     i++;
   }
 
-#ifdef USE_NNTP
   if (!OptNewsSend)
   {
-#endif
     /* If $sendmail contained a "--", we save the recipients to append to
      * args after other possible options added below. */
     if (ps)
@@ -416,9 +410,7 @@ int mutt_invoke_sendmail(struct Mailbox *m, struct AddressList *from,
     add_args(&args, to);
     add_args(&args, cc);
     add_args(&args, bcc);
-#ifdef USE_NNTP
   }
-#endif
 
   ARRAY_ADD(&args, NULL);
 

--- a/send/smtp.h
+++ b/send/smtp.h
@@ -27,7 +27,6 @@
 #include "config.h"
 #include <stdbool.h>
 
-#ifdef USE_SMTP
 struct AddressList;
 struct ConfigSubset;
 
@@ -35,6 +34,5 @@ bool smtp_auth_is_valid(const char *authenticator);
 int mutt_smtp_send(const struct AddressList *from, const struct AddressList *to,
                    const struct AddressList *cc, const struct AddressList *bcc,
                    const char *msgfile, bool eightbit, struct ConfigSubset *sub);
-#endif
 
 #endif /* MUTT_SEND_SMTP_H */

--- a/sort.c
+++ b/sort.c
@@ -38,15 +38,13 @@
 #include "core/lib.h"
 #include "alias/lib.h"
 #include "sort.h"
+#include "nntp/lib.h"
 #include "globals.h"
 #include "mutt_logging.h"
 #include "mutt_thread.h"
 #include "mview.h"
 #include "mx.h"
 #include "score.h"
-#ifdef USE_NNTP
-#include "nntp/lib.h"
-#endif
 
 /**
  * struct EmailCompare - Context for compare_email_shim()
@@ -287,11 +285,9 @@ static sort_mail_t get_sort_func(enum SortType method, enum MailboxType type)
     case SORT_LABEL:
       return compare_label;
     case SORT_ORDER:
-#ifdef USE_NNTP
       if (type == MUTT_NNTP)
         return nntp_compare_order;
       else
-#endif
         return compare_order;
     case SORT_RECEIVED:
       return compare_date_received;

--- a/status.c
+++ b/status.c
@@ -155,15 +155,12 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       FALLTHROUGH;
 
     case 'f':
-#ifdef USE_COMP_MBOX
       if (m && m->compress_info && (m->realpath[0] != '\0'))
       {
         mutt_str_copy(tmp, m->realpath, sizeof(tmp));
         mutt_pretty_mailbox(tmp, sizeof(tmp));
       }
-      else
-#endif
-          if (m && (m->type == MUTT_NOTMUCH) && m->name)
+      else if (m && (m->type == MUTT_NOTMUCH) && m->name)
       {
         mutt_str_copy(tmp, m->name, sizeof(tmp));
       }

--- a/system.c
+++ b/system.c
@@ -33,11 +33,9 @@
 #include <sys/wait.h> // IWYU pragma: keep
 #include <unistd.h>
 #include "mutt/lib.h"
+#include "imap/lib.h"
 #include "globals.h"
 #include "protos.h"
-#ifdef USE_IMAP
-#include "imap/lib.h"
-#endif
 
 /**
  * mutt_system - Run an external command
@@ -92,9 +90,7 @@ int mutt_system(const char *cmd)
   }
   else if (pid != -1)
   {
-#ifdef USE_IMAP
     rc = imap_wait_keep_alive(pid);
-#endif
   }
 
   sigaction(SIGCONT, &oldcont, NULL);

--- a/version.c
+++ b/version.c
@@ -255,11 +255,6 @@ static const struct CompileOptions CompOpts[] = {
 #else
   { "sqlite", 0 },
 #endif
-#ifdef SUN_ATTACHMENT
-  { "sun_attachment", 1 },
-#else
-  { "sun_attachment", 0 },
-#endif
 #ifdef NEOMUTT_DIRECT_COLORS
   { "truecolor", 1 },
 #else


### PR DESCRIPTION
Remove nearly 700 lines of clutter.

---

Strip out over 300 conditionals (`#if`) for symbols that are always defined.

- `USE_COMP_MBOX`
- `USE_IMAP`
- `USE_NNTP`
- `USE_POP`
- `USE_SIDEBAR`
- `USE_SOCKET`
- `USE_SMTP`
- `SUN_ATTACHMENT`

These were permanent set to true, long ago, because they didn't add any dependencies to the build.