### PR TITLE
file: upgrade mutt_file_fopen/fclose()

### DIFF
--- a/alias/alias.c
+++ b/alias/alias.c
@@ -524,7 +524,7 @@ retry_name:
     goto done;
   }
   mutt_expand_path(buf->data, buf->dsize);
-  fp_alias = fopen(buf_string(buf), "a+");
+  fp_alias = mutt_file_fopen(buf_string(buf), "a+");
   if (!fp_alias)
   {
     mutt_perror("%s", buf_string(buf));

--- a/attach/mutt_attach.c
+++ b/attach/mutt_attach.c
@@ -81,7 +81,7 @@ int mutt_get_tmp_attachment(struct Body *b)
   mailcap_entry_free(&entry);
 
   FILE *fp_in = NULL, *fp_out = NULL;
-  if ((fp_in = fopen(b->filename, "r")) &&
+  if ((fp_in = mutt_file_fopen(b->filename, "r")) &&
       (fp_out = mutt_file_fopen(buf_string(tmpfile), "w")))
   {
     mutt_file_copy_stream(fp_in, fp_out);
@@ -633,11 +633,7 @@ int mutt_view_attachment(FILE *fp, struct Body *b, enum ViewAttachMode mode,
         state.fp_in = fp;
         state.flags = STATE_CHARCONV;
         mutt_decode_attachment(b, &state);
-        if (mutt_file_fclose(&state.fp_out) == EOF)
-        {
-          mutt_debug(LL_DEBUG1, "fclose(%s) errno=%d %s\n",
-                     buf_string(pagerfile), errno, strerror(errno));
-        }
+        mutt_file_fclose(&state.fp_out);
       }
       else
       {
@@ -835,7 +831,7 @@ int mutt_pipe_attachment(FILE *fp, struct Body *b, const char *path, const char 
       infile = b->filename;
     }
 
-    fp_in = fopen(infile, "r");
+    fp_in = mutt_file_fopen(infile, "r");
     if (!fp_in)
     {
       mutt_perror("fopen");
@@ -886,9 +882,9 @@ bail:
 static FILE *save_attachment_open(const char *path, enum SaveAttach opt)
 {
   if (opt == MUTT_SAVE_APPEND)
-    return fopen(path, "a");
+    return mutt_file_fopen(path, "a");
   if (opt == MUTT_SAVE_OVERWRITE)
-    return fopen(path, "w");
+    return mutt_file_fopen(path, "w");
 
   return mutt_file_fopen(path, "w");
 }
@@ -994,7 +990,7 @@ int mutt_save_attachment(FILE *fp, struct Body *b, const char *path,
 
     /* In send mode, just copy file */
 
-    FILE *fp_old = fopen(b->filename, "r");
+    FILE *fp_old = mutt_file_fopen(b->filename, "r");
     if (!fp_old)
     {
       mutt_perror("fopen");
@@ -1049,9 +1045,9 @@ int mutt_decode_save_attachment(FILE *fp, struct Body *b, const char *path,
   state.flags = flags;
 
   if (opt == MUTT_SAVE_APPEND)
-    state.fp_out = fopen(path, "a");
+    state.fp_out = mutt_file_fopen(path, "a");
   else if (opt == MUTT_SAVE_OVERWRITE)
-    state.fp_out = fopen(path, "w");
+    state.fp_out = mutt_file_fopen(path, "w");
   else
     state.fp_out = mutt_file_fopen(path, "w");
 
@@ -1070,7 +1066,7 @@ int mutt_decode_save_attachment(FILE *fp, struct Body *b, const char *path,
   {
     /* When called from the compose menu, the attachment isn't parsed,
      * so we need to do it here. */
-    state.fp_in = fopen(b->filename, "r");
+    state.fp_in = mutt_file_fopen(b->filename, "r");
     if (!state.fp_in)
     {
       mutt_perror("fopen");
@@ -1182,7 +1178,7 @@ int mutt_print_attachment(FILE *fp, struct Body *b)
     /* interactive program */
     if (piped)
     {
-      fp_in = fopen(buf_string(newfile), "r");
+      fp_in = mutt_file_fopen(buf_string(newfile), "r");
       if (!fp_in)
       {
         mutt_perror("fopen");
@@ -1245,7 +1241,7 @@ int mutt_print_attachment(FILE *fp, struct Body *b)
       mutt_debug(LL_DEBUG2, "successfully decoded %s type attachment to %s\n",
                  type, buf_string(newfile));
 
-      fp_in = fopen(buf_string(newfile), "r");
+      fp_in = mutt_file_fopen(buf_string(newfile), "r");
       if (!fp_in)
       {
         mutt_perror("fopen");

--- a/attach/recvattach.c
+++ b/attach/recvattach.c
@@ -498,7 +498,7 @@ void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
         }
 
         rc = save_attachment_flowed_helper(fp, b, buf_string(tfile), opt, e);
-        if ((rc == 0) && c_attach_sep && (fp_out = fopen(buf_string(tfile), "a")))
+        if ((rc == 0) && c_attach_sep && (fp_out = mutt_file_fopen(buf_string(tfile), "a")))
         {
           fprintf(fp_out, "%s", c_attach_sep);
           mutt_file_fclose(&fp_out);
@@ -651,7 +651,7 @@ static void pipe_attachment(FILE *fp, struct Body *b, struct State *state)
       infile = b->filename;
     }
 
-    fp_in = fopen(infile, "r");
+    fp_in = mutt_file_fopen(infile, "r");
     if (!fp_in)
     {
       mutt_perror("fopen");
@@ -849,7 +849,7 @@ static void print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
               return;
             }
 
-            fp_in = fopen(buf_string(newfile), "r");
+            fp_in = mutt_file_fopen(buf_string(newfile), "r");
             if (fp_in)
             {
               mutt_file_copy_stream(fp_in, state->fp_out);

--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -97,9 +97,9 @@ static bool lock_realpath(struct Mailbox *m, bool excl)
     return true;
 
   if (excl)
-    ci->fp_lock = fopen(m->realpath, "a");
+    ci->fp_lock = mutt_file_fopen(m->realpath, "a");
   else
-    ci->fp_lock = fopen(m->realpath, "r");
+    ci->fp_lock = mutt_file_fopen(m->realpath, "r");
   if (!ci->fp_lock)
   {
     mutt_perror("%s", m->realpath);

--- a/convert/content_info.c
+++ b/convert/content_info.c
@@ -214,7 +214,7 @@ struct Content *mutt_get_content_info(const char *fname, struct Body *b,
     return NULL;
   }
 
-  fp = fopen(fname, "r");
+  fp = mutt_file_fopen(fname, "r");
   if (!fp)
   {
     mutt_debug(LL_DEBUG1, "%s: %s (errno %d)\n", fname, strerror(errno), errno);

--- a/debug/logging.c
+++ b/debug/logging.c
@@ -125,7 +125,8 @@ int log_disp_debug(time_t stamp, const char *file, int line, const char *functio
     bytes += snprintf(buf + bytes, buflen - bytes, "\033[0m"); // Escape
   }
 
-  bytes += snprintf(buf + bytes, buflen - bytes, "\n");
+  if (level < LL_DEBUG1)
+    bytes += snprintf(buf + bytes, buflen - bytes, "\n");
 
   fputs(buf, stdout);
   return bytes;

--- a/editmsg.c
+++ b/editmsg.c
@@ -181,7 +181,7 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
     goto bail;
   }
 
-  fp = fopen(buf_string(fname), "r");
+  fp = mutt_file_fopen(buf_string(fname), "r");
   if (!fp)
   {
     rc = -1;

--- a/handler.c
+++ b/handler.c
@@ -1419,7 +1419,7 @@ static int run_decode_and_handler(struct Body *b, struct State *state,
         return -1;
       }
 #else
-      state->fp_in = fopen(buf_string(tempfile), "r");
+      state->fp_in = mutt_file_fopen(buf_string(tempfile), "r");
       unlink(buf_string(tempfile));
       buf_pool_release(&tempfile);
 #endif

--- a/history/history.c
+++ b/history/history.c
@@ -290,7 +290,7 @@ cleanup:
   FREE(&linebuf);
   if (fp_tmp)
   {
-    if ((fflush(fp_tmp) == 0) && (fp = fopen(NONULL(c_history_file), "w")))
+    if ((fflush(fp_tmp) == 0) && (fp = mutt_file_fopen(NONULL(c_history_file), "w")))
     {
       rewind(fp_tmp);
       mutt_file_copy_stream(fp_tmp, fp);

--- a/imap/message.c
+++ b/imap/message.c
@@ -1535,7 +1535,7 @@ int imap_append_message(struct Mailbox *m, struct Message *msg)
   struct ImapAccountData *adata = imap_adata_get(m);
   struct ImapMboxData *mdata = imap_mdata_get(m);
 
-  fp = fopen(msg->path, "r");
+  fp = mutt_file_fopen(msg->path, "r");
   if (!fp)
   {
     mutt_perror("%s", msg->path);

--- a/mailcap.c
+++ b/mailcap.c
@@ -252,7 +252,7 @@ static bool rfc1524_mailcap_parse(struct Body *b, const char *filename, const ch
     return false;
   const int btlen = ch - type;
 
-  FILE *fp = fopen(filename, "r");
+  FILE *fp = mutt_file_fopen(filename, "r");
   if (fp)
   {
     size_t buflen;
@@ -428,9 +428,10 @@ static bool rfc1524_mailcap_parse(struct Body *b, const char *filename, const ch
           entry->xneomuttkeep = false;
         }
       }
-    } /* while (!found && (buf = mutt_file_read_line ())) */
+    }
     mutt_file_fclose(&fp);
-  } /* if ((fp = fopen ())) */
+  }
+
   FREE(&buf);
   return found;
 }

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -886,7 +886,7 @@ static FILE *maildir_open_find_message_dir(const char *folder, const char *uniqu
     if (mutt_str_equal(buf_string(tunique), unique))
     {
       buf_printf(fname, "%s/%s/%s", folder, subfolder, de->d_name);
-      fp = fopen(buf_string(fname), "r");
+      fp = mutt_file_fopen(buf_string(fname), "r");
       oe = errno;
       break;
     }
@@ -1025,7 +1025,7 @@ bool maildir_parse_message(const char *fname, bool is_old, struct Email *e)
   if (!fname || !e)
     return false;
 
-  FILE *fp = fopen(fname, "r");
+  FILE *fp = mutt_file_fopen(fname, "r");
   if (!fp)
     return false;
 
@@ -1606,14 +1606,13 @@ static bool maildir_msg_open(struct Mailbox *m, struct Message *msg, struct Emai
 
   snprintf(path, sizeof(path), "%s/%s", mailbox_path(m), e->path);
 
-  msg->fp = fopen(path, "r");
+  msg->fp = mutt_file_fopen(path, "r");
   if (!msg->fp && (errno == ENOENT))
     msg->fp = maildir_open_find_message(mailbox_path(m), e->path, NULL);
 
   if (!msg->fp)
   {
     mutt_perror("%s", path);
-    mutt_debug(LL_DEBUG1, "fopen: %s: %s (errno %d)\n", path, strerror(errno), errno);
     return false;
   }
 

--- a/main.c
+++ b/main.c
@@ -1036,7 +1036,7 @@ main
         {
           buf_strcpy(&expanded_infile, infile);
           buf_expand_path(&expanded_infile);
-          fp_in = fopen(buf_string(&expanded_infile), "r");
+          fp_in = mutt_file_fopen(buf_string(&expanded_infile), "r");
           if (!fp_in)
           {
             mutt_perror("%s", buf_string(&expanded_infile));
@@ -1081,7 +1081,7 @@ main
         }
         mutt_file_fclose(&fp_out);
 
-        fp_in = fopen(buf_string(&tempfile), "r");
+        fp_in = mutt_file_fopen(buf_string(&tempfile), "r");
         if (!fp_in)
         {
           mutt_perror("%s", buf_string(&tempfile));

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -798,7 +798,7 @@ static bool mbox_ac_add(struct Account *a, struct Mailbox *m)
  */
 static FILE *mbox_open_readwrite(struct Mailbox *m)
 {
-  FILE *fp = fopen(mailbox_path(m), "r+");
+  FILE *fp = mutt_file_fopen(mailbox_path(m), "r+");
   if (fp)
     m->readonly = false;
   return fp;
@@ -813,7 +813,7 @@ static FILE *mbox_open_readwrite(struct Mailbox *m)
  */
 static FILE *mbox_open_readonly(struct Mailbox *m)
 {
-  FILE *fp = fopen(mailbox_path(m), "r");
+  FILE *fp = mutt_file_fopen(mailbox_path(m), "r");
   if (fp)
     m->readonly = true;
   return fp;
@@ -1259,7 +1259,7 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
 
   unlink_tempfile = false;
 
-  fp = fopen(buf_string(tempfile), "r");
+  fp = mutt_file_fopen(buf_string(tempfile), "r");
   if (!fp)
   {
     mutt_sig_unblock();
@@ -1553,7 +1553,7 @@ enum MailboxType mbox_path_probe(const char *path, const struct stat *st)
   if (st->st_size == 0)
     return MUTT_MBOX;
 
-  FILE *fp = fopen(path, "r");
+  FILE *fp = mutt_file_fopen(path, "r");
   if (!fp)
     return MUTT_UNKNOWN;
 

--- a/mh/mh.c
+++ b/mh/mh.c
@@ -511,7 +511,7 @@ static int mh_sort_path(const void *a, const void *b, void *sdata)
  */
 static struct Email *mh_parse_message(const char *fname, struct Email *e)
 {
-  FILE *fp = fopen(fname, "r");
+  FILE *fp = mutt_file_fopen(fname, "r");
   if (!fp)
   {
     return NULL;
@@ -1144,11 +1144,10 @@ static bool mh_msg_open(struct Mailbox *m, struct Message *msg, struct Email *e)
 
   snprintf(path, sizeof(path), "%s/%s", mailbox_path(m), e->path);
 
-  msg->fp = fopen(path, "r");
+  msg->fp = mutt_file_fopen(path, "r");
   if (!msg->fp)
   {
     mutt_perror("%s", path);
-    mutt_debug(LL_DEBUG1, "fopen: %s: %s (errno %d)\n", path, strerror(errno), errno);
     return false;
   }
 

--- a/mh/sequence.c
+++ b/mh/sequence.c
@@ -132,7 +132,7 @@ void mh_seq_add_one(struct Mailbox *m, int n, bool unseen, bool flagged, bool re
   snprintf(seq_flagged, sizeof(seq_flagged), "%s:", NONULL(c_mh_seq_flagged));
 
   snprintf(sequences, sizeof(sequences), "%s/.mh_sequences", mailbox_path(m));
-  FILE *fp_old = fopen(sequences, "r");
+  FILE *fp_old = mutt_file_fopen(sequences, "r");
   if (fp_old)
   {
     while ((buf = mutt_file_read_line(buf, &sz, fp_old, NULL, MUTT_RL_NO_FLAGS)))
@@ -266,7 +266,7 @@ void mh_seq_update(struct Mailbox *m)
   snprintf(sequences, sizeof(sequences), "%s/.mh_sequences", mailbox_path(m));
 
   /* first, copy unknown sequences */
-  FILE *fp_old = fopen(sequences, "r");
+  FILE *fp_old = mutt_file_fopen(sequences, "r");
   if (fp_old)
   {
     while ((buf = mutt_file_read_line(buf, &s, fp_old, NULL, MUTT_RL_NO_FLAGS)))
@@ -385,7 +385,7 @@ int mh_seq_read(struct MhSequences *mhs, const char *path)
   char pathname[PATH_MAX] = { 0 };
   snprintf(pathname, sizeof(pathname), "%s/.mh_sequences", path);
 
-  FILE *fp = fopen(pathname, "r");
+  FILE *fp = mutt_file_fopen(pathname, "r");
   if (!fp)
     return 0; /* yes, ask callers to silently ignore the error */
 

--- a/mutt/file.h
+++ b/mutt/file.h
@@ -106,8 +106,8 @@ int         mutt_file_copy_stream(FILE *fp_in, FILE *fp_out);
 time_t      mutt_file_decrease_mtime(const char *fp, struct stat *st);
 void        mutt_file_expand_fmt(struct Buffer *dest, const char *fmt, const char *src);
 void        mutt_file_expand_fmt_quote(char *dest, size_t destlen, const char *fmt, const char *src);
-int         mutt_file_fclose(FILE **fp);
-FILE *      mutt_file_fopen(const char *path, const char *mode);
+int         mutt_file_fclose_full(FILE **fp, const char *file, int line, const char *func);
+FILE *      mutt_file_fopen_full(const char *path, const char *mode, const char *file, int line, const char *func);
 int         mutt_file_fsync_close(FILE **fp);
 long        mutt_file_get_size(const char *path);
 long        mutt_file_get_size_fp(FILE* fp);
@@ -142,5 +142,8 @@ void        mutt_file_resolve_symlink(struct Buffer *buf);
 
 void        buf_quote_filename(struct Buffer *buf, const char *filename, bool add_outer);
 void        buf_file_expand_fmt_quote(struct Buffer *dest, const char *fmt, const char *src);
+
+#define mutt_file_fopen(PATH, MODE) mutt_file_fopen_full(PATH, MODE, __FILE__, __LINE__, __func__)
+#define mutt_file_fclose(FP)        mutt_file_fclose_full(FP, __FILE__, __LINE__, __func__)
 
 #endif /* MUTT_MUTT_FILE_H */

--- a/mutt/random.c
+++ b/mutt/random.c
@@ -34,6 +34,7 @@
 #include <string.h>
 #include "random.h"
 #include "exit.h"
+#include "file.h"
 #include "logging2.h"
 #include "message.h"
 #ifdef HAVE_SYS_RANDOM_H
@@ -79,7 +80,7 @@ static int mutt_randbuf(void *buf, size_t buflen)
    * configured selinux, seccomp or something to not allow getrandom */
   if (!FpRandom)
   {
-    FpRandom = fopen("/dev/urandom", "rb");
+    FpRandom = mutt_file_fopen("/dev/urandom", "rb");
     if (!FpRandom)
     {
       mutt_error(_("open /dev/urandom: %s"), strerror(errno));

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -194,7 +194,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *e,
   fputc('\n', fp_out); /* tie off the header. */
 
   /* now copy the body of the message. */
-  FILE *fp_in = fopen(body, "r");
+  FILE *fp_in = mutt_file_fopen(body, "r");
   if (!fp_in)
   {
     mutt_perror("%s", body);
@@ -234,7 +234,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *e,
   mutt_list_free(&e->env->userhdrs);
 
   /* Read the temp file back in */
-  fp_in = fopen(buf_string(path), "r");
+  fp_in = mutt_file_fopen(buf_string(path), "r");
   if (!fp_in)
   {
     mutt_perror("%s", buf_string(path));

--- a/muttlib.c
+++ b/muttlib.c
@@ -1304,7 +1304,7 @@ FILE *mutt_open_read(const char *path, pid_t *thepid)
       errno = EINVAL;
       return NULL;
     }
-    fp = fopen(path, "r");
+    fp = mutt_file_fopen(path, "r");
     *thepid = -1;
   }
   return fp;

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -2186,7 +2186,7 @@ static int pgp_check_traditional_one_body(FILE *fp, struct Body *b)
     goto cleanup;
   }
 
-  FILE *fp_tmp = fopen(buf_string(tempfile), "r");
+  FILE *fp_tmp = mutt_file_fopen(buf_string(tempfile), "r");
   if (!fp_tmp)
   {
     unlink(buf_string(tempfile));

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -822,7 +822,7 @@ static bool pgp_check_traditional_one_body(FILE *fp, struct Body *b)
     goto cleanup;
   }
 
-  FILE *fp_tmp = fopen(buf_string(tempfile), "r");
+  FILE *fp_tmp = mutt_file_fopen(buf_string(tempfile), "r");
   if (!fp_tmp)
   {
     unlink(buf_string(tempfile));
@@ -1741,7 +1741,7 @@ struct Body *pgp_class_traditional_encryptsign(struct Body *b, SecurityFlags fla
   if (!mutt_istr_equal(b->subtype, "plain"))
     goto cleanup;
 
-  FILE *fp_body = fopen(b->filename, "r");
+  FILE *fp_body = mutt_file_fopen(b->filename, "r");
   if (!fp_body)
   {
     mutt_perror("%s", b->filename);

--- a/ncrypt/pgp_functions.c
+++ b/ncrypt/pgp_functions.c
@@ -116,7 +116,7 @@ static int op_generic_select_entry(struct PgpData *pd, int op)
  */
 static int op_verify_key(struct PgpData *pd, int op)
 {
-  FILE *fp_null = fopen("/dev/null", "w");
+  FILE *fp_null = mutt_file_fopen("/dev/null", "w");
   if (!fp_null)
   {
     mutt_perror(_("Can't open /dev/null"));

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -265,7 +265,7 @@ struct Body *pgp_class_make_key_attachment(void)
     goto cleanup;
   }
 
-  FILE *fp_null = fopen("/dev/null", "w");
+  FILE *fp_null = mutt_file_fopen("/dev/null", "w");
   if (!fp_null)
   {
     mutt_perror(_("Can't open /dev/null"));

--- a/ncrypt/pgpmicalg.c
+++ b/ncrypt/pgpmicalg.c
@@ -192,7 +192,7 @@ static short pgp_find_hash(const char *fname)
     goto bye;
   }
 
-  fp_in = fopen(fname, "r");
+  fp_in = mutt_file_fopen(fname, "r");
   if (!fp_in)
   {
     mutt_perror("%s", fname);

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1780,7 +1780,7 @@ int smime_class_verify_one(struct Body *b, struct State *state, const char *temp
   /* restore final destination and substitute the tempfile for input */
   state->fp_out = fp;
   fp = state->fp_in;
-  state->fp_in = fopen(buf_string(signedfile), "r");
+  state->fp_in = mutt_file_fopen(buf_string(signedfile), "r");
 
   /* restore the prefix */
   state->prefix = save_prefix;

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2355,7 +2355,7 @@ static bool nm_msg_open(struct Mailbox *m, struct Message *msg, struct Email *e)
 
   snprintf(path, sizeof(path), "%s/%s", folder, e->path);
 
-  msg->fp = fopen(path, "r");
+  msg->fp = mutt_file_fopen(path, "r");
   if (!msg->fp && (errno == ENOENT) && ((m->type == MUTT_MAILDIR) || (m->type == MUTT_NOTMUCH)))
   {
     msg->fp = maildir_open_find_message(folder, e->path, NULL);

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -319,7 +319,7 @@ int dlg_pager(struct PagerView *pview)
   pview->win_pager->size = MUTT_WIN_SIZE_MAXIMISE;
   priv->lines_max = LINES; // number of lines on screen, from curses
   priv->lines = mutt_mem_calloc(priv->lines_max, sizeof(struct Line));
-  priv->fp = fopen(pview->pdata->fname, "r");
+  priv->fp = mutt_file_fopen(pview->pdata->fname, "r");
   priv->has_types = ((pview->mode == PAGER_MODE_EMAIL) || (pview->flags & MUTT_SHOWCOLOR)) ?
                         MUTT_TYPES :
                         0; // main message or rfc822 attachment

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -996,7 +996,7 @@ static bool pop_msg_open(struct Mailbox *m, struct Message *msg, struct Email *e
     if (cache->index == e->index)
     {
       /* yes, so just return a pointer to the message */
-      msg->fp = fopen(cache->path, "r");
+      msg->fp = mutt_file_fopen(cache->path, "r");
       if (msg->fp)
         return true;
 

--- a/send/body.c
+++ b/send/body.c
@@ -337,7 +337,7 @@ int mutt_write_mime_body(struct Body *b, FILE *fp, struct ConfigSubset *sub)
     return 0;
   }
 
-  fp_in = fopen(b->filename, "r");
+  fp_in = mutt_file_fopen(b->filename, "r");
   if (!fp_in)
   {
     mutt_debug(LL_DEBUG1, "%s no longer exists\n", b->filename);

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -109,7 +109,7 @@ enum ContentType mutt_lookup_mime_type(struct Body *b, const char *path)
         goto bye; /* shouldn't happen */
     }
 
-    fp = fopen(buf, "r");
+    fp = mutt_file_fopen(buf, "r");
     if (fp)
     {
       found_mimetypes = true;
@@ -265,7 +265,7 @@ void mutt_message_to_7bit(struct Body *b, FILE *fp, struct ConfigSubset *sub)
   {
     fp_in = fp;
   }
-  else if (!b->filename || !(fp_in = fopen(b->filename, "r")))
+  else if (!b->filename || !(fp_in = mutt_file_fopen(b->filename, "r")))
   {
     mutt_error(_("Could not open %s"), b->filename ? b->filename : "(null)");
     return;

--- a/send/smtp.c
+++ b/send/smtp.c
@@ -242,7 +242,7 @@ static int smtp_data(struct SmtpAccountData *adata, const char *msgfile)
   int term = 0;
   size_t buflen = 0;
 
-  FILE *fp = fopen(msgfile, "r");
+  FILE *fp = mutt_file_fopen(msgfile, "r");
   if (!fp)
   {
     mutt_error(_("SMTP session failed: unable to open %s"), msgfile);


### PR DESCRIPTION
Turn two file functions into macros:
- `mutt_file_fopen()`  -> `mutt_file_fopen_full()`
- `mutt_file_fclose()` -> `mutt_file_fclose_full()`

The macro records the source file, source line and function of the caller.

The second commit upgrades all the plain `fopen()` / `fclose()` to use the neomutt wrappers.

Sample logging:
```
mutt_open_read() File opened (fd=3): /home/mutt/.mutt/muttrc
mutt_open_read() File opened (fd=4): /home/mutt/.mutt/alternates.rc
source_rc() File closed (fd=4)
mutt_open_read() File opened (fd=4): /home/mutt/.mutt/crypto-dev.rc
source_rc() File closed (fd=4)
mutt_open_read() File opened (fd=4): /home/mutt/.mutt/sidebar-dev.rc
source_rc() File closed (fd=4)
mutt_open_read() File opened (fd=4): /home/mutt/.mutt/mailbox.rc
mutt_open_read() File opened (fd=5): /home/mutt/.mutt/account/common.rc
source_rc() File closed (fd=5)
mutt_open_read() File opened (fd=5): /home/mutt/.mutt/account/maildir.rc
source_rc() File closed (fd=5)
source_rc() File closed (fd=4)
mutt_open_read() File opened (fd=4): /home/mutt/.mutt/colours-dev.rc
mutt_open_read() File opened (fd=5): /home/mutt/.mutt/markdown.rc
source_rc() File closed (fd=5)
source_rc() File closed (fd=4)
mutt_open_read() File opened (fd=4): /home/mutt/.mutt/status-color.rc
source_rc() File closed (fd=4)
mutt_open_read() File opened (fd=4): /home/mutt/.muttrc.local
mutt_open_read() File opened (fd=5): /home/github/neomutt/source/sample-data/actor-alias.rc
source_rc() File closed (fd=5)
source_rc() File closed (fd=4)
source_rc() File closed (fd=3)
```