### PR TITLE
Fix memory leak in mx.c

### DIFF
--- a/mx.c
+++ b/mx.c
@@ -566,6 +566,7 @@ static int trash_append(struct Mailbox *m)
         // L10N: Displayed if appending to $trash fails when syncing or closing a mailbox
         mutt_error(_("Unable to append to trash folder"));
         m_trash->append = old_append;
+        mailbox_free(&m_trash);
         return -1;
       }
     }


### PR DESCRIPTION
* **What does this PR do?**
* The PR fixes a memory leak involving `mx_path_resolve`. It addresses some leaks in `trash_append` where `m_trash` is allocated by `mx_path_resolve` but not freed on a given path when appending to trash fails when syncing or closing a mailbox.
In fact there is a similar error path above where `m_trash` is freed and returns -1. Additionally I was able to verify that all tests succeeded with the patch
