### PR TITLE
Educate Coverity about ARRAYs

### DIFF
--- a/mutt/array.h
+++ b/mutt/array.h
@@ -289,15 +289,13 @@
       true)                                                                    \
    : false)
 
+#ifndef __COVERITY__
+#define __coverity_escape__(x) 0
+#endif
 #define ARRAY_ADD_NORESERVE(head, elem)                                        \
   ((head)->capacity > (head)->size                                             \
    ? (((head)->entries[(head)->size++] = (elem)),                              \
-      true)                                                                    \
-   : false)
-
-#ifdef __COVERITY__
-#undef ARRAY_ADD_NORESERVE
-#define ARRAY_ADD_NORESERVE(head,elem) __coverity_escape__(elem);
-#endif
+      __coverity_escape__(elem), true)                                         \
+   : __coverity_escape__(elem), false)
 
 #endif /* MUTT_MUTT_ARRAY_H */


### PR DESCRIPTION
Use `__coverity_escape__()` to tell Coverity that memory isn't being leaked.
This only affects Coverity's build.

---

Coverity has trouble tracking memory allocations in our `ARRAY` and `TAILQ` macros.
This leads to false-positive defects.

Redefine `ARRAY_ADD_NORESERVE()` to call `__coverity_escape__()`.

"Fixes":
- [Defect 215478](https://scan9.scan.coverity.com/reports.htm#v34346/p12145/fileInstanceId=124135703&defectInstanceId=9495496&mergedDefectId=215478)
- [Defect 215480](https://scan9.scan.coverity.com/reports.htm#v34346/p12145/fileInstanceId=124135699&defectInstanceId=9456300&mergedDefectId=215480)
- [Defect 257775](https://scan9.scan.coverity.com/reports.htm#v34346/p12145/fileInstanceId=124135455&defectInstanceId=9475297&mergedDefectId=257775)
- [Defect 333337](https://scan9.scan.coverity.com/reports.htm#v34346/p12145/fileInstanceId=124135703&defectInstanceId=9495495&mergedDefectId=333337)

It might be possible to do something similar for the `TAILQ` macros.