### PR TITLE
Several fixes for the manual pages

### DIFF
--- a/docs/mbox.5
+++ b/docs/mbox.5
@@ -176,7 +176,7 @@ format folders.
 .BR mmdf (5),
 .BR RFC822 ,
 .BR RFC976 ,
-.BR RFC2822
+.B RFC2822
 .\"
 .SH AUTHOR
 Thomas Roessler <roessler@does-not-exist.org>, Urs Janssen <urs@tin.org>

--- a/docs/mbox.5
+++ b/docs/mbox.5
@@ -8,79 +8,94 @@
 .TH mbox 5 "2002-02-19" Unix "User Manuals"
 .\"
 .SH NAME
-mbox \- Format for mail message storage.
+mbox
+\-
+Format for mail message storage.
 .\"
 .SH DESCRIPTION
 This document describes the format traditionally used by Unix hosts
 to store mail messages locally.
 .B mbox
-files typically reside in the system's mail spool, under various
-names in users' Mail directories, and under the name
+files typically reside in the system's mail spool,
+under various names in users' Mail directories,
+and under the name
 .B mbox
 in users' home directories.
 .PP
 An
 .B mbox
 is a text file containing an arbitrary number of e-mail messages.
-Each message consists of a postmark, followed by an e-mail message
-formatted according to \fBRFC822\fP, \fBRFC2822\fP. The file format
-is line-oriented. Lines are separated by line feed characters (ASCII 10).
+Each message consists of a postmark,
+followed by an e-mail message
+formatted according to \fBRFC822\fP, \fBRFC2822\fP.
+The file format is line-oriented.
+Lines are separated by line feed characters (ASCII 10).
 .PP
-A postmark line consists of the four characters "From", followed by
-a space character, followed by the message's envelope sender
-address, followed by whitespace, and followed by a time stamp. This
-line is often called From_ line.
+A postmark line consists of the four characters "From",
+followed by a space character,
+followed by the message's envelope sender address,
+followed by whitespace,
+and followed by a time stamp.
+This line is often called From_ line.
 .PP
 The sender address is expected to be
 .B addr-spec
-as defined in \fBRFC2822\fP 3.4.1. The date is expected to be
+as defined in \fBRFC2822\fP 3.4.1.
+The date is expected to be
 .B date-time
 as output by
 .BR asctime (3).
-For compatibility reasons with legacy software, two-digit years
-greater than or equal to 70 should be interpreted as the years
-1970+, while two-digit years less than 70 should be interpreted as
-the years 2000-2069. Software reading files in this format should
-also be prepared to accept non-numeric timezone information such as
-"CET DST" for Central European Time, daylight saving time.
+For compatibility reasons with legacy software,
+two-digit years greater than or equal to 70
+should be interpreted as the years 1970+,
+while two-digit years less than 70
+should be interpreted as the years 2000-2069.
+Software reading files in this format
+should also be prepared to accept non-numeric timezone information
+such as "CET DST" for Central European Time, daylight saving time.
 .PP
 Example:
 .IP "" 1
 >From example@example.com Fri Jun 23 02:56:55 2000
 .PP
-In order to avoid misinterpretation of lines in message bodies
-which begin with the four characters "From", followed by a space
-character, the mail delivery agent must quote any occurrence
-of "From " at the start of a body line.
+In order to avoid misinterpretation of lines in
+message bodies which begin with the four characters "From",
+followed by a space character,
+the mail delivery agent must quote any occurrence of
+"From " at the start of a body line.
 .sp
-There are two different quoting schemes, the first (\fBMBOXO\fP) only
-quotes plain "From " lines in the body by prepending a '>' to the
-line; the second (\fBMBOXRD\fP) also quotes already quoted "From "
-lines by prepending a '>' (i.e. ">From ", ">>From ", ...). The later
-has the advantage that lines like
+There are two different quoting schemes,
+the first (\fBMBOXO\fP) only quotes plain "From " lines in the body
+by prepending a '>' to the line;
+the second (\fBMBOXRD\fP) also quotes already quoted "From " lines
+by prepending a '>' (i.e. ">From ", ">>From ", ...).
+The later has the advantage that lines like
 .IP "" 1
 >From the command line you can use the '\-p' option
 .PP
-aren't dequoted wrongly as a \fBMBOXRD\fP-MDA would turn the line
-into
+aren't dequoted wrongly as a \fBMBOXRD\fP-MDA would turn the line into
 .IP "" 1
 >>From the command line you can use the '\-p' option
 .PP
-before storing it. Besides \fBMBOXO\fP and \fBMBOXRD\fP there is also
-\fBMBOXCL\fP which is \fBMBOXO\fP with a "Content-Length:"\-field with the
-number of bytes in the message body; some MUAs (like
+before storing it.
+Besides \fBMBOXO\fP and \fBMBOXRD\fP there is also \fBMBOXCL\fP
+which is \fBMBOXO\fP with a "Content-Length:"\-field
+with the number of bytes in the message body;
+some MUAs (like
 .BR neomutt (1))
-do automatically transform \fBMBOXO\fP mailboxes into \fBMBOXCL\fP ones when
-ever they write them back as \fBMBOXCL\fP can be read by any \fBMBOXO\fP-MUA
+do automatically transform \fBMBOXO\fP mailboxes into \fBMBOXCL\fP ones
+when ever they write them back as \fBMBOXCL\fP
+can be read by any \fBMBOXO\fP-MUA
 without any problems.
 .PP
-If the modification-time (usually determined via
+If the modification-time
+(usually determined via
 .BR stat (2))
 of a nonempty
 .B mbox
-file is greater than the access-time the file has new mail. Many MUAs
-place a Status: header in each message to indicate which messages have
-already been read.
+file is greater than the access-time the file has new mail.
+Many MUAs place a Status: header in each message
+to indicate which messages have already been read.
 .\"
 .SH LOCKING
 Since
@@ -89,40 +104,45 @@ files are frequently accessed by multiple programs in parallel,
 .B mbox
 files should generally not be accessed without locking.
 .PP
-Three different locking mechanisms (and combinations thereof) are in
-general use:
+Three different locking mechanisms (and combinations thereof)
+are in general use:
 .IP "\(bu"
 .BR fcntl (2)
-locking is mostly used on recent, POSIX-compliant systems. Use of
-this locking method is, in particular, advisable if
+locking is mostly used on recent,
+POSIX-compliant systems.
+Use of this locking method is, in particular, advisable if
 .B mbox
-files are accessed through the Network File System (NFS), since it
-seems the only way to reliably invalidate NFS clients' caches.
+files are accessed through the Network File System (NFS),
+since it seems the only way to reliably invalidate NFS clients' caches.
 .IP "\(bu"
 .BR flock (2)
 locking is mostly used on BSD-based systems.
 .PP
-If multiple methods are combined, implementors should make sure to
+If multiple methods are combined,
+implementors should make sure to
 use the non-blocking variants of the
 .BR fcntl (2)
 and
 .BR flock (2)
 system calls in order to avoid deadlocks.
 .PP
-If multiple methods are combined, an
+If multiple methods are combined,
+an
 .B mbox
-file must not be considered to have been successfully locked before
-all individual locks were obtained. When one of the individual
-locking methods fails, an application should release all locks it
-acquired successfully, and restart the entire locking procedure from
-the beginning, after a suitable delay.
+file must not be considered to have been successfully locked
+before all individual locks were obtained.
+When one of the individual locking methods fails,
+an application should release all locks it acquired successfully,
+and restart the entire locking procedure from the beginning,
+after a suitable delay.
 .PP
-The locking mechanism used on a particular system is a matter of
-local policy, and should be consistently used by all applications
+The locking mechanism used on a particular system is a matter of local policy,
+and should be consistently used by all applications
 installed on the system which access
 .B mbox
-files. Failure to do so may result in loss of e-mail data, and in
-corrupted
+files.
+Failure to do so may result in loss of e-mail data,
+and in corrupted
 .B mbox
 files.
 .\"
@@ -134,7 +154,8 @@ files.
 .PP
 .IR $HOME/mbox
 .RS
-user's archived mail messages, in his \fB$HOME\fP directory.
+user's archived mail messages,
+in his \fB$HOME\fP directory.
 .RE
 .PP
 .IR $HOME/Mail/

--- a/docs/mbox.5
+++ b/docs/mbox.5
@@ -147,18 +147,18 @@ and in corrupted
 files.
 .\"
 .SH FILES
-.IR /var/spool/mail/$LOGNAME
+.IR /var/spool/mail/ $LOGNAME
 .RS
 \fB$LOGNAME\fP's incoming mail folder.
 .RE
 .PP
-.IR $HOME/mbox
+.RI $HOME /mbox
 .RS
 user's archived mail messages,
 in his \fB$HOME\fP directory.
 .RE
 .PP
-.IR $HOME/Mail/
+.RI $HOME /Mail/
 .RS
 A directory in user's \fB$HOME\fP directory which is commonly used to hold
 .B mbox

--- a/docs/mbox.5
+++ b/docs/mbox.5
@@ -79,7 +79,7 @@ aren't dequoted wrongly as a \fBMBOXRD\fP-MDA would turn the line into
 .PP
 before storing it.
 Besides \fBMBOXO\fP and \fBMBOXRD\fP there is also \fBMBOXCL\fP
-which is \fBMBOXO\fP with a "Content-Length:"\-field
+which is \fBMBOXO\fP with a "Content-Length:" field
 with the number of bytes in the message body;
 some MUAs (like
 .BR neomutt (1))

--- a/docs/mbox.5
+++ b/docs/mbox.5
@@ -1,4 +1,3 @@
-'\" t
 .\" -*-nroff-*-
 .\"
 .\"     Copyright (C) 2000 Thomas Roessler <roessler@does-not-exist.org>

--- a/docs/mbox.5
+++ b/docs/mbox.5
@@ -6,7 +6,7 @@
 .\"     This document is in the public domain and may be distributed and
 .\"     changed arbitrarily.
 .\"
-.TH mbox 5 "February 19th, 2002" Unix "User Manuals"
+.TH mbox 5 "2002-02-19" Unix "User Manuals"
 .\"
 .SH NAME
 mbox \- Format for mail message storage.

--- a/docs/mbox.5
+++ b/docs/mbox.5
@@ -144,7 +144,6 @@ A directory in user's \fB$HOME\fP directory which is commonly used to hold
 .B mbox
 format folders.
 .RE
-.PP
 .\"
 .SH "SEE ALSO"
 .BR neomutt (1),

--- a/docs/mmdf.5
+++ b/docs/mmdf.5
@@ -10,7 +10,7 @@
 .SH NAME
 MMDF
 \-
-Multi\-channel Memorandum Distribution Facility mailbox format
+Multi-channel Memorandum Distribution Facility mailbox format
 .\"
 .SH DESCRIPTION
 This document describes the
@@ -56,7 +56,7 @@ bar
 In contrast to most other single file mailbox formats
 like MBOXO and MBOXRD (see
 .BR mbox (5))
-there is no need to quote/dequote "From "\-lines in
+there is no need to quote/dequote "From " lines in
 .B MMDF
 mailboxes as such lines have no special meaning in this format.
 .PP

--- a/docs/mmdf.5
+++ b/docs/mmdf.5
@@ -23,14 +23,14 @@ mailbox is a text file containing an arbitrary number of e-mail messages.
 Each message consists of a postmark, followed by an e-mail message formatted
 according to \fBRFC822\fP / \fBRFC2822\fP, followed by a postmark. The file
 format is line-oriented. Lines are separated by line feed characters (ASCII
-10). A postmark line consists of the four characters "^A^A^A^A" (Control-A;
+10). A postmark line consists of the four characters "\[ha]A\[ha]A\[ha]A\[ha]A" (Control-A;
 ASCII 1).
 .TP
 Example of a \fBMMDF\fP mailbox holding two mails:
 .RS
 .nf
 .sp
-^A^A^A^A
+\[ha]A\[ha]A\[ha]A\[ha]A
 .br
 From: example@example.com
 .br
@@ -43,9 +43,9 @@ Subject: test
 >From what I learned about the MMDF-format:
 .br
 .br
-^A^A^A^A
+\[ha]A\[ha]A\[ha]A\[ha]A
 .br
-^A^A^A^A
+\[ha]A\[ha]A\[ha]A\[ha]A
 .br
 From: example@example.com
 .br
@@ -57,7 +57,7 @@ Subject: test 2
 .br
 bar
 .br
-^A^A^A^A
+\[ha]A\[ha]A\[ha]A\[ha]A
 .fi
 .RE
 .PP

--- a/docs/mmdf.5
+++ b/docs/mmdf.5
@@ -138,7 +138,7 @@ was developed at the University of Delaware by Dave Crocker.
 .BR stat (2),
 .BR mbox (5),
 .BR RFC822 ,
-.BR RFC2822
+.B RFC2822
 .\"
 .SH AUTHOR
 Urs Janssen <urs@tin.org>

--- a/docs/mmdf.5
+++ b/docs/mmdf.5
@@ -8,23 +8,29 @@
 .TH mmdf 5 "2002-02-18" "Unix" "User Manuals"
 .\"
 .SH NAME
-MMDF \- Multi\-channel Memorandum Distribution Facility mailbox format
+MMDF
+\-
+Multi\-channel Memorandum Distribution Facility mailbox format
 .\"
 .SH DESCRIPTION
 This document describes the
 .B MMDF
-mailbox format used by some MTAs and MUAs (i.e.
+mailbox format used by some MTAs and MUAs
+(i.e.
 .BR scomail (1))
 to store mail messages locally.
 .PP
 An
 .B MMDF
 mailbox is a text file containing an arbitrary number of e-mail messages.
-Each message consists of a postmark, followed by an e-mail message formatted
-according to \fBRFC822\fP / \fBRFC2822\fP, followed by a postmark. The file
-format is line-oriented. Lines are separated by line feed characters (ASCII
-10). A postmark line consists of the four characters "\[ha]A\[ha]A\[ha]A\[ha]A" (Control-A;
-ASCII 1).
+Each message consists of a postmark,
+followed by an e-mail message
+formatted according to \fBRFC822\fP / \fBRFC2822\fP,
+followed by a postmark.
+The file format is line-oriented.
+Lines are separated by line feed characters (ASCII 10).
+A postmark line consists of the four characters
+"\[ha]A\[ha]A\[ha]A\[ha]A" (Control-A; ASCII 1).
 .TP
 Example of a \fBMMDF\fP mailbox holding two mails:
 .PP
@@ -47,19 +53,20 @@ bar
 .EE
 .RE
 .PP
-In contrast to most other single file mailbox formats like
-MBOXO and MBOXRD (see
+In contrast to most other single file mailbox formats
+like MBOXO and MBOXRD (see
 .BR mbox (5))
 there is no need to quote/dequote "From "\-lines in
 .B MMDF
 mailboxes as such lines have no special meaning in this format.
 .PP
-If the modification-time (usually determined via
+If the modification-time
+(usually determined via
 .BR stat (2))
-of a nonempty mailbox file is greater than the access-time
-the file has new mail. Many MUAs place a Status: header in
-each message to indicate which messages have already been
-read.
+of a nonempty mailbox file is greater than the access-time,
+the file has new mail.
+Many MUAs place a Status: header in each message
+to indicate which messages have already been read.
 .\"
 .SH LOCKING
 Since
@@ -68,40 +75,44 @@ files are frequently accessed by multiple programs in parallel,
 .B MMDF
 files should generally not be accessed without locking.
 .PP
-Three different locking mechanisms (and combinations thereof) are in
-general use:
+Three different locking mechanisms (and combinations thereof)
+are in general use:
 .IP "\(bu"
 .BR fcntl (2)
-locking is mostly used on recent, POSIX-compliant systems. Use of
-this locking method is, in particular, advisable if
+locking is mostly used on recent,
+POSIX-compliant systems.
+Use of this locking method is, in particular, advisable if
 .B MMDF
-files are accessed through the Network File System (NFS), since it
-seems the only way to reliably invalidate NFS clients' caches.
+files are accessed through the Network File System (NFS),
+since it seems the only way to reliably invalidate NFS clients' caches.
 .IP "\(bu"
 .BR flock (2)
 locking is mostly used on BSD-based systems.
 .PP
-If multiple methods are combined, implementors should make sure to
-use the non-blocking variants of the
+If multiple methods are combined,
+implementors should make sure to use the non-blocking variants of the
 .BR fcntl (2)
 and
 .BR flock (2)
 system calls in order to avoid deadlocks.
 .PP
-If multiple methods are combined, an
+If multiple methods are combined,
+an
 .B MMDF
-file must not be considered to have been successfully locked before
-all individual locks were obtained. When one of the individual
-locking methods fails, an application should release all locks it
-acquired successfully, and restart the entire locking procedure from
-the beginning, after a suitable delay.
+file must not be considered to have been successfully locked
+before all individual locks were obtained.
+When one of the individual locking methods fails,
+an application should release all locks it acquired successfully,
+and restart the entire locking procedure from the beginning,
+after a suitable delay.
 .PP
-The locking mechanism used on a particular system is a matter of
-local policy, and should be consistently used by all applications
+The locking mechanism used on a particular system is a matter of local policy,
+and should be consistently used by all applications
 installed on the system which access
 .B MMDF
-files. Failure to do so may result in loss of e-mail data, and in
-corrupted
+files.
+Failure to do so may result in loss of e-mail data,
+and in corrupted
 .B MMDF
 files.
 .\"

--- a/docs/mmdf.5
+++ b/docs/mmdf.5
@@ -139,6 +139,6 @@ was developed at the University of Delaware by Dave Crocker.
 .BR mbox (5),
 .BR RFC822 ,
 .BR RFC2822
-
+.\"
 .SH AUTHOR
 Urs Janssen <urs@tin.org>

--- a/docs/mmdf.5
+++ b/docs/mmdf.5
@@ -27,38 +27,24 @@ format is line-oriented. Lines are separated by line feed characters (ASCII
 ASCII 1).
 .TP
 Example of a \fBMMDF\fP mailbox holding two mails:
+.PP
 .RS
-.nf
-.sp
+.EX
 \[ha]A\[ha]A\[ha]A\[ha]A
-.br
 From: example@example.com
-.br
 To: example@example.org
-.br
 Subject: test
-.br
-.sp
-.br
+\&
 >From what I learned about the MMDF-format:
-.br
-.br
 \[ha]A\[ha]A\[ha]A\[ha]A
-.br
 \[ha]A\[ha]A\[ha]A\[ha]A
-.br
 From: example@example.com
-.br
 To: example@example.org
-.br
 Subject: test 2
-.br
-.sp
-.br
+\&
 bar
-.br
 \[ha]A\[ha]A\[ha]A\[ha]A
-.fi
+.EE
 .RE
 .PP
 In contrast to most other single file mailbox formats like

--- a/docs/mmdf.5
+++ b/docs/mmdf.5
@@ -5,7 +5,7 @@
 .\" Updated   :
 .\" Notes     : needs a lot of work
 .\"
-.TH mmdf 5 "February 18th, 2002" "Unix" "User Manuals"
+.TH mmdf 5 "2002-02-18" "Unix" "User Manuals"
 .\"
 .SH NAME
 MMDF \- Multi\-channel Memorandum Distribution Facility mailbox format

--- a/docs/neomutt.man
+++ b/docs/neomutt.man
@@ -46,9 +46,9 @@ The NeoMutt Mail User Agent (MUA)
 .RB [ \-s\~\c
 .IR subject ]
 .RB [ \-a\~\c
-.IR file \~[ .\|.\|.\& ]]
+.IR file ]\~.\|.\|.\&
 .RB [ \-\- ]
-.IR address \~[ .\|.\|.\& ]
+.IR address \~.\|.\|.
 .YS
 .
 .SY neomutt
@@ -64,9 +64,9 @@ The NeoMutt Mail User Agent (MUA)
 .RB [ \-s\~\c
 .IR subject ]
 .RB [ \-a\~\c
-.IR file \~[ .\|.\|.\& ]]
+.IR file ]\~.\|.\|.\&
 .RB [ \-\- ]
-.IR address \~[ .\|.\|.\& ]
+.IR address \~.\|.\|.\&
 .BI <\~ message
 .YS
 .

--- a/docs/neomutt.man
+++ b/docs/neomutt.man
@@ -78,7 +78,7 @@ The NeoMutt Mail User Agent (MUA)
 .OP \-n
 .OP \-e command
 .OP \-F config
-.BR \-B
+.B \-B
 .YS
 .
 .SY neomutt
@@ -100,7 +100,7 @@ The NeoMutt Mail User Agent (MUA)
 .OP \-n
 .OP \-e command
 .OP \-F config
-.BI \-G
+.B \-G
 .YS
 .
 .SY neomutt
@@ -114,7 +114,7 @@ The NeoMutt Mail User Agent (MUA)
 .OP \-n
 .OP \-e command
 .OP \-F config
-.BI \-p
+.B \-p
 .YS
 .
 .SY neomutt
@@ -128,14 +128,14 @@ The NeoMutt Mail User Agent (MUA)
 .OP \-n
 .OP \-e command
 .OP \-F config
-.BI \-Z
+.B \-Z
 .YS
 .
 .SY neomutt
 .OP \-n
 .OP \-e command
 .OP \-F config
-.BI \-z
+.B \-z
 .OP \-f mailbox
 .YS
 .
@@ -167,7 +167,7 @@ and/or PDF format.
 .SH OPTIONS
 .\" --------------------------------------------------------------------
 .TP
-.BI \-\-
+.B \-\-
 Special argument forces NeoMutt to stop option parsing and
 treat remaining arguments as \fIaddress\fPes even if they start with a dash
 .
@@ -188,7 +188,7 @@ Add any addresses after the \(aq\fB\-\-\fP\(aq argument, e.g.:
 .RE
 .
 .TP
-.BI \-B
+.B \-B
 Run in batch mode (do not start the ncurses UI)
 .
 .TP
@@ -200,17 +200,17 @@ Specify a blind carbon copy (Bcc) recipient
 Specify a carbon copy (Cc) recipient
 .
 .TP
-.BI \-D
+.B \-D
 Dump all configuration variables as
 .RB \(aq name = value \(aq
 pairs to stdout
 .
 .TP
-.BI \-D\ \-O
+.B \-D\ \-O
 Like \fB\-D\fP, but show one-liner documentation
 .
 .TP
-.BI \-D\ \-S
+.B \-D\ \-S
 Like \fB\-D\fP, but hide the value of sensitive variables
 .
 .TP
@@ -224,7 +224,7 @@ to log the early startup process
 (before reading any configuration and hence $debug_level and $debug_file)
 .
 .TP
-.BI \-E
+.B \-E
 Edit \fIdraft\fP (\fB\-H\fP) or \fIinclude\fP (\fB\-i\fP) file
 during message composition
 .
@@ -242,7 +242,7 @@ see \fIFILES\fP section below for a list of regular configuration files
 Specify a \fImailbox\fP (as defined with \fBmailboxes\fP command) to load
 .
 .TP
-.BI \-G
+.B \-G
 Start NeoMutt with a listing of subscribed newsgroups
 .
 .TP
@@ -261,7 +261,7 @@ if an mbox "\fBFrom\~\fP" line is present,
 it will be silently discarded.
 .
 .TP
-.BI \-h
+.B \-h
 Print this help message and exit
 .
 .TP
@@ -284,11 +284,11 @@ Specify a default mailbox format \fItype\fP for newly created folders
 The \fItype\fP is either MH, MMDF, Maildir or mbox (case-insensitive)
 .
 .TP
-.BI \-n
+.B \-n
 Do not read the system-wide configuration file
 .
 .TP
-.BI \-p
+.B \-p
 Resume a prior postponed message, if any
 .
 .TP
@@ -298,7 +298,7 @@ Query a configuration \fIvariable\fP and print its value to stdout
 Add -O for one-liner documentation.
 .
 .TP
-.BI \-R
+.B \-R
 Open mailbox in read-only mode
 .
 .TP
@@ -307,25 +307,25 @@ Specify a \fIsubject\fP
 (must be enclosed in quotes if it has spaces)
 .
 .TP
-.BI \-v
+.B \-v
 Print the NeoMutt version and compile-time definitions and exit
 .
 .TP
-.BI \-vv
+.B \-vv
 Print the NeoMutt license and copyright information and exit
 .
 .TP
-.BI \-y
+.B \-y
 Start NeoMutt with a listing of all defined mailboxes
 .
 .TP
-.BI \-Z
+.B \-Z
 Open the first mailbox with new message
 or exit immediately with exit code 1
 if none is found in all defined mailboxes
 .
 .TP
-.BI \-z
+.B \-z
 Open the first or specified (\fB\-f\fP) mailbox
 if it holds any message
 or exit immediately with exit code 1 otherwise
@@ -533,27 +533,27 @@ NeoMutt will process all grouped files in the order
 as they are specified in that listing.
 .
 .TP
-.IR "~/.mailcap"
+.I "~/.mailcap"
 .TQ
-.IR "@MAN_SYSCONFDIR@/mailcap"
+.I "@MAN_SYSCONFDIR@/mailcap"
 User-specific and system-wide definitions for handling non-text MIME types,
 look at environment variable \fBMAILCAPS\fP above
 for additional search locations.
 .
 .TP
-.IR "~/.neomuttdebug0"
+.I "~/.neomuttdebug0"
 User's default debug log file.
 For further details or customising file path
 see command line options \fB\-d\fP and \fB\-l\fP above.
 .
 .TP
-.IR "/etc/mime.types"
+.I "/etc/mime.types"
 .TQ
-.IR "@MAN_SYSCONFDIR@/mime.types"
+.I "@MAN_SYSCONFDIR@/mime.types"
 .TQ
-.IR "@MAN_DATADIR@/mime.types"
+.I "@MAN_DATADIR@/mime.types"
 .TQ
-.IR "~/.mime.types"
+.I "~/.mime.types"
 Description files for
 simple plain text mapping between MIME types and filename extensions.
 NeoMutt parses these files in the stated order

--- a/docs/neomutt.man
+++ b/docs/neomutt.man
@@ -22,7 +22,9 @@
 .\" --------------------------------------------------------------------
 .SH NAME
 .\" --------------------------------------------------------------------
-neomutt \- The NeoMutt Mail User Agent (MUA)
+neomutt
+\-
+The NeoMutt Mail User Agent (MUA)
 .
 .\" --------------------------------------------------------------------
 .SH SYNTAX
@@ -144,23 +146,30 @@ neomutt \- The NeoMutt Mail User Agent (MUA)
 .\" --------------------------------------------------------------------
 .SH DESCRIPTION
 .\" --------------------------------------------------------------------
-NeoMutt is a small but very powerful text based program for reading and sending
-electronic mail under Unix operating systems, including support for color
-terminals, MIME, OpenPGP, and a threaded sorting mode.
+NeoMutt is a small but very powerful
+text based program for reading and sending electronic mail
+under Unix operating systems,
+including support for
+color terminals,
+MIME,
+OpenPGP,
+and a threaded sorting mode.
 .
 .PP
 .B Note:
-This manual page gives a brief overview of NeoMutt's command line options. You
-should find a copy of the full manual in \fI@MAN_DOCDIR@\fP, in plain text,
-HTML, and/or PDF format.
+This manual page gives a brief overview of NeoMutt's command line options.
+You should find a copy of the full manual in \fI@MAN_DOCDIR@\fP,
+in plain text,
+HTML,
+and/or PDF format.
 .
 .\" --------------------------------------------------------------------
 .SH OPTIONS
 .\" --------------------------------------------------------------------
 .TP
 .BI \-\-
-Special argument forces NeoMutt to stop option parsing and treat remaining
-arguments as \fIaddress\fPes even if they start with a dash
+Special argument forces NeoMutt to stop option parsing and
+treat remaining arguments as \fIaddress\fPes even if they start with a dash
 .
 .TP
 .BI \-A " alias"
@@ -168,8 +177,8 @@ Print an expanded version of the given \fIalias\fP to stdout and exit
 .
 .TP
 .BI \-a " file"
-Attach one or more \fIfile\fPs to a message (must be the last option). Add any
-addresses after the \(aq\fB\-\-\fP\(aq argument, e.g.:
+Attach one or more \fIfile\fPs to a message (must be the last option).
+Add any addresses after the \(aq\fB\-\-\fP\(aq argument, e.g.:
 .RS
 .IP
 .EX
@@ -207,17 +216,17 @@ Like \fB\-D\fP, but hide the value of sensitive variables
 .TP
 .BI \-d " level"
 Log debugging output to a file (default is \(dq\fI~/.neomuttdebug0\fP\(dq).
-The \fIlevel\fP can range from 1\(en5 and affects verbosity (a value of 2 is
-recommended)
+The \fIlevel\fP can range from 1\(en5 and affects verbosity
+(a value of 2 is recommended)
 .IP
-Using this option along with \fB\-l\fP is useful to log the early startup
-process (before reading any configuration and hence $debug_level and
-$debug_file)
+Using this option along with \fB\-l\fP is useful
+to log the early startup process
+(before reading any configuration and hence $debug_level and $debug_file)
 .
 .TP
 .BI \-E
-Edit \fIdraft\fP (\fB\-H\fP) or \fIinclude\fP (\fB\-i\fP) file during message
-composition
+Edit \fIdraft\fP (\fB\-H\fP) or \fIinclude\fP (\fB\-i\fP) file
+during message composition
 .
 .TP
 .BI \-e " command"
@@ -225,8 +234,8 @@ Specify a \fIcommand\fP to be run after reading the config files
 .
 .TP
 .BI \-F " config"
-Specify an alternative initialization file to read, see \fIFILES\fP section
-below for a list of regular configuration files
+Specify an alternative initialization file to read,
+see \fIFILES\fP section below for a list of regular configuration files
 .
 .TP
 .BI \-f " mailbox"
@@ -242,11 +251,13 @@ Like \fB\-G\fP, but start at specified news \fIserver\fP
 .
 .TP
 .BI \-H " draft"
-Specify a \fIdraft\fP file which contains header and body to use to send a
-message.
+Specify a \fIdraft\fP file which contains
+header and body to use to send a message.
 If \fIdraft\fP is \*(lq\fB\-\fP\*(rq, then data is read from stdin.
-The draft file is expected to contain just an RFC822 email \(em headers and a body.
-Although it is not an mbox file, if an mbox "\fBFrom\~\fP" line is present,
+The draft file is expected to
+contain just an RFC822 email \(em headers and a body.
+Although it is not an mbox file,
+if an mbox "\fBFrom\~\fP" line is present,
 it will be silently discarded.
 .
 .TP
@@ -282,8 +293,8 @@ Resume a prior postponed message, if any
 .
 .TP
 .BI \-Q " variable"
-Query a configuration \fIvariable\fP and print its value to stdout (after the
-config has been read and any commands executed).
+Query a configuration \fIvariable\fP and print its value to stdout
+(after the config has been read and any commands executed).
 Add -O for one-liner documentation.
 .
 .TP
@@ -292,7 +303,8 @@ Open mailbox in read-only mode
 .
 .TP
 .BI \-s " subject"
-Specify a \fIsubject\fP (must be enclosed in quotes if it has spaces)
+Specify a \fIsubject\fP
+(must be enclosed in quotes if it has spaces)
 .
 .TP
 .BI \-v
@@ -308,13 +320,15 @@ Start NeoMutt with a listing of all defined mailboxes
 .
 .TP
 .BI \-Z
-Open the first mailbox with new message or exit immediately with exit code 1 if
-none is found in all defined mailboxes
+Open the first mailbox with new message
+or exit immediately with exit code 1
+if none is found in all defined mailboxes
 .
 .TP
 .BI \-z
-Open the first or specified (\fB\-f\fP) mailbox if it holds any message or exit
-immediately with exit code 1 otherwise
+Open the first or specified (\fB\-f\fP) mailbox
+if it holds any message
+or exit immediately with exit code 1 otherwise
 .
 .\" --------------------------------------------------------------------
 .SH ENVIRONMENT
@@ -322,17 +336,21 @@ immediately with exit code 1 otherwise
 .TP
 .SM
 .B EDITOR
-Specifies the editor to use if \fIVISUAL\fP is unset. Defaults to the \fBVi\fP
-editor if unset.
+Specifies the editor to use if \fIVISUAL\fP is unset.
+Defaults to the \fBVi\fP editor if unset.
 .
 .TP
 .SM
 .B EGDSOCKET
-For OpenSSL since version 0.9.5, files, mentioned at \fIRANDFILE\fP below, can
-be Entropy Gathering Daemon (EGD) sockets. Also, and if exists,
-\fI~/.entropy\fP and \fI/tmp/entropy\fP will be used to initialize SSL library
-functions. Specified sockets must be owned by the user and have permission of
-600 (octal number representing).
+For OpenSSL since version 0.9.5,
+files,
+mentioned at \fIRANDFILE\fP below,
+can be Entropy Gathering Daemon (EGD) sockets.
+Also, and if exists,
+\fI~/.entropy\fP and \fI/tmp/entropy\fP
+will be used to initialize SSL library functions.
+Specified sockets must be owned by the user
+and have permission of 600 (octal number representing).
 .
 .TP
 .SM
@@ -352,8 +370,10 @@ Full path of the user's spool mailbox.
 .TP
 .SM
 .B MAILCAPS
-Path to search for mailcap files. If unset, a RFC1524 compliant search path
-that is extended with NeoMutt related paths (at position two and three):
+Path to search for mailcap files.
+If unset,
+a RFC1524 compliant search path that is extended with NeoMutt related paths
+(at position two and three):
 .\" .RS
 .\" .IP
 .RI \(dq \
@@ -370,49 +390,56 @@ will be used instead.
 .TP
 .SM
 .B MAILDIR
-Full path of the user's spool mailbox if \fIMAIL\fP is unset. Commonly used
-when the spool mailbox is a
+Full path of the user's spool mailbox if \fIMAIL\fP is unset.
+Commonly used when the spool mailbox is a
 .BR maildir (5)
 folder.
 .
 .TP
 .SM
 .B MM_NOASK
-If this variable is set, mailcap are always used without prompting first.
+If this variable is set,
+mailcap are always used without prompting first.
 .
 .TP
 .SM
 .B NNTPSERVER
-Similar to configuration variable $news_server, specifies the domain name or
-address of the default NNTP server to connect. If unset,
+Similar to configuration variable $news_server,
+specifies the domain name or address of the default NNTP server to connect.
+If unset,
 \fI@MAN_SYSCONFDIR@/nntpserver\fP is used but can be overridden by command line
 option \fB\-g\fP.
 .
 .TP
 .SM
 .B RANDFILE
-Like configuration variable $entropy_file, defines a path to a file which
-includes random data that is used to initialize SSL library functions. If
-unset, \fI~/.rnd\fP is used. DO NOT store important data in the specified file.
+Like configuration variable $entropy_file,
+defines a path to a file which
+includes random data that is used to initialize SSL library functions.
+If unset,
+\fI~/.rnd\fP is used.
+DO NOT store important data in the specified file.
 .
 .TP
 .SM
 .B REPLYTO
-When set, specifies the default Reply-To address.
+When set,
+specifies the default Reply-To address.
 .
 .TP
 .SM
 .B TEXTDOMAINDIR
-Defines an absolute path corresponding to \fI@MAN_TEXTDOMAINDIR@\fP that will
-be recognised by GNU
+Defines an absolute path corresponding to \fI@MAN_TEXTDOMAINDIR@\fP that
+will be recognised by GNU
 .BR gettext (1)
 and used for Native Language Support (NLS) if enabled.
 .
 .TP
 .SM
 .B TMPDIR
-Directory in which temporary files are created. Defaults to \fI/tmp\fP if
-unset. Configuration variable $tmp_dir takes precedence over this one.
+Directory in which temporary files are created.
+Defaults to \fI/tmp\fP if unset.
+Configuration variable $tmp_dir takes precedence over this one.
 .
 .TP
 .SM
@@ -422,28 +449,32 @@ Specifies the editor to use when composing messages.
 .TP
 .SM
 .B XDG_CONFIG_DIRS
-Specifies a X Desktop Group (XDG) compliant location for the system-wide
-configuration file, as described in \fIFILES\fP section below. This variable
-defaults to \fI/etc/xdg\fP. Bypass loading with command line option \fB\-n\fP.
+Specifies a X Desktop Group (XDG) compliant location
+for the system-wide configuration file,
+as described in \fIFILES\fP section below.
+This variable defaults to \fI/etc/xdg\fP.
+Bypass loading with command line option \fB\-n\fP.
 .
 .TP
 .SM
 .B XDG_CONFIG_HOME
-Specifies a XDG compliant location for the user-specific configuration file, as
-described in \fIFILES\fP section below. This variable defaults to
-\fI$HOME/.config\fP. Can be overridden by command line option \fB\-F\fP.
+Specifies a XDG compliant location for the user-specific configuration file,
+as described in \fIFILES\fP section below.
+This variable defaults to \fI$HOME/.config\fP.
+Can be overridden by command line option \fB\-F\fP.
 .
 .\" --------------------------------------------------------------------
 .SH FILES
 .\" --------------------------------------------------------------------
 .SS "\s-1Configuration files\s0"
 .\" --------------------------------------------------------------------
-NeoMutt will read just the first found configuration file of system-wide and
-user-specific category, from the list below and in that order.
+NeoMutt will read just the first found
+configuration file of system-wide and user-specific category,
+from the list below and in that order.
 .
 .PP
-But it allows building of a recursive configuration by using the \fBsource\fP
-command.
+But it allows building of a recursive configuration
+by using the \fBsource\fP command.
 .
 .PP
 .na
@@ -496,21 +527,24 @@ l s s .
 .
 .SS "\s-1Other relevant files\s0"
 .\" --------------------------------------------------------------------
-Unless otherwise stated, NeoMutt will process all grouped files in the order
-(from top to bottom) as they are specified in that listing.
+Unless otherwise stated,
+NeoMutt will process all grouped files in the order
+(from top to bottom)
+as they are specified in that listing.
 .
 .TP
 .IR "~/.mailcap"
 .TQ
 .IR "@MAN_SYSCONFDIR@/mailcap"
 User-specific and system-wide definitions for handling non-text MIME types,
-look at environment variable \fBMAILCAPS\fP above for additional search
-locations.
+look at environment variable \fBMAILCAPS\fP above
+for additional search locations.
 .
 .TP
 .IR "~/.neomuttdebug0"
-User's default debug log file. For further details or customising file path see
-command line options \fB\-d\fP and \fB\-l\fP above.
+User's default debug log file.
+For further details or customising file path
+see command line options \fB\-d\fP and \fB\-l\fP above.
 .
 .TP
 .IR "/etc/mime.types"
@@ -520,9 +554,10 @@ command line options \fB\-d\fP and \fB\-l\fP above.
 .IR "@MAN_DATADIR@/mime.types"
 .TQ
 .IR "~/.mime.types"
-Description files for simple plain text mapping between MIME types and filename
-extensions. NeoMutt parses these files in the stated order while processing
-attachments to determine their MIME type.
+Description files for
+simple plain text mapping between MIME types and filename extensions.
+NeoMutt parses these files in the stated order
+while processing attachments to determine their MIME type.
 .
 .TP
 .IR "@MAN_DOCDIR@/manual." { html , pdf , txt }
@@ -530,10 +565,11 @@ The full NeoMutt manual in HTML, PDF or plain text format.
 .
 .TP
 .IR "/tmp/neomutt-XXXX-XXXX-XXXX"
-Temporary files created by NeoMutt. For custom locations look at description of
-the environment variable \fBTMPDIR\fP above. Notice that the suffix
-\fI-XXXX-XXXX-XXXX\fP is just a placeholder for, e.g. hostname, user name/ID,
-process ID and/or other random data.
+Temporary files created by NeoMutt.
+For custom locations
+look at description of the environment variable \fBTMPDIR\fP above.
+Notice that the suffix \fI-XXXX-XXXX-XXXX\fP is just a placeholder
+for, e.g. hostname, user name/ID, process ID and/or other random data.
 .
 .\" --------------------------------------------------------------------
 .SH BUGS
@@ -543,9 +579,11 @@ See issue tracker at <https://github.com/neomutt/neomutt/issues>.
 .\" --------------------------------------------------------------------
 .SH NO WARRANTIES
 .\" --------------------------------------------------------------------
-This program is distributed in the hope that it will be useful, but WITHOUT ANY
-WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY;
+without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
 .
 .\" --------------------------------------------------------------------
 .SH SEE ALSO
@@ -576,6 +614,6 @@ For further NeoMutt information:
 .\" --------------------------------------------------------------------
 .SH AUTHOR
 .\" --------------------------------------------------------------------
-Michael Elkins, and others. Use <neomutt-devel@\:neomutt.org> to contact the
-developers.
+Michael Elkins, and others.
+Use <neomutt-devel@\:neomutt.org> to contact the developers.
 .

--- a/docs/neomutt.man
+++ b/docs/neomutt.man
@@ -144,7 +144,6 @@ neomutt \- The NeoMutt Mail User Agent (MUA)
 .\" --------------------------------------------------------------------
 .SH DESCRIPTION
 .\" --------------------------------------------------------------------
-.PP
 NeoMutt is a small but very powerful text based program for reading and sending
 electronic mail under Unix operating systems, including support for color
 terminals, MIME, OpenPGP, and a threaded sorting mode.
@@ -178,7 +177,6 @@ addresses after the \(aq\fB\-\-\fP\(aq argument, e.g.:
 .BI "neomutt \-a " "image.jpg *.png " "\-\- " "address1 address2 "
 .EE
 .RE
-.IP
 .
 .TP
 .BI \-B
@@ -440,7 +438,6 @@ described in \fIFILES\fP section below. This variable defaults to
 .\" --------------------------------------------------------------------
 .SS "\s-1Configuration files\s0"
 .\" --------------------------------------------------------------------
-.PP
 NeoMutt will read just the first found configuration file of system-wide and
 user-specific category, from the list below and in that order.
 .
@@ -495,12 +492,10 @@ r c li .
 l s s .
 \0\fB*\fP) Note the case of the filename
 .TE
-.PP
 .ad
 .
 .SS "\s-1Other relevant files\s0"
 .\" --------------------------------------------------------------------
-.PP
 Unless otherwise stated, NeoMutt will process all grouped files in the order
 (from top to bottom) as they are specified in that listing.
 .
@@ -543,13 +538,11 @@ process ID and/or other random data.
 .\" --------------------------------------------------------------------
 .SH BUGS
 .\" --------------------------------------------------------------------
-.PP
 See issue tracker at <https://github.com/neomutt/neomutt/issues>.
 .
 .\" --------------------------------------------------------------------
 .SH NO WARRANTIES
 .\" --------------------------------------------------------------------
-.PP
 This program is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
 A PARTICULAR PURPOSE. See the GNU General Public License for more details.
@@ -557,7 +550,6 @@ A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 .\" --------------------------------------------------------------------
 .SH SEE ALSO
 .\" --------------------------------------------------------------------
-.PP
 .\" sorted by category and name
 .BR gettext (1),
 .BR msmtp (1),
@@ -584,7 +576,6 @@ For further NeoMutt information:
 .\" --------------------------------------------------------------------
 .SH AUTHOR
 .\" --------------------------------------------------------------------
-.PP
 Michael Elkins, and others. Use <neomutt-devel@\:neomutt.org> to contact the
 developers.
 .

--- a/docs/neomutt.man
+++ b/docs/neomutt.man
@@ -30,113 +30,152 @@ The NeoMutt Mail User Agent (MUA)
 .SH SYNTAX
 .\" --------------------------------------------------------------------
 .SY neomutt
-.OP \-Enx
-.OP \-e command
-.OP \-F config
-.OP \-H draft
-.OP \-i include
-.br
-.OP \-b address
-.OP \-c address
-.OP \-s subject
-.RB [ \-a
-.IR file " [" .\|.\|.\& ]
-.BR \-\- ]
-.IR address " [" .\|.\|.\& ]
+.RB [ \-Enx ]
+.RB [ \-e\~\c
+.IR command ]
+.RB [ \-F\~\c
+.IR config ]
+.RB [ \-H\~\c
+.IR draft ]
+.RB [ \-i\~\c
+.IR include ]
+.RB [ \-b\~\c
+.IR address ]
+.RB [ \-c\~\c
+.IR address ]
+.RB [ \-s\~\c
+.IR subject ]
+.RB [ \-a\~\c
+.IR file \~[ .\|.\|.\& ]]
+.RB [ \-\- ]
+.IR address \~[ .\|.\|.\& ]
 .YS
 .
 .SY neomutt
-.OP \-nx
-.OP \-e command
-.OP \-F config
-.OP \-b address
-.OP \-c address
-.br
-.OP \-s subject
-.RB [ \-a
-.IR file " [" .\|.\|.\& ]
-.BR \-\- ]
-.IR address " [" .\|.\|.\& "] < message"
+.RB [ \-nx ]
+.RB [ \-e\~\c
+.IR command ]
+.RB [ \-F\~\c
+.IR config ]
+.RB [ \-b\~\c
+.IR address ]
+.RB [ \-c\~\c
+.IR address ]
+.RB [ \-s\~\c
+.IR subject ]
+.RB [ \-a\~\c
+.IR file \~[ .\|.\|.\& ]]
+.RB [ \-\- ]
+.IR address \~[ .\|.\|.\& ]
+.BI <\~ message
 .YS
 .
 .SY neomutt
-.OP \-nRy
-.OP \-e command
-.OP \-F config
-.OP \-f mailbox
-.OP \-m type
+.RB [ \-nRy ]
+.RB [ \-e\~\c
+.IR command ]
+.RB [ \-F\~\c
+.IR config ]
+.RB [ \-f\~\c
+.IR mailbox ]
+.RB [ \-m\~\c
+.IR type ]
 .YS
 .
 .SY neomutt
-.OP \-n
-.OP \-e command
-.OP \-F config
-.BI \-A " alias"
+.RB [ \-n ]
+.RB [ \-e\~\c
+.IR command ]
+.RB [ \-F\~\c
+.IR config ]
+.BI \-A\~ alias
 .YS
 .
 .SY neomutt
-.OP \-n
-.OP \-e command
-.OP \-F config
+.RB [ \-n ]
+.RB [ \-e\~\c
+.IR command ]
+.RB [ \-F\~\c
+.IR config ]
 .B \-B
 .YS
 .
 .SY neomutt
-.OP \-n
-.OP \-e command
-.OP \-F config
-.BR \-D " [" \-S ] " [" \-O ]
+.RB [ \-n ]
+.RB [ \-e\~\c
+.IR command ]
+.RB [ \-F\~\c
+.IR config ]
+.B \-D
+.RB [ \-S ]
+.RB [ \-O ]
 .YS
 .
 .SY neomutt
-.OP \-n
-.OP \-e command
-.OP \-F config
-.BI \-d " level"
-.BI \-l " file"
+.RB [ \-n ]
+.RB [ \-e\~\c
+.IR command ]
+.RB [ \-F\~\c
+.IR config ]
+.BI \-d\~ level
+.BI \-l\~ file
 .YS
 .
 .SY neomutt
-.OP \-n
-.OP \-e command
-.OP \-F config
+.RB [ \-n ]
+.RB [ \-e\~\c
+.IR command ]
+.RB [ \-F\~\c
+.IR config ]
 .B \-G
 .YS
 .
 .SY neomutt
-.OP \-n
-.OP \-e command
-.OP \-F config
-.BI \-g " server"
+.RB [ \-n ]
+.RB [ \-e\~\c
+.IR command ]
+.RB [ \-F\~\c
+.IR config ]
+.BI \-g\~ server
 .YS
 .
 .SY neomutt
-.OP \-n
-.OP \-e command
-.OP \-F config
+.RB [ \-n ]
+.RB [ \-e\~\c
+.IR command ]
+.RB [ \-F\~\c
+.IR config ]
 .B \-p
 .YS
 .
 .SY neomutt
-.OP \-n
-.OP \-e command
-.OP \-F config
-.BI \-Q " variable [" \-O ]
+.RB [ \-n ]
+.RB [ \-e\~\c
+.IR command ]
+.RB [ \-F\~\c
+.IR config ]
+.BI \-Q\~ variable
+.RB [ \-O ]
 .YS
 .
 .SY neomutt
-.OP \-n
-.OP \-e command
-.OP \-F config
+.RB [ \-n ]
+.RB [ \-e\~\c
+.IR command ]
+.RB [ \-F\~\c
+.IR config ]
 .B \-Z
 .YS
 .
 .SY neomutt
-.OP \-n
-.OP \-e command
-.OP \-F config
+.RB [ \-n ]
+.RB [ \-e\~\c
+.IR command ]
+.RB [ \-F\~\c
+.IR config ]
 .B \-z
-.OP \-f mailbox
+.RB [ \-f\~\c
+.IR mailbox ]
 .YS
 .
 .SY neomutt

--- a/docs/neomutt.man
+++ b/docs/neomutt.man
@@ -564,7 +564,7 @@ while processing attachments to determine their MIME type.
 The full NeoMutt manual in HTML, PDF or plain text format.
 .
 .TP
-.IR "/tmp/neomutt-XXXX-XXXX-XXXX"
+.IR /tmp/neomutt- XXXX-XXXX-XXXX
 Temporary files created by NeoMutt.
 For custom locations
 look at description of the environment variable \fBTMPDIR\fP above.

--- a/docs/pgpewrap.1
+++ b/docs/pgpewrap.1
@@ -19,17 +19,19 @@
 .\"
 .TH pgpewrap 1 "2013-05" Unix "User Manuals"
 .SH NAME
-pgpewrap \- NeoMutt command line munging tool
+pgpewrap
+\-
+NeoMutt command line munging tool
 
 .SH SYNTAX
 \fBpgpewrap\fP [ \fBflags\fP ] \-\- \fBprefix\fP [ \fBrecipients\fP ]
 
 .SH DESCRIPTION
-This is a little C program which does some command line munging: The
-first argument is a command to be executed.  When \fBpgpewrap\fP
-encounters a "\-\-" (dash\-dash) argument, it will interpret the next
-argument as a prefix which is put in front of all following
-arguments.
+This is a little C program which does some command line munging:
+The first argument is a command to be executed.
+When \fBpgpewrap\fP encounters a "\-\-" (dash\-dash) argument,
+it will interpret the next argument
+as a prefix which is put in front of all following arguments.
 
 .SH EXAMPLE
 
@@ -39,6 +41,7 @@ will execute:
 
         pgpe file -r a -r b -r c
 
-This script is needed with PGP 5 and with GPG, since their command
-line interfaces can't be properly served by neomutt's format mechanism.
+This script is needed with PGP 5 and with GPG,
+since their command line interfaces
+can't be properly served by neomutt's format mechanism.
 

--- a/docs/pgpewrap.1
+++ b/docs/pgpewrap.1
@@ -22,11 +22,9 @@
 pgpewrap \- NeoMutt command line munging tool
 
 .SH SYNTAX
-.PP
 \fBpgpewrap\fP [ \fBflags\fP ] \-\- \fBprefix\fP [ \fBrecipients\fP ]
 
 .SH DESCRIPTION
-.PP
 This is a little C program which does some command line munging: The
 first argument is a command to be executed.  When \fBpgpewrap\fP
 encounters a "\-\-" (dash\-dash) argument, it will interpret the next

--- a/docs/pgpewrap.1
+++ b/docs/pgpewrap.1
@@ -18,30 +18,37 @@
 .\"     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 .\"
 .TH pgpewrap 1 "2013-05" Unix "User Manuals"
+.\"
 .SH NAME
 pgpewrap
 \-
 NeoMutt command line munging tool
-
+.\"
 .SH SYNTAX
 \fBpgpewrap\fP [ \fBflags\fP ] \-\- \fBprefix\fP [ \fBrecipients\fP ]
-
+.\"
 .SH DESCRIPTION
 This is a little C program which does some command line munging:
 The first argument is a command to be executed.
 When \fBpgpewrap\fP encounters a "\-\-" (dash\-dash) argument,
 it will interpret the next argument
 as a prefix which is put in front of all following arguments.
-
+.\"
 .SH EXAMPLE
-
-        pgpewrap pgpe file \-\- \-r a b c
-
+.in +4n
+.EX
+pgpewrap pgpe file \-\- \-r a b c
+.EE
+.in
+.PP
 will execute:
-
-        pgpe file -r a -r b -r c
-
+.PP
+.in +4n
+.EX
+pgpe file -r a -r b -r c
+.EE
+.in
+.PP
 This script is needed with PGP 5 and with GPG,
 since their command line interfaces
 can't be properly served by neomutt's format mechanism.
-

--- a/docs/pgpewrap.1
+++ b/docs/pgpewrap.1
@@ -30,7 +30,7 @@ NeoMutt command line munging tool
 .SH DESCRIPTION
 This is a little C program which does some command line munging:
 The first argument is a command to be executed.
-When \fBpgpewrap\fP encounters a "\-\-" (dash\-dash) argument,
+When \fBpgpewrap\fP encounters a "\-\-" (dash-dash) argument,
 it will interpret the next argument
 as a prefix which is put in front of all following arguments.
 .\"

--- a/docs/pgpewrap.1
+++ b/docs/pgpewrap.1
@@ -17,7 +17,7 @@
 .\"     along with this program; if not, write to the Free Software
 .\"     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 .\"
-.TH pgpewrap 1 "May 2013" Unix "User Manuals"
+.TH pgpewrap 1 "2013-05" Unix "User Manuals"
 .SH NAME
 pgpewrap \- NeoMutt command line munging tool
 

--- a/docs/smime_keys.1
+++ b/docs/smime_keys.1
@@ -24,7 +24,6 @@
 .SH "NAME"
 smime_keys \- Utility to add S/MIME certificate to the internal database used by neomutt
 .SH SYNTAX
-.PP
 .B smime_keys
 <operation>  [file(s) | keyID [file(s)]]
 .SH "DESCRIPTION"
@@ -32,7 +31,6 @@ The purpose of this tool is to manipulate the internal database of S/MIME certif
 used by neomutt to sign mail messages which will be sent or to verify mail messages received
 and signed with S/MIME
 .SH OPTIONS
-.PP
 .IP \fBinit\fP
 no files needed, inits directory structure.
 .IP \fBlist\fP

--- a/docs/smime_keys.1
+++ b/docs/smime_keys.1
@@ -20,7 +20,7 @@
 .\"     along with this program; if not, write to the Free Software
 .\"     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 .\"
-.TH smime_keys 1 "May 2009" Unix "User Manuals"
+.TH smime_keys 1 "2009-05" Unix "User Manuals"
 .SH "NAME"
 smime_keys \- Utility to add S/MIME certificate to the internal database used by neomutt
 .SH SYNTAX

--- a/docs/smime_keys.1
+++ b/docs/smime_keys.1
@@ -22,27 +22,33 @@
 .\"
 .TH smime_keys 1 "2009-05" Unix "User Manuals"
 .SH "NAME"
-smime_keys \- Utility to add S/MIME certificate to the internal database used by neomutt
+smime_keys
+\-
+Utility to add S/MIME certificate to the internal database used by neomutt
 .SH SYNTAX
 .B smime_keys
 <operation>  [file(s) | keyID [file(s)]]
 .SH "DESCRIPTION"
-The purpose of this tool is to manipulate the internal database of S/MIME certificates
-used by neomutt to sign mail messages which will be sent or to verify mail messages received
-and signed with S/MIME
+The purpose of this tool is to
+manipulate the internal database of S/MIME certificates
+used by neomutt to sign mail messages which will be sent
+or to verify mail messages received and signed with S/MIME
 .SH OPTIONS
 .IP \fBinit\fP
-no files needed, inits directory structure.
+no files needed,
+inits directory structure.
 .IP \fBlist\fP
 lists the certificates stored in database.
 .IP \fBlabel\fP
-keyID required. changes/removes/adds label.
+keyID required.
+changes/removes/adds label.
 .IP \fBremove\fP
 keyID required.
 .IP \fBverify\fP
 1=keyID and optionally 2=CRL
-Verifies the certificate chain, and optionally whether
-this certificate is included in supplied CRL (PEM format).
+Verifies the certificate chain,
+and optionally
+whether this certificate is included in supplied CRL (PEM format).
 Note: to verify all certificates at the same time,
 replace keyID with "all"
 .IP \fBadd_cert\fP
@@ -54,15 +60,18 @@ plus 3=intermediate certificate(s).
 one file reqd. Adds keypair to database.
 file is PKCS12 (e.g. export from netscape).
 .IP \fBadd_pem\fP
-one file reqd. Adds keypair to database.
+one file reqd.
+Adds keypair to database.
 (file was converted from e.g. PKCS12).
 .IP \fBadd_root\fP
-one file reqd. Adds PEM root certificate to the location
+one file reqd.
+Adds PEM root certificate to the location
 specified within muttrc (smime_verify_* command)
 .SH NO WARRANTIES
 This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+but WITHOUT ANY WARRANTY;
+without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
 .PP
 NeoMutt Home Page: https://neomutt.org/


### PR DESCRIPTION
Before these patches, the Linux man-pages build system reported many problems in the pages:

```sh
$ make -C ~/src/linux/man-pages/man-pages/master/ -k build lint check MANDIR=~/src/mutt/neomutt/main/ builddir=old
make: Entering directory '/home/alx/src/linux/man-pages/man-pages/master'
MKDIR	old/man/
Build	old/man/man-pages.pdf
for my (...) is experimental at ./scripts/LinuxManBook/prepare.pl line 62.
grep: /home/alx/src/mutt/neomutt/main//man*/*: No such file or directory
MKDIR	old/man/docs/
PRECONV	old/man/docs/pgpewrap.1.tbl
TBL	old/man/docs/pgpewrap.1.eqn
EQN	old/man/docs/pgpewrap.1.cat.troff
TROFF	old/man/docs/pgpewrap.1.cat.set
an.tmac:/home/alx/src/mutt/neomutt/main//docs/pgpewrap.1:23: style: blank line in input
an.tmac:/home/alx/src/mutt/neomutt/main//docs/pgpewrap.1:27: style: blank line in input
an.tmac:/home/alx/src/mutt/neomutt/main//docs/pgpewrap.1:35: style: blank line in input
an.tmac:/home/alx/src/mutt/neomutt/main//docs/pgpewrap.1:37: style: blank line in input
an.tmac:/home/alx/src/mutt/neomutt/main//docs/pgpewrap.1:38: style: 8 leading space(s) on input line
an.tmac:/home/alx/src/mutt/neomutt/main//docs/pgpewrap.1:39: style: blank line in input
an.tmac:/home/alx/src/mutt/neomutt/main//docs/pgpewrap.1:41: style: blank line in input
an.tmac:/home/alx/src/mutt/neomutt/main//docs/pgpewrap.1:42: style: 8 leading space(s) on input line
an.tmac:/home/alx/src/mutt/neomutt/main//docs/pgpewrap.1:43: style: blank line in input
an.tmac:/home/alx/src/mutt/neomutt/main//docs/pgpewrap.1:46: style: blank line in input
make: *** [share/mk/build/catman.mk:54: old/man/docs/pgpewrap.1.cat.set] Error 1
make: *** Deleting file 'old/man/docs/pgpewrap.1.cat.set'
PRECONV	old/man/docs/smime_keys.1.tbl
TBL	old/man/docs/smime_keys.1.eqn
EQN	old/man/docs/smime_keys.1.cat.troff
TROFF	old/man/docs/smime_keys.1.cat.set
GROTTY	old/man/docs/smime_keys.1.cat
PRECONV	old/man/docs/mbox.5.tbl
TBL	old/man/docs/mbox.5.eqn
EQN	old/man/docs/mbox.5.cat.troff
TROFF	old/man/docs/mbox.5.cat.set
an.tmac:/home/alx/src/mutt/neomutt/main//docs/mbox.5:131: style: .IR expects at least 2 arguments, got 1
an.tmac:/home/alx/src/mutt/neomutt/main//docs/mbox.5:136: style: .IR expects at least 2 arguments, got 1
an.tmac:/home/alx/src/mutt/neomutt/main//docs/mbox.5:141: style: .IR expects at least 2 arguments, got 1
an.tmac:/home/alx/src/mutt/neomutt/main//docs/mbox.5:160: style: .BR expects at least 2 arguments, got 1
make: *** [share/mk/build/catman.mk:54: old/man/docs/mbox.5.cat.set] Error 1
make: *** Deleting file 'old/man/docs/mbox.5.cat.set'
PRECONV	old/man/docs/mmdf.5.tbl
TBL	old/man/docs/mmdf.5.eqn
EQN	old/man/docs/mmdf.5.cat.troff
TROFF	old/man/docs/mmdf.5.cat.set
an.tmac:/home/alx/src/mutt/neomutt/main//docs/mmdf.5:144: style: .BR expects at least 2 arguments, got 1
an.tmac:/home/alx/src/mutt/neomutt/main//docs/mmdf.5:145: style: blank line in input
make: *** [share/mk/build/catman.mk:54: old/man/docs/mmdf.5.cat.set] Error 1
make: *** Deleting file 'old/man/docs/mmdf.5.cat.set'
MKDIR	old/html/docs/
MAN2HTML	old/html/docs/pgpewrap.1.html
MAN2HTML	old/html/docs/smime_keys.1.html
MAN2HTML	old/html/docs/mbox.5.html
MAN2HTML	old/html/docs/mmdf.5.html
EQN	old/man/docs/pgpewrap.1.pdf.troff
TROFF	old/man/docs/pgpewrap.1.pdf.set
GROPDF	old/man/docs/pgpewrap.1.pdf
EQN	old/man/docs/smime_keys.1.pdf.troff
TROFF	old/man/docs/smime_keys.1.pdf.set
GROPDF	old/man/docs/smime_keys.1.pdf
EQN	old/man/docs/mbox.5.pdf.troff
TROFF	old/man/docs/mbox.5.pdf.set
GROPDF	old/man/docs/mbox.5.pdf
EQN	old/man/docs/mmdf.5.pdf.troff
TROFF	old/man/docs/mmdf.5.pdf.set
GROPDF	old/man/docs/mmdf.5.pdf
EQN	old/man/docs/pgpewrap.1.ps.troff
TROFF	old/man/docs/pgpewrap.1.ps.set
GROPS	old/man/docs/pgpewrap.1.ps
EQN	old/man/docs/smime_keys.1.ps.troff
TROFF	old/man/docs/smime_keys.1.ps.set
GROPS	old/man/docs/smime_keys.1.ps
EQN	old/man/docs/mbox.5.ps.troff
TROFF	old/man/docs/mbox.5.ps.set
GROPS	old/man/docs/mbox.5.ps
EQN	old/man/docs/mmdf.5.ps.troff
TROFF	old/man/docs/mmdf.5.ps.set
GROPS	old/man/docs/mmdf.5.ps
make: Target 'build' not remade because of errors.
LINT (mandoc)	old/man/docs/pgpewrap.1.lint-man.mandoc.touch
mandoc: /home/alx/src/mutt/neomutt/main//docs/pgpewrap.1:20:16: WARNING: cannot parse date, using it verbatim: TH 2013-05
mandoc: /home/alx/src/mutt/neomutt/main//docs/pgpewrap.1:25:2: WARNING: skipping paragraph macro: PP after SH
mandoc: /home/alx/src/mutt/neomutt/main//docs/pgpewrap.1:29:2: WARNING: skipping paragraph macro: PP after SH
make: *** [share/mk/lint/man/man.mk:32: old/man/docs/pgpewrap.1.lint-man.mandoc.touch] Error 1
LINT (mandoc)	old/man/docs/smime_keys.1.lint-man.mandoc.touch
mandoc: /home/alx/src/mutt/neomutt/main//docs/smime_keys.1:25:88: STYLE: input text line longer than 80 bytes: smime_keys \- Utilit...
mandoc: /home/alx/src/mutt/neomutt/main//docs/smime_keys.1:31:86: STYLE: input text line longer than 80 bytes: The purpose of this ...
mandoc: /home/alx/src/mutt/neomutt/main//docs/smime_keys.1:32:92: STYLE: input text line longer than 80 bytes: used by neomutt to s...
mandoc: /home/alx/src/mutt/neomutt/main//docs/smime_keys.1:23:18: WARNING: cannot parse date, using it verbatim: TH 2009-05
mandoc: /home/alx/src/mutt/neomutt/main//docs/smime_keys.1:27:2: WARNING: skipping paragraph macro: PP after SH
mandoc: /home/alx/src/mutt/neomutt/main//docs/smime_keys.1:35:2: WARNING: skipping paragraph macro: PP empty
make: *** [share/mk/lint/man/man.mk:32: old/man/docs/smime_keys.1.lint-man.mandoc.touch] Error 1
LINT (mandoc)	old/man/docs/mbox.5.lint-man.mandoc.touch
mandoc: /home/alx/src/mutt/neomutt/main//docs/mbox.5:9:12: WARNING: cannot parse date, using it verbatim: TH February 19th, 2002
mandoc: /home/alx/src/mutt/neomutt/main//docs/mbox.5:147:2: WARNING: skipping paragraph macro: PP empty
make: *** [share/mk/lint/man/man.mk:32: old/man/docs/mbox.5.lint-man.mandoc.touch] Error 1
LINT (mandoc)	old/man/docs/mmdf.5.lint-man.mandoc.touch
mandoc: /home/alx/src/mutt/neomutt/main//docs/mmdf.5:8:12: WARNING: cannot parse date, using it verbatim: TH February 18th, 2002
mandoc: /home/alx/src/mutt/neomutt/main//docs/mmdf.5:40:2: WARNING: skipping paragraph macro: br before sp
mandoc: /home/alx/src/mutt/neomutt/main//docs/mmdf.5:42:2: WARNING: skipping paragraph macro: br after sp
mandoc: /home/alx/src/mutt/neomutt/main//docs/mmdf.5:45:2: WARNING: skipping paragraph macro: br after br
mandoc: /home/alx/src/mutt/neomutt/main//docs/mmdf.5:55:2: WARNING: skipping paragraph macro: br before sp
mandoc: /home/alx/src/mutt/neomutt/main//docs/mmdf.5:57:2: WARNING: skipping paragraph macro: br after sp
make: *** [share/mk/lint/man/man.mk:32: old/man/docs/mmdf.5.lint-man.mandoc.touch] Error 1
LINT (tbl comment)	old/man/docs/pgpewrap.1.lint-man.tbl.touch
LINT (tbl comment)	old/man/docs/smime_keys.1.lint-man.tbl.touch
LINT (tbl comment)	old/man/docs/mbox.5.lint-man.tbl.touch
/home/alx/src/mutt/neomutt/main//docs/mbox.5:1: spurious '\" t' comment:
'\" t
make: *** [share/mk/lint/man/man.mk:42: old/man/docs/mbox.5.lint-man.tbl.touch] Error 1
LINT (tbl comment)	old/man/docs/mmdf.5.lint-man.tbl.touch
make: Target 'lint' not remade because of errors.
COL	old/man/docs/smime_keys.1.cat.grep
GREP	old/man/docs/smime_keys.1.check-catman.touch
make: Target 'check' not remade because of errors.
make: Leaving directory '/home/alx/src/linux/man-pages/man-pages/master'
```

After these patches, it's mostly clean:

```sh
$ make -C ~/src/linux/man-pages/man-pages/master/ -k build lint check MANDIR=~/src/mutt/neomutt/man/ builddir=new
make: Entering directory '/home/alx/src/linux/man-pages/man-pages/master'
MKDIR	new/man/
Build	new/man/man-pages.pdf
for my (...) is experimental at ./scripts/LinuxManBook/prepare.pl line 62.
grep: /home/alx/src/mutt/neomutt/man//man*/*: No such file or directory
MKDIR	new/man/docs/
PRECONV	new/man/docs/pgpewrap.1.tbl
TBL	new/man/docs/pgpewrap.1.eqn
EQN	new/man/docs/pgpewrap.1.cat.troff
TROFF	new/man/docs/pgpewrap.1.cat.set
GROTTY	new/man/docs/pgpewrap.1.cat
PRECONV	new/man/docs/smime_keys.1.tbl
TBL	new/man/docs/smime_keys.1.eqn
EQN	new/man/docs/smime_keys.1.cat.troff
TROFF	new/man/docs/smime_keys.1.cat.set
GROTTY	new/man/docs/smime_keys.1.cat
PRECONV	new/man/docs/mbox.5.tbl
TBL	new/man/docs/mbox.5.eqn
EQN	new/man/docs/mbox.5.cat.troff
TROFF	new/man/docs/mbox.5.cat.set
GROTTY	new/man/docs/mbox.5.cat
PRECONV	new/man/docs/mmdf.5.tbl
TBL	new/man/docs/mmdf.5.eqn
EQN	new/man/docs/mmdf.5.cat.troff
TROFF	new/man/docs/mmdf.5.cat.set
GROTTY	new/man/docs/mmdf.5.cat
MKDIR	new/html/docs/
MAN2HTML	new/html/docs/pgpewrap.1.html
MAN2HTML	new/html/docs/smime_keys.1.html
MAN2HTML	new/html/docs/mbox.5.html
MAN2HTML	new/html/docs/mmdf.5.html
EQN	new/man/docs/pgpewrap.1.pdf.troff
TROFF	new/man/docs/pgpewrap.1.pdf.set
GROPDF	new/man/docs/pgpewrap.1.pdf
EQN	new/man/docs/smime_keys.1.pdf.troff
TROFF	new/man/docs/smime_keys.1.pdf.set
GROPDF	new/man/docs/smime_keys.1.pdf
EQN	new/man/docs/mbox.5.pdf.troff
TROFF	new/man/docs/mbox.5.pdf.set
GROPDF	new/man/docs/mbox.5.pdf
EQN	new/man/docs/mmdf.5.pdf.troff
TROFF	new/man/docs/mmdf.5.pdf.set
GROPDF	new/man/docs/mmdf.5.pdf
EQN	new/man/docs/pgpewrap.1.ps.troff
TROFF	new/man/docs/pgpewrap.1.ps.set
GROPS	new/man/docs/pgpewrap.1.ps
EQN	new/man/docs/smime_keys.1.ps.troff
TROFF	new/man/docs/smime_keys.1.ps.set
GROPS	new/man/docs/smime_keys.1.ps
EQN	new/man/docs/mbox.5.ps.troff
TROFF	new/man/docs/mbox.5.ps.set
GROPS	new/man/docs/mbox.5.ps
EQN	new/man/docs/mmdf.5.ps.troff
TROFF	new/man/docs/mmdf.5.ps.set
GROPS	new/man/docs/mmdf.5.ps
LINT (mandoc)	new/man/docs/pgpewrap.1.lint-man.mandoc.touch
mandoc: /home/alx/src/mutt/neomutt/man//docs/pgpewrap.1:20:16: WARNING: cannot parse date, using it verbatim: TH 2013-05
make: *** [share/mk/lint/man/man.mk:32: new/man/docs/pgpewrap.1.lint-man.mandoc.touch] Error 1
LINT (mandoc)	new/man/docs/smime_keys.1.lint-man.mandoc.touch
mandoc: /home/alx/src/mutt/neomutt/man//docs/smime_keys.1:23:18: WARNING: cannot parse date, using it verbatim: TH 2009-05
make: *** [share/mk/lint/man/man.mk:32: new/man/docs/smime_keys.1.lint-man.mandoc.touch] Error 1
LINT (mandoc)	new/man/docs/mbox.5.lint-man.mandoc.touch
LINT (mandoc)	new/man/docs/mmdf.5.lint-man.mandoc.touch
LINT (tbl comment)	new/man/docs/pgpewrap.1.lint-man.tbl.touch
LINT (tbl comment)	new/man/docs/smime_keys.1.lint-man.tbl.touch
LINT (tbl comment)	new/man/docs/mbox.5.lint-man.tbl.touch
LINT (tbl comment)	new/man/docs/mmdf.5.lint-man.tbl.touch
make: Target 'lint' not remade because of errors.
COL	new/man/docs/pgpewrap.1.cat.grep
GREP	new/man/docs/pgpewrap.1.check-catman.touch
COL	new/man/docs/smime_keys.1.cat.grep
GREP	new/man/docs/smime_keys.1.check-catman.touch
COL	new/man/docs/mbox.5.cat.grep
GREP	new/man/docs/mbox.5.check-catman.touch
COL	new/man/docs/mmdf.5.cat.grep
GREP	new/man/docs/mmdf.5.check-catman.touch
make: Leaving directory '/home/alx/src/linux/man-pages/man-pages/master'
```