### PR TITLE
config: fix flag overlaps

### DIFF
--- a/config/charset.h
+++ b/config/charset.h
@@ -25,6 +25,8 @@
 
 #include <stdint.h>
 
+/* Note: To save space, sets of config variable flags are packed into a uint32_t.
+ * When adding flags, check all config variables to ensure there are no overlaps of values */
 #define DT_CHARSET_SINGLE  (1 << 24) ///< Flag for charset_validator to allow only one charset
 #define DT_CHARSET_STRICT  (1 << 25) ///< Flag for charset_validator to use strict char check
 

--- a/config/charset.h
+++ b/config/charset.h
@@ -25,8 +25,8 @@
 
 #include <stdint.h>
 
-#define DT_CHARSET_SINGLE  (1 << 11) ///< Flag for charset_validator to allow only one charset
-#define DT_CHARSET_STRICT  (1 << 12) ///< Flag for charset_validator to use strict char check
+#define DT_CHARSET_SINGLE  (1 << 24) ///< Flag for charset_validator to allow only one charset
+#define DT_CHARSET_STRICT  (1 << 25) ///< Flag for charset_validator to use strict char check
 
 struct Buffer;
 struct ConfigDef;

--- a/config/sort2.h
+++ b/config/sort2.h
@@ -28,6 +28,8 @@
 extern const struct Mapping SortMethods[];
 
 /* ... DT_SORT */
+/* Note: To save space, sets of config variable flags are packed into a uint32_t.
+ * When adding flags, check all config variables to ensure there are no overlaps of values */
 #define DT_SORT_LAST    (1 << 21) ///< Sort flag for -last prefix
 #define DT_SORT_REVERSE (1 << 22) ///< Sort flag for -reverse prefix
 

--- a/config/sort2.h
+++ b/config/sort2.h
@@ -28,8 +28,8 @@
 extern const struct Mapping SortMethods[];
 
 /* ... DT_SORT */
-#define DT_SORT_LAST    (1 << 11) ///< Sort flag for -last prefix
-#define DT_SORT_REVERSE (1 << 12) ///< Sort flag for -reverse prefix
+#define DT_SORT_LAST    (1 << 21) ///< Sort flag for -last prefix
+#define DT_SORT_REVERSE (1 << 22) ///< Sort flag for -reverse prefix
 
 /**
  * enum SortType - Methods for sorting

--- a/config/types.h
+++ b/config/types.h
@@ -25,6 +25,9 @@
 
 #include <stdint.h>
 
+/* Note: To save space, sets of config variable flags are packed into a uint32_t.
+ * When adding flags, check all config variables to ensure there are no overlaps of values */
+
 /* Data Types */
 #define DT_ADDRESS   1  ///< e-mail address
 #define DT_BOOL      2  ///< boolean option

--- a/mutt/regex3.h
+++ b/mutt/regex3.h
@@ -32,6 +32,8 @@
 struct Buffer;
 
 /* ... DT_REGEX */
+/* Note: To save space, sets of config variable flags are packed into a uint32_t.
+ * When adding flags, check all config variables to ensure there are no overlaps of values */
 #define DT_REGEX_MATCH_CASE (1 << 17)  ///< Case-sensitive matching
 #define DT_REGEX_ALLOW_NOT  (1 << 18)  ///< Regex can begin with '!'
 #define DT_REGEX_NOSUB      (1 << 19)  ///< Do not report what was matched (REG_NOSUB)

--- a/mutt/regex3.h
+++ b/mutt/regex3.h
@@ -32,9 +32,9 @@
 struct Buffer;
 
 /* ... DT_REGEX */
-#define DT_REGEX_MATCH_CASE (1 << 6)  ///< Case-sensitive matching
-#define DT_REGEX_ALLOW_NOT  (1 << 7)  ///< Regex can begin with '!'
-#define DT_REGEX_NOSUB      (1 << 8)  ///< Do not report what was matched (REG_NOSUB)
+#define DT_REGEX_MATCH_CASE (1 << 17)  ///< Case-sensitive matching
+#define DT_REGEX_ALLOW_NOT  (1 << 18)  ///< Regex can begin with '!'
+#define DT_REGEX_NOSUB      (1 << 19)  ///< Do not report what was matched (REG_NOSUB)
 
 /* This is a non-standard option supported by Solaris 2.5.x
  * which allows patterns of the form \<...\> */

--- a/mutt/slist.h
+++ b/mutt/slist.h
@@ -30,15 +30,15 @@
 
 struct Buffer;
 
-#define SLIST_SEP_SPACE (1 << 13)
-#define SLIST_SEP_COMMA (1 << 14)
-#define SLIST_SEP_COLON (1 << 15)
+#define SLIST_SEP_SPACE (1 << 17)         ///< Slist items are space-separated
+#define SLIST_SEP_COMMA (1 << 18)         ///< Slist items are comma-separated
+#define SLIST_SEP_COLON (1 << 19)         ///< Slist items are colon-separated
 
-#define SLIST_SEP_MASK  0xE000
+#define SLIST_SEP_MASK  0xE0000
 
-#define SLIST_ALLOW_DUPES    (1 << 17)
-#define SLIST_ALLOW_EMPTY    (1 << 18)
-#define SLIST_CASE_SENSITIVE (1 << 19)
+#define SLIST_ALLOW_DUPES    (1 << 21)    ///< Slist may contain duplicates
+#define SLIST_ALLOW_EMPTY    (1 << 22)    ///< Slist may be empty
+#define SLIST_CASE_SENSITIVE (1 << 23)    ///< Slist is case-sensitive
 
 /**
  * struct Slist - String list

--- a/mutt/slist.h
+++ b/mutt/slist.h
@@ -30,6 +30,8 @@
 
 struct Buffer;
 
+/* Note: To save space, sets of config variable flags are packed into a uint32_t.
+ * When adding flags, check all config variables to ensure there are no overlaps of values */
 #define SLIST_SEP_SPACE (1 << 17)         ///< Slist items are space-separated
 #define SLIST_SEP_COMMA (1 << 18)         ///< Slist items are comma-separated
 #define SLIST_SEP_COLON (1 << 19)         ///< Slist items are colon-separated


### PR DESCRIPTION
Adding the `DT_ON_STARTUP` config flag, in 9a904e578, exposed a bug.
Some of the config flags overlapped causing a bug in the browser.

Trying to set the file mask in the browser <kbd>m</kbd> (`<enter-mask>`)
fails with the message: "Option mask may only be set at startup".

---

Each config variable has a type, e.g. `DT_STRING`.
Additionally, they have flags `OR`d with the type, e.g. `DT_NOT_EMPTY`.

`$mask` has the flag `DT_REGEX_MATCH_CASE` which had the same value as `DT_ON_STARTUP`.
This caused the bug.

Of the 471 config variables, just 8 have flags from multiple sets of flags:
 
```c
{ "charset",            DT_NOT_EMPTY|DT_CHARSET_SINGLE },
{ "group_index_format", DT_NOT_EMPTY|R_INDEX },
{ "index_format",       DT_NOT_EMPTY|R_INDEX },
{ "mbox",               DT_MAILBOX|R_INDEX },
{ "postponed",          DT_MAILBOX|R_INDEX },
{ "send_charset",       SLIST_SEP_COLON|SLIST_ALLOW_EMPTY|DT_CHARSET_STRICT },
{ "sort",               DT_SORT_REVERSE|DT_SORT_LAST|R_INDEX|R_RESORT },
{ "sort_aux",           DT_SORT_REVERSE|DT_SORT_LAST|R_INDEX|R_RESORT|R_RESORT_SUB },
```

They can be confirmed to be non-overlapping.

https://github.com/neomutt/neomutt/blob/349c9824a0efcb348547e38e0568d69f3bbe4c72/config/types.h#L49-L58
https://github.com/neomutt/neomutt/blob/349c9824a0efcb348547e38e0568d69f3bbe4c72/config/types.h#L69-L72
https://github.com/neomutt/neomutt/blob/349c9824a0efcb348547e38e0568d69f3bbe4c72/config/sort2.h#L31-L32
https://github.com/neomutt/neomutt/blob/349c9824a0efcb348547e38e0568d69f3bbe4c72/mutt/slist.h#L33-L41
https://github.com/neomutt/neomutt/blob/349c9824a0efcb348547e38e0568d69f3bbe4c72/config/charset.h#L28-L29
https://github.com/neomutt/neomutt/blob/349c9824a0efcb348547e38e0568d69f3bbe4c72/mutt/regex3.h#L35-L37
