### PR TITLE
bufferize mutt_strn_rfind() as buf_rfind()

### DIFF
--- a/attach/cid.c
+++ b/attach/cid.c
@@ -188,7 +188,7 @@ void cid_to_filename(struct Buffer *filename, const struct CidMapList *cid_map_l
 
   /* ensure tmpfile has the same file extension as filename otherwise an
    * HTML file may be opened as plain text by the viewer */
-  const char *suffix = mutt_strn_rfind(buf_string(filename), buf_len(filename), ".");
+  const char *suffix = buf_rfind(filename, ".");
   if (suffix && *(suffix++))
     buf_mktemp_pfx_sfx(tmpfile, "neomutt", suffix);
   else

--- a/complete/lib.h
+++ b/complete/lib.h
@@ -50,7 +50,7 @@ extern const struct CompleteOps CompleteLabelOps;
 int  mutt_command_complete  (struct CompletionData *cd, struct Buffer *buf, int pos, int numtabs);
 int  mutt_complete          (struct CompletionData *cd, struct Buffer *buf);
 int  mutt_label_complete    (struct CompletionData *cd, struct Buffer *buf, int numtabs);
-bool mutt_nm_query_complete (struct CompletionData *cd, struct Buffer *buf, int pos, int numtabs);
+bool mutt_nm_query_complete (struct CompletionData *cd, struct Buffer *buf, int numtabs);
 bool mutt_nm_tag_complete   (struct CompletionData *cd, struct Buffer *buf, int numtabs);
 int  mutt_var_value_complete(struct CompletionData *cd, struct Buffer *buf, int pos);
 void matches_ensure_morespace(struct CompletionData *cd, int new_size);

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -771,3 +771,34 @@ void buf_inline_replace(struct Buffer *buf, size_t pos, size_t len, const char *
 
   buf_fix_dptr(buf);
 }
+
+/**
+ * buf_rfind - Find last instance of a substring
+ * @param buf   Buffer to search through
+ * @param str   String to find
+ * @retval NULL String not found
+ * @retval ptr  Location of string
+ *
+ * Return the last instance of str in the buffer, or NULL.
+ */
+const char *buf_rfind(const struct Buffer *buf, const char *str)
+{
+  if (buf_is_empty(buf) || !str)
+    return NULL;
+
+  int len = strlen(str);
+  const char *end = buf->data + buf->dsize - len;
+
+  for (const char *p = end; p >= buf->data; --p)
+  {
+    for (size_t i = 0; i < len; i++)
+    {
+      if (p[i] != str[i])
+        goto next;
+    }
+    return p;
+
+  next:;
+  }
+  return NULL;
+}

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -57,6 +57,7 @@ bool           buf_str_equal       (const struct Buffer *a, const struct Buffer 
 bool           buf_istr_equal      (const struct Buffer *a, const struct Buffer *b);
 int            buf_coll            (const struct Buffer *a, const struct Buffer *b);
 size_t         buf_startswith      (const struct Buffer *buf, const char *prefix);
+const char    *buf_rfind           (const struct Buffer *buf, const char *str);
 
 // Functions that APPEND to a Buffer
 size_t         buf_addch           (struct Buffer *buf, char c);

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -722,39 +722,6 @@ bool mutt_istr_equal(const char *a, const char *b)
 }
 
 /**
- * mutt_strn_rfind - Find last instance of a substring
- * @param haystack        String to search through
- * @param haystack_length Length of the string
- * @param needle          String to find
- * @retval NULL String not found
- * @retval ptr  Location of string
- *
- * Return the last instance of needle in the haystack, or NULL.
- * Like strstr(), only backwards, and for a limited haystack length.
- */
-const char *mutt_strn_rfind(const char *haystack, size_t haystack_length, const char *needle)
-{
-  if (!haystack || (haystack_length == 0) || !needle)
-    return NULL;
-
-  int needle_length = strlen(needle);
-  const char *haystack_end = haystack + haystack_length - needle_length;
-
-  for (const char *p = haystack_end; p >= haystack; --p)
-  {
-    for (size_t i = 0; i < needle_length; i++)
-    {
-      if (p[i] != needle[i])
-        goto next;
-    }
-    return p;
-
-  next:;
-  }
-  return NULL;
-}
-
-/**
  * mutt_str_is_ascii - Is a string ASCII (7-bit)?
  * @param str String to examine
  * @param len Length of string to examine

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -84,7 +84,6 @@ char *      mutt_strn_cat(char *dest, size_t l, const char *s, size_t sl);
 char *      mutt_strn_copy(char *dest, const char *src, size_t len, size_t dsize);
 char *      mutt_strn_dup(const char *begin, size_t l);
 bool        mutt_strn_equal(const char *a, const char *b, size_t num);
-const char *mutt_strn_rfind(const char *haystack, size_t haystack_length, const char *needle);
 
 /* case-insensitive flavours */
 int         mutt_istr_cmp(const char *a, const char *b);

--- a/notmuch/complete.c
+++ b/notmuch/complete.c
@@ -92,14 +92,13 @@ done:
  * mutt_nm_query_complete - Complete to the nearest notmuch tag
  * @param cd      Completion Data
  * @param buf     Buffer for the result
- * @param pos     Cursor position in the buffer
  * @param numtabs Number of times the user has hit 'tab'
  * @retval true  Success, a match
  * @retval false Error, no match
  *
- * Complete the nearest "tag:"-prefixed string previous to pos.
+ * Complete the last "tag:"-prefixed string.
  */
-bool mutt_nm_query_complete(struct CompletionData *cd, struct Buffer *buf, int pos, int numtabs)
+bool mutt_nm_query_complete(struct CompletionData *cd, struct Buffer *buf, int numtabs)
 {
   char *pt = buf->data;
   int spaces;
@@ -107,7 +106,7 @@ bool mutt_nm_query_complete(struct CompletionData *cd, struct Buffer *buf, int p
   SKIPWS(pt);
   spaces = pt - buf->data;
 
-  pt = (char *) mutt_strn_rfind((char *) buf, pos, "tag:");
+  pt = (char *) buf_rfind(buf, "tag:");
   if (pt)
   {
     pt += 4;
@@ -218,8 +217,7 @@ int complete_nm_query(struct EnterWindowData *wdata, int op)
 
   int rc = FR_SUCCESS;
   buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf, wdata->state->curpos);
-  size_t len = buf_len(wdata->buffer);
-  if (!mutt_nm_query_complete(wdata->cd, wdata->buffer, len, wdata->tabs))
+  if (!mutt_nm_query_complete(wdata->cd, wdata->buffer, wdata->tabs))
     rc = FR_ERROR;
 
   replace_part(wdata->state, 0, buf_string(wdata->buffer));

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -88,6 +88,7 @@ BUFFER_OBJS	= test/buffer/buf_add_printf.o \
 		  test/buffer/buf_new.o \
 		  test/buffer/buf_printf.o \
 		  test/buffer/buf_reset.o \
+		  test/buffer/buf_rfind.o \
 		  test/buffer/buf_startswith.o \
 		  test/buffer/buf_strcpy.o \
 		  test/buffer/buf_strcpy_n.o \
@@ -567,7 +568,6 @@ STRING_OBJS	= test/string/mutt_istrn_cmp.o \
 		  test/string/mutt_strn_copy.o \
 		  test/string/mutt_strn_dup.o \
 		  test/string/mutt_strn_equal.o \
-		  test/string/mutt_strn_rfind.o \
 		  test/string/mutt_str_adjust.o \
 		  test/string/mutt_str_asprintf.o \
 		  test/string/mutt_str_cat.o \

--- a/test/main.c
+++ b/test/main.c
@@ -124,6 +124,7 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_buf_pool_release)                                     \
   NEOMUTT_TEST_ITEM(test_buf_printf)                                           \
   NEOMUTT_TEST_ITEM(test_buf_reset)                                            \
+  NEOMUTT_TEST_ITEM(test_buf_rfind)                                            \
   NEOMUTT_TEST_ITEM(test_buf_startswith)                                       \
   NEOMUTT_TEST_ITEM(test_buf_strcpy)                                           \
   NEOMUTT_TEST_ITEM(test_buf_strcpy_n)                                         \
@@ -614,7 +615,6 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_mutt_strn_copy)                                       \
   NEOMUTT_TEST_ITEM(test_mutt_strn_dup)                                        \
   NEOMUTT_TEST_ITEM(test_mutt_strn_equal)                                      \
-  NEOMUTT_TEST_ITEM(test_mutt_strn_rfind)                                      \
                                                                                \
   /* tags */                                                                   \
   NEOMUTT_TEST_ITEM(test_driver_tags_free)                                     \


### PR DESCRIPTION
Bufferize `mutt_strn_rfind()`. The callers already have a `struct Buffer`.

I've also simplified and fixed the Notmuch code. `mutt_nm_query_complete()` is only called from one place and the "position" parameter was always set to the buffer length. I've removed it. Also it used to pass the Buffer pointer instead of `buf->data` for the string to search into `mutt_strn_rfind()`.