### PR TITLE
add parse_extract_color_name() to extract color name tokens

### DIFF
--- a/color/parse_color.c
+++ b/color/parse_color.c
@@ -70,6 +70,31 @@ static struct Mapping AttributeNames[] = {
 };
 
 /**
+ * parse_extract_color_name - Extract one color name (eg. red) from a string
+ * @param dest  Buffer for the result
+ * @param buf   Buffer containing tokens
+ * @retval  0 Success
+ * @retval -1 Error
+ */
+static int parse_extract_color_name(struct Buffer *dest, struct Buffer *buf)
+{
+  if (buf_is_empty(buf) || !*buf->dptr)
+    return -1;
+
+  buf_reset(dest);
+
+  SKIPWS(buf->dptr);
+  char ch;
+  while ((ch = *buf->dptr++) && !isspace(ch))
+    buf_addch(dest, ch);
+
+  if (buf_is_empty(dest))
+    return -1;
+
+  return 0;
+}
+
+/**
  * parse_color_prefix - Parse a colour prefix, e.g. "bright"
  * @param[in]  s      String to parse
  * @param[out] prefix parsed prefix, see #ColorPrefix
@@ -283,13 +308,12 @@ enum CommandResult parse_color_pair(struct Buffer *buf, struct Buffer *s,
 {
   while (true)
   {
-    if (!MoreArgsF(s, TOKEN_COMMENT))
+    if (parse_extract_color_name(buf, s) == -1)
     {
       buf_printf(err, _("%s: too few arguments"), "color");
       return MUTT_CMD_WARNING;
     }
 
-    parse_extract_token(buf, s, TOKEN_COMMENT);
     if (buf_is_empty(buf))
       continue;
 
@@ -308,13 +332,11 @@ enum CommandResult parse_color_pair(struct Buffer *buf, struct Buffer *s,
       ac->attrs |= attr; // Merge with other attributes
   }
 
-  if (!MoreArgsF(s, TOKEN_COMMENT))
+  if (parse_extract_color_name(buf, s) == -1)
   {
     buf_printf(err, _("%s: too few arguments"), "color");
     return MUTT_CMD_WARNING;
   }
-
-  parse_extract_token(buf, s, TOKEN_COMMENT);
 
   return parse_color_name(buf->data, &ac->bg, err);
 }

--- a/parse/extract.h
+++ b/parse/extract.h
@@ -31,17 +31,6 @@ struct Buffer;
 
 #define MoreArgs(buf) (*(buf)->dptr && (*(buf)->dptr != ';') && (*(buf)->dptr != '#'))
 
-/* The same conditions as in mutt_extract_token() */
-#define MoreArgsF(buf, flags) (*(buf)->dptr && \
-    (!isspace(*(buf)->dptr) || ((flags) & TOKEN_SPACE)) && \
-    ((*(buf)->dptr != '#') ||  ((flags) & TOKEN_COMMENT)) && \
-    ((*(buf)->dptr != '+') || !((flags) & TOKEN_PLUS)) && \
-    ((*(buf)->dptr != '-') || !((flags) & TOKEN_MINUS)) && \
-    ((*(buf)->dptr != '=') || !((flags) & TOKEN_EQUAL)) && \
-    ((*(buf)->dptr != '?') || !((flags) & TOKEN_QUESTION)) && \
-    ((*(buf)->dptr != ';') || ((flags) & TOKEN_SEMICOLON)) && \
-    (!((flags) & TOKEN_PATTERN) || strchr("~%=!|", *(buf)->dptr)))
-
 typedef uint16_t TokenFlags;          ///< Flags for parse_extract_token(), e.g. #TOKEN_EQUAL
 #define TOKEN_NO_FLAGS            0   ///< No flags are set
 #define TOKEN_EQUAL         (1 << 0)  ///< Treat '=' as a special


### PR DESCRIPTION
Color names are simple to parse. Adding a dedicated function allows us to get rid of the `MoreArgsF()` macro and maybe later simplify `parse_extract_token()`.

Related: https://github.com/neomutt/neomutt/pull/4173, https://github.com/neomutt/neomutt/discussions/4174