### PR TITLE
maildir: encapsulate the header cache

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -544,7 +544,9 @@ LIBMAILDIROBJS= maildir/account.o maildir/config.o maildir/edata.o \
 		maildir/mailbox.o maildir/maildir.o maildir/mdata.o \
 		maildir/mdemail.o maildir/message.o maildir/path.o \
 		maildir/shared.o
-
+@if USE_HCACHE
+LIBMAILDIROBJS+=maildir/hcache.o
+@endif
 CLEANFILES+=	$(LIBMAILDIR) $(LIBMAILDIROBJS)
 ALLOBJS+=	$(LIBMAILDIROBJS)
 

--- a/maildir/account.c
+++ b/maildir/account.c
@@ -28,7 +28,6 @@
 
 #include "config.h"
 #include "account.h"
-#include "lib.h"
 
 // Mailbox API -----------------------------------------------------------------
 

--- a/maildir/hcache.c
+++ b/maildir/hcache.c
@@ -1,0 +1,164 @@
+/**
+ * @file
+ * Maildir Header Cache
+ *
+ * @authors
+ * Copyright (C) 2024 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page maildir_hcache Maildir Header Cache
+ *
+ * Maildir Header Cache
+ */
+
+#include "config.h"
+#include <stdbool.h>
+#include <string.h>
+#include <sys/stat.h>
+#include "mutt/lib.h"
+#include "config/lib.h"
+#include "email/lib.h"
+#include "core/lib.h"
+#include "hcache/lib.h"
+#include "edata.h"
+#include "mailbox.h"
+
+/**
+ * maildir_hcache_key - Get the header cache key for an Email
+ * @param e Email
+ * @retval str Header cache key string
+ */
+static const char *maildir_hcache_key(struct Email *e)
+{
+  return e->path + 4;
+}
+
+/**
+ * maildir_hcache_keylen - Calculate the length of the Maildir path
+ * @param fn File name
+ * @retval num Length in bytes
+ *
+ * @note This length excludes the flags, which will vary
+ */
+static size_t maildir_hcache_keylen(const char *fn)
+{
+  const char c_maildir_field_delimiter = *cc_maildir_field_delimiter();
+  const char *p = strrchr(fn, c_maildir_field_delimiter);
+  return p ? (size_t) (p - fn) : mutt_str_len(fn);
+}
+
+/**
+ * maildir_hcache_close - Close the Header Cache
+ * @param ptr Header Cache
+ */
+void maildir_hcache_close(struct HeaderCache **ptr)
+{
+  hcache_close(ptr);
+}
+
+/**
+ * maildir_hcache_delete - Delete an Email from the Header Cache
+ * @param hc Header Cache
+ * @param e  Email to delete
+ * @retval  0 Success
+ * @retval -1 Error
+ */
+int maildir_hcache_delete(struct HeaderCache *hc, struct Email *e)
+{
+  if (!hc || !e)
+    return 0;
+
+  const char *key = maildir_hcache_key(e);
+  size_t keylen = maildir_hcache_keylen(key);
+
+  return hcache_delete_email(hc, key, keylen);
+}
+
+/**
+ * maildir_hcache_open - Open the Header Cache
+ * @param m Mailbox
+ */
+struct HeaderCache *maildir_hcache_open(struct Mailbox *m)
+{
+  if (!m)
+    return NULL;
+
+  const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
+
+  return hcache_open(c_header_cache, mailbox_path(m), NULL);
+}
+
+/**
+ * maildir_hcache_read - Read an Email from the Header Cache
+ * @param[in] hc Header Cache
+ * @param[in] e  Email to find
+ * @param[in] fn Filename
+ * @retval ptr Email from Header Cache
+ */
+struct Email *maildir_hcache_read(struct HeaderCache *hc, struct Email *e, const char *fn)
+{
+  if (!hc || !e)
+    return NULL;
+
+  struct stat st_lastchanged = { 0 };
+  int rc = 0;
+
+  const char *key = maildir_hcache_key(e);
+  size_t keylen = maildir_hcache_keylen(key);
+
+  struct HCacheEntry hce = hcache_fetch_email(hc, key, keylen, 0);
+  if (!hce.email)
+    return NULL;
+
+  const bool c_maildir_header_cache_verify = cs_subset_bool(NeoMutt->sub, "maildir_header_cache_verify");
+  if (c_maildir_header_cache_verify)
+    rc = stat(fn, &st_lastchanged);
+
+  if ((rc == 0) && (st_lastchanged.st_mtime <= hce.uidvalidity))
+  {
+    hce.email->edata = maildir_edata_new();
+    hce.email->edata_free = maildir_edata_free;
+    hce.email->old = e->old;
+    hce.email->path = mutt_str_dup(e->path);
+    maildir_parse_flags(hce.email, fn);
+  }
+  else
+  {
+    email_free(&hce.email);
+  }
+
+  return hce.email;
+}
+
+/**
+ * maildir_hcache_store - Save an Email to the Header Cache
+ * @param hc        Header Cache
+ * @param e         Email to save
+ * @retval  0 Success
+ * @retval -1 Error
+ */
+int maildir_hcache_store(struct HeaderCache *hc, struct Email *e)
+{
+  if (!hc || !e)
+    return 0;
+
+  const char *key = maildir_hcache_key(e);
+  size_t keylen = maildir_hcache_keylen(key);
+
+  return hcache_store_email(hc, key, keylen, e, 0);
+}

--- a/maildir/hcache.h
+++ b/maildir/hcache.h
@@ -1,0 +1,50 @@
+/**
+ * @file
+ * Maildir Header Cache
+ *
+ * @authors
+ * Copyright (C) 2024 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_MAILDIR_HCACHE_H
+#define MUTT_MAILDIR_HCACHE_H
+
+#include <stdlib.h>
+
+struct Email;
+struct HeaderCache;
+struct Mailbox;
+
+#ifdef USE_HCACHE
+
+void                maildir_hcache_close (struct HeaderCache **ptr);
+int                 maildir_hcache_delete(struct HeaderCache *hc, struct Email *e);
+struct HeaderCache *maildir_hcache_open  (struct Mailbox *m);
+struct Email *      maildir_hcache_read  (struct HeaderCache *hc, struct Email *e, const char *fn);
+int                 maildir_hcache_store (struct HeaderCache *hc, struct Email *e);
+
+#else
+
+static inline void                maildir_hcache_close (struct HeaderCache **ptr) {}
+static inline int                 maildir_hcache_delete(struct HeaderCache *hc, struct Email *e) { return 0; }
+static inline struct HeaderCache *maildir_hcache_open  (struct Mailbox *m) { return NULL; }
+static inline struct Email *      maildir_hcache_read  (struct HeaderCache *hc, struct Email *e, const char *fn) { return NULL; }
+static inline int                 maildir_hcache_store (struct HeaderCache *hc, struct Email *e) { return 0; }
+
+#endif
+
+#endif /* MUTT_MAILDIR_HCACHE_H */

--- a/maildir/lib.h
+++ b/maildir/lib.h
@@ -30,6 +30,7 @@
  * | maildir/account.c  | @subpage maildir_account  |
  * | maildir/config.c   | @subpage maildir_config   |
  * | maildir/edata.c    | @subpage maildir_edata    |
+ * | maildir/hcache.c   | @subpage maildir_hcache   |
  * | maildir/mailbox.c  | @subpage maildir_mailbox  |
  * | maildir/maildir.c  | @subpage maildir_maildir  |
  * | maildir/mdata.c    | @subpage maildir_mdata    |

--- a/maildir/mailbox.h
+++ b/maildir/mailbox.h
@@ -27,11 +27,14 @@
 #include <stdint.h>
 #include "core/lib.h"
 
-enum MxStatus      maildir_mbox_check_stats(struct Mailbox *m, uint8_t flags);
+struct Email;
+
 enum MxStatus      maildir_mbox_check      (struct Mailbox *m);
+enum MxStatus      maildir_mbox_check_stats(struct Mailbox *m, uint8_t flags);
 enum MxStatus      maildir_mbox_close      (struct Mailbox *m);
-bool               maildir_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags);
 enum MxOpenReturns maildir_mbox_open       (struct Mailbox *m);
+bool               maildir_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags);
 enum MxStatus      maildir_mbox_sync       (struct Mailbox *m);
+void               maildir_parse_flags     (struct Email *e, const char *path);
 
 #endif /* MUTT_MAILDIR_MAILBOX_H */

--- a/maildir/path.c
+++ b/maildir/path.c
@@ -27,10 +27,13 @@
  */
 
 #include "config.h"
+#include <dirent.h>
 #include <limits.h>
+#include <stdbool.h>
+#include <stdio.h>
 #include <sys/stat.h>
+#include "mutt/lib.h"
 #include "path.h"
-#include "lib.h"
 #include "globals.h"
 
 // Mailbox API -----------------------------------------------------------------

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -36,12 +36,7 @@
 #include "email/lib.h"
 #include "core/lib.h"
 #include "mutt.h"
-#include "lib.h"
-#include "account.h"
-#include "mailbox.h"
 #include "mdata.h"
-#include "message.h"
-#include "path.h"
 #include "protos.h"
 
 /**
@@ -64,32 +59,6 @@ mode_t maildir_umask(struct Mailbox *m)
 
   return 0777 & ~st.st_mode;
 }
-
-/**
- * maildir_hcache_key - Get the header cache key for an Email
- * @param e Email
- * @retval str Header cache key string
- */
-const char *maildir_hcache_key(struct Email *e)
-{
-  return e->path + 4;
-}
-
-#ifdef USE_HCACHE
-/**
- * maildir_hcache_keylen - Calculate the length of the Maildir path
- * @param fn File name
- * @retval num Length in bytes
- *
- * @note This length excludes the flags, which will vary
- */
-size_t maildir_hcache_keylen(const char *fn)
-{
-  const char c_maildir_field_delimiter = *cc_maildir_field_delimiter();
-  const char *p = strrchr(fn, c_maildir_field_delimiter);
-  return p ? (size_t) (p - fn) : mutt_str_len(fn);
-}
-#endif
 
 /**
  * maildir_canon_filename - Generate the canonical filename for a Maildir folder

--- a/maildir/shared.h
+++ b/maildir/shared.h
@@ -26,16 +26,15 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <sys/types.h>
-#include "core/lib.h"
 
 struct Buffer;
 struct Email;
 struct HeaderCache;
+struct Mailbox;
+struct Message;
 
 // These are needed by Maildir
 void          maildir_canon_filename      (struct Buffer *dest, const char *src);
-const char *  maildir_hcache_key          (struct Email *e);
-size_t        maildir_hcache_keylen       (const char *fn);
 mode_t        maildir_umask               (struct Mailbox *m);
 bool          maildir_update_flags        (struct Mailbox *m, struct Email *e_old, struct Email *e_new);
 


### PR DESCRIPTION
Encapsulate all of Maildir's Header Cache code.
No _functional_ changes.

Wrapping the header cache calls simplifies the maildir code and reduces dependencies.

---

Currently, the header cache calls are deeply embedded in maildir.
The next step (part of #4112) is to move the header cache calls into the top-level MXAPI functions.
This would create a clearer separation between the two.

A possible future direction might be to turn the header cache into a layer **above** the backends.