### PR TITLE
Improve the Progress Bar

### DIFF
--- a/external.c
+++ b/external.c
@@ -969,7 +969,8 @@ int mutt_save_message(struct Mailbox *m, struct EmailArray *ea,
     if (m->type == MUTT_NOTMUCH)
       nm_db_longrun_init(m, true);
 #endif
-    struct Progress *progress = progress_new(progress_msg, MUTT_PROGRESS_WRITE, msg_count);
+    struct Progress *progress = progress_new(MUTT_PROGRESS_WRITE, msg_count);
+    progress_set_message(progress, "%s", progress_msg);
     struct Email **ep = NULL;
     ARRAY_FOREACH(ep, ea)
     {

--- a/imap/message.c
+++ b/imap/message.c
@@ -686,7 +686,8 @@ static int read_headers_normal_eval_cache(struct ImapAccountData *adata,
   if (m->verbose)
   {
     /* L10N: Comparing the cached data with the IMAP server's data */
-    progress = progress_new(_("Evaluating cache..."), MUTT_PROGRESS_READ, msn_end);
+    progress = progress_new(MUTT_PROGRESS_READ, msn_end);
+    progress_set_message(progress, _("Evaluating cache..."));
   }
 
   /* If we are using CONDSTORE's "FETCH CHANGEDSINCE", then we keep
@@ -915,7 +916,8 @@ static int read_headers_condstore_qresync_updates(struct ImapAccountData *adata,
   if (m->verbose)
   {
     /* L10N: Fetching IMAP flag changes, using the CONDSTORE extension */
-    progress = progress_new(_("Fetching flag updates..."), MUTT_PROGRESS_READ, msn_end);
+    progress = progress_new(MUTT_PROGRESS_READ, msn_end);
+    progress_set_message(progress, _("Fetching flag updates..."));
   }
 
   snprintf(buf, sizeof(buf), "UID FETCH 1:%u (FLAGS) (CHANGEDSINCE %llu%s)",
@@ -1148,7 +1150,8 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
 
   if (m->verbose)
   {
-    progress = progress_new(_("Fetching message headers..."), MUTT_PROGRESS_READ, msn_end);
+    progress = progress_new(MUTT_PROGRESS_READ, msn_end);
+    progress_set_message(progress, _("Fetching message headers..."));
   }
 
   buf = buf_pool_get();
@@ -1556,7 +1559,10 @@ int imap_append_message(struct Mailbox *m, struct Message *msg)
   rewind(fp);
 
   if (m->verbose)
-    progress = progress_new(_("Uploading message..."), MUTT_PROGRESS_NET, len);
+  {
+    progress = progress_new(MUTT_PROGRESS_NET, len);
+    progress_set_message(progress, _("Uploading message..."));
+  }
 
   mutt_date_make_imap(internaldate, sizeof(internaldate), msg->received);
 

--- a/index/functions.c
+++ b/index/functions.c
@@ -1385,7 +1385,8 @@ static int op_main_modify_tags(struct IndexSharedData *shared,
 
     if (m->verbose)
     {
-      progress = progress_new(_("Update tags..."), MUTT_PROGRESS_WRITE, m->msg_tagged);
+      progress = progress_new(MUTT_PROGRESS_WRITE, m->msg_tagged);
+      progress_set_message(progress, _("Update tags..."));
     }
 
 #ifdef USE_NOTMUCH

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -777,9 +777,8 @@ static int maildir_read_dir(struct Mailbox *m, const char *subdir)
 
   if (m->verbose)
   {
-    char msg[PATH_MAX] = { 0 };
-    snprintf(msg, sizeof(msg), _("Scanning %s..."), mailbox_path(m));
-    progress = progress_new(msg, MUTT_PROGRESS_READ, 0);
+    progress = progress_new(MUTT_PROGRESS_READ, 0);
+    progress_set_message(progress, _("Scanning %s..."), mailbox_path(m));
   }
 
   struct MaildirMboxData *mdata = maildir_mdata_get(m);
@@ -798,9 +797,8 @@ static int maildir_read_dir(struct Mailbox *m, const char *subdir)
 
   if (m->verbose)
   {
-    char msg[PATH_MAX] = { 0 };
-    snprintf(msg, sizeof(msg), _("Reading %s..."), mailbox_path(m));
-    progress = progress_new(msg, MUTT_PROGRESS_READ, ARRAY_SIZE(&mda));
+    progress = progress_new(MUTT_PROGRESS_READ, ARRAY_SIZE(&mda));
+    progress_set_message(progress, _("Reading %s..."), mailbox_path(m));
   }
   maildir_delayed_parsing(m, &mda, progress);
   progress_free(&progress);
@@ -1548,9 +1546,8 @@ static enum MxStatus maildir_mbox_sync(struct Mailbox *m)
   struct Progress *progress = NULL;
   if (m->verbose)
   {
-    char msg[PATH_MAX] = { 0 };
-    snprintf(msg, sizeof(msg), _("Writing %s..."), mailbox_path(m));
-    progress = progress_new(msg, MUTT_PROGRESS_WRITE, m->msg_count);
+    progress = progress_new(MUTT_PROGRESS_WRITE, m->msg_count);
+    progress_set_message(progress, _("Writing %s..."), mailbox_path(m));
   }
 
   for (int i = 0; i < m->msg_count; i++)

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -37,7 +37,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
-#include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -212,9 +211,8 @@ static enum MxOpenReturns mmdf_parse_mailbox(struct Mailbox *m)
 
   if (m->verbose)
   {
-    char msg[PATH_MAX] = { 0 };
-    snprintf(msg, sizeof(msg), _("Reading %s..."), mailbox_path(m));
-    progress = progress_new(msg, MUTT_PROGRESS_READ, 0);
+    progress = progress_new(MUTT_PROGRESS_READ, 0);
+    progress_set_message(progress, _("Reading %s..."), mailbox_path(m));
   }
 
   while (true)
@@ -382,9 +380,8 @@ static enum MxOpenReturns mbox_parse_mailbox(struct Mailbox *m)
 
   if (m->verbose)
   {
-    char msg[PATH_MAX] = { 0 };
-    snprintf(msg, sizeof(msg), _("Reading %s..."), mailbox_path(m));
-    progress = progress_new(msg, MUTT_PROGRESS_READ, 0);
+    progress = progress_new(MUTT_PROGRESS_READ, 0);
+    progress_set_message(progress, _("Reading %s..."), mailbox_path(m));
   }
 
   loc = ftello(adata->fp);
@@ -1175,9 +1172,8 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
 
   if (m->verbose)
   {
-    char msg[PATH_MAX] = { 0 };
-    snprintf(msg, sizeof(msg), _("Writing %s..."), mailbox_path(m));
-    progress = progress_new(msg, MUTT_PROGRESS_WRITE, m->msg_count);
+    progress = progress_new(MUTT_PROGRESS_WRITE, m->msg_count);
+    progress_set_message(progress, _("Writing %s..."), mailbox_path(m));
   }
 
   for (i = first, j = 0; i < m->msg_count; i++)

--- a/mh/mh.c
+++ b/mh/mh.c
@@ -670,9 +670,8 @@ static bool mh_read_dir(struct Mailbox *m)
 
   if (m->verbose)
   {
-    char msg[PATH_MAX] = { 0 };
-    snprintf(msg, sizeof(msg), _("Scanning %s..."), mailbox_path(m));
-    progress = progress_new(msg, MUTT_PROGRESS_READ, 0);
+    progress = progress_new(MUTT_PROGRESS_READ, 0);
+    progress_set_message(progress, _("Scanning %s..."), mailbox_path(m));
   }
 
   struct MhMboxData *mdata = mh_mdata_get(m);
@@ -693,9 +692,8 @@ static bool mh_read_dir(struct Mailbox *m)
 
   if (m->verbose)
   {
-    char msg[PATH_MAX] = { 0 };
-    snprintf(msg, sizeof(msg), _("Reading %s..."), mailbox_path(m));
-    progress = progress_new(msg, MUTT_PROGRESS_READ, ARRAY_SIZE(&mha));
+    progress = progress_new(MUTT_PROGRESS_READ, ARRAY_SIZE(&mha));
+    progress_set_message(progress, _("Reading %s..."), mailbox_path(m));
   }
   mh_delayed_parsing(m, &mha, progress);
   progress_free(&progress);
@@ -1078,9 +1076,8 @@ static enum MxStatus mh_mbox_sync(struct Mailbox *m)
   struct Progress *progress = NULL;
   if (m->verbose)
   {
-    char msg[PATH_MAX] = { 0 };
-    snprintf(msg, sizeof(msg), _("Writing %s..."), mailbox_path(m));
-    progress = progress_new(msg, MUTT_PROGRESS_WRITE, m->msg_count);
+    progress = progress_new(MUTT_PROGRESS_WRITE, m->msg_count);
+    progress_set_message(progress, _("Writing %s..."), mailbox_path(m));
   }
 
   for (int i = 0; i < m->msg_count; i++)

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -806,7 +806,10 @@ static int nntp_fetch_lines(struct NntpMboxData *mdata, char *query, size_t qlen
     rc = 0;
 
     if (msg)
-      progress = progress_new(msg, MUTT_PROGRESS_READ, 0);
+    {
+      progress = progress_new(MUTT_PROGRESS_READ, 0);
+      progress_set_message(progress, "%s", msg);
+    }
 
     while (true)
     {
@@ -1246,8 +1249,8 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
   /* fetching header from cache or server, or fallback to fetch overview */
   if (m->verbose)
   {
-    fc.progress = progress_new(_("Fetching message headers..."),
-                               MUTT_PROGRESS_READ, last - first + 1);
+    fc.progress = progress_new(MUTT_PROGRESS_READ, last - first + 1);
+    progress_set_message(fc.progress, _("Fetching message headers..."));
   }
   for (current = first; (current <= last) && (rc == 0); current++)
   {
@@ -2128,8 +2131,8 @@ int nntp_check_new_groups(struct Mailbox *m, struct NntpAccountData *adata)
     if (c_nntp_load_description)
     {
       unsigned int count = 0;
-      struct Progress *progress = progress_new(_("Loading descriptions..."), MUTT_PROGRESS_READ,
-                                               adata->groups_num - i);
+      struct Progress *progress = progress_new(MUTT_PROGRESS_READ, adata->groups_num - i);
+      progress_set_message(progress, _("Loading descriptions..."));
 
       for (i = groups_num; i < adata->groups_num; i++)
       {

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -677,8 +677,8 @@ static void progress_setup(struct Mailbox *m)
 
   mdata->oldmsgcount = m->msg_count;
   mdata->ignmsgcount = 0;
-  mdata->progress = progress_new(_("Reading messages..."), MUTT_PROGRESS_READ,
-                                 mdata->oldmsgcount);
+  mdata->progress = progress_new(MUTT_PROGRESS_READ, mdata->oldmsgcount);
+  progress_set_message(mdata->progress, _("Reading messages..."));
 }
 
 /**
@@ -2229,9 +2229,8 @@ static enum MxStatus nm_mbox_sync(struct Mailbox *m)
   if (m->verbose)
   {
     /* all is in this function so we don't use data->progress here */
-    char msg[PATH_MAX] = { 0 };
-    snprintf(msg, sizeof(msg), _("Writing %s..."), mailbox_path(m));
-    progress = progress_new(msg, MUTT_PROGRESS_WRITE, m->msg_count);
+    progress = progress_new(MUTT_PROGRESS_WRITE, m->msg_count);
+    progress_set_message(progress, _("Writing %s..."), mailbox_path(m));
   }
 
   struct HeaderCache *hc = nm_hcache_open(m);

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -230,8 +230,8 @@ int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata, struct Me
     match_all = true;
   }
 
-  progress = progress_new(_("Executing command on matching messages..."),
-                          MUTT_PROGRESS_READ, ARRAY_SIZE(&mdata->ava));
+  progress = progress_new(MUTT_PROGRESS_READ, ARRAY_SIZE(&mdata->ava));
+  progress_set_message(progress, _("Executing command on matching messages..."));
 
   int vcounter = 0;
   struct AliasView *avp = NULL;
@@ -329,8 +329,8 @@ int mutt_pattern_func(struct MailboxView *mv, int op, char *prompt)
   if ((m->type == MUTT_IMAP) && (!imap_search(m, pat)))
     goto bail;
 
-  progress = progress_new(_("Executing command on matching messages..."), MUTT_PROGRESS_READ,
-                          (op == MUTT_LIMIT) ? m->msg_count : m->vcount);
+  progress = progress_new(MUTT_PROGRESS_READ, (op == MUTT_LIMIT) ? m->msg_count : m->vcount);
+  progress_set_message(progress, _("Executing command on matching messages..."));
 
   if (op == MUTT_LIMIT)
   {
@@ -501,7 +501,8 @@ int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
   if (flags & SEARCH_OPPOSITE)
     incr = -incr;
 
-  progress = progress_new(_("Searching..."), MUTT_PROGRESS_READ, m->vcount);
+  progress = progress_new(MUTT_PROGRESS_READ, m->vcount);
+  progress_set_message(progress, _("Searching..."));
 
   const bool c_wrap_search = cs_subset_bool(NeoMutt->sub, "wrap_search");
   for (int i = cur + incr, j = 0; j != m->vcount; j++)
@@ -656,7 +657,8 @@ int mutt_search_alias_command(struct Menu *menu, int cur,
   if (flags & SEARCH_OPPOSITE)
     incr = -incr;
 
-  progress = progress_new(_("Searching..."), MUTT_PROGRESS_READ, ARRAY_SIZE(ava));
+  progress = progress_new(MUTT_PROGRESS_READ, ARRAY_SIZE(ava));
+  progress_set_message(progress, _("Searching..."));
 
   const bool c_wrap_search = cs_subset_bool(NeoMutt->sub, "wrap_search");
   for (int i = cur + incr, j = 0; j != ARRAY_SIZE(ava); j++)

--- a/po/bg.po
+++ b/po/bg.po
@@ -7610,27 +7610,47 @@ msgstr "Писмото не може да бъде копирано."
 msgid "No postponed messages"
 msgstr "Няма запазени чернови"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7732,27 +7732,47 @@ msgstr "No s’ha pogut desxifrar el missatge PGP."
 msgid "No postponed messages"
 msgstr "No hi ha cap missatge posposat"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7349,18 +7349,38 @@ msgstr "Nelze rozšifrovat odloženou zprávu"
 msgid "No postponed messages"
 msgstr "Žádné zprávy nejsou odloženy"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d %%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
 #, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d %%)"
 
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
+
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
+#: progress/window.c:208
 #, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d %%)"
@@ -7368,7 +7388,7 @@ msgstr "%s %s/%s (%d %%)"
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
+#: progress/window.c:216
 #, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d %%)"

--- a/po/da.po
+++ b/po/da.po
@@ -7477,27 +7477,47 @@ msgstr "Kunne ikke dekryptere PGP-brev"
 msgid "No postponed messages"
 msgstr "Ingen tilbageholdte breve"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/de.po
+++ b/po/de.po
@@ -7311,18 +7311,38 @@ msgstr "Konnte aufgeschobene Nachricht nicht entschlüsseln"
 msgid "No postponed messages"
 msgstr "Keine zurückgestellten Nachrichten"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d %%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
 #, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d %%)"
 
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
+
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
+#: progress/window.c:208
 #, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d %%)"
@@ -7330,7 +7350,7 @@ msgstr "%s %s/%s (%d %%)"
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
+#: progress/window.c:216
 #, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d %%)"

--- a/po/el.po
+++ b/po/el.po
@@ -7536,27 +7536,47 @@ msgstr "Αδυναμία αντιγραφής του μηνύματος."
 msgid "No postponed messages"
 msgstr "Δεν υπάρχουν αναβληθέντα μηνύματα"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7301,18 +7301,38 @@ msgstr "Could not decrypt postponed message"
 msgid "No postponed messages"
 msgstr "No postponed messages"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
 #, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
 
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
+
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
+#: progress/window.c:208
 #, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
@@ -7320,7 +7340,7 @@ msgstr "%s %s/%s (%d%%)"
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
+#: progress/window.c:216
 #, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7427,27 +7427,47 @@ msgstr "Ne eblis malĉifri PGP-mesaĝon"
 msgid "No postponed messages"
 msgstr "Malestas prokrastitaj mesaĝoj"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/es.po
+++ b/po/es.po
@@ -7327,24 +7327,47 @@ msgstr "No se pudo descifrar el mensaje pospuesto"
 msgid "No postponed messages"
 msgstr "No hay mensajes pospuestos"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/et.po
+++ b/po/et.po
@@ -7619,27 +7619,47 @@ msgstr "Teadet ei õnnestu kopeerida."
 msgid "No postponed messages"
 msgstr "Postitusootel teateid pole"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -7585,27 +7585,47 @@ msgstr "Ezin da PGP mezua desenkriptatu"
 msgid "No postponed messages"
 msgstr "Ez da atzeraturiko mezurik"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7351,27 +7351,47 @@ msgstr "Ei voitu purkaa PGP-viestiä"
 msgid "No postponed messages"
 msgstr "Ei lykättyjä viestejä"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7610,27 +7610,47 @@ msgstr "Impossible de déchiffrer le message PGP"
 msgid "No postponed messages"
 msgstr "Pas de message ajourné"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/ga.po
+++ b/po/ga.po
@@ -7672,27 +7672,47 @@ msgstr "Níorbh fhéidir an teachtaireacht PGP a dhíchriptiú"
 msgid "No postponed messages"
 msgstr "Níl aon teachtaireacht ar athlá"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -7677,27 +7677,47 @@ msgstr "Non foi posible copia-la mensaxe."
 msgid "No postponed messages"
 msgstr "Non hai mensaxes pospostas"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -7300,18 +7300,38 @@ msgstr "Elhalasztott levél dekódolása sikertelen"
 msgid "No postponed messages"
 msgstr "Nincsenek elhalasztott levelek"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
 #, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
 
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
+
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
+#: progress/window.c:208
 #, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
@@ -7319,7 +7339,7 @@ msgstr "%s %s/%s (%d%%)"
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
+#: progress/window.c:216
 #, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"

--- a/po/id.po
+++ b/po/id.po
@@ -7546,27 +7546,47 @@ msgstr "Tidak bisa mendekripsi surat PGP"
 msgid "No postponed messages"
 msgstr "Tidak ada surat yg ditunda"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/it.po
+++ b/po/it.po
@@ -7573,27 +7573,47 @@ msgstr "Impossibile decifrare il messaggio PGP"
 msgid "No postponed messages"
 msgstr "Non ci sono messaggi rimandati"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7419,27 +7419,47 @@ msgstr "PGP メッセージを復号化できなかった"
 msgid "No postponed messages"
 msgstr "書きかけメッセージがない。"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7586,27 +7586,47 @@ msgstr "메일을 복사할 수 없음"
 msgid "No postponed messages"
 msgstr "발송 연기된 메일 없음"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -7333,18 +7333,38 @@ msgstr "Negalėjau iššifruoti atidėto laiško"
 msgid "No postponed messages"
 msgstr "Nėra atidėtų laiškų"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
 #, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
 
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
+
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
+#: progress/window.c:208
 #, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
@@ -7352,7 +7372,7 @@ msgstr "%s %s/%s (%d%%)"
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
+#: progress/window.c:216
 #, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7293,27 +7293,47 @@ msgstr "Kunne ikke dekryptere tilbakeholdt melding"
 msgid "No postponed messages"
 msgstr "Ingen tilbakeholdte meldinger"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7526,27 +7526,47 @@ msgstr "Kon PGP-gericht niet ontsleutelen"
 msgid "No postponed messages"
 msgstr "Geen uitgestelde berichten"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7333,18 +7333,38 @@ msgstr "Nie udało się odszyfrowanie odłożonego listu"
 msgid "No postponed messages"
 msgstr "Brak odłożonych listów"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
 #, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
 
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
+
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
+#: progress/window.c:208
 #, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
@@ -7352,7 +7372,7 @@ msgstr "%s %s/%s (%d%%)"
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
+#: progress/window.c:216
 #, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7300,27 +7300,47 @@ msgstr "Não foi possível descriptografar mensagem adiada"
 msgid "No postponed messages"
 msgstr "Nenhuma mensagem adiada"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7446,27 +7446,47 @@ msgstr "Не удалось расшифровать PGP-сообщение"
 msgid "No postponed messages"
 msgstr "Нет отложенных сообщений"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -7334,18 +7334,38 @@ msgstr "Nemožno dešifrovať odloženú správu"
 msgid "No postponed messages"
 msgstr "Žiadne odložené správy"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d %%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
 #, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d %%)"
 
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
+
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
+#: progress/window.c:208
 #, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d %%)"
@@ -7353,7 +7373,7 @@ msgstr "%s %s/%s (%d %%)"
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
+#: progress/window.c:216
 #, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d %%)"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7338,18 +7338,38 @@ msgstr "Не може се дешифровати одложена порука"
 msgid "No postponed messages"
 msgstr "Нема одложених порука"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
 #, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
 
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
+
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
+#: progress/window.c:208
 #, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
@@ -7357,7 +7377,7 @@ msgstr "%s %s/%s (%d%%)"
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
+#: progress/window.c:216
 #, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7588,27 +7588,47 @@ msgstr "Kunde inte avkryptera PGP-meddelande"
 msgid "No postponed messages"
 msgstr "Inga uppskjutna meddelanden"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7311,29 +7311,49 @@ msgstr "Ertelenen iletinin şifresi çözülemedi"
 msgid "No postponed messages"
 msgstr "Ertelenen ileti yok"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
 #, c-format
 msgid "%s %zu (%d%%)"
-msgstr "%s %zu (%%%d)"
+msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
+#: progress/window.c:208
 #, c-format
 msgid "%s %s/%s (%d%%)"
-msgstr "%s %s/%s (%%%d)"
+msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
+#: progress/window.c:216
 #, c-format
 msgid "%s %zu/%zu (%d%%)"
-msgstr "%s %zu/%zu (%%%d)"
+msgstr "%s %zu/%zu (%d%%)"
 
 #: question/question.c:184
 msgid "yes"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7337,27 +7337,47 @@ msgstr "Не вийшло розшифрувати повідомлення PGP"
 msgid "No postponed messages"
 msgstr "Жодного листа не залишено"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7285,27 +7285,47 @@ msgstr "无法解密 PGP 信件"
 msgid "No postponed messages"
 msgstr "没有被延迟寄出的信件"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7632,27 +7632,47 @@ msgstr "無法複制信件"
 msgid "No postponed messages"
 msgstr "沒有被延遲寄出的信件"
 
-#. L10N: Progress bar: `%s` loading text, `%zu` item count,
-#. `%d` percentage, `%%` is the percent symbol.
+#. L10N: Progress bar: `%s` loading text, `%s` pretty size (e.g. 4.6K),
+#. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:169
-#, fuzzy, c-format
+#: progress/window.c:175
+#, c-format
+msgid "%s %s (%d%%)"
+msgstr "%s %s (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position,
+#. `%d` is the number, `%%` is the percent symbol.
+#. `%d` and `%%` may be reordered, or space inserted, if you wish.
+#: progress/window.c:183
+#, c-format
 msgid "%s %zu (%d%%)"
 msgstr "%s %zu (%d%%)"
+
+#. L10N: Progress bar: `%s` loading text, `%s` position/size
+#: progress/window.c:192
+#, c-format
+msgid "%s %s"
+msgstr "%s %s"
+
+#. L10N: Progress bar: `%s` loading text, `%zu` position
+#: progress/window.c:197
+#, c-format
+msgid "%s %zu"
+msgstr "%s %zu"
 
 #. L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:179
-#, fuzzy, c-format
+#: progress/window.c:208
+#, c-format
 msgid "%s %s/%s (%d%%)"
 msgstr "%s %s/%s (%d%%)"
 
 #. L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
 #. `%d` is the number, `%%` is the percent symbol.
 #. `%d` and `%%` may be reordered, or space inserted, if you wish.
-#: progress/window.c:187
-#, fuzzy, c-format
+#: progress/window.c:216
+#, c-format
 msgid "%s %zu/%zu (%d%%)"
 msgstr "%s %zu/%zu (%d%%)"
 

--- a/pop/lib.c
+++ b/pop/lib.c
@@ -619,8 +619,8 @@ int pop_reconnect(struct Mailbox *m)
     int rc = pop_open_connection(adata);
     if (rc == 0)
     {
-      struct Progress *progress = progress_new(_("Verifying message indexes..."),
-                                               MUTT_PROGRESS_NET, 0);
+      struct Progress *progress = progress_new(MUTT_PROGRESS_NET, 0);
+      progress_set_message(progress, _("Verifying message indexes..."));
 
       for (int i = 0; i < m->msg_count; i++)
       {

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -368,8 +368,8 @@ static int pop_fetch_headers(struct Mailbox *m)
 
   if (m->verbose)
   {
-    progress = progress_new(_("Fetching message headers..."),
-                            MUTT_PROGRESS_READ, new_count - old_count);
+    progress = progress_new(MUTT_PROGRESS_READ, new_count - old_count);
+    progress_set_message(progress, _("Fetching message headers..."));
   }
 
   if (rc == 0)
@@ -887,8 +887,8 @@ static enum MxStatus pop_mbox_sync(struct Mailbox *m)
     struct Progress *progress = NULL;
     if (m->verbose)
     {
-      progress = progress_new(_("Marking messages deleted..."),
-                              MUTT_PROGRESS_WRITE, num_deleted);
+      progress = progress_new(MUTT_PROGRESS_WRITE, num_deleted);
+      progress_set_message(progress, _("Marking messages deleted..."));
     }
 
     for (i = 0, j = 0, rc = 0; (rc == 0) && (i < m->msg_count); i++)
@@ -1042,8 +1042,9 @@ static bool pop_msg_open(struct Mailbox *m, struct Message *msg, struct Email *e
 
     snprintf(buf, sizeof(buf), "RETR %d\r\n", edata->refno);
 
-    struct Progress *progress = progress_new(_("Fetching message..."), MUTT_PROGRESS_NET,
+    struct Progress *progress = progress_new(MUTT_PROGRESS_NET,
                                              e->body->length + e->body->offset - 1);
+    progress_set_message(progress, _("Fetching message..."));
     const int rc = pop_fetch_data(adata, buf, progress, fetch_message, msg->fp);
     progress_free(&progress);
 

--- a/progress/lib.h
+++ b/progress/lib.h
@@ -83,8 +83,10 @@ enum ProgressType
   MUTT_PROGRESS_WRITE, ///< Progress tracks elements, according to `$write_inc`
 };
 
-void             progress_free  (struct Progress **ptr);
-struct Progress *progress_new   (const char *msg, enum ProgressType type, size_t size);
-bool             progress_update(struct Progress *progress, size_t pos, int percent);
+void             progress_free       (struct Progress **ptr);
+struct Progress *progress_new        (enum ProgressType type, size_t size);
+bool             progress_update     (struct Progress *progress, size_t pos, int percent);
+void             progress_set_message(struct Progress *progress, const char *fmt, ...)
+                                      __attribute__((__format__(__printf__, 2, 3)));
 
 #endif /* MUTT_PROGRESS_LIB_H */

--- a/progress/lib.h
+++ b/progress/lib.h
@@ -1,6 +1,6 @@
 /**
  * @file
- * Progress bar
+ * Progress Bar
  *
  * @authors
  * Copyright (C) 2018-2021 Richard Russon <rich@flatcap.org>
@@ -22,9 +22,41 @@
  */
 
 /**
- * @page lib_progress Progress
+ * @page lib_progress Progress Bar
  *
- * Progress Bar
+ * Display a colourful Progress Bar with text.
+ *
+ * The Progress Bar can be used to display the progress of a Read, Write or Net
+ * operation.  It may look like this:
+ *
+ * ```
+ * Reading from cache 34/125 (27%)
+ * ```
+ *
+ * The Progress Bar can be used in three ways, depending on what's expected.
+ *
+ * - Unknown amount of data
+ *   - Call `progress_new(0)`
+ *   - Call `progress_update(n,-1)` -- records/bytes so far
+ *
+ * - Fixed number of records/bytes
+ *   - Call `progress_new(n)` -- number of records/bytes
+ *   - Call `progress_update(n,-1)` -- records/bytes so far
+ *
+ * - Percentage
+ *   - Call `progress_new(0)`
+ *   - Call `progress_update(n,pc)` -- records/bytes so far, percentage
+ *
+ * The frequency of screen updates can be configured.
+ * For each variable, a value of 0 means show **every** update.
+ *
+ * - `$net_inc`   -- Update after this many KB sent/received
+ * - `$read_inc`  -- Update after this many records read
+ * - `$write_inc` -- Update after this many records written
+ *
+ * Additionally,
+ *
+ * - `$time_inc` - Frequency of progress bar updates (milliseconds)
  *
  * | File                | Description                |
  * | :------------------ | :------------------------- |
@@ -46,9 +78,9 @@ struct Progress;
  */
 enum ProgressType
 {
+  MUTT_PROGRESS_NET,   ///< Progress tracks bytes,    according to `$net_inc`
   MUTT_PROGRESS_READ,  ///< Progress tracks elements, according to `$read_inc`
   MUTT_PROGRESS_WRITE, ///< Progress tracks elements, according to `$write_inc`
-  MUTT_PROGRESS_NET    ///< Progress tracks bytes, according to `$net_inc`
 };
 
 void             progress_free  (struct Progress **ptr);

--- a/progress/lib.h
+++ b/progress/lib.h
@@ -88,5 +88,6 @@ struct Progress *progress_new        (enum ProgressType type, size_t size);
 bool             progress_update     (struct Progress *progress, size_t pos, int percent);
 void             progress_set_message(struct Progress *progress, const char *fmt, ...)
                                       __attribute__((__format__(__printf__, 2, 3)));
+void             progress_set_size   (struct Progress *progress, size_t size);
 
 #endif /* MUTT_PROGRESS_LIB_H */

--- a/progress/progress.c
+++ b/progress/progress.c
@@ -32,6 +32,7 @@
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <unistd.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"
@@ -109,6 +110,9 @@ void progress_free(struct Progress **ptr)
 
   // Decloak an opaque pointer
   struct MuttWindow **wptr = (struct MuttWindow **) ptr;
+  window_redraw(*wptr);
+  usleep(100000); // 0.1s to ensure 100% is seen
+
   struct MuttWindow *win_pop = msgcont_pop_window();
   if (win_pop != *wptr)
     return;

--- a/progress/progress.c
+++ b/progress/progress.c
@@ -86,10 +86,21 @@ bool progress_update(struct Progress *progress, size_t pos, int percent)
   // Decloak an opaque pointer
   struct MuttWindow *win = (struct MuttWindow *) progress;
   const bool updated = progress_window_update(win, pos, percent);
-  if (updated)
+
+  if (SigWinch)
   {
-    window_redraw(win);
+    SigWinch = false;
+    notify_send(NeoMutt->notify_resize, NT_RESIZE, 0, NULL);
+    window_redraw(NULL);
   }
+  else
+  {
+    if (updated)
+    {
+      window_redraw(win);
+    }
+  }
+
   return updated;
 }
 

--- a/progress/progress.c
+++ b/progress/progress.c
@@ -49,11 +49,17 @@ struct Progress;
  */
 static size_t choose_increment(enum ProgressType type)
 {
-  const short c_read_inc = cs_subset_number(NeoMutt->sub, "read_inc");
-  const short c_write_inc = cs_subset_number(NeoMutt->sub, "write_inc");
-  const short c_net_inc = cs_subset_number(NeoMutt->sub, "net_inc");
-  const short *incs[] = { &c_read_inc, &c_write_inc, &c_net_inc };
-  return (type >= mutt_array_size(incs)) ? 0 : *incs[type];
+  switch (type)
+  {
+    case MUTT_PROGRESS_NET:
+      return cs_subset_number(NeoMutt->sub, "net_inc");
+    case MUTT_PROGRESS_READ:
+      return cs_subset_number(NeoMutt->sub, "read_inc");
+    case MUTT_PROGRESS_WRITE:
+      return cs_subset_number(NeoMutt->sub, "write_inc");
+    default:
+      return 0;
+  }
 }
 
 /**

--- a/progress/progress.c
+++ b/progress/progress.c
@@ -172,3 +172,14 @@ void progress_set_message(struct Progress *progress, const char *fmt, ...)
 
   va_end(ap);
 }
+
+/**
+ * progress_set_size - Set the progress size
+ */
+void progress_set_size(struct Progress *progress, size_t size)
+{
+  // Decloak an opaque pointer
+  struct MuttWindow *win = (struct MuttWindow *) progress;
+
+  progress_window_set_size(win, size);
+}

--- a/progress/window.c
+++ b/progress/window.c
@@ -323,3 +323,22 @@ void progress_window_set_message(struct MuttWindow *win, const char *fmt, va_lis
 
   win->actions |= WA_RECALC;
 }
+
+/**
+ * progress_window_set_size - Set the progress size
+ * @param win  Window to draw on
+ * @param size New size
+ */
+void progress_window_set_size(struct MuttWindow *win, size_t size)
+{
+  if (!win || !win->wdata)
+    return;
+
+  struct ProgressWindowData *wdata = win->wdata;
+
+  wdata->size = size;
+  wdata->display_pos = 0;
+  wdata->display_percent = 0;
+  wdata->display_time = 0;
+  win->actions |= WA_RECALC;
+}

--- a/progress/window.c
+++ b/progress/window.c
@@ -271,14 +271,13 @@ bool progress_window_update(struct MuttWindow *win, size_t pos, int percent)
 
 /**
  * progress_window_new - Create a new Progress Bar Window
- * @param msg      Progress message to display
  * @param size     Expected number of records or size of traffic
  * @param size_inc Size increment (step size)
  * @param time_inc Time increment
  * @param is_bytes true if measuring bytes
  * @retval ptr New Progress Window
  */
-struct MuttWindow *progress_window_new(const char *msg, size_t size, size_t size_inc,
+struct MuttWindow *progress_window_new(size_t size, size_t size_inc,
                                        size_t time_inc, bool is_bytes)
 {
   if (size_inc == 0) // The user has disabled the progress bar
@@ -297,7 +296,6 @@ struct MuttWindow *progress_window_new(const char *msg, size_t size, size_t size
   wdata->size_inc = size_inc;
   wdata->time_inc = time_inc;
   wdata->is_bytes = is_bytes;
-  mutt_str_copy(wdata->msg, msg, sizeof(wdata->msg));
 
   if (is_bytes)
     mutt_str_pretty_size(wdata->pretty_size, sizeof(wdata->pretty_size), size);
@@ -306,4 +304,22 @@ struct MuttWindow *progress_window_new(const char *msg, size_t size, size_t size
   win->wdata_free = progress_wdata_free;
 
   return win;
+}
+
+/**
+ * progress_window_set_message - Set the progress message
+ * @param win Window to draw on
+ * @param fmt printf format string
+ * @param ap  printf arguments
+ */
+void progress_window_set_message(struct MuttWindow *win, const char *fmt, va_list ap)
+{
+  if (!win || !win->wdata || !fmt)
+    return;
+
+  struct ProgressWindowData *wdata = win->wdata;
+
+  vsnprintf(wdata->msg, sizeof(wdata->msg), fmt, ap);
+
+  win->actions |= WA_RECALC;
 }

--- a/progress/window.h
+++ b/progress/window.h
@@ -24,11 +24,13 @@
 #define MUTT_PROGRESS_WINDOW_H
 
 #include <stddef.h>
+#include <stdarg.h>
 #include <stdbool.h>
 
 struct MuttWindow;
 
-struct MuttWindow *progress_window_new(const char *msg, size_t size, size_t size_inc, size_t time_inc, bool is_bytes);
-bool               progress_window_update(struct MuttWindow *win, size_t pos, int percent);
+struct MuttWindow *progress_window_new        (size_t size, size_t size_inc, size_t time_inc, bool is_bytes);
+void               progress_window_set_message(struct MuttWindow *win, const char *fmt, va_list ap);
+bool               progress_window_update     (struct MuttWindow *win, size_t pos, int percent);
 
 #endif /* MUTT_PROGRESS_WINDOW_H */

--- a/progress/window.h
+++ b/progress/window.h
@@ -31,6 +31,7 @@ struct MuttWindow;
 
 struct MuttWindow *progress_window_new        (size_t size, size_t size_inc, size_t time_inc, bool is_bytes);
 void               progress_window_set_message(struct MuttWindow *win, const char *fmt, va_list ap);
+void               progress_window_set_size   (struct MuttWindow *win, size_t size);
 bool               progress_window_update     (struct MuttWindow *win, size_t pos, int percent);
 
 #endif /* MUTT_PROGRESS_WINDOW_H */

--- a/send/smtp.c
+++ b/send/smtp.c
@@ -255,7 +255,8 @@ static int smtp_data(struct SmtpAccountData *adata, const char *msgfile)
     return -1;
   }
   unlink(msgfile);
-  progress = progress_new(_("Sending message..."), MUTT_PROGRESS_NET, size);
+  progress = progress_new(MUTT_PROGRESS_NET, size);
+  progress_set_message(progress, _("Sending message..."));
 
   snprintf(buf, sizeof(buf), "DATA\r\n");
   if (mutt_socket_send(adata->conn, buf) == -1)


### PR DESCRIPTION
- Fix a few minor display issues
- Refactor message setting for easier reuse
- Respond to `SIGWINCH` (and repaint all windows)

---

- b8ec31867 tidy
- 80a2f3065 set message
- c6305f340 set size
- 948869335 fix behaviour of unknown amounts
- 60ffc5ece window resize

---

### Testing

The final commit has add some tests to the Index -- They won't be committed :-)
Each displays a progress bar for 5 seconds:

**test.rc**
```sh
set read_inc  = 50
set write_inc = 100
set net_inc   = 500
set time_inc  = 0
color progress white red 
```

For each test, press _that_ number in the Index:

1. Unknown amount - Read
2. Unknown amount - Write
3. Unknown amount - Net
4. Fixed amount - Read
5. Fixed amount - Write
6. Fixed amount - Net
7. Percentage - Read
8. Percentage - Write
9. Percentage - Net