### PR TITLE
refactor token parsing

### DIFF
--- a/alias/commands.c
+++ b/alias/commands.c
@@ -139,7 +139,7 @@ enum CommandResult parse_alias(struct Buffer *buf, struct Buffer *s,
   struct GroupList gl = STAILQ_HEAD_INITIALIZER(gl);
   enum NotifyAlias event;
 
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     buf_strcpy(err, _("alias: no address"));
     return MUTT_CMD_WARNING;
@@ -221,7 +221,7 @@ enum CommandResult parse_alias(struct Buffer *buf, struct Buffer *s,
     }
   }
   mutt_grouplist_destroy(&gl);
-  if (!MoreArgs(s) && (s->dptr[0] == '#'))
+  if (!has_more_tokens(s) && (s->dptr[0] == '#'))
   {
     s->dptr++; // skip over the "# "
     if (*s->dptr == ' ')
@@ -277,6 +277,6 @@ enum CommandResult parse_unalias(struct Buffer *buf, struct Buffer *s,
       alias_free(&np);
       break;
     }
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
   return MUTT_CMD_SUCCESS;
 }

--- a/alias/commands.c
+++ b/alias/commands.c
@@ -221,7 +221,8 @@ enum CommandResult parse_alias(struct Buffer *buf, struct Buffer *s,
     }
   }
   mutt_grouplist_destroy(&gl);
-  if (!has_more_tokens(s) && (s->dptr[0] == '#'))
+
+  if (s->dptr[0] == '#')
   {
     s->dptr++; // skip over the "# "
     if (*s->dptr == ' ')

--- a/alternates.c
+++ b/alternates.c
@@ -108,7 +108,7 @@ enum CommandResult parse_alternates(struct Buffer *buf, struct Buffer *s,
 
     if (mutt_grouplist_add_regex(&gl, buf->data, REG_ICASE, err) != 0)
       goto bail;
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
   mutt_grouplist_destroy(&gl);
 
@@ -139,7 +139,7 @@ enum CommandResult parse_unalternates(struct Buffer *buf, struct Buffer *s,
       return MUTT_CMD_ERROR;
     }
 
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
   mutt_debug(LL_NOTIFY, "NT_ALTERN_DELETE: %s\n", buf->data);
   notify_send(AlternatesNotify, NT_ALTERN, NT_ALTERN_DELETE, NULL);

--- a/attach/attachments.c
+++ b/attach/attachments.c
@@ -372,7 +372,7 @@ static enum CommandResult parse_attach_list(struct Buffer *buf, struct Buffer *s
     mutt_debug(LL_DEBUG3, "added %s/%s [%d]\n", a->major, a->minor, a->major_int);
 
     mutt_list_insert_tail(head, (char *) a);
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
   if (!a)
     return MUTT_CMD_ERROR;
@@ -441,7 +441,7 @@ static enum CommandResult parse_unattach_list(struct Buffer *buf, struct Buffer 
       }
     }
 
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
   FREE(&tmp);
 

--- a/color/command.c
+++ b/color/command.c
@@ -180,7 +180,7 @@ static enum CommandResult parse_object(struct Buffer *buf, struct Buffer *s,
 
   if (mutt_istr_equal(buf->data, "compose"))
   {
-    if (!MoreArgs(s))
+    if (!has_more_tokens(s))
     {
       buf_printf(err, _("%s: too few arguments"), "color");
       return MUTT_CMD_WARNING;
@@ -231,7 +231,7 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
 {
   if (OptNoCurses) // No GUI, so quietly discard the command
   {
-    while (MoreArgs(s))
+    while (has_more_tokens(s))
     {
       parse_extract_token(buf, s, TOKEN_NO_FLAGS);
     }
@@ -265,7 +265,7 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
     return quoted_colors_parse_uncolor(cid, ql, err);
   }
 
-  if ((cid == MT_COLOR_STATUS) && !MoreArgs(s))
+  if ((cid == MT_COLOR_STATUS) && !has_more_tokens(s))
   {
     color_debug(LL_DEBUG5, "simple\n");
     simple_color_reset(cid); // default colour for the status bar
@@ -279,7 +279,7 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
     return MUTT_CMD_SUCCESS;
   }
 
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     if (regex_colors_parse_uncolor(cid, NULL, uncolor))
       return MUTT_CMD_SUCCESS;
@@ -300,7 +300,7 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
 
     regex_colors_parse_uncolor(cid, buf->data, uncolor);
 
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
   return MUTT_CMD_SUCCESS;
 }
@@ -328,7 +328,7 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
   enum CommandResult rc = MUTT_CMD_ERROR;
   struct AttrColor *ac = NULL;
 
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     if (StartupComplete)
     {
@@ -387,7 +387,7 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
   if (mutt_color_has_pattern(cid) && (cid != MT_COLOR_STATUS))
   {
     color_debug(LL_DEBUG5, "regex needed\n");
-    if (MoreArgs(s))
+    if (has_more_tokens(s))
     {
       parse_extract_token(buf, s, TOKEN_NO_FLAGS);
     }
@@ -397,7 +397,7 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
     }
   }
 
-  if (MoreArgs(s) && (cid != MT_COLOR_STATUS))
+  if (has_more_tokens(s) && (cid != MT_COLOR_STATUS))
   {
     buf_printf(err, _("%s: too many arguments"), color ? "color" : "mono");
     rc = MUTT_CMD_WARNING;
@@ -416,7 +416,7 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
     goto done;
     // do nothing
   }
-  else if ((cid == MT_COLOR_STATUS) && MoreArgs(s))
+  else if ((cid == MT_COLOR_STATUS) && has_more_tokens(s))
   {
     color_debug(LL_DEBUG5, "status\n");
     /* 'color status fg bg' can have up to 2 arguments:
@@ -425,7 +425,7 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
      * 2 arguments: colorize nth submatch of pattern */
     parse_extract_token(buf, s, TOKEN_NO_FLAGS);
 
-    if (MoreArgs(s))
+    if (has_more_tokens(s))
     {
       struct Buffer *tmp = buf_pool_get();
       parse_extract_token(tmp, s, TOKEN_NO_FLAGS);
@@ -439,7 +439,7 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
       buf_pool_release(&tmp);
     }
 
-    if (MoreArgs(s))
+    if (has_more_tokens(s))
     {
       buf_printf(err, _("%s: too many arguments"), color ? "color" : "mono");
       rc = MUTT_CMD_WARNING;
@@ -479,7 +479,7 @@ enum CommandResult mutt_parse_uncolor(struct Buffer *buf, struct Buffer *s,
 {
   if (OptNoCurses) // No GUI, so quietly discard the command
   {
-    while (MoreArgs(s))
+    while (has_more_tokens(s))
     {
       parse_extract_token(buf, s, TOKEN_NO_FLAGS);
     }
@@ -511,7 +511,7 @@ enum CommandResult mutt_parse_color(struct Buffer *buf, struct Buffer *s,
   // No GUI, or no colours, so quietly discard the command
   if (OptNoCurses || (COLORS == 0))
   {
-    while (MoreArgs(s))
+    while (has_more_tokens(s))
     {
       parse_extract_token(buf, s, TOKEN_NO_FLAGS);
     }
@@ -533,7 +533,7 @@ enum CommandResult mutt_parse_mono(struct Buffer *buf, struct Buffer *s,
   // No GUI, or colours available, so quietly discard the command
   if (OptNoCurses || (COLORS != 0))
   {
-    while (MoreArgs(s))
+    while (has_more_tokens(s))
     {
       parse_extract_token(buf, s, TOKEN_NO_FLAGS);
     }

--- a/color/parse_color.c
+++ b/color/parse_color.c
@@ -274,6 +274,31 @@ enum CommandResult parse_color_name(const char *s, struct ColorElement *elem,
 }
 
 /**
+ * parse_extract_color_name - Extract a color name (eg. red or #FF66EE) from a string
+ * @param dest  Buffer for the result
+ * @param buf   Buffer containing tokens
+ * @retval  true  Success
+ * @retval  false No color name found
+ */
+static bool parse_extract_color_name(struct Buffer *dest, struct Buffer *buf)
+{
+  if (buf_is_empty(buf) || !*buf->dptr)
+    return false;
+
+  buf_reset(dest);
+
+  SKIPWS(buf->dptr);
+  char ch;
+  while ((ch = *buf->dptr++) && !isspace(ch))
+    buf_addch(dest, ch);
+
+  if (buf_is_empty(dest))
+    return false;
+
+  return true;
+}
+
+/**
  * parse_color_pair - Parse a pair of colours - Implements ::parser_callback_t - @ingroup parser_callback_api
  *
  * Parse a pair of colours, e.g. "red default"
@@ -283,7 +308,7 @@ enum CommandResult parse_color_pair(struct Buffer *buf, struct Buffer *s,
 {
   while (true)
   {
-    if (!parse_extract_word(buf, s))
+    if (!parse_extract_color_name(buf, s))
     {
       buf_printf(err, _("%s: too few arguments"), "color");
       return MUTT_CMD_WARNING;
@@ -307,7 +332,7 @@ enum CommandResult parse_color_pair(struct Buffer *buf, struct Buffer *s,
       ac->attrs |= attr; // Merge with other attributes
   }
 
-  if (!parse_extract_word(buf, s))
+  if (!parse_extract_color_name(buf, s))
   {
     buf_printf(err, _("%s: too few arguments"), "color");
     return MUTT_CMD_WARNING;

--- a/color/parse_color.c
+++ b/color/parse_color.c
@@ -283,13 +283,12 @@ enum CommandResult parse_color_pair(struct Buffer *buf, struct Buffer *s,
 {
   while (true)
   {
-    if (!MoreArgsF(s, TOKEN_COMMENT))
+    if (!parse_extract_word(buf, s))
     {
       buf_printf(err, _("%s: too few arguments"), "color");
       return MUTT_CMD_WARNING;
     }
 
-    parse_extract_token(buf, s, TOKEN_COMMENT);
     if (buf_is_empty(buf))
       continue;
 
@@ -308,13 +307,11 @@ enum CommandResult parse_color_pair(struct Buffer *buf, struct Buffer *s,
       ac->attrs |= attr; // Merge with other attributes
   }
 
-  if (!MoreArgsF(s, TOKEN_COMMENT))
+  if (!parse_extract_word(buf, s))
   {
     buf_printf(err, _("%s: too few arguments"), "color");
     return MUTT_CMD_WARNING;
   }
-
-  parse_extract_token(buf, s, TOKEN_COMMENT);
 
   return parse_color_name(buf->data, &ac->bg, err);
 }

--- a/color/parse_color.c
+++ b/color/parse_color.c
@@ -325,7 +325,7 @@ enum CommandResult parse_attr_spec(struct Buffer *buf, struct Buffer *s,
   if (!buf || !s || !ac)
     return MUTT_CMD_ERROR;
 
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     buf_printf(err, _("%s: too few arguments"), "mono");
     return MUTT_CMD_WARNING;

--- a/commands.c
+++ b/commands.c
@@ -132,7 +132,7 @@ int parse_grouplist(struct GroupList *gl, struct Buffer *buf, struct Buffer *s,
 {
   while (mutt_istr_equal(buf->data, "-group"))
   {
-    if (!MoreArgs(s))
+    if (!has_more_tokens(s))
     {
       buf_strcpy(err, _("-group: no group name"));
       return -1;
@@ -142,7 +142,7 @@ int parse_grouplist(struct GroupList *gl, struct Buffer *buf, struct Buffer *s,
 
     mutt_grouplist_add(gl, mutt_pattern_group(buf->data));
 
-    if (!MoreArgs(s))
+    if (!has_more_tokens(s))
     {
       buf_strcpy(err, _("out of arguments"));
       return -1;
@@ -383,7 +383,7 @@ static enum CommandResult parse_cd(struct Buffer *buf, struct Buffer *s,
 static enum CommandResult parse_echo(struct Buffer *buf, struct Buffer *s,
                                      intptr_t data, struct Buffer *err)
 {
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     buf_printf(err, _("%s: too few arguments"), "echo");
     return MUTT_CMD_WARNING;
@@ -407,7 +407,7 @@ static enum CommandResult parse_echo(struct Buffer *buf, struct Buffer *s,
 static enum CommandResult parse_finish(struct Buffer *buf, struct Buffer *s,
                                        intptr_t data, struct Buffer *err)
 {
-  if (MoreArgs(s))
+  if (has_more_tokens(s))
   {
     buf_printf(err, _("%s: too many arguments"), "finish");
     return MUTT_CMD_WARNING;
@@ -491,7 +491,7 @@ static enum CommandResult parse_group(struct Buffer *buf, struct Buffer *s,
         }
       }
     }
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
 out:
   mutt_grouplist_destroy(&gl);
@@ -540,7 +540,7 @@ static enum CommandResult parse_ifdef(struct Buffer *buf, struct Buffer *s,
 #endif
              || mutt_str_getenv(buf->data); // an environment variable?
 
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     buf_printf(err, _("%s: too few arguments"), (data ? "ifndef" : "ifdef"));
     return MUTT_CMD_WARNING;
@@ -572,7 +572,7 @@ static enum CommandResult parse_ignore(struct Buffer *buf, struct Buffer *s,
     parse_extract_token(buf, s, TOKEN_NO_FLAGS);
     remove_from_stailq(&UnIgnore, buf->data);
     add_to_stailq(&Ignore, buf->data);
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
   return MUTT_CMD_SUCCESS;
 }
@@ -599,7 +599,7 @@ static enum CommandResult parse_lists(struct Buffer *buf, struct Buffer *s,
 
     if (mutt_grouplist_add_regex(&gl, buf->data, REG_ICASE, err) != 0)
       goto bail;
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
   mutt_grouplist_destroy(&gl);
   return MUTT_CMD_SUCCESS;
@@ -724,7 +724,7 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
   struct Buffer *mailbox = buf_pool_get();
 
   const char *const c_folder = cs_subset_string(NeoMutt->sub, "folder");
-  while (MoreArgs(s))
+  while (has_more_tokens(s))
   {
     bool label_set = false;
     enum TriBool notify = TB_UNSET;
@@ -737,7 +737,7 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
 
       if (mutt_str_equal(buf_string(buf), "-label"))
       {
-        if (!MoreArgs(s))
+        if (!has_more_tokens(s))
         {
           buf_printf(err, _("%s: too few arguments"), "mailboxes -label");
           goto done;
@@ -769,7 +769,7 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
       }
       else if ((data & MUTT_NAMED) && !label_set)
       {
-        if (!MoreArgs(s))
+        if (!has_more_tokens(s))
         {
           buf_printf(err, _("%s: too few arguments"), "named-mailboxes");
           goto done;
@@ -783,7 +783,7 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
         buf_copy(mailbox, buf);
         break;
       }
-    } while (MoreArgs(s));
+    } while (has_more_tokens(s));
 
     if (buf_is_empty(mailbox))
     {
@@ -903,7 +903,7 @@ static enum CommandResult parse_setenv(struct Buffer *buf, struct Buffer *s,
   bool prefix = false;
   bool unset = (data == MUTT_SET_UNSET);
 
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     if (!StartupComplete)
     {
@@ -1030,7 +1030,7 @@ static enum CommandResult parse_setenv(struct Buffer *buf, struct Buffer *s,
     SKIPWS(s->dptr);
   }
 
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     buf_printf(err, _("%s: too few arguments"), "setenv");
     return MUTT_CMD_WARNING;
@@ -1068,7 +1068,7 @@ static enum CommandResult parse_source(struct Buffer *buf, struct Buffer *s,
       return MUTT_CMD_ERROR;
     }
 
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
   return MUTT_CMD_SUCCESS;
 }
@@ -1079,7 +1079,7 @@ static enum CommandResult parse_source(struct Buffer *buf, struct Buffer *s,
 static enum CommandResult parse_nospam(struct Buffer *buf, struct Buffer *s,
                                        intptr_t data, struct Buffer *err)
 {
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     buf_printf(err, _("%s: too few arguments"), "nospam");
     return MUTT_CMD_ERROR;
@@ -1088,7 +1088,7 @@ static enum CommandResult parse_nospam(struct Buffer *buf, struct Buffer *s,
   // Extract the first token, a regex or "*"
   parse_extract_token(buf, s, TOKEN_NO_FLAGS);
 
-  if (MoreArgs(s))
+  if (has_more_tokens(s))
   {
     buf_printf(err, _("%s: too many arguments"), "finish");
     return MUTT_CMD_ERROR;
@@ -1119,7 +1119,7 @@ static enum CommandResult parse_nospam(struct Buffer *buf, struct Buffer *s,
 static enum CommandResult parse_spam(struct Buffer *buf, struct Buffer *s,
                                      intptr_t data, struct Buffer *err)
 {
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     buf_printf(err, _("%s: too few arguments"), "spam");
     return MUTT_CMD_ERROR;
@@ -1129,7 +1129,7 @@ static enum CommandResult parse_spam(struct Buffer *buf, struct Buffer *s,
   parse_extract_token(buf, s, TOKEN_NO_FLAGS);
 
   // If there's a second parameter, it's a template for the spam tag
-  if (MoreArgs(s))
+  if (has_more_tokens(s))
   {
     struct Buffer *templ = buf_pool_get();
     parse_extract_token(templ, s, TOKEN_NO_FLAGS);
@@ -1161,7 +1161,7 @@ static enum CommandResult parse_stailq(struct Buffer *buf, struct Buffer *s,
   {
     parse_extract_token(buf, s, TOKEN_NO_FLAGS);
     add_to_stailq((struct ListHead *) data, buf->data);
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
   return MUTT_CMD_SUCCESS;
 }
@@ -1190,7 +1190,7 @@ static enum CommandResult parse_subscribe(struct Buffer *buf, struct Buffer *s,
       goto bail;
     if (mutt_grouplist_add_regex(&gl, buf->data, REG_ICASE, err) != 0)
       goto bail;
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
   mutt_grouplist_destroy(&gl);
   return MUTT_CMD_SUCCESS;
@@ -1215,11 +1215,11 @@ enum CommandResult parse_subscribe_to(struct Buffer *buf, struct Buffer *s,
 
   buf_reset(err);
 
-  if (MoreArgs(s))
+  if (has_more_tokens(s))
   {
     parse_extract_token(buf, s, TOKEN_NO_FLAGS);
 
-    if (MoreArgs(s))
+    if (has_more_tokens(s))
     {
       buf_printf(err, _("%s: too many arguments"), "subscribe-to");
       return MUTT_CMD_WARNING;
@@ -1262,7 +1262,7 @@ static enum CommandResult parse_tag_formats(struct Buffer *buf, struct Buffer *s
   struct Buffer *tagbuf = buf_pool_get();
   struct Buffer *fmtbuf = buf_pool_get();
 
-  while (MoreArgs(s))
+  while (has_more_tokens(s))
   {
     parse_extract_token(tagbuf, s, TOKEN_NO_FLAGS);
     const char *tag = buf_string(tagbuf);
@@ -1304,7 +1304,7 @@ static enum CommandResult parse_tag_transforms(struct Buffer *buf, struct Buffer
   struct Buffer *tagbuf = buf_pool_get();
   struct Buffer *trnbuf = buf_pool_get();
 
-  while (MoreArgs(s))
+  while (has_more_tokens(s))
   {
     parse_extract_token(tagbuf, s, TOKEN_NO_FLAGS);
     const char *tag = buf_string(tagbuf);
@@ -1345,7 +1345,7 @@ static enum CommandResult parse_unignore(struct Buffer *buf, struct Buffer *s,
       add_to_stailq(&UnIgnore, buf->data);
 
     remove_from_stailq(&Ignore, buf->data);
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
   return MUTT_CMD_SUCCESS;
 }
@@ -1368,7 +1368,7 @@ static enum CommandResult parse_unlists(struct Buffer *buf, struct Buffer *s,
     {
       return MUTT_CMD_ERROR;
     }
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
   return MUTT_CMD_SUCCESS;
 }
@@ -1422,7 +1422,7 @@ static void do_unmailboxes_star(void)
 enum CommandResult parse_unmailboxes(struct Buffer *buf, struct Buffer *s,
                                      intptr_t data, struct Buffer *err)
 {
-  while (MoreArgs(s))
+  while (has_more_tokens(s))
   {
     parse_extract_token(buf, s, TOKEN_NO_FLAGS);
 
@@ -1488,7 +1488,7 @@ static enum CommandResult parse_unmy_hdr(struct Buffer *buf, struct Buffer *s,
         header_free(&UserHeader, np);
       }
     }
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
   return MUTT_CMD_SUCCESS;
 }
 
@@ -1510,7 +1510,7 @@ static enum CommandResult parse_unstailq(struct Buffer *buf, struct Buffer *s,
       break;
     }
     remove_from_stailq((struct ListHead *) data, buf->data);
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
   return MUTT_CMD_SUCCESS;
 }
@@ -1532,7 +1532,7 @@ static enum CommandResult parse_unsubscribe(struct Buffer *buf, struct Buffer *s
     {
       return MUTT_CMD_ERROR;
     }
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
   return MUTT_CMD_SUCCESS;
 }
@@ -1550,11 +1550,11 @@ enum CommandResult parse_unsubscribe_from(struct Buffer *buf, struct Buffer *s,
   if (!buf || !s || !err)
     return MUTT_CMD_ERROR;
 
-  if (MoreArgs(s))
+  if (has_more_tokens(s))
   {
     parse_extract_token(buf, s, TOKEN_NO_FLAGS);
 
-    if (MoreArgs(s))
+    if (has_more_tokens(s))
     {
       buf_printf(err, _("%s: too many arguments"), "unsubscribe-from");
       return MUTT_CMD_WARNING;

--- a/commands.c
+++ b/commands.c
@@ -353,7 +353,7 @@ int source_rc(const char *rcfile_path, struct Buffer *err)
 static enum CommandResult parse_cd(struct Buffer *buf, struct Buffer *s,
                                    intptr_t data, struct Buffer *err)
 {
-  parse_extract_token(buf, s, TOKEN_NO_FLAGS);
+  parse_extract_word(buf, s);
   buf_expand_path(buf);
   if (buf_is_empty(buf))
   {
@@ -388,7 +388,7 @@ static enum CommandResult parse_echo(struct Buffer *buf, struct Buffer *s,
     buf_printf(err, _("%s: too few arguments"), "echo");
     return MUTT_CMD_WARNING;
   }
-  parse_extract_token(buf, s, TOKEN_NO_FLAGS);
+  parse_extract_word(buf, s);
   OptForceRefresh = true;
   mutt_message("%s", buf->data);
   OptForceRefresh = false;

--- a/hook.c
+++ b/hook.c
@@ -136,7 +136,7 @@ enum CommandResult mutt_parse_charset_iconv_hook(struct Buffer *buf, struct Buff
     buf_printf(err, _("%s: too few arguments"), buf->data);
     rc = MUTT_CMD_WARNING;
   }
-  else if (MoreArgs(s))
+  else if (has_more_tokens(s))
   {
     buf_printf(err, _("%s: too many arguments"), buf->data);
     buf_reset(s); // clean up buffer to avoid a mess with further rcfile processing
@@ -186,7 +186,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
     if (folder_or_mbox && mutt_str_equal(buf_string(pattern), "-noregex"))
     {
       use_regex = false;
-      if (!MoreArgs(s))
+      if (!has_more_tokens(s))
       {
         buf_printf(err, _("%s: too few arguments"), buf->data);
         rc = MUTT_CMD_WARNING;
@@ -195,7 +195,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
       parse_extract_token(pattern, s, TOKEN_NO_FLAGS);
     }
 
-    if (!MoreArgs(s))
+    if (!has_more_tokens(s))
     {
       buf_printf(err, _("%s: too few arguments"), buf->data);
       rc = MUTT_CMD_WARNING;
@@ -216,7 +216,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
     goto cleanup;
   }
 
-  if (MoreArgs(s))
+  if (has_more_tokens(s))
   {
     buf_printf(err, _("%s: too many arguments"), buf->data);
     rc = MUTT_CMD_WARNING;
@@ -437,7 +437,7 @@ static enum CommandResult mutt_parse_idxfmt_hook(struct Buffer *buf, struct Buff
     mutt_hash_set_destructor(IdxFmtHooks, idxfmt_hashelem_free, 0);
   }
 
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     buf_printf(err, _("%s: too few arguments"), buf->data);
     goto out;
@@ -453,14 +453,14 @@ static enum CommandResult mutt_parse_idxfmt_hook(struct Buffer *buf, struct Buff
   }
   parse_extract_token(pattern, s, TOKEN_NO_FLAGS);
 
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     buf_printf(err, _("%s: too few arguments"), buf->data);
     goto out;
   }
   parse_extract_token(fmtstring, s, TOKEN_NO_FLAGS);
 
-  if (MoreArgs(s))
+  if (has_more_tokens(s))
   {
     buf_printf(err, _("%s: too many arguments"), buf->data);
     goto out;
@@ -551,7 +551,7 @@ static HookFlags mutt_get_hook_type(const char *name)
 static enum CommandResult mutt_parse_unhook(struct Buffer *buf, struct Buffer *s,
                                             intptr_t data, struct Buffer *err)
 {
-  while (MoreArgs(s))
+  while (has_more_tokens(s))
   {
     parse_extract_token(buf, s, TOKEN_NO_FLAGS);
     if (mutt_str_equal("*", buf->data))

--- a/key/dump.c
+++ b/key/dump.c
@@ -175,12 +175,12 @@ enum CommandResult dump_bind_macro(struct Buffer *buf, struct Buffer *s,
   FILE *fp_out = NULL;
   bool dump_all = false, bind = (data == 0);
 
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
     dump_all = true;
   else
     parse_extract_token(buf, s, TOKEN_NO_FLAGS);
 
-  if (MoreArgs(s))
+  if (has_more_tokens(s))
   {
     /* More arguments potentially means the user is using the
      * ::command_t :bind command thus we delegate the task. */

--- a/key/parse.c
+++ b/key/parse.c
@@ -234,7 +234,7 @@ static char *parse_keymap(enum MenuType *mtypes, struct Buffer *s, int max_menus
   /* menu name */
   parse_extract_token(buf, s, TOKEN_NO_FLAGS);
   char *p = buf->data;
-  if (MoreArgs(s))
+  if (has_more_tokens(s))
   {
     while (i < max_menus)
     {
@@ -263,7 +263,7 @@ static char *parse_keymap(enum MenuType *mtypes, struct Buffer *s, int max_menus
     {
       buf_printf(err, _("%s: null key sequence"), bind ? "bind" : "macro");
     }
-    else if (MoreArgs(s))
+    else if (has_more_tokens(s))
     {
       result = buf_strdup(buf);
       goto done;
@@ -345,7 +345,7 @@ enum CommandResult mutt_parse_push(struct Buffer *buf, struct Buffer *s,
                                    intptr_t data, struct Buffer *err)
 {
   parse_extract_token(buf, s, TOKEN_CONDENSE);
-  if (MoreArgs(s))
+  if (has_more_tokens(s))
   {
     buf_printf(err, _("%s: too many arguments"), "push");
     return MUTT_CMD_ERROR;
@@ -385,7 +385,7 @@ enum CommandResult mutt_parse_bind(struct Buffer *buf, struct Buffer *s,
 
   /* function to execute */
   parse_extract_token(buf, s, TOKEN_NO_FLAGS);
-  if (MoreArgs(s))
+  if (has_more_tokens(s))
   {
     buf_printf(err, _("%s: too many arguments"), "bind");
     rc = MUTT_CMD_ERROR;
@@ -487,7 +487,7 @@ enum CommandResult mutt_parse_unbind(struct Buffer *buf, struct Buffer *s,
     parse_menu(menu_matches, buf->data, err);
   }
 
-  if (MoreArgs(s))
+  if (has_more_tokens(s))
   {
     parse_extract_token(buf, s, TOKEN_NO_FLAGS);
     key = buf->data;
@@ -497,7 +497,7 @@ enum CommandResult mutt_parse_unbind(struct Buffer *buf, struct Buffer *s,
     all_keys = true;
   }
 
-  if (MoreArgs(s))
+  if (has_more_tokens(s))
   {
     const char *cmd = (data & MUTT_UNMACRO) ? "unmacro" : "unbind";
 
@@ -586,12 +586,12 @@ enum CommandResult mutt_parse_macro(struct Buffer *buf, struct Buffer *s,
   }
   else
   {
-    if (MoreArgs(s))
+    if (has_more_tokens(s))
     {
       char *seq = mutt_str_dup(buf->data);
       parse_extract_token(buf, s, TOKEN_CONDENSE);
 
-      if (MoreArgs(s))
+      if (has_more_tokens(s))
       {
         buf_printf(err, _("%s: too many arguments"), "macro");
       }
@@ -650,7 +650,7 @@ enum CommandResult mutt_parse_exec(struct Buffer *buf, struct Buffer *s,
   const struct MenuFuncOp *funcs = NULL;
   char *function = NULL;
 
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     buf_strcpy(err, _("exec: no arguments"));
     return MUTT_CMD_ERROR;
@@ -679,7 +679,7 @@ enum CommandResult mutt_parse_exec(struct Buffer *buf, struct Buffer *s,
       return MUTT_CMD_ERROR;
     }
     nops++;
-  } while (MoreArgs(s) && nops < mutt_array_size(ops));
+  } while (has_more_tokens(s) && nops < mutt_array_size(ops));
 
   while (nops)
     mutt_push_macro_event(0, ops[--nops]);

--- a/mutt_lua.c
+++ b/mutt_lua.c
@@ -510,7 +510,7 @@ enum CommandResult mutt_lua_source_file(struct Buffer *buf, struct Buffer *s,
     buf_printf(err, _("source: error at %s"), s->dptr);
     return MUTT_CMD_ERROR;
   }
-  if (MoreArgs(s))
+  if (has_more_tokens(s))
   {
     buf_printf(err, _("%s: too many arguments"), "source");
     return MUTT_CMD_WARNING;

--- a/muttlib.c
+++ b/muttlib.c
@@ -825,7 +825,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
         }
         buf_addch(&cmd, '\'');
         buf_addch(&cmd, ' ');
-      } while (MoreArgs(&srcbuf));
+      } while (has_more_tokens(&srcbuf));
 
       mutt_debug(LL_DEBUG3, "fmtpipe > %s\n", cmd.data);
 

--- a/parse/extract.c
+++ b/parse/extract.c
@@ -30,6 +30,7 @@
 
 #include "config.h"
 #include <ctype.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
@@ -38,6 +39,23 @@
 #include "core/lib.h"
 #include "extract.h"
 #include "globals.h"
+
+/**
+ * has_more_tokens - Check if the buffer contains more tokens
+ * @param tok   Buffer with string
+ * @retval true Success
+ * @retval false Error
+ *
+ * Checks if the current buffer location is not NULL and is not a character
+ * indicating the end of the command (eg. ';' or '#').
+ */
+bool has_more_tokens(struct Buffer *buf)
+{
+  if (buf_is_empty(buf))
+    return false;
+
+  return *buf->dptr && *buf->dptr != ';' && *buf->dptr != '#';
+}
 
 /**
  * parse_extract_token - Extract one token from a string

--- a/parse/extract.c
+++ b/parse/extract.c
@@ -304,3 +304,39 @@ int parse_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flag
   SKIPWS(tok->dptr);
   return 0;
 }
+
+/**
+ * parse_extract_word - Extract the next word from a string
+ * @param dest  Buffer for the result
+ * @param buf   Buffer containing tokens
+ * @retval  true  Success
+ * @retval  false No word found
+ *
+ * Extracts the next set of consecutive non-whitespace characters from a string
+ * _excluding_ comments.
+ */
+bool parse_extract_word(struct Buffer *dest, struct Buffer *buf)
+{
+  buf_reset(dest);
+
+  if (buf_is_empty(buf) || !*buf->dptr)
+    return false;
+
+  SKIPWS(buf->dptr);
+  char ch;
+  while ((ch = *buf->dptr))
+  {
+    if (isspace(ch) || ch == '#')
+      break;
+
+    buf_addch(dest, ch);
+    buf->dptr++;
+  }
+
+  SKIPWS(buf->dptr);
+
+  if (buf_is_empty(dest))
+    return false;
+
+  return true;
+}

--- a/parse/extract.h
+++ b/parse/extract.h
@@ -31,17 +31,6 @@ struct Buffer;
 
 #define MoreArgs(buf) (*(buf)->dptr && (*(buf)->dptr != ';') && (*(buf)->dptr != '#'))
 
-/* The same conditions as in mutt_extract_token() */
-#define MoreArgsF(buf, flags) (*(buf)->dptr && \
-    (!isspace(*(buf)->dptr) || ((flags) & TOKEN_SPACE)) && \
-    ((*(buf)->dptr != '#') ||  ((flags) & TOKEN_COMMENT)) && \
-    ((*(buf)->dptr != '+') || !((flags) & TOKEN_PLUS)) && \
-    ((*(buf)->dptr != '-') || !((flags) & TOKEN_MINUS)) && \
-    ((*(buf)->dptr != '=') || !((flags) & TOKEN_EQUAL)) && \
-    ((*(buf)->dptr != '?') || !((flags) & TOKEN_QUESTION)) && \
-    ((*(buf)->dptr != ';') || ((flags) & TOKEN_SEMICOLON)) && \
-    (!((flags) & TOKEN_PATTERN) || strchr("~%=!|", *(buf)->dptr)))
-
 typedef uint16_t TokenFlags;          ///< Flags for parse_extract_token(), e.g. #TOKEN_EQUAL
 #define TOKEN_NO_FLAGS            0   ///< No flags are set
 #define TOKEN_EQUAL         (1 << 0)  ///< Treat '=' as a special
@@ -58,5 +47,6 @@ typedef uint16_t TokenFlags;          ///< Flags for parse_extract_token(), e.g.
 #define TOKEN_MINUS         (1 << 11) ///< Treat '-' as a special
 
 int parse_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags);
+bool parse_extract_word(struct Buffer *dest, struct Buffer *buf);
 
 #endif /* MUTT_PARSE_EXTRACT_H */

--- a/parse/extract.h
+++ b/parse/extract.h
@@ -25,11 +25,10 @@
 #define MUTT_PARSE_EXTRACT_H
 
 #include <ctype.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 struct Buffer;
-
-#define MoreArgs(buf) (*(buf)->dptr && (*(buf)->dptr != ';') && (*(buf)->dptr != '#'))
 
 typedef uint16_t TokenFlags;          ///< Flags for parse_extract_token(), e.g. #TOKEN_EQUAL
 #define TOKEN_NO_FLAGS            0   ///< No flags are set
@@ -46,6 +45,7 @@ typedef uint16_t TokenFlags;          ///< Flags for parse_extract_token(), e.g.
 #define TOKEN_PLUS          (1 << 10) ///< Treat '+' as a special
 #define TOKEN_MINUS         (1 << 11) ///< Treat '-' as a special
 
+bool has_more_tokens(struct Buffer *buf);
 int parse_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags);
 bool parse_extract_word(struct Buffer *dest, struct Buffer *buf);
 

--- a/parse/set.c
+++ b/parse/set.c
@@ -637,7 +637,7 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
     // the current variable failed.
     if (rc != MUTT_CMD_SUCCESS)
       return rc;
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
 
   return MUTT_CMD_SUCCESS;
 }

--- a/score.c
+++ b/score.c
@@ -94,14 +94,14 @@ enum CommandResult mutt_parse_score(struct Buffer *buf, struct Buffer *s,
   char *pattern = NULL, *pc = NULL;
 
   parse_extract_token(buf, s, TOKEN_NO_FLAGS);
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     buf_printf(err, _("%s: too few arguments"), "score");
     return MUTT_CMD_WARNING;
   }
   pattern = buf_strdup(buf);
   parse_extract_token(buf, s, TOKEN_NO_FLAGS);
-  if (MoreArgs(s))
+  if (has_more_tokens(s))
   {
     FREE(&pattern);
     buf_printf(err, _("%s: too many arguments"), "score");
@@ -202,7 +202,7 @@ enum CommandResult mutt_parse_unscore(struct Buffer *buf, struct Buffer *s,
 {
   struct Score *tmp = NULL, *last = NULL;
 
-  while (MoreArgs(s))
+  while (has_more_tokens(s))
   {
     parse_extract_token(buf, s, TOKEN_NO_FLAGS);
     if (mutt_str_equal("*", buf->data))

--- a/sidebar/commands.c
+++ b/sidebar/commands.c
@@ -48,7 +48,7 @@ enum CommandResult sb_parse_sidebar_pin(struct Buffer *buf, struct Buffer *s,
     parse_extract_token(path, s, TOKEN_BACKTICK_VARS);
     buf_expand_path(path);
     add_to_stailq(&SidebarPinned, buf_string(path));
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
   buf_pool_release(&path);
 
   return MUTT_CMD_SUCCESS;
@@ -73,7 +73,7 @@ enum CommandResult sb_parse_sidebar_unpin(struct Buffer *buf, struct Buffer *s,
     }
     buf_expand_path(path);
     remove_from_stailq(&SidebarPinned, buf_string(path));
-  } while (MoreArgs(s));
+  } while (has_more_tokens(s));
   buf_pool_release(&path);
 
   return MUTT_CMD_SUCCESS;

--- a/subjectrx.c
+++ b/subjectrx.c
@@ -68,7 +68,7 @@ static enum CommandResult parse_unreplace_list(struct Buffer *buf, struct Buffer
                                                struct ReplaceList *list, struct Buffer *err)
 {
   /* First token is a regex. */
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     buf_printf(err, _("%s: too few arguments"), "unsubjectrx");
     return MUTT_CMD_WARNING;
@@ -96,7 +96,7 @@ static enum CommandResult parse_replace_list(struct Buffer *buf, struct Buffer *
   struct Buffer templ = buf_make(0);
 
   /* First token is a regex. */
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     buf_printf(err, _("%s: too few arguments"), "subjectrx");
     return MUTT_CMD_WARNING;
@@ -104,7 +104,7 @@ static enum CommandResult parse_replace_list(struct Buffer *buf, struct Buffer *
   parse_extract_token(buf, s, TOKEN_NO_FLAGS);
 
   /* Second token is a replacement template */
-  if (!MoreArgs(s))
+  if (!has_more_tokens(s))
   {
     buf_printf(err, _("%s: too few arguments"), "subjectrx");
     return MUTT_CMD_WARNING;

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -434,6 +434,7 @@ PARAMETER_OBJS	= test/parameter/mutt_param_cmp_strict.o \
 		  test/parameter/mutt_param_set.o
 
 PARSE_OBJS	= test/parse/common.o \
+		  test/parse/has_more_tokens.o \
 		  test/parse/mutt_auto_subscribe.o \
 		  test/parse/mutt_check_encoding.o \
 		  test/parse/mutt_check_mime_type.o \

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -450,6 +450,7 @@ PARSE_OBJS	= test/parse/common.o \
 		  test/parse/mutt_rfc822_read_header.o \
 		  test/parse/mutt_rfc822_read_line.o \
 		  test/parse/parse_extract_token.o \
+		  test/parse/parse_extract_word.o \
 		  test/parse/parse_rc.o \
 		  test/parse/parse_rc_line.o \
 		  test/parse/parse_set.o

--- a/test/main.c
+++ b/test/main.c
@@ -483,6 +483,7 @@ void test_fini(void);
                                                                                \
   /* parse */                                                                  \
   NEOMUTT_TEST_ITEM(test_command_set)                                          \
+  NEOMUTT_TEST_ITEM(test_has_more_tokens)                                      \
   NEOMUTT_TEST_ITEM(test_mutt_auto_subscribe)                                  \
   NEOMUTT_TEST_ITEM(test_mutt_check_encoding)                                  \
   NEOMUTT_TEST_ITEM(test_mutt_check_mime_type)                                 \

--- a/test/main.c
+++ b/test/main.c
@@ -499,6 +499,7 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_mutt_rfc822_read_header)                              \
   NEOMUTT_TEST_ITEM(test_mutt_rfc822_read_line)                                \
   NEOMUTT_TEST_ITEM(test_parse_extract_token)                                  \
+  NEOMUTT_TEST_ITEM(test_parse_extract_word)                                   \
   NEOMUTT_TEST_ITEM(test_parse_rc)                                             \
   NEOMUTT_TEST_ITEM(test_parse_set)                                            \
                                                                                \

--- a/test/parse/has_more_tokens.c
+++ b/test/parse/has_more_tokens.c
@@ -1,0 +1,89 @@
+/**
+ * @file
+ * Test code for checking for tokens in strings
+ *
+ * @authors
+ * Copyright (C) 2024 Dennis Schön <mail@dennis-schoen.de>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <string.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "parse/lib.h"
+
+struct ArgTest
+{
+  const char *str;
+  size_t pos;
+  bool result;
+};
+
+void test_has_more_tokens(void)
+{
+  // bool has_more_tokens(struct Buffer *buf);
+
+  // clang-format off
+  static const struct ArgTest arg_tests[] =
+  {
+    { NULL, 0, false },
+    { "",   0, false },
+
+    { "apple",  0, true  },
+    { "apple;", 4, true  },
+    { "apple;", 5, false },
+
+    { "apple#", 0, true  },
+    { "apple#", 4, true  },
+    { "apple#", 5, false },
+
+    { "apple # orange", 0, true  },
+    { "apple # orange", 5, true  },
+    { "apple # orange", 6, false },
+
+    { "apple; orange", 0, true  },
+    { "apple; orange", 4, true  },
+    { "apple; orange", 5, false },
+
+    { "foo#bar", 3, false },
+    { "foo+bar", 3, true  },
+    { "foo-bar", 3, true  },
+    { "foo=bar", 3, true  },
+    { "foo?bar", 3, true  },
+    { "foo;bar", 3, false },
+  };
+  // clang-format on
+
+  {
+    for (size_t i = 0; i < mutt_array_size(arg_tests); i++)
+    {
+      const struct ArgTest *t = &arg_tests[i];
+      struct Buffer *buf = NULL;
+      if (t->str)
+      {
+        buf = buf_new(t->str);
+        buf->dptr = buf->data + t->pos;
+      }
+
+      TEST_CASE_("has_more_tokens(\"%s\"[%d]) == %d", buf_string(buf), t->pos, t->result);
+      TEST_CHECK(has_more_tokens(buf) == t->result);
+      buf_free(&buf);
+    }
+  }
+}

--- a/test/parse/parse_extract_word.c
+++ b/test/parse/parse_extract_word.c
@@ -1,0 +1,75 @@
+/**
+ * @file
+ * Test code for extracting words from strings
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <string.h>
+#include "parse/lib.h"
+#include "test_common.h"
+
+struct ExtractTest
+{
+  const char *str;
+  size_t pos;
+  bool result;
+  const char *word;
+};
+
+void test_parse_extract_word(void)
+{
+  // bool parse_extract_word(struct Buffer *dest, struct Buffer *buf)
+
+  // clang-format off
+  static const struct ExtractTest arg_tests[] =
+  {
+    { "hello # world",  0, true,  "hello"        },
+    { "hello # world",  5, false, ""             },
+    { "hello # world",  6, false, ""             },
+    { "hello #world",   0, true,  "hello"        },
+    { "hello#world",    0, true,  "hello"        },
+    { "\"foo bar\"",    0, true,  "foo bar"      },
+    { "foo\\ bar",      0, true,  "foo bar"      },
+    { "foo \\\" # bar", 0, true,  "foo \" # bar" },
+  };
+  // clang-format on
+
+  {
+    for (size_t i = 0; i < mutt_array_size(arg_tests); i++)
+    {
+      const struct ExtractTest *t = &arg_tests[i];
+      struct Buffer *buf = NULL;
+      if (t->str)
+      {
+        buf = buf_new(t->str);
+        buf->dptr = buf->data + t->pos;
+      }
+
+      TEST_CASE_("parse_extract_word(\"%s\"[%d]) == %d -> %s", buf_string(buf),
+                 t->pos, t->result, t->word);
+      struct Buffer *dest = buf_pool_get();
+      TEST_CHECK(parse_extract_word(dest, buf) == t->result);
+      TEST_CHECK_STR_EQ(buf_string(dest), t->word);
+      buf_free(&buf);
+    }
+  }
+}


### PR DESCRIPTION
Add a dedicated function `parse_next_word()` that handles a simple case of `parse_next_token()` - extracting the next set of consecutive non-whitespace characters from a string.

This allows us to get rid of the `MoreArgsF()` macro and maybe later simplify `parse_extract_token()`.

I've also move the `MoreArgs()` macro into a function `has_more_tokens()` and added tests for it. I renamed `args` to `tokens` to match the extract function name.

Related discussion: https://github.com/neomutt/neomutt/discussions/4174

Supersedes: https://github.com/neomutt/neomutt/pull/4173, https://github.com/neomutt/neomutt/pull/4176