### PR TITLE
Fix Header Cache Key Handling

### DIFF
--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -769,9 +769,13 @@ int hcache_delete_email(struct HeaderCache *hc, const char *key, size_t keylen)
 
   struct Buffer *path = buf_pool_get();
 
-  keylen = buf_printf(path, "%s%s", hc->folder, key);
+  struct RealKey *rk = realkey(hc, key, keylen, true);
+  keylen = buf_printf(path, "%s%s", hc->folder, rk->key);
+
   int rc = hc->store_ops->delete_record(hc->store_handle, buf_string(path), keylen);
+
   buf_pool_release(&path);
+
   return rc;
 }
 
@@ -785,7 +789,7 @@ int hcache_delete_raw(struct HeaderCache *hc, const char *key, size_t keylen)
 
   struct Buffer *path = buf_pool_get();
 
-  keylen = buf_printf(path, "%s%s", hc->folder, key);
+  keylen = buf_printf(path, "%s%.*s", hc->folder, (int) keylen, key);
   int rc = hc->store_ops->delete_record(hc->store_handle, buf_string(path), keylen);
   buf_pool_release(&path);
   return rc;

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -85,7 +85,7 @@ static struct RealKey *realkey(struct HeaderCache *hc, const char *key,
 {
   static struct RealKey rk;
 
-  rk.keylen = snprintf(rk.key, sizeof(rk.key), "%s%.*s", hc->folder, (int) keylen, key);
+  rk.keylen = snprintf(rk.key, sizeof(rk.key), "%s/%.*s", hc->folder, (int) keylen, key);
 
 #ifdef USE_HCACHE_COMPRESSION
   if (compress && hc->compr_ops)

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -720,10 +720,13 @@ int hcache_store_email(struct HeaderCache *hc, const char *key, size_t keylen,
   }
 #endif
 
-  /* store uncompressed data */
-  struct RealKey *rk = realkey(hc, key, keylen);
-  int rc = hcache_store_raw(hc, rk->key, rk->keylen, data, dlen);
+  struct Buffer *path = buf_pool_get();
 
+  struct RealKey *rk = realkey(hc, key, keylen);
+  rk->keylen = buf_printf(path, "%s%.*s", hc->folder, (int) rk->keylen, rk->key);
+  int rc = hc->store_ops->store(hc->store_handle, buf_string(path), rk->keylen, data, dlen);
+
+  buf_pool_release(&path);
   FREE(&data);
 
   return rc;

--- a/imap/mdata.c
+++ b/imap/mdata.c
@@ -93,10 +93,10 @@ struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char *n
   imap_hcache_open(adata, mdata);
   if (mdata->hcache)
   {
-    if (hcache_fetch_raw_obj(mdata->hcache, "/UIDVALIDITY", 12, &mdata->uidvalidity))
+    if (hcache_fetch_raw_obj(mdata->hcache, "UIDVALIDITY", 11, &mdata->uidvalidity))
     {
-      hcache_fetch_raw_obj(mdata->hcache, "/UIDNEXT", 8, &mdata->uid_next);
-      hcache_fetch_raw_obj(mdata->hcache, "/MODSEQ", 7, &mdata->modseq);
+      hcache_fetch_raw_obj(mdata->hcache, "UIDNEXT", 7, &mdata->uid_next);
+      hcache_fetch_raw_obj(mdata->hcache, "MODSEQ", 6, &mdata->modseq);
       mutt_debug(LL_DEBUG3, "hcache uidvalidity %u, uidnext %u, modseq %llu\n",
                  mdata->uidvalidity, mdata->uid_next, mdata->modseq);
     }

--- a/imap/message.c
+++ b/imap/message.c
@@ -1051,7 +1051,7 @@ fail:
   }
   m->msg_count = 0;
   m->size = 0;
-  hcache_delete_raw(mdata->hcache, "/MODSEQ", 7);
+  hcache_delete_raw(mdata->hcache, "MODSEQ", 6);
   imap_hcache_clear_uid_seqset(mdata);
   imap_hcache_close(mdata);
 
@@ -1369,8 +1369,8 @@ retry:
 
   if (mdata->hcache && initial_download)
   {
-    hcache_fetch_raw_obj(mdata->hcache, "/UIDVALIDITY", 12, &uidvalidity);
-    hcache_fetch_raw_obj(mdata->hcache, "/UIDNEXT", 8, &uid_next);
+    hcache_fetch_raw_obj(mdata->hcache, "UIDVALIDITY", 11, &uidvalidity);
+    hcache_fetch_raw_obj(mdata->hcache, "UIDNEXT", 7, &uid_next);
     if (mdata->modseq)
     {
       const bool c_imap_condstore = cs_subset_bool(NeoMutt->sub, "imap_condstore");
@@ -1386,7 +1386,7 @@ retry:
     if (uidvalidity && uid_next && uidvalidity == mdata->uidvalidity)
     {
       evalhc = true;
-      if (hcache_fetch_raw_obj(mdata->hcache, "/MODSEQ", 7, &modseq))
+      if (hcache_fetch_raw_obj(mdata->hcache, "MODSEQ", 6, &modseq))
       {
         if (has_qresync)
         {
@@ -1460,7 +1460,7 @@ retry:
     mdata->uid_next = maxuid + 1;
 
 #ifdef USE_HCACHE
-  hcache_store_raw(mdata->hcache, "/UIDVALIDITY", 12, &mdata->uidvalidity,
+  hcache_store_raw(mdata->hcache, "UIDVALIDITY", 11, &mdata->uidvalidity,
                    sizeof(mdata->uidvalidity));
   if (maxuid && (mdata->uid_next < maxuid + 1))
   {
@@ -1469,8 +1469,7 @@ retry:
   }
   if (mdata->uid_next > 1)
   {
-    hcache_store_raw(mdata->hcache, "/UIDNEXT", 8, &mdata->uid_next,
-                     sizeof(mdata->uid_next));
+    hcache_store_raw(mdata->hcache, "UIDNEXT", 7, &mdata->uid_next, sizeof(mdata->uid_next));
   }
 
   /* We currently only sync CONDSTORE and QRESYNC on the initial download.
@@ -1481,11 +1480,11 @@ retry:
   {
     if (has_condstore || has_qresync)
     {
-      hcache_store_raw(mdata->hcache, "/MODSEQ", 7, &mdata->modseq, sizeof(mdata->modseq));
+      hcache_store_raw(mdata->hcache, "MODSEQ", 6, &mdata->modseq, sizeof(mdata->modseq));
     }
     else
     {
-      hcache_delete_raw(mdata->hcache, "/MODSEQ", 7);
+      hcache_delete_raw(mdata->hcache, "MODSEQ", 6);
     }
 
     if (has_qresync)

--- a/imap/util.c
+++ b/imap/util.c
@@ -357,7 +357,7 @@ struct Email *imap_hcache_get(struct ImapMboxData *mdata, unsigned int uid)
 
   char key[16] = { 0 };
 
-  snprintf(key, sizeof(key), "/%u", uid);
+  snprintf(key, sizeof(key), "%u", uid);
   struct HCacheEntry hce = hcache_fetch_email(mdata->hcache, key, mutt_str_len(key),
                                               mdata->uidvalidity);
   if (!hce.email && hce.uidvalidity)
@@ -382,7 +382,7 @@ int imap_hcache_put(struct ImapMboxData *mdata, struct Email *e)
 
   char key[16] = { 0 };
 
-  snprintf(key, sizeof(key), "/%u", imap_edata_get(e)->uid);
+  snprintf(key, sizeof(key), "%u", imap_edata_get(e)->uid);
   return hcache_store_email(mdata->hcache, key, mutt_str_len(key), e, mdata->uidvalidity);
 }
 
@@ -400,7 +400,7 @@ int imap_hcache_del(struct ImapMboxData *mdata, unsigned int uid)
 
   char key[16] = { 0 };
 
-  snprintf(key, sizeof(key), "/%u", uid);
+  snprintf(key, sizeof(key), "%u", uid);
   return hcache_delete_email(mdata->hcache, key, mutt_str_len(key));
 }
 
@@ -419,8 +419,8 @@ int imap_hcache_store_uid_seqset(struct ImapMboxData *mdata)
   struct Buffer buf = buf_make(8192);
   imap_msn_index_to_uid_seqset(&buf, mdata);
 
-  int rc = hcache_store_raw(mdata->hcache, "/UIDSEQSET", 10, buf.data, buf_len(&buf) + 1);
-  mutt_debug(LL_DEBUG3, "Stored /UIDSEQSET %s\n", buf.data);
+  int rc = hcache_store_raw(mdata->hcache, "UIDSEQSET", 9, buf.data, buf_len(&buf) + 1);
+  mutt_debug(LL_DEBUG3, "Stored UIDSEQSET %s\n", buf.data);
   buf_dealloc(&buf);
   return rc;
 }
@@ -436,7 +436,7 @@ int imap_hcache_clear_uid_seqset(struct ImapMboxData *mdata)
   if (!mdata->hcache)
     return -1;
 
-  return hcache_delete_raw(mdata->hcache, "/UIDSEQSET", 10);
+  return hcache_delete_raw(mdata->hcache, "UIDSEQSET", 9);
 }
 
 /**
@@ -450,8 +450,8 @@ char *imap_hcache_get_uid_seqset(struct ImapMboxData *mdata)
   if (!mdata->hcache)
     return NULL;
 
-  char *seqset = hcache_fetch_raw_str(mdata->hcache, "/UIDSEQSET", 10);
-  mutt_debug(LL_DEBUG3, "Retrieved /UIDSEQSET %s\n", NONULL(seqset));
+  char *seqset = hcache_fetch_raw_str(mdata->hcache, "UIDSEQSET", 9);
+  mutt_debug(LL_DEBUG3, "Retrieved UIDSEQSET %s\n", NONULL(seqset));
 
   return seqset;
 }

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -105,7 +105,7 @@ mode_t maildir_umask(struct Mailbox *m)
  */
 static inline const char *maildir_hcache_key(struct Email *e)
 {
-  return e->path + 3;
+  return e->path + 4;
 }
 
 /**


### PR DESCRIPTION
This PR is mostly refactoring, but also fixes a few bugs.
(It's also shown me that the Notmuch backend is a disaster area, w.r.t. the Header Cache)

MH/Pop/NNTP didn't put a leading `/` on their Header Cache Key.
This was inconsistent the the other backends.

Code called `hcache_delete_record()` for both Emails and raw data.
When compression was enabled, the wrong key would be generated.

---

The Header Cache Key is generated from several pieces of data:
- Mailbox path
- Unique Email ID
- Compression suffix

The refactoring centralises the key assembly, saving effort in the callers.

- 39469ac72 separate `store_email()` from `store_raw()`
  Call the underlying `Store` function directly from `store_email()`.

- c18b3e72c `realkey()` separate out compression
  Make the compression suffix, e.g. `-zstd`, optional.
  This will allow the raw functions to use the same key generator.

- 2b3462946 fix `_delete_()`s key
  `hcache_delete_email()` uses a compression suffix
  `hcache_delete_raw()` doesn't

- 7355346b5 refactor `realkey()`, `fetch_raw()`
  Factor the Header Cache folder into the `realkey()` generation.
  This eliminates the need for `fetch_raw()`

- 4c880e5cc change `realkey()` to insert a `/`
  Finally, strip the leading `/` from the keys in the backends.
  Instead, insert a `/` in one place, `realkey()`