### PR TITLE
Respect umask when saving attachments

### DIFF
--- a/attach/mutt_attach.c
+++ b/attach/mutt_attach.c
@@ -542,8 +542,9 @@ int mutt_view_attachment(FILE *fp, struct Body *b, enum ViewAttachMode mode,
     const bool c_wait_key = cs_subset_bool(NeoMutt->sub, "wait_key");
     if (use_pager || use_pipe)
     {
-      if (use_pager && ((fd_pager = mutt_file_open(buf_string(pagerfile),
-                                                   O_CREAT | O_EXCL | O_WRONLY)) == -1))
+      if (use_pager &&
+          ((fd_pager = mutt_file_open(buf_string(pagerfile),
+                                      O_CREAT | O_EXCL | O_WRONLY, 0600)) == -1))
       {
         mutt_perror("open");
         goto return_error;
@@ -745,7 +746,7 @@ int mutt_pipe_attachment(FILE *fp, struct Body *b, const char *path, const char 
 
   if (outfile && *outfile)
   {
-    out = mutt_file_open(outfile, O_CREAT | O_EXCL | O_WRONLY);
+    out = mutt_file_open(outfile, O_CREAT | O_EXCL | O_WRONLY, 0600);
     if (out < 0)
     {
       mutt_perror("open");

--- a/attach/mutt_attach.c
+++ b/attach/mutt_attach.c
@@ -886,11 +886,11 @@ bail:
 static FILE *save_attachment_open(const char *path, enum SaveAttach opt)
 {
   if (opt == MUTT_SAVE_APPEND)
-    return mutt_file_fopen(path, "a");
+    return mutt_file_fopen_masked(path, "a");
   if (opt == MUTT_SAVE_OVERWRITE)
-    return mutt_file_fopen(path, "w");
+    return mutt_file_fopen_masked(path, "w");
 
-  return mutt_file_fopen(path, "w");
+  return mutt_file_fopen_masked(path, "w");
 }
 
 /**
@@ -1049,11 +1049,11 @@ int mutt_decode_save_attachment(FILE *fp, struct Body *b, const char *path,
   state.flags = flags;
 
   if (opt == MUTT_SAVE_APPEND)
-    state.fp_out = mutt_file_fopen(path, "a");
+    state.fp_out = mutt_file_fopen_masked(path, "a");
   else if (opt == MUTT_SAVE_OVERWRITE)
-    state.fp_out = mutt_file_fopen(path, "w");
+    state.fp_out = mutt_file_fopen_masked(path, "w");
   else
-    state.fp_out = mutt_file_fopen(path, "w");
+    state.fp_out = mutt_file_fopen_masked(path, "w");
 
   if (!state.fp_out)
   {

--- a/core/neomutt.c
+++ b/core/neomutt.c
@@ -229,11 +229,13 @@ FILE *mutt_file_fopen_masked_full(const char *path, const char *mode,
 {
   // Set the user's umask (saved on startup)
   mode_t old_umask = umask(NeoMutt->user_default_umask);
+  mutt_debug(LL_DEBUG3, "umask set to %03o\n", NeoMutt->user_default_umask);
 
   // The permissions will be limited by the umask
   FILE *fp = mutt_file_fopen_full(path, mode, 0666, file, line, func);
 
   umask(old_umask); // Immediately restore the umask
+  mutt_debug(LL_DEBUG3, "umask set to %03o\n", old_umask);
 
   return fp;
 }

--- a/core/neomutt.h
+++ b/core/neomutt.h
@@ -45,6 +45,7 @@ struct NeoMutt
   struct ConfigSubset *sub;      ///< Inherited config items
   struct AccountList accounts;   ///< List of all Accounts
   locale_t time_c_locale;        ///< Current locale but LC_TIME=C
+  mode_t user_default_umask;     ///< User's default file writing permissions (inferred from umask)
 };
 
 extern struct NeoMutt *NeoMutt;
@@ -68,5 +69,8 @@ struct NeoMutt *neomutt_new           (struct ConfigSet *cs);
 
 void   neomutt_mailboxlist_clear  (struct MailboxList *ml);
 size_t neomutt_mailboxlist_get_all(struct MailboxList *head, struct NeoMutt *n, enum MailboxType type);
+
+// Similar to mutt_file_fopen, but with the proper permissions inferred from
+#define mutt_file_fopen_masked(PATH, MODE) mutt_file_fopen_masked_full(PATH, MODE, __FILE__, __LINE__, __func__)
 
 #endif /* MUTT_CORE_NEOMUTT_H */

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -11039,6 +11039,36 @@ macro index ,a "&lt;save-message&gt;=archive&lt;enter&gt;&lt;enter-command&gt;ec
             </varlistentry>
           </variablelist>
         </sect3>
+
+        <sect3 id="attach-saving">
+          <title>Saving Attachments</title>
+
+          <variablelist>
+            <varlistentry>
+              <term>
+                <literal>&lt;save-entry&gt;</literal>
+                (default keybinding: s)
+              </term>
+              <listitem>
+                <para>
+                  This will save the attachment to disk.
+                </para>
+                <para>
+                  The permissions of the saved file will depend on the user's
+                  <literal>umask</literal>. e.g. <literal>umask 022</literal>
+                  will create a file with permissions <literal>rw-r--r--</literal>.
+                </para>
+                <para>
+                  See also: <link linkend="attach-save-dir">$attach_save_dir</link>,
+                  <link linkend="attach-save-without-prompting">$attach_save_without_prompting</link>,
+                  <link linkend="attach-sep">$attach_sep</link>,
+                  <link linkend="attach-split">$attach_split</link>
+                </para>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+        </sect3>
+
       </sect2>
 
       <sect2 id="compose-menu">

--- a/main.c
+++ b/main.c
@@ -595,8 +595,6 @@ main
 
   init_locale();
 
-  umask(077);
-
   EnvList = envlist_init(envp);
   for (optind = 1; optind < double_dash;)
   {
@@ -754,6 +752,9 @@ main
 
   NeoMutt = neomutt_new(cs);
   init_config(cs);
+
+  // Change the current umask, and save the original one
+  NeoMutt->user_default_umask = umask(077);
   subjrx_init();
   attach_init();
   alternates_init();

--- a/main.c
+++ b/main.c
@@ -792,6 +792,8 @@ main
   mutt_log_prep();
   MuttLogger = log_disp_queue;
   log_translation();
+  mutt_debug(LL_DEBUG1, "user's umask %03o\n", NeoMutt->user_default_umask);
+  mutt_debug(LL_DEBUG3, "umask set to 077\n");
 
   if (!STAILQ_EMPTY(&cc_list) || !STAILQ_EMPTY(&bcc_list))
   {

--- a/mh/shared.c
+++ b/mh/shared.c
@@ -75,7 +75,10 @@ bool mh_mkstemp(struct Mailbox *m, FILE **fp, char **tgt)
   int fd;
   char path[PATH_MAX] = { 0 };
 
-  mode_t omask = umask(mh_umask(m));
+  mode_t new_umask = mh_umask(m);
+  mode_t old_umask = umask(new_umask);
+  mutt_debug(LL_DEBUG3, "umask set to %03o\n", new_umask);
+
   while (true)
   {
     snprintf(path, sizeof(path), "%s/.neomutt-%s-%d-%" PRIu64, mailbox_path(m),
@@ -86,7 +89,8 @@ bool mh_mkstemp(struct Mailbox *m, FILE **fp, char **tgt)
       if (errno != EEXIST)
       {
         mutt_perror("%s", path);
-        umask(omask);
+        umask(old_umask);
+        mutt_debug(LL_DEBUG3, "umask set to %03o\n", old_umask);
         return false;
       }
     }
@@ -96,7 +100,8 @@ bool mh_mkstemp(struct Mailbox *m, FILE **fp, char **tgt)
       break;
     }
   }
-  umask(omask);
+  umask(old_umask);
+  mutt_debug(LL_DEBUG3, "umask set to %03o\n", old_umask);
 
   *fp = fdopen(fd, "w");
   if (!*fp)

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -569,10 +569,11 @@ const char *mutt_file_rotate(const char *path, int count)
  * mutt_file_open - Open a file
  * @param path  Pathname to open
  * @param flags Flags, e.g. O_EXCL
+ * @param mode  Permissions of the file (Relevant only when writing or appending)
  * @retval >0 Success, file handle
  * @retval -1 Error
  */
-int mutt_file_open(const char *path, uint32_t flags)
+int mutt_file_open(const char *path, uint32_t flags, mode_t mode)
 {
   if (!path)
     return -1;
@@ -592,7 +593,7 @@ int mutt_file_open(const char *path, uint32_t flags)
       goto cleanup;
     }
 
-    fd = open(buf_string(safe_file), flags, 0600);
+    fd = open(buf_string(safe_file), flags, mode);
     if (fd < 0)
     {
       rmdir(buf_string(safe_dir));
@@ -651,6 +652,7 @@ DIR *mutt_file_opendir(const char *path, enum MuttOpenDirMode mode)
  * mutt_file_fopen_full - Call fopen() safely
  * @param path  Filename
  * @param mode  Mode e.g. "r" readonly; "w" read-write
+ * @param perms Permissions of the file (Relevant only when writing or appending)
  * @param file  Source file
  * @param line  Source line number
  * @param func  Source function
@@ -660,8 +662,8 @@ DIR *mutt_file_opendir(const char *path, enum MuttOpenDirMode mode)
  * When opening files for writing, make sure the file doesn't already exist to
  * avoid race conditions.
  */
-FILE *mutt_file_fopen_full(const char *path, const char *mode, const char *file,
-                           int line, const char *func)
+FILE *mutt_file_fopen_full(const char *path, const char *mode, const mode_t perms,
+                           const char *file, int line, const char *func)
 {
   if (!path || !mode)
     return NULL;
@@ -676,7 +678,7 @@ FILE *mutt_file_fopen_full(const char *path, const char *mode, const char *file,
     else
       flags |= O_WRONLY;
 
-    int fd = mutt_file_open(path, flags);
+    int fd = mutt_file_open(path, flags, perms);
     if (fd >= 0)
     {
       fp = fdopen(fd, mode);

--- a/mutt/file.h
+++ b/mutt/file.h
@@ -108,7 +108,8 @@ time_t      mutt_file_decrease_mtime(const char *fp, struct stat *st);
 void        mutt_file_expand_fmt(struct Buffer *dest, const char *fmt, const char *src);
 void        mutt_file_expand_fmt_quote(char *dest, size_t destlen, const char *fmt, const char *src);
 int         mutt_file_fclose_full(FILE **fp, const char *file, int line, const char *func);
-FILE *      mutt_file_fopen_full(const char *path, const char *mode, const char *file, int line, const char *func);
+FILE *      mutt_file_fopen_full(const char *path, const char *mode, const mode_t perms, const char *file, int line, const char *func);
+FILE *      mutt_file_fopen_masked_full(const char *path, const char *mode, const char *file, int line, const char *func);
 int         mutt_file_fsync_close(FILE **fp);
 long        mutt_file_get_size(const char *path);
 long        mutt_file_get_size_fp(FILE* fp);
@@ -117,7 +118,7 @@ bool        mutt_file_iter_line(struct MuttFileIter *iter, FILE *fp, ReadLineFla
 int         mutt_file_lock(int fd, bool excl, bool timeout);
 bool        mutt_file_map_lines(mutt_file_map_t func, void *user_data, FILE *fp, ReadLineFlags flags);
 int         mutt_file_mkdir(const char *path, mode_t mode);
-int         mutt_file_open(const char *path, uint32_t flags);
+int         mutt_file_open(const char *path, uint32_t flags, mode_t mode);
 DIR *       mutt_file_opendir(const char *path, enum MuttOpenDirMode mode);
 char *      mutt_file_read_keyword(const char *file, char *buf, size_t buflen);
 char *      mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, ReadLineFlags flags);
@@ -143,7 +144,8 @@ void        mutt_file_resolve_symlink(struct Buffer *buf);
 void        buf_quote_filename(struct Buffer *buf, const char *filename, bool add_outer);
 void        buf_file_expand_fmt_quote(struct Buffer *dest, const char *fmt, const char *src);
 
-#define mutt_file_fopen(PATH, MODE) mutt_file_fopen_full(PATH, MODE, __FILE__, __LINE__, __func__)
+// Safest default permissions should be 0600
+#define mutt_file_fopen(PATH, MODE) mutt_file_fopen_full(PATH, MODE, 0600, __FILE__, __LINE__, __func__)
 #define mutt_file_fclose(FP)        mutt_file_fclose_full(FP, __FILE__, __LINE__, __func__)
 
 #endif /* MUTT_MUTT_FILE_H */

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -471,7 +471,7 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e,
 
   struct Buffer *buf = buf_pool_get();
   buf_mktemp(buf);
-  fp = mutt_file_fopen(buf_string(buf), "w+");
+  fp = mutt_file_fopen_masked(buf_string(buf), "w+");
   if (!fp)
   {
     buf_pool_release(&buf);

--- a/test/file/mutt_file_open.c
+++ b/test/file/mutt_file_open.c
@@ -31,6 +31,6 @@ void test_mutt_file_open(void)
   // int mutt_file_open(const char *path, uint32_t flags);
 
   {
-    TEST_CHECK(mutt_file_open(NULL, 0) != 0);
+    TEST_CHECK(mutt_file_open(NULL, 0, 0644) != 0);
   }
 }


### PR DESCRIPTION
* **What does this PR do?**
Adds a new option that allows for umask to be respected when attachments are saved, or when the attachments are viewed in an external program. Fixes #4148.

* **Does this PR meet the acceptance criteria?** Not yet, that's why I added a TODO list. I'm currently failing one of the tests, and probably righteously, since an assertion fails. Something is wrong with how I use the `NeoMutt` "global" variable.

 - [ ] Documentation created/updated (you have to edit [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head) for that).
 - [x] All builds and tests are passing.
 - [ ] Added [doxygen code documentation](https://neomutt.org/dev/doxygen) ([syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)).
 - [x] Code follows the [style guide](https://neomutt.org/dev/code)

* **What are the relevant issue numbers?**

#4148