### PR TITLE
mutt_oauth2.py: error out if ENCRYPTION_PIPE was not supplied

### DIFF
--- a/contrib/oauth2/mutt_oauth2.py
+++ b/contrib/oauth2/mutt_oauth2.py
@@ -140,6 +140,8 @@ if args.debug:
 if not token:
     if not args.authorize:
         sys.exit('You must run script with "--authorize" at least once.')
+    if not ENCRYPTION_PIPE:
+        sys.exit("You need to provide a suitable --encryption-pipe setting")
     print('', )
     token['registration'] = args.provider or input(
         'Available app and endpoint registrations: {regs}\nOAuth2 registration: '.format(


### PR DESCRIPTION
Currently when this is not set on the command line then a complex error backtrace is the result, since the script tries to run `None` via subprocess.

Thus require the command line argument, but only if we are actually going to need encryption.

* **What does this PR do?**

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/code)

* **What are the relevant issue numbers?**
