### PR TITLE
add mutt_time_now()

### DIFF
--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1700,7 +1700,7 @@ static enum MxStatus mbox_mbox_check_stats(struct Mailbox *m, uint8_t flags)
       mx_mbox_open(m, MUTT_QUIET | MUTT_NOSORT | MUTT_PEEK);
       mx_mbox_close(m);
       m->peekonly = old_peek;
-      adata->stats_last_checked.tv_sec = mutt_date_now();
+      mutt_time_now(&adata->stats_last_checked);
     }
   }
 

--- a/mutt/date.c
+++ b/mutt/date.c
@@ -462,6 +462,26 @@ uint64_t mutt_date_now_ms(void)
 }
 
 /**
+ * mutt_time_now - Set the provided time field to the current time.
+ * @param[out] tp Field to set
+ *
+ * Uses nanosecond precision if available, if not we fallback to microseconds.
+ */
+void mutt_time_now(struct timespec *tp)
+{
+#ifdef HAVE_CLOCK_GETTIME
+  if (clock_gettime(CLOCK_REALTIME, tp) != 0)
+    mutt_perror("clock_gettime");
+#else
+  struct timeval tv = { 0, 0 };
+  if (gettimeofday(&tv, NULL) != 0)
+    mutt_perror("gettimeofday");
+  tp->tv_sec = tv.tv_sec;
+  tp->tv_nsec = tv.tv_usec * 1000;
+#endif
+}
+
+/**
  * parse_small_uint - Parse a positive integer of at most 5 digits
  * @param[in]  str String to parse
  * @param[in]  end End of the string

--- a/mutt/date.h
+++ b/mutt/date.h
@@ -68,5 +68,6 @@ void      mutt_date_normalize_time(struct tm *tm);
 time_t    mutt_date_parse_date(const char *s, struct Tz *tz_out);
 time_t    mutt_date_parse_imap(const char *s);
 void      mutt_date_sleep_ms(size_t ms);
+void      mutt_time_now(struct timespec *tp);
 
 #endif /* MUTT_MUTT_DATE_H */

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -303,12 +303,7 @@ void mutt_mailbox_set_notified(struct Mailbox *m)
     return;
 
   m->notified = true;
-#ifdef HAVE_CLOCK_GETTIME
-  clock_gettime(CLOCK_REALTIME, &m->last_visited);
-#else
-  m->last_visited.tv_sec = mutt_date_now();
-  m->last_visited.tv_nsec = 0;
-#endif
+  mutt_time_now(&m->last_visited);
 }
 
 /**


### PR DESCRIPTION
Abstracts away the `#ifdef` and also uses nanosecond precision for the mbox `stats_last_checked` field if available.

Nanosecond precision was introduced in commit 42b436392846f06ebbc01dba7642361f163a8aad to fix high resolution issues with the inotify interface.