### PR TITLE
status: fix refresh after sync-mailbox

### DIFF
--- a/index/functions.c
+++ b/index/functions.c
@@ -1911,6 +1911,9 @@ static int op_main_sync_folder(struct IndexSharedData *shared,
   priv->menu->max = shared->mailbox->vcount;
   menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
 
+  struct EventMailbox ev_m = { shared->mailbox };
+  notify_send(shared->mailbox->notify, NT_MAILBOX, NT_MAILBOX_CHANGE, &ev_m);
+
   return FR_SUCCESS;
 }
 


### PR DESCRIPTION
Fixes: #4157 - Manual sync "$" should be reflected immediately in status bar

At the end of `<sync-mailbox>` send out a notification of change.
This triggers the Index Bar (status) to refresh itself.

**To Test**:
- Open an Imap Mailbox
- Toggle the New status of an Email
  (the Index Bar should show `-*-`)
- Press <kbd>$</kbd> to `<sync-mailbox>`
  (the Index Bar should show `---` again)

---

The purists among you will realise that the notification should be coming from the IMAP backend.
If someone has the time to refactor `imap_sync_mailbox()` it'd be very welcome.