### PR TITLE
Fix two memory leaks in notmuch support

### DIFF
--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -737,6 +737,8 @@ struct Mailbox *change_folder_notmuch(struct Menu *menu, char *buf, int buflen, 
 
   struct Mailbox *m_query = mx_path_resolve(buf);
   change_folder_mailbox(menu, m_query, oldcount, shared, read_only);
+  if (!shared->mailbox_view)
+    mailbox_free(&m_query);
   return m_query;
 }
 #endif

--- a/notmuch/db.c
+++ b/notmuch/db.c
@@ -129,11 +129,12 @@ notmuch_database_t *nm_db_do_open(const char *filename, bool writable, bool verb
     const char *config_file = get_nm_config_file();
     const char *const c_nm_config_profile = cs_subset_string(NeoMutt->sub, "nm_config_profile");
 
+    FREE(&msg);
     st = notmuch_database_open_with_config(filename, mode, config_file,
                                            c_nm_config_profile, &db, &msg);
 
     // Attempt opening database without configuration file. Don't if the user specified no config.
-    if (st == NOTMUCH_STATUS_NO_CONFIG && !mutt_str_equal(config_file, ""))
+    if ((st == NOTMUCH_STATUS_NO_CONFIG) && !mutt_str_equal(config_file, ""))
     {
       mutt_debug(LL_DEBUG1, "nm: Could not find notmuch configuration file: %s\n", config_file);
       mutt_debug(LL_DEBUG1, "nm: Attempting to open notmuch db without configuration file.\n");
@@ -141,6 +142,10 @@ notmuch_database_t *nm_db_do_open(const char *filename, bool writable, bool verb
       FREE(&msg);
 
       st = notmuch_database_open_with_config(filename, mode, "", NULL, &db, &msg);
+    }
+    else if ((st == NOTMUCH_STATUS_NO_CONFIG) && !config_file)
+    {
+      FREE(&msg);
     }
 #elif LIBNOTMUCH_CHECK_VERSION(4, 2, 0)
     st = notmuch_database_open_verbose(filename, mode, &db, &msg);


### PR DESCRIPTION
This addresses issue #4033 as well as another leak when opening a notmuch database.

* **What does this PR do?**

It fixes two memory leaks that have to do with notmuch support.

The first has to do with `change_folder_mailbox` returning a nonnull pointer to a mailbox on which the call to `change_folder_mailbox` failed. Since `change_folder_mailbox` doesn’t return any error code, the checking is done by checking whether it stored a mailbox view into the index shared data.

The second has to do with the case of `config_file` being a null pointer instead of an empty string in `nm_db_do_open`. This lead to `msg` not being freed.

With this patch, Valgrind no longer reports any definitely lost block in @scottkosty’s example.

* **What are the relevant issue numbers?**
#4033 