### PR TITLE
fix parsing of $REPLYTO

### DIFF
--- a/init.c
+++ b/init.c
@@ -385,6 +385,7 @@ int mutt_init(struct ConfigSet *cs, const char *dlevel, const char *dfile,
     struct Buffer *token = buf_pool_get();
 
     buf_printf(&buf, "Reply-To: %s", p);
+    buf_seek(&buf, 0);
     parse_my_hdr(token, &buf, 0, &err); /* adds to UserHeader */
     buf_pool_release(&token);
   }


### PR DESCRIPTION
The environment variable REPLYTO should be parsed into a user header of "Reply-To:"

---

Some past refactoring broke this.
The fix is to reset the `Buffer` pointer so that `parse_extract_token()` reads from the beginning of the string.

---

To test:
```sh
REPLYTO=john.doe@example.com neomutt
```

then compose an email.
In Compose, you'll see: `Reply-To: john.doe@example.com`
