### PR TITLE
fix(change-folder): don't exclude notmuch

### DIFF
--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -330,10 +330,6 @@ static struct Mailbox *find_next_mailbox(struct Buffer *s, bool find_new)
     struct MailboxNode *np = NULL;
     STAILQ_FOREACH(np, &ml, entries)
     {
-      // Match only real mailboxes if looking for new mail.
-      if (find_new && np->mailbox->type == MUTT_NOTMUCH)
-        continue;
-
       buf_expand_path(&np->mailbox->pathbuf);
       struct Mailbox *m_cur = np->mailbox;
 


### PR DESCRIPTION
Remove the arbitrary exclusion of notmuch mailboxes. This appears as holdover behavior from before the 4e5d94bc2a281d3f171d2b6c61f89cbbf9b7b394 unification of mailboxes.

Fixes #1982

Original commit by @Austin-Ray 