### PR TITLE
mutt: -C: Enable message security in modes that by default don't enable it

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -19546,6 +19546,17 @@ neomutt -a image.jpg *.png -- address1 address2
               </entry>
             </row>
             <row>
+              <entry>-C</entry>
+              <entry>
+                Enable cryptographic operations
+                in the cases in which they're disabled by default.
+                Those include
+                batch mode,
+                sending a postponed message,
+                and resending a message.
+              </entry>
+            </row>
+            <row>
               <entry>-c <literal>address</literal></entry>
               <entry>
                 Specify a carbon copy (Cc) recipient

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -13378,6 +13378,85 @@ color   attach_headers     brightmagenta   default    "invalid node with packet 
       </sect2>
     </sect1>
 
+    <sect1 id="cli-crypto">
+      <title>Command-line Crypto (-C) Feature</title>
+      <subtitle>Enable message security in modes that by default don't
+      enable it</subtitle>
+
+      <sect2 id="cli-crypto-support">
+        <title>Support</title>
+        <para>
+          <emphasis role="bold">Since:</emphasis> NeoMutt 2024-01-21
+        </para>
+        <para>
+          <emphasis role="bold">Dependencies:</emphasis> Gpgme
+        </para>
+      </sect2>
+
+      <sect2 id="cli-crypto-intro">
+        <title>Introduction</title>
+        <para>
+          This feature allows enabling message security in modes that
+          don't enable it by default.  Those include batch mode, sending
+          a postponed message, and resending a message.
+        </para>
+        <para>
+          This allows using NeoMutt as a driver for git-send-email(1),
+          to send patches in signed and/or encrypted mail.
+        </para>
+      </sect2>
+
+      <sect2 id="cli-crypto-usage">
+        <title>Usage</title>
+        <para>
+          To send an email from a file, enabling cryptographic
+          operations as when sending interactively, simply use the
+          <literal>-C</literal> flag.
+        </para>
+        <screen>$ neomutt -C -H - &lt; /mail/to/be/sent</screen>
+      </sect2>
+
+      <sect2 id="cli-crypto-neomuttrc">
+        <title>neomuttrc</title>
+
+<screen>
+<emphasis role="comment"># Example NeoMutt config file for the cli-crypto feature.</emphasis>
+
+set pgp_default_key = "1111111111111111111111111111111111111111"
+<emphasis role="comment"># Sign all mail</emphasis>
+set crypt_autosign = yes
+<emphasis role="comment"># Encrypt mail if all recipients have valid public keys</emphasis>
+set crypt_opportunistic_encrypt = yes
+<emphasis role="comment"># Sign/encrypt protected headers (Subject)</emphasis>
+set crypt_protected_headers_write = yes
+<emphasis role="comment"># Self encrypt mail</emphasis>
+set crypt_self_encrypt = yes
+
+<emphasis role="comment"># vim: syntax=neomuttrc</emphasis>
+</screen>
+
+      </sect2>
+
+      <sect2 id="cli-crypto-gitconfig">
+        <title>neomuttrc</title>
+
+<screen>
+<emphasis role="comment"># Example .gitconfig config file for the cli-crypto feature.</emphasis>
+
+[sendemail]
+sendmailcmd = neomutt -C -H - &amp;&amp; true
+</screen>
+
+      </sect2>
+
+      <sect2 id="cli-crypto-credits">
+        <title>Credits</title>
+        <para>
+          Alejandro Colomar, Richard Russon, Jenya Sovetkin
+        </para>
+      </sect2>
+    </sect1>
+
     <sect1 id="compose-to-sender">
       <title>Compose to Sender Feature</title>
       <subtitle>Send new mail to the sender of the current mail</subtitle>
@@ -19548,12 +19627,9 @@ neomutt -a image.jpg *.png -- address1 address2
             <row>
               <entry>-C</entry>
               <entry>
-                Enable cryptographic operations
-                in the cases in which they're disabled by default.
-                Those include
-                batch mode,
-                sending a postponed message,
-                and resending a message.
+                Enable cryptographic operations in the cases in which they're
+                disabled by default. Those include batch mode, sending a
+                postponed message, and resending a message.
               </entry>
             </row>
             <row>

--- a/docs/neomutt.man
+++ b/docs/neomutt.man
@@ -235,6 +235,22 @@ Run in batch mode (do not start the ncurses UI)
 Specify a blind carbon copy (Bcc) recipient
 .
 .TP
+.BI \-C
+Enable cryptographic operations
+in the cases in which they're disabled by default.
+Those include:
+.RS
+.PD 0
+.IP \(bu 3
+Batch mode.
+.IP \(bu
+Sending a postponed message.
+.IP \(bu
+Resending a message.
+.PD
+.RE
+.
+.TP
 .BI \-c " address"
 Specify a carbon copy (Cc) recipient
 .

--- a/main.c
+++ b/main.c
@@ -246,10 +246,10 @@ static bool usage(void)
   // clang-format off
   /* L10N: Try to limit to 80 columns */
   puts(_("usage:"));
-  puts(_("  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+  puts(_("  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
          "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
          "          <address> [...]"));
-  puts(_("  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+  puts(_("  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
          "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"));
   puts(_("  neomutt [-nRy] [-e <command>] [-F <config>] [-f <mailbox>] [-m <type>]"));
   puts(_("  neomutt [-n] [-e <command>] [-F <config>] -A <alias>"));
@@ -274,6 +274,7 @@ static bool usage(void)
   puts(_("  -B            Run in batch mode (do not start the ncurses UI)"));
   puts(_("  -b <address>  Specify a blind carbon copy (Bcc) recipient"));
   puts(_("  -c <address>  Specify a carbon copy (Cc) recipient"));
+  puts(_("  -C            Enable Command-line Crypto (signing/encryption)"));
   puts(_("  -D            Dump all config variables as 'name=value' pairs to stdout"));
   puts(_("  -D -O         Like -D, but show one-liner documentation"));
   puts(_("  -D -S         Like -D, but hide the value of sensitive variables"));
@@ -579,7 +580,7 @@ main
         argv[nargc++] = argv[optind];
     }
 
-    i = getopt(argc, argv, "+A:a:Bb:F:f:c:Dd:l:Ee:g:GH:i:hm:nOpQ:RSs:TvxyzZ");
+    i = getopt(argc, argv, "+A:a:Bb:F:f:Cc:Dd:l:Ee:g:GH:i:hm:nOpQ:RSs:TvxyzZ");
     if (i != EOF)
     {
       switch (i)
@@ -595,6 +596,9 @@ main
           break;
         case 'b':
           mutt_list_insert_tail(&bcc_list, mutt_str_dup(optarg));
+          break;
+        case 'C':
+          sendflags |= SEND_CLI_CRYPTO;
           break;
         case 'c':
           mutt_list_insert_tail(&cc_list, mutt_str_dup(optarg));
@@ -770,7 +774,7 @@ main
       dump_variables || batch_mode)
   {
     OptNoCurses = true;
-    sendflags = SEND_BATCH;
+    sendflags |= SEND_BATCH;
     MuttLogger = log_disp_terminal;
     log_queue_flush(log_disp_terminal);
   }

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3233,7 +3233,7 @@ static struct CryptKeyInfo *crypt_getkeybyaddr(struct Address *a,
 
   if (matches)
   {
-    if (oppenc_mode)
+    if (oppenc_mode || !isatty(STDIN_FILENO))
     {
       const bool c_crypt_opportunistic_encrypt_strong_keys =
           cs_subset_bool(NeoMutt->sub, "crypt_opportunistic_encrypt_strong_keys");
@@ -3496,7 +3496,7 @@ static char *find_keys(const struct AddressList *addrlist, unsigned int app, boo
         k_info = crypt_getkeybyaddr(p, KEYFLAG_CANENCRYPT, app, &forced_valid, oppenc_mode);
       }
 
-      if (!k_info && !oppenc_mode)
+      if (!k_info && !oppenc_mode && isatty(STDIN_FILENO))
       {
         snprintf(buf, sizeof(buf), _("Enter keyID for %s: "), buf_string(p->mailbox));
 

--- a/ncrypt/gpgme_functions.c
+++ b/ncrypt/gpgme_functions.c
@@ -711,6 +711,22 @@ static bool crypt_key_is_valid(struct CryptKeyInfo *k)
   return true;
 }
 
+/**
+ * crypt_keys_are_valid - Are all these keys valid?
+ * @param keys Set of keys to test
+ * @retval true All keys are valid
+ */
+bool crypt_keys_are_valid(struct CryptKeyInfo *keys)
+{
+  for (struct CryptKeyInfo *k = keys; k != NULL; k = k->next)
+  {
+    if (!crypt_key_is_valid(k))
+      return false;
+  }
+
+  return true;
+}
+
 // -----------------------------------------------------------------------------
 
 /**

--- a/ncrypt/gpgme_functions.h
+++ b/ncrypt/gpgme_functions.h
@@ -25,6 +25,7 @@
 
 #include <stdbool.h>
 
+struct CryptKeyInfo;
 struct MuttWindow;
 
 /**
@@ -60,6 +61,7 @@ struct GpgmeFunction
   gpgme_function_t function; ///< Function to call
 };
 
+bool crypt_keys_are_valid(struct CryptKeyInfo *keys);
 int gpgme_function_dispatcher(struct MuttWindow *win, int op);
 
 #endif /* MUTT_NCRYPT_GPGME_FUNCTIONS_H */

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1546,7 +1546,7 @@ char *pgp_class_find_keys(const struct AddressList *addrlist, bool oppenc_mode)
         k_info = pgp_getkeybyaddr(p, KEYFLAG_CANENCRYPT, PGP_PUBRING, oppenc_mode);
       }
 
-      if (!k_info && !oppenc_mode)
+      if (!k_info && !oppenc_mode && isatty(STDIN_FILENO))
       {
         snprintf(buf, sizeof(buf), _("Enter keyID for %s: "), buf_string(p->mailbox));
         k_info = pgp_ask_for_key(buf, buf_string(p->mailbox), KEYFLAG_CANENCRYPT, PGP_PUBRING);

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1496,7 +1496,7 @@ char *pgp_class_find_keys(const struct AddressList *addrlist, bool oppenc_mode)
       {
         keyid = crypt_hook->data;
         enum QuadOption ans = MUTT_YES;
-        if (!oppenc_mode && c_crypt_confirm_hook)
+        if (!oppenc_mode && c_crypt_confirm_hook && isatty(STDIN_FILENO))
         {
           snprintf(buf, sizeof(buf), _("Use keyID = \"%s\" for %s?"), keyid,
                    buf_string(p->mailbox));

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -444,7 +444,7 @@ struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, KeyFlags abilities,
 
   if (matches)
   {
-    if (oppenc_mode)
+    if (oppenc_mode || !isatty(STDIN_FILENO))
     {
       const bool c_crypt_opportunistic_encrypt_strong_keys =
           cs_subset_bool(NeoMutt->sub, "crypt_opportunistic_encrypt_strong_keys");

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -110,6 +110,22 @@ bool pgp_key_is_valid(struct PgpKeyInfo *k)
 }
 
 /**
+ * pgp_keys_are_valid - Are all these PGP keys valid?
+ * @param keys Set of keys to examine
+ * @retval true All keys are valid
+ */
+bool pgp_keys_are_valid(struct PgpKeyInfo *keys)
+{
+  for (struct PgpKeyInfo *k = keys; k != NULL; k = k->next)
+  {
+    if (!pgp_key_is_valid(k))
+      return false;
+  }
+
+  return true;
+}
+
+/**
  * pgp_id_is_strong - Is a PGP key strong?
  * @param uid UID of a PGP key
  * @retval true Key is strong
@@ -563,16 +579,24 @@ struct PgpKeyInfo *pgp_getkeybystr(const char *cp, KeyFlags abilities, enum PgpR
 
   pgp_key_free(&keys);
 
+  k = NULL;
   if (matches)
   {
-    k = dlg_pgp(matches, NULL, p);
-    if (k)
-      pgp_remove_key(&matches, k);
-    pgp_key_free(&matches);
-  }
-  else
-  {
-    k = NULL;
+    if (isatty(STDIN_FILENO))
+    {
+      k = dlg_pgp(matches, NULL, p);
+      if (k)
+        pgp_remove_key(&matches, k);
+      pgp_key_free(&matches);
+    }
+    else if (pgp_keys_are_valid(matches))
+    {
+      k = matches;
+    }
+    else
+    {
+      mutt_error(_("A key can't be used: expired/disabled/revoked"));
+    }
   }
 
   FREE(&pfcopy);

--- a/ncrypt/pgpkey.h
+++ b/ncrypt/pgpkey.h
@@ -47,6 +47,7 @@ struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, KeyFlags abilities, enum 
 struct PgpKeyInfo *pgp_getkeybystr(const char *p, KeyFlags abilities, enum PgpRing keyring);
 struct PgpKeyInfo *pgp_principal_key(struct PgpKeyInfo *key);
 bool               pgp_key_is_valid(struct PgpKeyInfo *k);
+bool               pgp_keys_are_valid(struct PgpKeyInfo *keys);
 bool               pgp_id_is_valid(struct PgpUid *uid);
 bool               pgp_id_is_strong(struct PgpUid *uid);
 

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -36,7 +36,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <time.h>
+#include <unistd.h>
 #include "private.h"
 #include "mutt/lib.h"
 #include "address/lib.h"
@@ -646,7 +646,7 @@ static struct SmimeKey *smime_get_key_by_addr(const char *mailbox, KeyFlags abil
 
   if (matches)
   {
-    if (oppenc_mode)
+    if (oppenc_mode || !isatty(STDIN_FILENO))
     {
       const bool c_crypt_opportunistic_encrypt_strong_keys =
           cs_subset_bool(NeoMutt->sub, "crypt_opportunistic_encrypt_strong_keys");
@@ -848,7 +848,7 @@ char *smime_class_find_keys(const struct AddressList *al, bool oppenc_mode)
   TAILQ_FOREACH(a, al, entries)
   {
     key = smime_get_key_by_addr(buf_string(a->mailbox), KEYFLAG_CANENCRYPT, true, oppenc_mode);
-    if (!key && !oppenc_mode)
+    if (!key && !oppenc_mode && isatty(STDIN_FILENO))
     {
       char buf[1024] = { 0 };
       snprintf(buf, sizeof(buf), _("Enter keyID for %s: "), buf_string(a->mailbox));

--- a/po/bg.po
+++ b/po/bg.po
@@ -4822,15 +4822,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4911,6 +4913,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/ca.po
+++ b/po/ca.po
@@ -4890,15 +4890,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4979,6 +4981,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/cs.po
+++ b/po/cs.po
@@ -4650,21 +4650,23 @@ msgid "usage:"
 msgstr "Použití:"
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <příkaz>] [-F <konfigurace>] [-H <soubor>] [-i <soubor>]\n"
+"  neomutt [-CEnx] [-e <příkaz>] [-F <konfigurace>] [-H <soubor>] [-i <soubor>]\n"
 "          [-b <adresa>] [-c <adresa>] [-s <věc>] [-a <soubor> [...] --]\n"
 "          <adresa> [...]"
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <příkaz>] [-F <konfigurace>] [-b <adresa>] [-c <adresa>]\n"
+"  neomutt [-Cnx] [-e <příkaz>] [-F <konfigurace>] [-b <adresa>] [-c <adresa>]\n"
 "          [-s <věc>] [-a <soubor> [...] --] <adresa> [...] < zpráva"
 
 #: main.c:254
@@ -4747,6 +4749,11 @@ msgstr "  -B            Dávkový režim (nespustí se uživatelské rozhraní)"
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <adresa>   Určuje adresu pro utajenou kopii (BCC)"
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/da.po
+++ b/po/da.po
@@ -4750,15 +4750,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4839,6 +4841,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/de.po
+++ b/po/de.po
@@ -4616,21 +4616,23 @@ msgid "usage:"
 msgstr "Benutzung:"
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 
 #: main.c:254
@@ -4713,6 +4715,11 @@ msgstr "  -B            Benutze den Batch-Modus (startet ohne ncurses Oberfläch
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <address>  Verwende Adresse für unsichtbare Kopie (Bcc:) an Empfänger"
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/el.po
+++ b/po/el.po
@@ -4743,15 +4743,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4832,6 +4834,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -4611,20 +4611,20 @@ msgstr "usage:"
 
 #: main.c:249
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 
 #: main.c:252
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 
 #: main.c:254
@@ -4707,6 +4707,10 @@ msgstr "  -B            Run in batch mode (do not start the ncurses UI)"
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
+
+#: main.c:277
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/eo.po
+++ b/po/eo.po
@@ -4719,15 +4719,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4808,6 +4810,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/es.po
+++ b/po/es.po
@@ -4612,21 +4612,23 @@ msgid "usage:"
 msgstr "uso:"
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <comando>] [-F <config>] [-H <borrador>] [-i <incluir>]\n"
+"  neomutt [-CEnx] [-e <comando>] [-F <config>] [-H <borrador>] [-i <incluir>]\n"
 "          [-b <dirección>] [-c <dirección>] [-s <asunto>] [-a <archivo> [...] --]\n"
 "          <address> [...]"
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <comando>] [-F <config>] [-b <dirección>] [-c <dirección>]\n"
+"  neomutt [-Cnx] [-e <comando>] [-F <config>] [-b <dirección>] [-c <dirección>]\n"
 "          [-s <asunto>] [-a <archivo> [...] --] <dirección> [...] < mensaje"
 
 #: main.c:254
@@ -4711,6 +4713,11 @@ msgstr "  -B            Abrir en modo batch (no activar la interfaz 'ncurses')"
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <dirección>  Especificar un destinatario para copia (Cc)"
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/et.po
+++ b/po/et.po
@@ -4827,15 +4827,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4916,6 +4918,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/eu.po
+++ b/po/eu.po
@@ -4808,15 +4808,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4897,6 +4899,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/fi.po
+++ b/po/fi.po
@@ -4653,21 +4653,23 @@ msgid "usage:"
 msgstr "käyttö:"
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < viesti"
 
 #: main.c:254
@@ -4750,6 +4752,11 @@ msgstr "  -B            Eräajotila (ei käynnistä ncurses-käyttöliittymää)
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <address>  Lisää piilokopion (Bcc) osoite"
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/fr.po
+++ b/po/fr.po
@@ -4834,21 +4834,23 @@ msgid "usage:"
 msgstr "utilisation:"
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 
 #: main.c:254
@@ -4928,6 +4930,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <address>  indique un destinataire en Cci (Blind Carbon Copy - Bcc)"
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/ga.po
+++ b/po/ga.po
@@ -4870,15 +4870,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4959,6 +4961,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/gl.po
+++ b/po/gl.po
@@ -4850,15 +4850,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4939,6 +4941,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/hu.po
+++ b/po/hu.po
@@ -4613,21 +4613,23 @@ msgid "usage:"
 msgstr "használat:"
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <parancs>] [-F <konfig>] [-H <piszkozat>] [-i <beilleszt>]\n"
+"  neomutt [-CEnx] [-e <parancs>] [-F <konfig>] [-H <piszkozat>] [-i <beilleszt>]\n"
 "          [-b <cím>] [-c <cím>] [-s <tárgy>] [-a <file> [...] --]\n"
 "          <cím> [...]"
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <parancs>] [-F <konfig>] [-b <cím>] [-c <cím>]\n"
+"  neomutt [-Cnx] [-e <parancs>] [-F <konfig>] [-b <cím>] [-c <cím>]\n"
 "          [-s <tárgy>] [-a <file> [...] --] <cím> [...] < message"
 
 #: main.c:254
@@ -4708,6 +4710,11 @@ msgstr "  -B           Kötegelt mód (batch) (nincs ncourses felület)"
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <cím>  Titkos másolatot kapó címzett (Bcc) megadása"
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/id.po
+++ b/po/id.po
@@ -4779,15 +4779,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4868,6 +4870,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/it.po
+++ b/po/it.po
@@ -4805,15 +4805,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4894,6 +4896,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/ja.po
+++ b/po/ja.po
@@ -4718,15 +4718,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4807,6 +4809,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/ko.po
+++ b/po/ko.po
@@ -4795,15 +4795,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4884,6 +4886,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/lt.po
+++ b/po/lt.po
@@ -4631,21 +4631,23 @@ msgid "usage:"
 msgstr "naudojimas:"
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <komanda>] [-F <konf>] [-H <juodr>] [-i <įtraukti>]\n"
+"  neomutt [-CEnx] [-e <komanda>] [-F <konf>] [-H <juodr>] [-i <įtraukti>]\n"
 "          [-b <adresas>] [-c <adresas>] [-s <tema>] [-a <priedas> [...] --]\n"
 "          <adresas> [...]"
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <komanda>] [-F <konf>] [-b <adresas>] [-c <adresas>]\n"
+"  neomutt [-Cnx] [-e <komanda>] [-F <konf>] [-b <adresas>] [-c <adresas>]\n"
 "          [-s <tema>] [-a <priedas> [...] --] <adresas> [...] < žinutė"
 
 #: main.c:254
@@ -4728,6 +4730,11 @@ msgstr "  -B            Veikti automatiniame režime (be ncurses sąsajos)"
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <adresas>  Nurodyti slaptos kopijos (Bcc) gavėją"
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -4612,21 +4612,23 @@ msgid "usage:"
 msgstr "bruk:"
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <kommando>] [-F <oppsett>] [-H <kladd>] [-i <inkluder>]\n"
+"  neomutt [-CEnx] [-e <kommando>] [-F <oppsett>] [-H <kladd>] [-i <inkluder>]\n"
 "          [-b <adresse>] [-c <adresse>] [-s <emne>] [-a <fil> [...] --]\n"
 "          <adresse> [...]"
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <kommando>] [-F <oppsett>] [-b <adresse>] [-c <adresse>]\n"
+"  neomutt [-Cnx] [-e <kommando>] [-F <oppsett>] [-b <adresse>] [-c <adresse>]\n"
 "          [-s <emne>] [-a <fil> [...] --] <adresse> [...] < melding"
 
 #: main.c:254
@@ -4709,6 +4711,11 @@ msgstr "  -B            Kjør i knippe-modus (ikke start ncurses-grensesnittet)"
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <adresse>  Angi en blindkopi (Bcc)-mottager"
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/nl.po
+++ b/po/nl.po
@@ -4765,15 +4765,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4854,6 +4856,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/pl.po
+++ b/po/pl.po
@@ -4632,21 +4632,23 @@ msgid "usage:"
 msgstr "użycie:"
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <polecenie>] [-F <config>] [-H <wersja robocza>]\n"
+"  neomutt [-CEnx] [-e <polecenie>] [-F <config>] [-H <wersja robocza>]\n"
 "          [-i <plik>] [-b <adres>] [-c <adres>] [-s <temat>]\n"
 "          [-a <plik> [...] --] <adres> [...]"
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <polecenie>] [-F <config>] [-b <adres>] [-c <adres>]\n"
+"  neomutt [-Cnx] [-e <polecenie>] [-F <config>] [-b <adres>] [-c <adres>]\n"
 "          [-s <temat>] [-a <plik> [...] --] <adres> [...] < wiadomość"
 
 #: main.c:254
@@ -4731,6 +4733,11 @@ msgstr "  -B            Wykonaj w trybie wsadowym (nie uruchamiaj UI)"
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <address>  Wyszczególnij odbiorcę blind carbon copy (Bcc)"
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4613,21 +4613,23 @@ msgid "usage:"
 msgstr "uso:"
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <comando>] [-F <config>] [-H <rascunho>] [-i <incluso>]\n"
+"  neomutt [-CEnx] [-e <comando>] [-F <config>] [-H <rascunho>] [-i <incluso>]\n"
 "          [-b <endereço>] [-c <endereço>] [-s <assunto>] [-a <arquivo> [...] --]\n"
 "          <endereço> [...]"
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <comando>] [-F <config>] [-b <endereço>] [-c <endereço>]\n"
+"  neomutt [-Cnx] [-e <comando>] [-F <config>] [-b <endereço>] [-c <endereço>]\n"
 "          [-s <assunto>] [-a <arquivo> [...] --] <endereço> [...] < mensagem"
 
 #: main.c:254
@@ -4710,6 +4712,11 @@ msgstr "  -B            Executa no modo 'batch' (não inicia interface ncurses)"
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <endereço> Especifica endereço destinatário em cópia oculta (BCC)"
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/ru.po
+++ b/po/ru.po
@@ -4723,15 +4723,17 @@ msgid "usage:"
 msgstr "использование:"
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4811,6 +4813,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/sk.po
+++ b/po/sk.po
@@ -4635,21 +4635,23 @@ msgid "usage:"
 msgstr "Použitie:"
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <príkaz>] [-F <konfigurácia>] [-H <súbor>] [-i <súbor>]\n"
+"  neomutt [-CEnx] [-e <príkaz>] [-F <konfigurácia>] [-H <súbor>] [-i <súbor>]\n"
 "          [-b <adresa>] [-c <adresa>] [-s <predmet>] [-a <súbor> [...] --]\n"
 "          <adresa> [...]"
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <príkaz>] [-F <konfigurácia>] [-b <adresa>] [-c <adresa>]\n"
+"  neomutt [-Cnx] [-e <príkaz>] [-F <konfigurácia>] [-b <adresa>] [-c <adresa>]\n"
 "          [-s <predmet>] [-a <súbor> [...] --] <adresa> [...] < správa"
 
 #: main.c:254
@@ -4732,6 +4734,11 @@ msgstr "  -B            Dávkový režim (nespustí sa užívateľské rozhranie
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <adresa>   Určuje adresu pre utajenú kópiu (Bcc)"
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/sr.po
+++ b/po/sr.po
@@ -4631,21 +4631,23 @@ msgid "usage:"
 msgstr "употреба:"
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <наредба>] [-F <конфиг>] [-H <скица>] [-i <укључење>]\n"
+"  neomutt [-CEnx] [-e <наредба>] [-F <конфиг>] [-H <скица>] [-i <укључење>]\n"
 "          [-b <адреса>] [-c <адреса>] [-s <тема>] [-a <датотека> [...] --]\n"
 "          <адреса> [...]"
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <наредба>] [-F <конфиг>] [-b <адреса>] [-c <адреса>]\n"
+"  neomutt [-Cnx] [-e <наредба>] [-F <конфиг>] [-b <адреса>] [-c <адреса>]\n"
 "          [-s <тема>] [-a <датотека> [...] --] <адреса> [...] < порука"
 
 #: main.c:254
@@ -4729,6 +4731,11 @@ msgstr "  -B            Рад у аутоматском режиму (не по
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <адреса>   Задавање примаоца невидљиве копије (Bcc)"
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/sv.po
+++ b/po/sv.po
@@ -4807,15 +4807,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4896,6 +4898,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/tr.po
+++ b/po/tr.po
@@ -4613,21 +4613,23 @@ msgid "usage:"
 msgstr "kullanım:"
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <komut>] [-F <yapılandırma>] [-H <taslak>] [-i <içer>]\n"
+"  neomutt [-CEnx] [-e <komut>] [-F <yapılandırma>] [-H <taslak>] [-i <içer>]\n"
 "          [-b <adres>] [-c <adres>] [-s <konu>] [-a <dosya> [...] --]\n"
 "          <adres> [...]"
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <komut>] [-F <yapılandırma>] [-b <adres>] [-c <adres>]\n"
+"  neomutt [-Cnx] [-e <komut>] [-F <yapılandırma>] [-b <adres>] [-c <adres>]\n"
 "          [-s <konu>] [-a <dosya> [...] --] <adres> [...] < message"
 
 #: main.c:254
@@ -4711,6 +4713,11 @@ msgstr "  -B            Toplu iş kipinde çalıştır (ncurses arabirimini çal
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <adres>    Bir gizli karbon kopya (Bcc) alıcısı belirt"
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/uk.po
+++ b/po/uk.po
@@ -4639,21 +4639,23 @@ msgid "usage:"
 msgstr "викор.:"
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <команда>] [-F <конфіґ>] [-H <чернетка>] [-i <врахувати>]\n"
+"  neomutt [-CEnx] [-e <команда>] [-F <конфіґ>] [-H <чернетка>] [-i <врахувати>]\n"
 "          [-b <адреса>] [-c <адреса>] [-s <тема>] [-a <файл> [...] --]\n"
 "          <адреса> [...]"
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <команда>] [-F <конфіґ>] [-b <адреса>] [-c <адреса>]\n"
+"  neomutt [-Cnx] [-e <команда>] [-F <конфіґ>] [-b <адреса>] [-c <адреса>]\n"
 "          [-s <тема>] [-a <файл> [...] --] <адреса> [...] < повідомлення"
 
 #: main.c:254
@@ -4736,6 +4738,11 @@ msgstr "  -B            Запустити в пакетному режимі (�
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <адреса>  Визначає отримувача прихованої перебивної копії (Bcc)"
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4606,21 +4606,23 @@ msgid "usage:"
 msgstr "用法："
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
-"  neomutt [-Enx] [-e <命令>] [-F <配置>] [-H <草稿>] [-i <文件>]\n"
+"  neomutt [-CEnx] [-e <命令>] [-F <配置>] [-H <草稿>] [-i <文件>]\n"
 "          [-b <地址>] [-c <地址>] [-s <主题>] [-a <文件> [...] --]\n"
 "          <地址> [...]"
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
-"  neomutt [-nx] [-e <命令>] [-F <配置>] [-b <地址>] [-c <地址>]\n"
+"  neomutt [-Cnx] [-e <命令>] [-F <配置>] [-b <地址>] [-c <地址>]\n"
 "          [-s <主题>] [-a <文件> [...] --] <地址> [...] < 信件"
 
 #: main.c:254
@@ -4703,6 +4705,11 @@ msgstr "  -B            以批处理模式运行（不启动 ncurses 用户界�
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <地址>     指定一个密送(BCC)收件人"
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -4806,15 +4806,17 @@ msgid "usage:"
 msgstr ""
 
 #: main.c:249
+#, fuzzy
 msgid ""
-"  neomutt [-Enx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
+"  neomutt [-CEnx] [-e <command>] [-F <config>] [-H <draft>] [-i <include>]\n"
 "          [-b <address>] [-c <address>] [-s <subject>] [-a <file> [...] --]\n"
 "          <address> [...]"
 msgstr ""
 
 #: main.c:252
+#, fuzzy
 msgid ""
-"  neomutt [-nx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
+"  neomutt [-Cnx] [-e <command>] [-F <config>] [-b <address>] [-c <address>]\n"
 "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"
 msgstr ""
 
@@ -4895,6 +4897,11 @@ msgstr ""
 #: main.c:275
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""
+
+#: main.c:277
+#, fuzzy
+msgid "  -C            Enable Command-line Crypto (signing/encryption)"
+msgstr "  -C            Enable Command-line Crypto (signing/encryption)"
 
 #: main.c:276
 msgid "  -c <address>  Specify a carbon copy (Cc) recipient"

--- a/send/send.h
+++ b/send/send.h
@@ -35,7 +35,7 @@ struct EmailArray;
 struct Envelope;
 struct Mailbox;
 
-typedef uint16_t SendFlags;             ///< Flags for mutt_send_message(), e.g. #SEND_REPLY
+typedef uint32_t SendFlags;             ///< Flags for mutt_send_message(), e.g. #SEND_REPLY
 #define SEND_NO_FLAGS               0   ///< No flags are set
 #define SEND_REPLY            (1 << 0)  ///< Reply to sender
 #define SEND_GROUP_REPLY      (1 << 1)  ///< Reply to all
@@ -53,6 +53,7 @@ typedef uint16_t SendFlags;             ///< Flags for mutt_send_message(), e.g.
 #define SEND_NEWS             (1 << 13) ///< Reply to a news article
 #define SEND_REVIEW_TO        (1 << 14) ///< Allow the user to edit the To field
 #define SEND_CONSUMED_STDIN   (1 << 15) ///< stdin has been read; don't read it twice
+#define SEND_CLI_CRYPTO       (1 << 16) ///< Enable message security in modes that by default don't enable it
 
 void            mutt_add_to_reference_headers(struct Envelope *env, struct Envelope *env_cur, struct ConfigSubset *sub);
 struct Address *mutt_default_from(struct ConfigSubset *sub);


### PR DESCRIPTION
neomutt(1) didn't enable message security in some cases; the most notable one being batch mode.  This beahvior was inherited from mutt(1), and the rationale was originally to allow using mutt(1) non-interactively, such as in cron(8) jobs, where the keyring cannot be unlocked easily.

However, in some other cases, the keyring can be unlocked, and it's desirable to sign and encrypt mail.  Let's allow overriding that default by specifying the -C flag in the command line.

This allows using neomutt(1) as a driver for git-send-email(1) to enable encryption and signing of patches.  Here's a working configuration for that:

In <~/.gitconfig>, add this section:

	[sendemail]
		sendmailcmd = neomutt -H - && true

Closes: <https://github.com/neomutt/neomutt/issues/1471>
Link: <https://github.com/neomutt/neomutt/pull/1475>
Link: <https://github.com/neomutt/neomutt/pull/1476>
Link: <https://github.com/neomutt/neomutt/issues/1090>
Link: <https://marc.info/?l=mutt-dev&m=169996086410329>
Link: <https://lists.mutt.org/pipermail/mutt-dev/Week-of-Mon-20220725/001383.html>
Co-developed-by: @esovetkin 
Cc: @flatcap 
Cc: @hadmut
Cc: @mschilli87

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

     TODO, after we agree that the code is good.

   - All builds and tests are passing

     CI, hold my hand.

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

     N/A

   - Code follows the [style guide](https://neomutt.org/dev/code)

     More or less