### PR TITLE
alias: add tags

### DIFF
--- a/alias/alias.h
+++ b/alias/alias.h
@@ -26,16 +26,18 @@
 
 #include "mutt/lib.h"
 #include "address/lib.h"
+#include "email/lib.h"
 
 /**
  * struct Alias - A shortcut for an email address or addresses
  */
 struct Alias
 {
-  char *name;                 ///< Short name
-  struct AddressList addr;    ///< List of Addresses the Alias expands to
-  char *comment;              ///< Free-form comment string
-  TAILQ_ENTRY(Alias) entries; ///< Linked list
+  char              *name;        ///< Short name
+  struct AddressList addr;        ///< List of Addresses the Alias expands to
+  char              *comment;     ///< Free-form comment string
+  struct TagList     tags;        ///< Tags
+  TAILQ_ENTRY(Alias) entries;     ///< Linked list
 };
 TAILQ_HEAD(AliasList, Alias);
 

--- a/alias/commands.c
+++ b/alias/commands.c
@@ -32,12 +32,96 @@
 #include "mutt/lib.h"
 #include "address/lib.h"
 #include "config/lib.h"
+#include "email/lib.h"
 #include "core/lib.h"
 #include "commands.h"
 #include "lib.h"
 #include "parse/lib.h"
 #include "alias.h"
 #include "reverse.h"
+
+/**
+ * alias_tags_to_buffer - Write a comma-separated list of tags to a Buffer
+ * @param tl  Tags
+ * @param buf Buffer for the result
+ */
+void alias_tags_to_buffer(struct TagList *tl, struct Buffer *buf)
+{
+  struct Tag *np = NULL;
+  STAILQ_FOREACH(np, tl, entries)
+  {
+    buf_addstr(buf, np->name);
+    if (STAILQ_NEXT(np, entries))
+      buf_addch(buf, ',');
+  }
+}
+
+/**
+ * parse_alias_tags - Parse a comma-separated list of tags
+ * @param tags Comma-separated string
+ * @param tl   TagList for the results
+ */
+void parse_alias_tags(const char *tags, struct TagList *tl)
+{
+  if (!tags || !tl)
+    return;
+
+  struct Slist *sl = slist_parse(tags, SLIST_SEP_COMMA);
+  if (slist_is_empty(sl))
+    return;
+
+  struct ListNode *np = NULL;
+  STAILQ_FOREACH(np, &sl->head, entries)
+  {
+    struct Tag *tn = mutt_mem_calloc(1, sizeof(struct Tag));
+    tn->name = np->data; // Transfer string
+    np->data = NULL;
+    STAILQ_INSERT_TAIL(tl, tn, entries);
+  }
+  slist_free(&sl);
+}
+
+/**
+ * parse_alias_comments - Parse the alias/query comment field
+ * @param alias Alias for the result
+ * @param com   Comment string
+ *
+ * If the comment contains a 'tags:' field, the result will be put in alias.tags
+ */
+void parse_alias_comments(struct Alias *alias, const char *com)
+{
+  if (!com || (com[0] == '\0'))
+    return;
+
+  const regmatch_t *match = mutt_prex_capture(PREX_ALIAS_TAGS, com);
+  if (match)
+  {
+    const regmatch_t *pre = &match[PREX_ALIAS_TAGS_MATCH_PRE];
+    const regmatch_t *tags = &match[PREX_ALIAS_TAGS_MATCH_TAGS];
+    const regmatch_t *post = &match[PREX_ALIAS_TAGS_MATCH_POST];
+
+    struct Buffer *tmp = buf_pool_get();
+
+    // Extract the tags
+    buf_addstr_n(tmp, com + mutt_regmatch_start(tags),
+                 mutt_regmatch_end(tags) - mutt_regmatch_start(tags));
+    parse_alias_tags(buf_string(tmp), &alias->tags);
+    buf_reset(tmp);
+
+    // Collect all the other text as "comments"
+    buf_addstr_n(tmp, com + mutt_regmatch_start(pre),
+                 mutt_regmatch_end(pre) - mutt_regmatch_start(pre));
+    buf_addstr_n(tmp, com + mutt_regmatch_start(post),
+                 mutt_regmatch_end(post) - mutt_regmatch_start(post));
+    alias->comment = buf_strdup(tmp);
+
+    buf_pool_release(&tmp);
+  }
+  else
+  {
+    alias->comment = mutt_str_dup(com);
+  }
+}
 
 /**
  * parse_alias - Parse the 'alias' command - Implements Command::parse() - @ingroup command_parse
@@ -135,9 +219,12 @@ enum CommandResult parse_alias(struct Buffer *buf, struct Buffer *s,
   mutt_grouplist_destroy(&gl);
   if (!MoreArgs(s) && (s->dptr[0] == '#'))
   {
-    char *comment = s->dptr + 1;
-    SKIPWS(comment);
-    tmp->comment = mutt_str_dup(comment);
+    s->dptr++; // skip over the "# "
+    if (*s->dptr == ' ')
+      s->dptr++;
+
+    parse_alias_comments(tmp, s->dptr);
+    *s->dptr = '\0'; // We're done parsing
   }
 
   alias_reverse_add(tmp);

--- a/alias/dlg_alias.c
+++ b/alias/dlg_alias.c
@@ -118,6 +118,7 @@ static const struct Mapping AliasHelp[] = {
  * | \%n     | Index number
  * | \%r     | Address which alias expands to
  * | \%t     | Character which indicates if the alias is tagged for inclusion
+ * | \%Y     | Comma-separated tags
  */
 static const char *alias_format_str(char *buf, size_t buflen, size_t col, int cols,
                                     char op, const char *src, const char *prec,
@@ -157,6 +158,14 @@ static const char *alias_format_str(char *buf, size_t buflen, size_t col, int co
       buf[0] = av->is_tagged ? '*' : ' ';
       buf[1] = '\0';
       break;
+    case 'Y':
+    {
+      struct Buffer *tags = buf_pool_get();
+      alias_tags_to_buffer(&av->alias->tags, tags);
+      mutt_format_s(buf, buflen, prec, buf_string(tags));
+      buf_pool_release(&tags);
+      break;
+    }
   }
 
   return src;

--- a/alias/lib.h
+++ b/alias/lib.h
@@ -51,10 +51,12 @@
 
 struct Address;
 struct AddressList;
+struct Alias;
 struct Buffer;
 struct ConfigSubset;
 struct EnterWindowData;
 struct Envelope;
+struct TagList;
 
 extern const struct CompleteOps CompleteAliasOps;
 
@@ -71,6 +73,10 @@ struct AddressList *mutt_get_address       (struct Envelope *env, const char **p
 
 enum CommandResult parse_alias  (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult parse_unalias(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
+
+void alias_tags_to_buffer(struct TagList *tl, struct Buffer *buf);
+void parse_alias_comments(struct Alias *alias, const char *com);
+void parse_alias_tags    (const char *tags, struct TagList *tl);
 
 int  alias_complete(struct Buffer *buf, struct ConfigSubset *sub);
 void alias_dialog  (struct Mailbox *m, struct ConfigSubset *sub);

--- a/mutt/prex.c
+++ b/mutt/prex.c
@@ -249,6 +249,11 @@ static struct PrexStorage *prex(enum Prex which)
       PREX_ACCOUNT_CMD_MATCH_MAX,
       "^([[:alpha:]]+): (.*)$"
     },
+    {
+      PREX_ALIAS_TAGS,
+      PREX_ALIAS_TAGS_MATCH_MAX,
+      "^(.*)(tags:)([[:alnum:],]*) ?(.*)$"
+    },
     // clang-format on
   };
 

--- a/mutt/prex.h
+++ b/mutt/prex.h
@@ -39,6 +39,7 @@ enum Prex
   PREX_MBOX_FROM,             ///< `[From god@heaven.af.mil Sat Jan  3 01:05:34 1996]`
   PREX_MBOX_FROM_LAX,         ///< `[From god@heaven.af.mil Sat Jan  3 01:05:34 1996]`
   PREX_ACCOUNT_CMD,           ///< `key: value`
+  PREX_ALIAS_TAGS,            ///< `tags:a,b,c`
   PREX_MAX
 };
 
@@ -223,6 +224,20 @@ enum PrexAccountCmd
   PREX_ACCOUNT_CMD_MATCH_KEY,   ///< `[key]: value`
   PREX_ACCOUNT_CMD_MATCH_VALUE, ///< `key: [value]`
   PREX_ACCOUNT_CMD_MATCH_MAX
+};
+
+
+/**
+ * enum PrexAliasTags - Regex matches for the tags: field of an alias command
+ */
+enum PrexAliasTags
+{
+  PREX_ALIAS_TAGS_MATCH_FULL,  ///< `[... tags:a,b,c ...]`
+  PREX_ALIAS_TAGS_MATCH_PRE,   ///< `[... ]tags:a,b,c ...`
+  PREX_ALIAS_TAGS_MATCH_KEY,   ///< `... [tags:]a,b,c ...`
+  PREX_ALIAS_TAGS_MATCH_TAGS,  ///< `... tags:[a,b,c] ...`
+  PREX_ALIAS_TAGS_MATCH_POST,  ///< `... tags:a,b,c[ ...]`
+  PREX_ALIAS_TAGS_MATCH_MAX,
 };
 
 regmatch_t *mutt_prex_capture(enum Prex which, const char *str);

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -1169,6 +1169,24 @@ bool mutt_pattern_alias_exec(struct Pattern *pat, PatternExecFlags flags,
         return false;
       return pat->pat_not ^ match_addrlist(pat, (flags & MUTT_MATCH_FULL_ADDRESS),
                                            1, &av->alias->addr);
+    case MUTT_PAT_DRIVER_TAGS:
+    {
+      if (!av->alias)
+        return false;
+
+      struct Buffer *tags = buf_pool_get();
+      alias_tags_to_buffer(&av->alias->tags, tags);
+
+      bool rc = false;
+      if (!buf_is_empty(tags))
+      {
+        rc = (pat->pat_not ^ (patmatch(pat, buf_string(tags))));
+      }
+
+      buf_pool_release(&tags);
+      return rc;
+    }
+
     case MUTT_PAT_AND:
       return pat->pat_not ^ (perform_alias_and(pat->child, flags, av, cache) > 0);
     case MUTT_PAT_OR:

--- a/test/pattern/dummy.c
+++ b/test/pattern/dummy.c
@@ -324,3 +324,7 @@ struct MuttWindow *simple_dialog_new(enum MenuType mtype, enum WindowType wtype,
 {
   return NULL;
 }
+
+void alias_tags_to_buffer(struct TagList *tl, struct Buffer *buf)
+{
+}


### PR DESCRIPTION
A bit of time doing something easy :-)

## Overview

Parse a magic "tags:" field in the comment of an 'alias' or 'query' command. e.g.

```
alias jd John Doe <jd@example.com> # comment tags:work,football
```

This adds a new expando `%Y` to `$alias_format` and `$query_format` and a pattern `~Y` for searching / limiting.

## Testing

Using config from the [sample-data repo](https://github.com/neomutt/sample-data/blob/main/actor-alias-tags.rc):


[actor-alias-tags.rc](https://github.com/neomutt/sample-data/blob/main/actor-alias-tags.rc)
[actor-query-tags.txt](https://github.com/neomutt/sample-data/blob/main/actor-query-tags.txt)

and

```
set alias_format="%3n %f%t %-15a %-56r │ %c%>  %-25Y"
set query_format="%3c %t %-25.25n %-25.25a │ %e%>  %-25Y"
```

Resulting in something like:
```
 12    amanda          Amanda Bynes <ab@fig.com>                                │ cherry damson
 13    andie           Andie MacDowell <amd@raspberry.com>                      │ cherry
 14    andre           Andre De Shields <ads@cherry.com>                        │ banana cherry                    emmy,grammy,tony
 15    andrew          Andrew Lloyd Webber <alw@elderberry.com>                 │                                  emmy,grammy,oscar,tony
 16    angelina        Angelina Jolie <aj@nectarine.com>                        │ cherry
 17    anna            Anna Magnani <am@nectarine.com>                          │ apple banana cherry              oscar
```

Switch between winners:
```
macro alias <f5> "<limit>~Y emmy<enter>"
macro alias <f6> "<limit>~Y grammy<enter>"
macro alias <f7> "<limit>~Y oscar<enter>"
macro alias <f8> "<limit>~Y tony<enter>"
```

## Config Changes

I suggest changing the default format strings to:

```
set alias_format = "%3n %f%t %-15a %-56r | %c%>  %-15Y"
set query_format = "%3c %t %-25.25n %-25.25a | %e%>  %-15Y"
```

This will format the tags on the right-hand-side, giving priority to the comment.