### PR TITLE
create HelpBar after colours

### DIFF
--- a/main.c
+++ b/main.c
@@ -779,10 +779,6 @@ main
   if (!OptNoCurses && !isatty(1))
     goto main_curses;
 
-  /* Always create the mutt_windows because batch mode has some shared code
-   * paths that end up referencing them. */
-  rootwin_new();
-
   /* This must come before mutt_init() because curses needs to be started
    * before calling the init_pair() function to set the color scheme.  */
   if (!OptNoCurses)
@@ -790,7 +786,14 @@ main
     int crc = start_curses();
     if (crc != 0)
       goto main_curses; // TEST08: can't test -- fake term?
+  }
 
+  /* Always create the mutt_windows because batch mode has some shared code
+   * paths that end up referencing them. */
+  rootwin_new();
+
+  if (!OptNoCurses)
+  {
     /* check whether terminal status is supported (must follow curses init) */
     TsSupported = mutt_ts_capability();
     mutt_resize_screen();


### PR DESCRIPTION
The HelpBar has a colour observer, so it needs to be created after the colours are initialised.

**Test**, in NeoMutt:

- Enable the Help Bar, `set help = yes`
- Create a hook: `folder-hook . 'color status black yellow'`
- Change folder using `<sidebar-open>`

Both the Status Bar (Index) and the Help Bar should change colour.