### PR TITLE
buffer: make_entry()

### DIFF
--- a/alias/dlg_alias.c
+++ b/alias/dlg_alias.c
@@ -134,10 +134,10 @@ static const char *alias_format_str(char *buf, size_t buflen, size_t col, int co
   switch (op)
   {
     case 'a':
-      mutt_format_s(buf, buflen, prec, alias->name);
+      mutt_format(buf, buflen, prec, alias->name, false);
       break;
     case 'c':
-      mutt_format_s(buf, buflen, prec, alias->comment);
+      mutt_format(buf, buflen, prec, alias->comment, false);
       break;
     case 'f':
       snprintf(tmp, sizeof(tmp), "%%%ss", prec);
@@ -153,7 +153,7 @@ static const char *alias_format_str(char *buf, size_t buflen, size_t col, int co
       mutt_addrlist_write(&alias->addr, tmpbuf, true);
       mutt_str_copy(tmp, buf_string(tmpbuf), sizeof(tmp));
       buf_pool_release(&tmpbuf);
-      mutt_format_s(buf, buflen, prec, tmp);
+      mutt_format(buf, buflen, prec, tmp, false);
       break;
     }
     case 't':
@@ -164,7 +164,7 @@ static const char *alias_format_str(char *buf, size_t buflen, size_t col, int co
     {
       struct Buffer *tags = buf_pool_get();
       alias_tags_to_buffer(&av->alias->tags, tags);
-      mutt_format_s(buf, buflen, prec, buf_string(tags));
+      mutt_format(buf, buflen, prec, buf_string(tags), false);
       buf_pool_release(&tags);
       break;
     }

--- a/alias/dlg_alias.c
+++ b/alias/dlg_alias.c
@@ -178,7 +178,7 @@ static const char *alias_format_str(char *buf, size_t buflen, size_t col, int co
  *
  * @sa $alias_format, alias_format_str()
  */
-static void alias_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
+static void alias_make_entry(struct Menu *menu, int line, struct Buffer *buf)
 {
   const struct AliasMenuData *mdata = menu->mdata;
   const struct AliasViewArray *ava = &mdata->ava;
@@ -186,7 +186,7 @@ static void alias_make_entry(struct Menu *menu, char *buf, size_t buflen, int li
 
   const char *const c_alias_format = cs_subset_string(mdata->sub, "alias_format");
 
-  mutt_expando_format(buf, buflen, 0, menu->win->state.cols, NONULL(c_alias_format),
+  mutt_expando_format(buf->data, buf->dsize, 0, menu->win->state.cols, NONULL(c_alias_format),
                       alias_format_str, (intptr_t) av, MUTT_FORMAT_ARROWCURSOR);
 }
 

--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -230,7 +230,7 @@ static const char *query_format_str(char *buf, size_t buflen, size_t col, int co
  *
  * @sa $query_format, query_format_str()
  */
-static void query_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
+static void query_make_entry(struct Menu *menu, int line, struct Buffer *buf)
 {
   const struct AliasMenuData *mdata = menu->mdata;
   const struct AliasViewArray *ava = &mdata->ava;
@@ -238,7 +238,7 @@ static void query_make_entry(struct Menu *menu, char *buf, size_t buflen, int li
 
   const char *const c_query_format = cs_subset_string(mdata->sub, "query_format");
 
-  mutt_expando_format(buf, buflen, 0, menu->win->state.cols, NONULL(c_query_format),
+  mutt_expando_format(buf->data, buf->dsize, 0, menu->win->state.cols, NONULL(c_query_format),
                       query_format_str, (intptr_t) av, MUTT_FORMAT_ARROWCURSOR);
 }
 

--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -176,7 +176,7 @@ static const char *query_format_str(char *buf, size_t buflen, size_t col, int co
         tmp[len] = '>';
         tmp[len + 1] = '\0';
       }
-      mutt_format_s(buf, buflen, prec, tmp);
+      mutt_format(buf, buflen, prec, tmp, false);
       break;
     }
     case 'c':
@@ -185,12 +185,12 @@ static const char *query_format_str(char *buf, size_t buflen, size_t col, int co
       break;
     case 'e':
       if (!optional)
-        mutt_format_s(buf, buflen, prec, NONULL(alias->comment));
+        mutt_format(buf, buflen, prec, NONULL(alias->comment), false);
       else if (!alias->comment || (*alias->comment == '\0'))
         optional = false;
       break;
     case 'n':
-      mutt_format_s(buf, buflen, prec, NONULL(alias->name));
+      mutt_format(buf, buflen, prec, NONULL(alias->name), false);
       break;
     case 't':
       snprintf(fmt, sizeof(fmt), "%%%sc", prec);
@@ -200,7 +200,7 @@ static const char *query_format_str(char *buf, size_t buflen, size_t col, int co
     {
       struct Buffer *tags = buf_pool_get();
       alias_tags_to_buffer(&av->alias->tags, tags);
-      mutt_format_s(buf, buflen, prec, buf_string(tags));
+      mutt_format(buf, buflen, prec, buf_string(tags), false);
       buf_pool_release(&tags);
       break;
     }

--- a/attach/dlg_attach.c
+++ b/attach/dlg_attach.c
@@ -204,15 +204,16 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
         if (mutt_is_message_type(aptr->body->type, aptr->body->subtype) &&
             c_message_format && aptr->body->email)
         {
-          char s[128] = { 0 };
-          mutt_make_string(s, sizeof(s), cols, c_message_format, NULL, -1,
-                           aptr->body->email,
+          struct Buffer *s = buf_pool_get();
+          mutt_make_string(s, cols, c_message_format, NULL, -1, aptr->body->email,
                            MUTT_FORMAT_FORCESUBJ | MUTT_FORMAT_ARROWCURSOR, NULL);
-          if (*s)
-          {
-            mutt_format(buf, buflen, prec, s, false);
+          bool empty = buf_is_empty(s);
+          if (!empty)
+            mutt_format(buf, buflen, prec, buf_string(s), false);
+
+          buf_pool_release(&s);
+          if (!empty)
             break;
-          }
         }
         if (!aptr->body->d_filename && !aptr->body->filename)
         {

--- a/attach/dlg_attach.c
+++ b/attach/dlg_attach.c
@@ -165,11 +165,11 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
         if (mutt_is_text_part(aptr->body) &&
             mutt_body_get_charset(aptr->body, charset, sizeof(charset)))
         {
-          mutt_format_s(buf, buflen, prec, charset);
+          mutt_format(buf, buflen, prec, charset, false);
         }
         else
         {
-          mutt_format_s(buf, buflen, prec, "");
+          mutt_format(buf, buflen, prec, "", false);
         }
       }
       else if (!mutt_is_text_part(aptr->body) ||
@@ -198,7 +198,7 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
       {
         if (aptr->body->description)
         {
-          mutt_format_s(buf, buflen, prec, aptr->body->description);
+          mutt_format(buf, buflen, prec, aptr->body->description, false);
           break;
         }
         if (mutt_is_message_type(aptr->body->type, aptr->body->subtype) &&
@@ -210,13 +210,13 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
                            MUTT_FORMAT_FORCESUBJ | MUTT_FORMAT_ARROWCURSOR, NULL);
           if (*s)
           {
-            mutt_format_s(buf, buflen, prec, s);
+            mutt_format(buf, buflen, prec, s, false);
             break;
           }
         }
         if (!aptr->body->d_filename && !aptr->body->filename)
         {
-          mutt_format_s(buf, buflen, prec, "<no description>");
+          mutt_format(buf, buflen, prec, "<no description>", false);
           break;
         }
       }
@@ -234,7 +234,7 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
       {
         if (aptr->body->d_filename)
         {
-          mutt_format_s(buf, buflen, prec, aptr->body->d_filename);
+          mutt_format(buf, buflen, prec, aptr->body->d_filename, false);
           break;
         }
       }
@@ -254,12 +254,12 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
 
           buf_strcpy(path, aptr->body->filename);
           buf_pretty_mailbox(path);
-          mutt_format_s(buf, buflen, prec, buf_string(path));
+          mutt_format(buf, buflen, prec, buf_string(path), false);
           buf_pool_release(&path);
         }
         else
         {
-          mutt_format_s(buf, buflen, prec, NONULL(aptr->body->filename));
+          mutt_format(buf, buflen, prec, NONULL(aptr->body->filename), false);
         }
       }
       else if (!aptr->body->filename)
@@ -275,7 +275,7 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
       break;
     case 'e':
       if (!optional)
-        mutt_format_s(buf, buflen, prec, ENCODING(aptr->body->encoding));
+        mutt_format(buf, buflen, prec, ENCODING(aptr->body->encoding), false);
       break;
     case 'I':
       if (optional)
@@ -298,11 +298,11 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
       break;
     case 'm':
       if (!optional)
-        mutt_format_s(buf, buflen, prec, TYPE(aptr->body));
+        mutt_format(buf, buflen, prec, TYPE(aptr->body), false);
       break;
     case 'M':
       if (!optional)
-        mutt_format_s(buf, buflen, prec, aptr->body->subtype);
+        mutt_format(buf, buflen, prec, aptr->body->subtype, false);
       else if (!aptr->body->subtype)
         optional = false;
       break;
@@ -321,7 +321,7 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
       else
       {
         snprintf(fmt, sizeof(fmt), "%%%sc", prec);
-        mutt_format_s(buf, buflen, fmt, "Q");
+        mutt_format(buf, buflen, fmt, "Q", false);
       }
       break;
     case 's':
@@ -340,7 +340,7 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
       {
         char tmp[128] = { 0 };
         mutt_str_pretty_size(tmp, sizeof(tmp), l);
-        mutt_format_s(buf, buflen, prec, tmp);
+        mutt_format(buf, buflen, prec, tmp, false);
       }
       else if (l == 0)
       {
@@ -357,7 +357,7 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
       break;
     case 'T':
       if (!optional)
-        mutt_format_s_tree(buf, buflen, prec, NONULL(aptr->tree));
+        mutt_format(buf, buflen, prec, NONULL(aptr->tree), true);
       else if (!aptr->tree)
         optional = false;
       break;

--- a/attach/dlg_attach.c
+++ b/attach/dlg_attach.c
@@ -402,15 +402,15 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
  *
  * @sa $attach_format, attach_format_str()
  */
-static void attach_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
+static void attach_make_entry(struct Menu *menu, int line, struct Buffer *buf)
 {
   struct AttachPrivateData *priv = menu->mdata;
   struct AttachCtx *actx = priv->actx;
 
   const char *const c_attach_format = cs_subset_string(NeoMutt->sub, "attach_format");
-  mutt_expando_format(buf, buflen, 0, menu->win->state.cols, NONULL(c_attach_format),
-                      attach_format_str, (intptr_t) (actx->idx[actx->v2r[line]]),
-                      MUTT_FORMAT_ARROWCURSOR);
+  mutt_expando_format(buf->data, buf->dsize, 0, menu->win->state.cols,
+                      NONULL(c_attach_format), attach_format_str,
+                      (intptr_t) (actx->idx[actx->v2r[line]]), MUTT_FORMAT_ARROWCURSOR);
 }
 
 /**

--- a/autocrypt/dlg_autocrypt.c
+++ b/autocrypt/dlg_autocrypt.c
@@ -132,10 +132,10 @@ static const char *autocrypt_format_str(char *buf, size_t buflen, size_t col, in
   switch (op)
   {
     case 'a':
-      mutt_format_s(buf, buflen, prec, buf_string(entry->addr->mailbox));
+      mutt_format(buf, buflen, prec, buf_string(entry->addr->mailbox), false);
       break;
     case 'k':
-      mutt_format_s(buf, buflen, prec, entry->account->keyid);
+      mutt_format(buf, buflen, prec, entry->account->keyid, false);
       break;
     case 'n':
       snprintf(tmp, sizeof(tmp), "%%%sd", prec);
@@ -146,14 +146,14 @@ static const char *autocrypt_format_str(char *buf, size_t buflen, size_t col, in
       {
         /* L10N: Autocrypt Account menu.
            flag that an account has prefer-encrypt set */
-        mutt_format_s(buf, buflen, prec, _("prefer encrypt"));
+        mutt_format(buf, buflen, prec, _("prefer encrypt"), false);
       }
       else
       {
         /* L10N: Autocrypt Account menu.
            flag that an account has prefer-encrypt unset;
            thus encryption will need to be manually enabled.  */
-        mutt_format_s(buf, buflen, prec, _("manual encrypt"));
+        mutt_format(buf, buflen, prec, _("manual encrypt"), false);
       }
       break;
     case 's':
@@ -161,13 +161,13 @@ static const char *autocrypt_format_str(char *buf, size_t buflen, size_t col, in
       {
         /* L10N: Autocrypt Account menu.
            flag that an account is enabled/active */
-        mutt_format_s(buf, buflen, prec, _("active"));
+        mutt_format(buf, buflen, prec, _("active"), false);
       }
       else
       {
         /* L10N: Autocrypt Account menu.
            flag that an account is disabled/inactive */
-        mutt_format_s(buf, buflen, prec, _("inactive"));
+        mutt_format(buf, buflen, prec, _("inactive"), false);
       }
       break;
   }

--- a/autocrypt/dlg_autocrypt.c
+++ b/autocrypt/dlg_autocrypt.c
@@ -180,12 +180,12 @@ static const char *autocrypt_format_str(char *buf, size_t buflen, size_t col, in
  *
  * @sa $autocrypt_acct_format, autocrypt_format_str()
  */
-static void autocrypt_make_entry(struct Menu *menu, char *buf, size_t buflen, int num)
+static void autocrypt_make_entry(struct Menu *menu, int line, struct Buffer *buf)
 {
-  struct AccountEntry *entry = &((struct AccountEntry *) menu->mdata)[num];
+  struct AccountEntry *entry = &((struct AccountEntry *) menu->mdata)[line];
 
   const char *const c_autocrypt_acct_format = cs_subset_string(NeoMutt->sub, "autocrypt_acct_format");
-  mutt_expando_format(buf, buflen, 0, menu->win->state.cols,
+  mutt_expando_format(buf->data, buf->dsize, 0, menu->win->state.cols,
                       NONULL(c_autocrypt_acct_format), autocrypt_format_str,
                       (intptr_t) entry, MUTT_FORMAT_ARROWCURSOR);
 }

--- a/browser/dlg_browser.c
+++ b/browser/dlg_browser.c
@@ -897,7 +897,7 @@ static int select_file_search(struct Menu *menu, regex_t *rx, int line)
  *
  * @sa $folder_format, $group_index_format, $mailbox_folder_format, folder_format_str()
  */
-static void folder_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
+static void folder_make_entry(struct Menu *menu, int line, struct Buffer *buf)
 {
   struct BrowserState *bstate = menu->mdata;
   struct BrowserEntryArray *entry = &bstate->entry;
@@ -909,22 +909,23 @@ static void folder_make_entry(struct Menu *menu, char *buf, size_t buflen, int l
   if (OptNews)
   {
     const char *const c_group_index_format = cs_subset_string(NeoMutt->sub, "group_index_format");
-    mutt_expando_format(buf, buflen, 0, menu->win->state.cols,
+    mutt_expando_format(buf->data, buf->dsize, 0, menu->win->state.cols,
                         NONULL(c_group_index_format), group_index_format_str,
                         (intptr_t) &folder, MUTT_FORMAT_ARROWCURSOR);
   }
   else if (bstate->is_mailbox_list)
   {
     const char *const c_mailbox_folder_format = cs_subset_string(NeoMutt->sub, "mailbox_folder_format");
-    mutt_expando_format(buf, buflen, 0, menu->win->state.cols,
+    mutt_expando_format(buf->data, buf->dsize, 0, menu->win->state.cols,
                         NONULL(c_mailbox_folder_format), folder_format_str,
                         (intptr_t) &folder, MUTT_FORMAT_ARROWCURSOR);
   }
   else
   {
     const char *const c_folder_format = cs_subset_string(NeoMutt->sub, "folder_format");
-    mutt_expando_format(buf, buflen, 0, menu->win->state.cols, NONULL(c_folder_format),
-                        folder_format_str, (intptr_t) &folder, MUTT_FORMAT_ARROWCURSOR);
+    mutt_expando_format(buf->data, buf->dsize, 0, menu->win->state.cols,
+                        NONULL(c_folder_format), folder_format_str,
+                        (intptr_t) &folder, MUTT_FORMAT_ARROWCURSOR);
   }
 }
 

--- a/browser/dlg_browser.c
+++ b/browser/dlg_browser.c
@@ -272,11 +272,11 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
           mutt_date_localtime_format(date, sizeof(date), t_fmt, folder->ff->mtime);
         }
 
-        mutt_format_s(buf, buflen, prec, date);
+        mutt_format(buf, buflen, prec, date, false);
       }
       else
       {
-        mutt_format_s(buf, buflen, prec, "");
+        mutt_format(buf, buflen, prec, "", false);
       }
       break;
 
@@ -336,7 +336,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
       }
       else
       {
-        mutt_format_s(buf, buflen, prec, "");
+        mutt_format(buf, buflen, prec, "", false);
       }
       break;
 
@@ -355,7 +355,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
                              (((folder->ff->mode & S_IXUSR) != 0) ? "*" : ""))) :
                    "");
 
-      mutt_format_s(buf, buflen, prec, fn);
+      mutt_format(buf, buflen, prec, fn, false);
       break;
     }
     case 'F':
@@ -380,7 +380,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
                  ((folder->ff->mode & S_ISVTX) != 0) ? 't' :
                  ((folder->ff->mode & S_IXOTH) != 0) ? 'x' :
                                                        '-');
-        mutt_format_s(buf, buflen, prec, permission);
+        mutt_format(buf, buflen, prec, permission, false);
       }
       else if (folder->ff->imap)
       {
@@ -388,11 +388,11 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
         /* mark folders with subfolders AND mail */
         snprintf(permission, sizeof(permission), "IMAP %c",
                  (folder->ff->inferiors && folder->ff->selectable) ? '+' : ' ');
-        mutt_format_s(buf, buflen, prec, permission);
+        mutt_format(buf, buflen, prec, permission, false);
       }
       else
       {
-        mutt_format_s(buf, buflen, prec, "");
+        mutt_format(buf, buflen, prec, "", false);
       }
       break;
     }
@@ -403,7 +403,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
         struct group *gr = getgrgid(folder->ff->gid);
         if (gr)
         {
-          mutt_format_s(buf, buflen, prec, gr->gr_name);
+          mutt_format(buf, buflen, prec, gr->gr_name, false);
         }
         else
         {
@@ -413,7 +413,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
       }
       else
       {
-        mutt_format_s(buf, buflen, prec, "");
+        mutt_format(buf, buflen, prec, "", false);
       }
       break;
 
@@ -434,7 +434,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
                              (((folder->ff->mode & S_IXUSR) != 0) ? "*" : ""))) :
                    "");
 
-      mutt_format_s(buf, buflen, prec, fn);
+      mutt_format(buf, buflen, prec, fn, false);
       break;
     }
 
@@ -446,7 +446,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
       }
       else
       {
-        mutt_format_s(buf, buflen, prec, "");
+        mutt_format(buf, buflen, prec, "", false);
       }
       break;
 
@@ -460,7 +460,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
         }
         else
         {
-          mutt_format_s(buf, buflen, prec, "");
+          mutt_format(buf, buflen, prec, "", false);
         }
       }
       else if (folder->ff->msg_count == 0)
@@ -484,7 +484,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
         }
         else
         {
-          mutt_format_s(buf, buflen, prec, "");
+          mutt_format(buf, buflen, prec, "", false);
         }
       }
       else if (folder->ff->msg_unread == 0)
@@ -515,7 +515,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
       }
       else
       {
-        mutt_format_s(buf, buflen, prec, "");
+        mutt_format(buf, buflen, prec, "", false);
       }
       break;
 
@@ -530,7 +530,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
         struct passwd *pw = getpwuid(folder->ff->uid);
         if (pw)
         {
-          mutt_format_s(buf, buflen, prec, pw->pw_name);
+          mutt_format(buf, buflen, prec, pw->pw_name, false);
         }
         else
         {
@@ -540,7 +540,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
       }
       else
       {
-        mutt_format_s(buf, buflen, prec, "");
+        mutt_format(buf, buflen, prec, "", false);
       }
       break;
 

--- a/compose/attach.c
+++ b/compose/attach.c
@@ -215,7 +215,7 @@ static int compose_attach_tag(struct Menu *menu, int sel, int act)
  *
  * @sa $attach_format, attach_format_str()
  */
-static void compose_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
+static void compose_make_entry(struct Menu *menu, int line, struct Buffer *buf)
 {
   struct ComposeAttachData *adata = menu->mdata;
   struct AttachCtx *actx = adata->actx;
@@ -223,8 +223,9 @@ static void compose_make_entry(struct Menu *menu, char *buf, size_t buflen, int 
   struct ConfigSubset *sub = shared->sub;
 
   const char *const c_attach_format = cs_subset_string(sub, "attach_format");
-  mutt_expando_format(buf, buflen, 0, menu->win->state.cols, NONULL(c_attach_format),
-                      attach_format_str, (intptr_t) (actx->idx[actx->v2r[line]]),
+  mutt_expando_format(buf->data, buf->dsize, 0, menu->win->state.cols,
+                      NONULL(c_attach_format), attach_format_str,
+                      (intptr_t) (actx->idx[actx->v2r[line]]),
                       MUTT_FORMAT_STAT_FILE | MUTT_FORMAT_ARROWCURSOR);
 }
 

--- a/conn/dlg_verifycert.c
+++ b/conn/dlg_verifycert.c
@@ -130,20 +130,15 @@ static int menu_dialog_translate_op(int op)
 /**
  * cert_make_entry - Create a Certificate for the Menu - Implements Menu::make_entry() - @ingroup menu_make_entry
  */
-static void cert_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
+static void cert_make_entry(struct Menu *menu, int line, struct Buffer *buf)
 {
   struct CertMenuData *mdata = menu->mdata;
 
   menu->current = -1; /* hide menubar */
 
   const char **line_ptr = ARRAY_GET(mdata->carr, line);
-  if (!line_ptr)
-  {
-    buf[0] = '\0';
-    return;
-  }
-
-  mutt_str_copy(buf, *line_ptr, buflen);
+  if (line_ptr)
+    buf_addstr(buf, *line_ptr);
 }
 
 /**

--- a/copy.c
+++ b/copy.c
@@ -654,7 +654,7 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
                          CopyMessageFlags cmflags, CopyHeaderFlags chflags, int wraplen)
 {
   struct Body *body = e->body;
-  char prefix[128] = { 0 };
+  struct Buffer *prefix = buf_pool_get();
   LOFF_T new_offset = -1;
   int rc = 0;
 
@@ -663,7 +663,7 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
     const bool c_text_flowed = cs_subset_bool(NeoMutt->sub, "text_flowed");
     if (c_text_flowed)
     {
-      mutt_str_copy(prefix, ">", sizeof(prefix));
+      buf_strcpy(prefix, ">");
     }
     else
     {
@@ -671,8 +671,8 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
       const char *const c_indent_string = cs_subset_string(NeoMutt->sub, "indent_string");
       struct Mailbox *m_cur = get_current_mailbox();
       setlocale(LC_TIME, NONULL(c_attribution_locale));
-      mutt_make_string(prefix, sizeof(prefix), wraplen, NONULL(c_indent_string),
-                       m_cur, -1, e, MUTT_FORMAT_NO_FLAGS, NULL);
+      mutt_make_string(prefix, wraplen, NONULL(c_indent_string), m_cur, -1, e,
+                       MUTT_FORMAT_NO_FLAGS, NULL);
       setlocale(LC_TIME, "");
     }
   }
@@ -753,13 +753,15 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
 
     attach_del_cleanup:
       buf_pool_release(&quoted_date);
-      return rc_attach_del;
+      rc = rc_attach_del;
+      goto done;
     }
 
     if (mutt_copy_header(fp_in, e, fp_out, chflags,
-                         (chflags & CH_PREFIX) ? prefix : NULL, wraplen) == -1)
+                         (chflags & CH_PREFIX) ? buf_string(prefix) : NULL, wraplen) == -1)
     {
-      return -1;
+      rc = -1;
+      goto done;
     }
 
     new_offset = ftello(fp_out);
@@ -772,7 +774,7 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
     state.fp_in = fp_in;
     state.fp_out = fp_out;
     if (cmflags & MUTT_CM_PREFIX)
-      state.prefix = prefix;
+      state.prefix = buf_string(prefix);
     if (cmflags & MUTT_CM_DISPLAY)
     {
       state.flags |= STATE_DISPLAY;
@@ -804,7 +806,10 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
         (e->security & APPLICATION_PGP) && (e->body->type == TYPE_MULTIPART))
     {
       if (crypt_pgp_decrypt_mime(fp_in, &fp, e->body, &cur))
-        return -1;
+      {
+        rc = 1;
+        goto done;
+      }
       fputs("MIME-Version: 1.0\n", fp_out);
     }
 
@@ -812,25 +817,34 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
         (e->security & APPLICATION_SMIME) && (e->body->type == TYPE_APPLICATION))
     {
       if (crypt_smime_decrypt_mime(fp_in, &fp, e->body, &cur))
-        return -1;
+      {
+        rc = 1;
+        goto done;
+      }
     }
 
     if (!cur)
     {
       mutt_error(_("No decryption engine available for message"));
-      return -1;
+      rc = 1;
+      goto done;
     }
 
     mutt_write_mime_header(cur, fp_out, NeoMutt->sub);
     fputc('\n', fp_out);
 
     if (!mutt_file_seek(fp, cur->offset, SEEK_SET))
-      return -1;
+    {
+      rc = 1;
+      goto done;
+    }
+
     if (mutt_file_copy_bytes(fp, fp_out, cur->length) == -1)
     {
       mutt_file_fclose(&fp);
       mutt_body_free(&cur);
-      return -1;
+      rc = 1;
+      goto done;
     }
     mutt_body_free(&cur);
     mutt_file_fclose(&fp);
@@ -838,26 +852,30 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
   else
   {
     if (!mutt_file_seek(fp_in, body->offset, SEEK_SET))
-      return -1;
+    {
+      rc = 1;
+      goto done;
+    }
     if (cmflags & MUTT_CM_PREFIX)
     {
       int c;
       size_t bytes = body->length;
 
-      fputs(prefix, fp_out);
+      fputs(buf_string(prefix), fp_out);
 
       while (((c = fgetc(fp_in)) != EOF) && bytes--)
       {
         fputc(c, fp_out);
         if (c == '\n')
         {
-          fputs(prefix, fp_out);
+          fputs(buf_string(prefix), fp_out);
         }
       }
     }
     else if (mutt_file_copy_bytes(fp_in, fp_out, body->length) == -1)
     {
-      return -1;
+      rc = 1;
+      goto done;
     }
   }
 
@@ -868,6 +886,8 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
     mutt_body_free(&body->parts);
   }
 
+done:
+  buf_pool_release(&prefix);
   return rc;
 }
 

--- a/gui/format.c
+++ b/gui/format.c
@@ -162,7 +162,7 @@ void mutt_simple_format(char *buf, size_t buflen, int min_width, int max_width,
 }
 
 /**
- * mutt_format_s_x - Format a string like snprintf()
+ * mutt_format - Format a string like snprintf()
  * @param[out] buf      Buffer in which to save string
  * @param[in]  buflen   Buffer length
  * @param[in]  prec     Field precision, e.g. "-3.4"
@@ -175,7 +175,7 @@ void mutt_simple_format(char *buf, size_t buflen, int min_width, int max_width,
  * except that the numbers in the conversion specification refer to
  * the number of character cells when printed.
  */
-void mutt_format_s_x(char *buf, size_t buflen, const char *prec, const char *s, bool arboreal)
+void mutt_format(char *buf, size_t buflen, const char *prec, const char *s, bool arboreal)
 {
   enum FormatJustify justify = JUSTIFY_RIGHT;
   char *p = NULL;
@@ -203,28 +203,4 @@ void mutt_format_s_x(char *buf, size_t buflen, const char *prec, const char *s, 
 
   mutt_simple_format(buf, buflen, min_width, max_width, justify, ' ', s,
                      mutt_str_len(s), arboreal);
-}
-
-/**
- * mutt_format_s - Format a simple string
- * @param[out] buf      Buffer in which to save string
- * @param[in]  buflen   Buffer length
- * @param[in]  prec     Field precision, e.g. "-3.4"
- * @param[in]  s        String to format
- */
-void mutt_format_s(char *buf, size_t buflen, const char *prec, const char *s)
-{
-  mutt_format_s_x(buf, buflen, prec, s, false);
-}
-
-/**
- * mutt_format_s_tree - Format a simple string with tree characters
- * @param[out] buf      Buffer in which to save string
- * @param[in]  buflen   Buffer length
- * @param[in]  prec     Field precision, e.g. "-3.4"
- * @param[in]  s        String to format
- */
-void mutt_format_s_tree(char *buf, size_t buflen, const char *prec, const char *s)
-{
-  mutt_format_s_x(buf, buflen, prec, s, true);
 }

--- a/gui/format.h
+++ b/gui/format.h
@@ -36,9 +36,7 @@ enum FormatJustify
   JUSTIFY_RIGHT = 1,  ///< Right justify the text
 };
 
-void mutt_format_s     (char *buf, size_t buflen, const char *prec, const char *s);
-void mutt_format_s_tree(char *buf, size_t buflen, const char *prec, const char *s);
-void mutt_format_s_x   (char *buf, size_t buflen, const char *prec, const char *s, bool arboreal);
+void mutt_format       (char *buf, size_t buflen, const char *prec, const char *s, bool arboreal);
 void mutt_simple_format(char *buf, size_t buflen, int min_width, int max_width, enum FormatJustify justify, char pad_char, const char *s, size_t n, bool arboreal);
 
 #endif /* MUTT_GUI_FORMAT_H */

--- a/handler.c
+++ b/handler.c
@@ -1326,7 +1326,7 @@ static int multipart_handler(struct Body *b_email, struct State *state)
 static int run_decode_and_handler(struct Body *b, struct State *state,
                                   handler_t handler, bool plaintext)
 {
-  char *save_prefix = NULL;
+  const char *save_prefix = NULL;
   FILE *fp = NULL;
   size_t tmplength = 0;
   LOFF_T tmpoffset = 0;

--- a/hdrline.c
+++ b/hdrline.c
@@ -1425,7 +1425,6 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 /**
  * mutt_make_string - Create formatted strings using mailbox expandos
  * @param buf      Buffer for the result
- * @param buflen   Buffer length
  * @param cols     Number of screen columns (OPTIONAL)
  * @param s        printf-line format string
  * @param m        Mailbox
@@ -1436,7 +1435,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
  *
  * @sa index_format_str()
  */
-void mutt_make_string(char *buf, size_t buflen, int cols, const char *s,
+void mutt_make_string(struct Buffer *buf, int cols, const char *s,
                       struct Mailbox *m, int inpgr, struct Email *e,
                       MuttFormatFlags flags, const char *progress)
 {
@@ -1447,5 +1446,6 @@ void mutt_make_string(char *buf, size_t buflen, int cols, const char *s,
   hfi.msg_in_pager = inpgr;
   hfi.pager_progress = progress;
 
-  mutt_expando_format(buf, buflen, 0, cols, s, index_format_str, (intptr_t) &hfi, flags);
+  mutt_expando_format(buf->data, buf->dsize, 0, cols, s, index_format_str,
+                      (intptr_t) &hfi, flags);
 }

--- a/hdrline.c
+++ b/hdrline.c
@@ -437,8 +437,8 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         if (reply_to && reply_to->mailbox)
         {
           colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_AUTHOR);
-          mutt_format_s(buf + colorlen, buflen - colorlen, prec,
-                        mutt_addr_for_display(reply_to));
+          mutt_format(buf + colorlen, buflen - colorlen, prec,
+                      mutt_addr_for_display(reply_to), false);
           add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
           break;
         }
@@ -448,7 +448,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         if (mutt_mb_get_initials(mutt_get_name(from), tmp, sizeof(tmp)))
         {
           colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_AUTHOR);
-          mutt_format_s(buf + colorlen, buflen - colorlen, prec, tmp);
+          mutt_format(buf + colorlen, buflen - colorlen, prec, tmp, false);
           add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
           break;
         }
@@ -459,11 +459,12 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_AUTHOR);
       if (from && from->mailbox)
       {
-        mutt_format_s(buf + colorlen, buflen - colorlen, prec, mutt_addr_for_display(from));
+        mutt_format(buf + colorlen, buflen - colorlen, prec,
+                    mutt_addr_for_display(from), false);
       }
       else
       {
-        mutt_format_s(buf + colorlen, buflen - colorlen, prec, "");
+        mutt_format(buf + colorlen, buflen - colorlen, prec, "", false);
       }
       add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       break;
@@ -474,7 +475,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
           first_mailing_list(buf, buflen, &e->env->cc))
       {
         mutt_str_copy(tmp, buf, sizeof(tmp));
-        mutt_format_s(buf, buflen, prec, tmp);
+        mutt_format(buf, buflen, prec, tmp, false);
       }
       else if (optional)
       {
@@ -505,7 +506,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         mutt_str_copy(buf, "(null)", buflen);
       }
       mutt_str_copy(tmp, buf, sizeof(tmp));
-      mutt_format_s(buf, buflen, prec, tmp);
+      mutt_format(buf, buflen, prec, tmp, false);
       break;
 
     case 'c':
@@ -519,7 +520,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       {
         mutt_str_pretty_size(tmp, sizeof(tmp), e->body->length);
       }
-      mutt_format_s(buf + colorlen, buflen - colorlen, prec, tmp);
+      mutt_format(buf + colorlen, buflen - colorlen, prec, tmp, false);
       add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       break;
 
@@ -718,7 +719,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
           strftime(tmp, sizeof(tmp), buf, &tm);
 
         colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_DATE);
-        mutt_format_s(buf + colorlen, buflen - colorlen, prec, tmp);
+        mutt_format(buf + colorlen, buflen - colorlen, prec, tmp, false);
         add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
 
         if ((len > 0) && (op != 'd') && (op != 'D')) /* Skip ending op */
@@ -749,7 +750,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       mutt_addrlist_write(&e->env->from, tmpbuf, true);
       mutt_str_copy(tmp, buf_string(tmpbuf), sizeof(tmp));
       buf_pool_release(&tmpbuf);
-      mutt_format_s(buf, buflen, prec, tmp);
+      mutt_format(buf, buflen, prec, tmp, false);
       break;
     }
 
@@ -760,7 +761,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_AUTHOR);
         make_from(e->env, tmp, sizeof(tmp), false,
                   (is_plain ? MUTT_FORMAT_PLAIN : MUTT_FORMAT_NO_FLAGS));
-        mutt_format_s(buf + colorlen, buflen - colorlen, prec, tmp);
+        mutt_format(buf + colorlen, buflen - colorlen, prec, tmp, false);
         add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
 
         if (is_plain)
@@ -779,7 +780,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       if (!optional)
       {
         colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_TAGS);
-        mutt_format_s(buf + colorlen, buflen - colorlen, prec, buf_string(tags));
+        mutt_format(buf + colorlen, buflen - colorlen, prec, buf_string(tags), false);
         add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       }
       else if (buf_is_empty(tags))
@@ -807,7 +808,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
           struct Buffer *tags = buf_pool_get();
           driver_tags_get_transformed_for(&e->tags, tag, tags);
           colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_TAG);
-          mutt_format_s(buf + colorlen, buflen - colorlen, prec, buf_string(tags));
+          mutt_format(buf + colorlen, buflen - colorlen, prec, buf_string(tags), false);
           add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
           buf_pool_release(&tags);
         }
@@ -837,11 +838,12 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       if (optional)
         optional = !buf_is_empty(&e->env->spam);
 
-      mutt_format_s(buf, buflen, prec, buf_string(&e->env->spam));
+      mutt_format(buf, buflen, prec, buf_string(&e->env->spam), false);
       break;
 
     case 'i':
-      mutt_format_s(buf, buflen, prec, e->env->message_id ? e->env->message_id : "<no.id>");
+      mutt_format(buf, buflen, prec,
+                  e->env->message_id ? e->env->message_id : "<no.id>", false);
       break;
 
     case 'J':
@@ -878,9 +880,9 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 
       colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_TAGS);
       if (have_tags)
-        mutt_format_s(buf + colorlen, buflen - colorlen, prec, buf_string(tags));
+        mutt_format(buf + colorlen, buflen - colorlen, prec, buf_string(tags), false);
       else
-        mutt_format_s(buf + colorlen, buflen - colorlen, prec, "");
+        mutt_format(buf + colorlen, buflen - colorlen, prec, "", false);
       add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       buf_pool_release(&tags);
       break;
@@ -905,7 +907,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       {
         colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_AUTHOR);
         make_from(e->env, tmp, sizeof(tmp), true, flags);
-        mutt_format_s(buf + colorlen, buflen - colorlen, prec, tmp);
+        mutt_format(buf + colorlen, buflen - colorlen, prec, tmp, false);
         add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       }
       else if (!check_for_mailing_list(&e->env->to, NULL, NULL, 0) &&
@@ -929,7 +931,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 
     case 'n':
       colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_AUTHOR);
-      mutt_format_s(buf + colorlen, buflen - colorlen, prec, mutt_get_name(from));
+      mutt_format(buf + colorlen, buflen - colorlen, prec, mutt_get_name(from), false);
       add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       break;
 
@@ -945,7 +947,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         }
         else if (is_index && threads)
         {
-          mutt_format_s(buf + colorlen, buflen - colorlen, prec, " ");
+          mutt_format(buf + colorlen, buflen - colorlen, prec, " ", false);
           add_index_color(buf, buflen - colorlen, flags, MT_COLOR_INDEX);
         }
         else
@@ -980,7 +982,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         const bool c_save_address = cs_subset_bool(NeoMutt->sub, "save_address");
         if (!c_save_address && (p = strpbrk(tmp, "%@")))
           *p = '\0';
-        mutt_format_s(buf, buflen, prec, tmp);
+        mutt_format(buf, buflen, prec, tmp, false);
       }
       else if (!check_for_mailing_list_addr(&e->env->to, NULL, 0) &&
                !check_for_mailing_list_addr(&e->env->cc, NULL, 0))
@@ -994,7 +996,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       break;
 
     case 'q':
-      mutt_format_s(buf, buflen, prec, e->env->newsgroups ? e->env->newsgroups : "");
+      mutt_format(buf, buflen, prec, e->env->newsgroups ? e->env->newsgroups : "", false);
       break;
 
     case 'r':
@@ -1005,7 +1007,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       buf_pool_release(&tmpbuf);
       if (optional && (tmp[0] == '\0'))
         optional = false;
-      mutt_format_s(buf, buflen, prec, tmp);
+      mutt_format(buf, buflen, prec, tmp, false);
       break;
     }
 
@@ -1017,7 +1019,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       buf_pool_release(&tmpbuf);
       if (optional && (tmp[0] == '\0'))
         optional = false;
-      mutt_format_s(buf, buflen, prec, tmp);
+      mutt_format(buf, buflen, prec, tmp, false);
       break;
     }
 
@@ -1034,20 +1036,20 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         if (flags & MUTT_FORMAT_FORCESUBJ)
         {
           colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_SUBJECT);
-          mutt_format_s(buf + colorlen, buflen - colorlen, "", NONULL(subj));
+          mutt_format(buf + colorlen, buflen - colorlen, "", NONULL(subj), false);
           add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
           snprintf(tmp, sizeof(tmp), "%s%s", e->tree, buf);
-          mutt_format_s_tree(buf, buflen, prec, tmp);
+          mutt_format(buf, buflen, prec, tmp, true);
         }
         else
         {
-          mutt_format_s_tree(buf, buflen, prec, e->tree);
+          mutt_format(buf, buflen, prec, e->tree, true);
         }
       }
       else
       {
         colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_SUBJECT);
-        mutt_format_s(buf + colorlen, buflen - colorlen, prec, NONULL(subj));
+        mutt_format(buf + colorlen, buflen - colorlen, prec, NONULL(subj), false);
         add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       }
       break;
@@ -1075,7 +1077,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 
       snprintf(tmp, sizeof(tmp), "%s", wch);
       colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_FLAGS);
-      mutt_format_s(buf + colorlen, buflen - colorlen, prec, tmp);
+      mutt_format(buf + colorlen, buflen - colorlen, prec, tmp, false);
       add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       break;
     }
@@ -1090,7 +1092,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         else if (cc)
           snprintf(tmp, sizeof(tmp), "Cc %s", mutt_get_name(cc));
       }
-      mutt_format_s(buf, buflen, prec, tmp);
+      mutt_format(buf, buflen, prec, tmp, false);
       break;
 
     case 'T':
@@ -1116,33 +1118,34 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       {
         tmp[0] = '\0';
       }
-      mutt_format_s(buf, buflen, prec, tmp);
+      mutt_format(buf, buflen, prec, tmp, false);
       break;
 
     case 'v':
       if (mutt_addr_is_user(from))
       {
         if (to)
-          mutt_format_s(tmp, sizeof(tmp), prec, mutt_get_name(to));
+          mutt_format(tmp, sizeof(tmp), prec, mutt_get_name(to), false);
         else if (cc)
-          mutt_format_s(tmp, sizeof(tmp), prec, mutt_get_name(cc));
+          mutt_format(tmp, sizeof(tmp), prec, mutt_get_name(cc), false);
         else
           *tmp = '\0';
       }
       else
       {
-        mutt_format_s(tmp, sizeof(tmp), prec, mutt_get_name(from));
+        mutt_format(tmp, sizeof(tmp), prec, mutt_get_name(from), false);
       }
       p = strpbrk(tmp, " %@");
       if (p)
         *p = '\0';
-      mutt_format_s(buf, buflen, prec, tmp);
+      mutt_format(buf, buflen, prec, tmp, false);
       break;
 
     case 'W':
       if (!optional)
       {
-        mutt_format_s(buf, buflen, prec, e->env->organization ? e->env->organization : "");
+        mutt_format(buf, buflen, prec,
+                    e->env->organization ? e->env->organization : "", false);
       }
       else if (!e->env->organization)
       {
@@ -1153,7 +1156,8 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
     case 'x':
       if (!optional)
       {
-        mutt_format_s(buf, buflen, prec, e->env->x_comment_to ? e->env->x_comment_to : "");
+        mutt_format(buf, buflen, prec,
+                    e->env->x_comment_to ? e->env->x_comment_to : "", false);
       }
       else if (!e->env->x_comment_to)
       {
@@ -1184,7 +1188,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         optional = (e->env->x_label != NULL);
 
       colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_LABEL);
-      mutt_format_s(buf + colorlen, buflen - colorlen, prec, NONULL(e->env->x_label));
+      mutt_format(buf + colorlen, buflen - colorlen, prec, NONULL(e->env->x_label), false);
       add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       break;
 
@@ -1218,9 +1222,9 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 
       colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_LABEL);
       if (label)
-        mutt_format_s(buf + colorlen, buflen - colorlen, prec, NONULL(e->env->x_label));
+        mutt_format(buf + colorlen, buflen - colorlen, prec, NONULL(e->env->x_label), false);
       else
-        mutt_format_s(buf + colorlen, buflen - colorlen, prec, "");
+        mutt_format(buf + colorlen, buflen - colorlen, prec, "", false);
       add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       break;
     }
@@ -1309,7 +1313,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       }
 
       colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_FLAGS);
-      mutt_format_s(buf + colorlen, buflen - colorlen, prec, tmp);
+      mutt_format(buf + colorlen, buflen - colorlen, prec, tmp, false);
       add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       break;
 
@@ -1370,7 +1374,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
     }
 
       colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_FLAGS);
-      mutt_format_s(buf + colorlen, buflen - colorlen, prec, tmp);
+      mutt_format(buf + colorlen, buflen - colorlen, prec, tmp, false);
       add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       break;
 
@@ -1391,7 +1395,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         mutt_expando_format(tmp, sizeof(tmp), col, cols,
                             NONULL(mutt_idxfmt_hook(tmp, m, e)),
                             index_format_str, data, flags);
-        mutt_format_s_x(buf, buflen, prec, tmp, true);
+        mutt_format(buf, buflen, prec, tmp, true);
         recurse--;
 
         src = end + 1;

--- a/hdrline.h
+++ b/hdrline.h
@@ -25,9 +25,9 @@
 #ifndef MUTT_HDRLINE_H
 #define MUTT_HDRLINE_H
 
-#include <stdio.h>
 #include "format_flags.h"
 
+struct Buffer;
 struct Email;
 struct Mailbox;
 
@@ -75,7 +75,7 @@ enum ToChars
   FLAG_CHAR_TO_REPLY_TO,          ///< Character denoting that the user is in the Reply-To list
 };
 
-void mutt_make_string(char *buf, size_t buflen, int cols, const char *s,
+void mutt_make_string(struct Buffer *buf, int cols, const char *s,
                       struct Mailbox *m, int inpgr, struct Email *e,
                       MuttFormatFlags flags, const char *progress);
 

--- a/history/dlg_history.c
+++ b/history/dlg_history.c
@@ -109,7 +109,7 @@ static const char *history_format_str(char *buf, size_t buflen, size_t col, int 
     }
     case 's':
     {
-      mutt_format_s(buf, buflen, prec, NONULL(h->history));
+      mutt_format(buf, buflen, prec, NONULL(h->history), false);
       break;
     }
   }

--- a/history/dlg_history.c
+++ b/history/dlg_history.c
@@ -122,15 +122,16 @@ static const char *history_format_str(char *buf, size_t buflen, size_t col, int 
  *
  * @sa history_format_str()
  */
-static void history_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
+static void history_make_entry(struct Menu *menu, int line, struct Buffer *buf)
 {
   char *entry = ((char **) menu->mdata)[line];
 
   struct HistoryEntry h = { line, entry };
 
   const char *const c_history_format = cs_subset_string(NeoMutt->sub, "history_format");
-  mutt_expando_format(buf, buflen, 0, menu->win->state.cols, NONULL(c_history_format),
-                      history_format_str, (intptr_t) &h, MUTT_FORMAT_ARROWCURSOR);
+  mutt_expando_format(buf->data, buf->dsize, 0, menu->win->state.cols,
+                      NONULL(c_history_format), history_format_str,
+                      (intptr_t) &h, MUTT_FORMAT_ARROWCURSOR);
 }
 
 /**

--- a/hook.c
+++ b/hook.c
@@ -730,8 +730,7 @@ static int addr_hook(struct Buffer *path, HookFlags type, struct Mailbox *m, str
       if ((mutt_pattern_exec(SLIST_FIRST(hook->pattern), 0, m, e, &cache) > 0) ^
           hook->regex.pat_not)
       {
-        mutt_make_string(path->data, path->dsize, 0, hook->command, m, -1, e,
-                         MUTT_FORMAT_PLAIN, NULL);
+        mutt_make_string(path, 0, hook->command, m, -1, e, MUTT_FORMAT_PLAIN, NULL);
         buf_fix_dptr(path);
         return 0;
       }

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -794,10 +794,8 @@ void change_folder_string(struct Menu *menu, struct Buffer *buf, int *oldcount,
  *
  * @sa $index_format, index_format_str()
  */
-void index_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
+void index_make_entry(struct Menu *menu, int line, struct Buffer *buf)
 {
-  buf[0] = '\0';
-
   if (!menu || !menu->mdata)
     return;
 
@@ -882,8 +880,8 @@ void index_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
 
   const char *const c_index_format = cs_subset_string(shared->sub, "index_format");
   int msg_in_pager = shared->mailbox_view ? shared->mailbox_view->msg_in_pager : 0;
-  mutt_make_string(buf, buflen, menu->win->state.cols, NONULL(c_index_format),
-                   m, msg_in_pager, e, flags, NULL);
+  mutt_make_string(buf->data, buf->dsize, menu->win->state.cols,
+                   NONULL(c_index_format), m, msg_in_pager, e, flags, NULL);
 }
 
 /**

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -1172,11 +1172,11 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
               const char *const c_new_mail_command = cs_subset_string(shared->sub, "new_mail_command");
               if (c_new_mail_command)
               {
-                char cmd[1024] = { 0 };
-                menu_status_line(cmd, sizeof(cmd), shared, NULL, sizeof(cmd),
-                                 NONULL(c_new_mail_command));
-                if (mutt_system(cmd) != 0)
-                  mutt_error(_("Error running \"%s\""), cmd);
+                struct Buffer *cmd = buf_pool_get();
+                menu_status_line(cmd, shared, NULL, cmd->dsize, NONULL(c_new_mail_command));
+                if (mutt_system(buf_string(cmd)) != 0)
+                  mutt_error(_("Error running \"%s\""), buf_string(cmd));
+                buf_pool_release(&cmd);
               }
               break;
             }
@@ -1217,11 +1217,11 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
           const char *const c_new_mail_command = cs_subset_string(shared->sub, "new_mail_command");
           if (c_new_mail_command)
           {
-            char cmd[1024] = { 0 };
-            menu_status_line(cmd, sizeof(cmd), shared, priv->menu, sizeof(cmd),
-                             NONULL(c_new_mail_command));
-            if (mutt_system(cmd) != 0)
-              mutt_error(_("Error running \"%s\""), cmd);
+            struct Buffer *cmd = buf_pool_get();
+            menu_status_line(cmd, shared, priv->menu, cmd->dsize, NONULL(c_new_mail_command));
+            if (mutt_system(buf_string(cmd)) != 0)
+              mutt_error(_("Error running \"%s\""), buf_string(cmd));
+            buf_pool_release(&cmd);
           }
         }
       }

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -880,8 +880,8 @@ void index_make_entry(struct Menu *menu, int line, struct Buffer *buf)
 
   const char *const c_index_format = cs_subset_string(shared->sub, "index_format");
   int msg_in_pager = shared->mailbox_view ? shared->mailbox_view->msg_in_pager : 0;
-  mutt_make_string(buf->data, buf->dsize, menu->win->state.cols,
-                   NONULL(c_index_format), m, msg_in_pager, e, flags, NULL);
+  mutt_make_string(buf, menu->win->state.cols, NONULL(c_index_format), m,
+                   msg_in_pager, e, flags, NULL);
 }
 
 /**

--- a/index/ibar.c
+++ b/index/ibar.c
@@ -88,19 +88,18 @@ struct IBarPrivateData
  */
 static int ibar_recalc(struct MuttWindow *win)
 {
-  char buf[1024] = { 0 };
+  struct Buffer *buf = buf_pool_get();
 
   struct IBarPrivateData *ibar_data = win->wdata;
   struct IndexSharedData *shared = ibar_data->shared;
   struct IndexPrivateData *priv = ibar_data->priv;
 
   const char *c_status_format = cs_subset_string(shared->sub, "status_format");
-  menu_status_line(buf, sizeof(buf), shared, priv->menu, win->state.cols,
-                   NONULL(c_status_format));
+  menu_status_line(buf, shared, priv->menu, win->state.cols, NONULL(c_status_format));
 
-  if (!mutt_str_equal(buf, ibar_data->status_format))
+  if (!mutt_str_equal(buf_string(buf), ibar_data->status_format))
   {
-    mutt_str_replace(&ibar_data->status_format, buf);
+    mutt_str_replace(&ibar_data->status_format, buf_string(buf));
     win->actions |= WA_REPAINT;
     mutt_debug(LL_DEBUG5, "recalc done, request WA_REPAINT\n");
   }
@@ -109,26 +108,25 @@ static int ibar_recalc(struct MuttWindow *win)
   if (c_ts_enabled && TsSupported)
   {
     const char *c_ts_status_format = cs_subset_string(shared->sub, "ts_status_format");
-    menu_status_line(buf, sizeof(buf), shared, priv->menu, sizeof(buf),
-                     NONULL(c_ts_status_format));
-    if (!mutt_str_equal(buf, ibar_data->ts_status_format))
+    menu_status_line(buf, shared, priv->menu, buf->dsize, NONULL(c_ts_status_format));
+    if (!mutt_str_equal(buf_string(buf), ibar_data->ts_status_format))
     {
-      mutt_str_replace(&ibar_data->ts_status_format, buf);
+      mutt_str_replace(&ibar_data->ts_status_format, buf_string(buf));
       win->actions |= WA_REPAINT;
       mutt_debug(LL_DEBUG5, "recalc done, request WA_REPAINT\n");
     }
 
     const char *c_ts_icon_format = cs_subset_string(shared->sub, "ts_icon_format");
-    menu_status_line(buf, sizeof(buf), shared, priv->menu, sizeof(buf),
-                     NONULL(c_ts_icon_format));
-    if (!mutt_str_equal(buf, ibar_data->ts_icon_format))
+    menu_status_line(buf, shared, priv->menu, buf->dsize, NONULL(c_ts_icon_format));
+    if (!mutt_str_equal(buf_string(buf), ibar_data->ts_icon_format))
     {
-      mutt_str_replace(&ibar_data->ts_icon_format, buf);
+      mutt_str_replace(&ibar_data->ts_icon_format, buf_string(buf));
       win->actions |= WA_REPAINT;
       mutt_debug(LL_DEBUG5, "recalc done, request WA_REPAINT\n");
     }
   }
 
+  buf_pool_release(&buf);
   return 0;
 }
 

--- a/index/lib.h
+++ b/index/lib.h
@@ -88,7 +88,7 @@ struct MailboxView *    get_current_mailbox_view(void);
 struct Menu *           get_current_menu        (void);
 void                    index_change_folder     (struct MuttWindow *dlg, struct Mailbox *m);
 const struct AttrColor *index_color             (struct Menu *menu, int line);
-void                    index_make_entry        (struct Menu *menu, char *buf, size_t buflen, int line);
+void                    index_make_entry        (struct Menu *menu, int line, struct Buffer *buf);
 struct MuttWindow *     index_pager_init        (void);
 int                     mutt_dlgindex_observer  (struct NotifyCallback *nc);
 void                    mutt_draw_statusline    (struct MuttWindow *win, int cols, const char *buf, size_t buflen);

--- a/menu/draw.c
+++ b/menu/draw.c
@@ -284,21 +284,19 @@ static void print_enriched_string(struct MuttWindow *win, int index,
  * menu_pad_string - Pad a string with spaces for display in the Menu
  * @param menu   Current Menu
  * @param buf    Buffer containing the string
- * @param buflen Length of the buffer
  *
  * @note The string is padded in-place.
  */
-static void menu_pad_string(struct Menu *menu, char *buf, size_t buflen)
+static void menu_pad_string(struct Menu *menu, struct Buffer *buf)
 {
-  char *scratch = mutt_str_dup(buf);
+  char *scratch = buf_strdup(buf);
   const bool c_arrow_cursor = cs_subset_bool(menu->sub, "arrow_cursor");
   const char *const c_arrow_string = cs_subset_string(menu->sub, "arrow_string");
   const int shift = c_arrow_cursor ? mutt_strwidth(c_arrow_string) + 1 : 0;
   const int cols = menu->win->state.cols - shift;
 
-  mutt_simple_format(buf, buflen, cols, cols, JUSTIFY_LEFT, ' ', scratch,
-                     mutt_str_len(scratch), true);
-  buf[buflen - 1] = '\0';
+  mutt_simple_format(buf->data, buf->dsize, cols, cols, JUSTIFY_LEFT, ' ',
+                     scratch, mutt_str_len(scratch), true);
   FREE(&scratch);
 }
 
@@ -337,7 +335,7 @@ void menu_redraw_index(struct Menu *menu)
 
       buf_reset(buf);
       menu->make_entry(menu, i, buf);
-      menu_pad_string(menu, buf->data, buf->dsize);
+      menu_pad_string(menu, buf);
 
       mutt_curses_set_color(ac);
       mutt_window_move(menu->win, 0, i - menu->top);
@@ -408,7 +406,7 @@ void menu_redraw_motion(struct Menu *menu)
     mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
 
     menu->make_entry(menu, menu->old_current, buf);
-    menu_pad_string(menu, buf->data, buf->dsize);
+    menu_pad_string(menu, buf);
     mutt_window_move(menu->win, arrow_width + 1, menu->old_current - menu->top);
     print_enriched_string(menu->win, menu->old_current, old_color, NULL, buf, menu->sub);
 
@@ -421,7 +419,7 @@ void menu_redraw_motion(struct Menu *menu)
     mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
     /* erase the current indicator */
     menu->make_entry(menu, menu->old_current, buf);
-    menu_pad_string(menu, buf->data, buf->dsize);
+    menu_pad_string(menu, buf);
     print_enriched_string(menu->win, menu->old_current, old_color, NULL, buf, menu->sub);
 
     /* now draw the new one to reflect the change */
@@ -429,7 +427,7 @@ void menu_redraw_motion(struct Menu *menu)
     cur_color = merged_color_overlay(cur_color, ac_ind);
     buf_reset(buf);
     menu->make_entry(menu, menu->current, buf);
-    menu_pad_string(menu, buf->data, buf->dsize);
+    menu_pad_string(menu, buf);
     mutt_window_move(menu->win, 0, menu->current - menu->top);
     mutt_curses_set_color(cur_color);
     print_enriched_string(menu->win, menu->current, cur_color, ac_ind, buf, menu->sub);
@@ -449,7 +447,7 @@ void menu_redraw_current(struct Menu *menu)
 
   mutt_window_move(menu->win, 0, menu->current - menu->top);
   menu->make_entry(menu, menu->current, buf);
-  menu_pad_string(menu, buf->data, buf->dsize);
+  menu_pad_string(menu, buf);
 
   struct AttrColor *ac_ind = simple_color_get(MT_COLOR_INDICATOR);
   const bool c_arrow_cursor = cs_subset_bool(menu->sub, "arrow_cursor");
@@ -460,7 +458,7 @@ void menu_redraw_current(struct Menu *menu)
     mutt_window_addstr(menu->win, c_arrow_string);
     mutt_curses_set_color(ac);
     mutt_window_addch(menu->win, ' ');
-    menu_pad_string(menu, buf->data, buf->dsize);
+    menu_pad_string(menu, buf);
     print_enriched_string(menu->win, menu->current, ac, NULL, buf, menu->sub);
   }
   else

--- a/menu/draw.c
+++ b/menu/draw.c
@@ -103,16 +103,17 @@ static const struct AttrColor *get_color(int index, unsigned char *s)
  * @param index    Index number
  * @param ac_def   Default colour for the line
  * @param ac_ind   Indicator colour for the line
- * @param s        String of embedded colour codes
+ * @param buf      String of embedded colour codes
  * @param sub      Config items
  */
 static void print_enriched_string(struct MuttWindow *win, int index,
                                   const struct AttrColor *ac_def, struct AttrColor *ac_ind,
-                                  unsigned char *s, struct ConfigSubset *sub)
+                                  struct Buffer *buf, struct ConfigSubset *sub)
 {
   wchar_t wc = 0;
   size_t k;
-  size_t n = mutt_str_len((char *) s);
+  size_t n = mutt_str_len(buf_string(buf));
+  unsigned char *s = (unsigned char *) buf->data;
   mbstate_t mbstate = { 0 };
 
   const bool c_ascii_chars = cs_subset_bool(sub, "ascii_chars");
@@ -361,13 +362,11 @@ void menu_redraw_index(struct Menu *menu)
 
       if ((i == menu->current) && !c_arrow_cursor)
       {
-        print_enriched_string(menu->win, i, ac, ac_ind,
-                              (unsigned char *) buf->data, menu->sub);
+        print_enriched_string(menu->win, i, ac, ac_ind, buf, menu->sub);
       }
       else
       {
-        print_enriched_string(menu->win, i, ac, NULL,
-                              (unsigned char *) buf->data, menu->sub);
+        print_enriched_string(menu->win, i, ac, NULL, buf, menu->sub);
       }
     }
     else
@@ -411,8 +410,7 @@ void menu_redraw_motion(struct Menu *menu)
     menu->make_entry(menu, menu->old_current, buf);
     menu_pad_string(menu, buf->data, buf->dsize);
     mutt_window_move(menu->win, arrow_width + 1, menu->old_current - menu->top);
-    print_enriched_string(menu->win, menu->old_current, old_color, NULL,
-                          (unsigned char *) buf->data, menu->sub);
+    print_enriched_string(menu->win, menu->old_current, old_color, NULL, buf, menu->sub);
 
     /* now draw it in the new location */
     mutt_curses_set_color(ac_ind);
@@ -424,8 +422,7 @@ void menu_redraw_motion(struct Menu *menu)
     /* erase the current indicator */
     menu->make_entry(menu, menu->old_current, buf);
     menu_pad_string(menu, buf->data, buf->dsize);
-    print_enriched_string(menu->win, menu->old_current, old_color, NULL,
-                          (unsigned char *) buf->data, menu->sub);
+    print_enriched_string(menu->win, menu->old_current, old_color, NULL, buf, menu->sub);
 
     /* now draw the new one to reflect the change */
     const struct AttrColor *cur_color = menu->color(menu, menu->current);
@@ -435,8 +432,7 @@ void menu_redraw_motion(struct Menu *menu)
     menu_pad_string(menu, buf->data, buf->dsize);
     mutt_window_move(menu->win, 0, menu->current - menu->top);
     mutt_curses_set_color(cur_color);
-    print_enriched_string(menu->win, menu->current, cur_color, ac_ind,
-                          (unsigned char *) buf->data, menu->sub);
+    print_enriched_string(menu->win, menu->current, cur_color, ac_ind, buf, menu->sub);
   }
   mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
   buf_pool_release(&buf);
@@ -465,13 +461,11 @@ void menu_redraw_current(struct Menu *menu)
     mutt_curses_set_color(ac);
     mutt_window_addch(menu->win, ' ');
     menu_pad_string(menu, buf->data, buf->dsize);
-    print_enriched_string(menu->win, menu->current, ac, NULL,
-                          (unsigned char *) buf->data, menu->sub);
+    print_enriched_string(menu->win, menu->current, ac, NULL, buf, menu->sub);
   }
   else
   {
-    print_enriched_string(menu->win, menu->current, ac, ac_ind,
-                          (unsigned char *) buf->data, menu->sub);
+    print_enriched_string(menu->win, menu->current, ac, ac_ind, buf, menu->sub);
   }
   mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
   buf_pool_release(&buf);

--- a/menu/lib.h
+++ b/menu/lib.h
@@ -42,7 +42,6 @@
 #define MUTT_MENU_LIB_H
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include "mutt/lib.h"
@@ -89,11 +88,10 @@ struct Menu
    *
    * make_entry - Format a item for a menu
    * @param[in]  menu   Menu containing items
-   * @param[out] buf    Buffer in which to save string
-   * @param[in]  buflen Buffer length
    * @param[in]  line   Menu line number
+   * @param[out] buf    Buffer for the result
    */
-  void (*make_entry)(struct Menu *menu, char *buf, size_t buflen, int line);
+  void (*make_entry)(struct Menu *menu, int line, struct Buffer *buf);
 
   /**
    * @defgroup menu_search search()

--- a/menu/menu.c
+++ b/menu/menu.c
@@ -54,10 +54,13 @@ static const struct AttrColor *default_color(struct Menu *menu, int line)
  */
 static int generic_search(struct Menu *menu, regex_t *rx, int line)
 {
-  char buf[1024] = { 0 };
+  struct Buffer *buf = buf_pool_get();
 
-  menu->make_entry(menu, buf, sizeof(buf), line);
-  return regexec(rx, buf, 0, NULL, 0);
+  menu->make_entry(menu, line, buf);
+  int rc = regexec(rx, buf->data, 0, NULL, 0);
+  buf_pool_release(&buf);
+
+  return rc;
 }
 
 /**

--- a/mixmaster/win_hosts.c
+++ b/mixmaster/win_hosts.c
@@ -191,16 +191,17 @@ static const char *mix_format_str(char *buf, size_t buflen, size_t col, int cols
  *
  * @sa $mix_entry_format, mix_format_str()
  */
-static void mix_make_entry(struct Menu *menu, char *buf, size_t buflen, int num)
+static void mix_make_entry(struct Menu *menu, int line, struct Buffer *buf)
 {
   struct RemailerArray *ra = menu->mdata;
-  struct Remailer **r = ARRAY_GET(ra, num);
+  struct Remailer **r = ARRAY_GET(ra, line);
   if (!r)
     return;
 
   const char *const c_mix_entry_format = cs_subset_string(NeoMutt->sub, "mix_entry_format");
-  mutt_expando_format(buf, buflen, 0, menu->win->state.cols, NONULL(c_mix_entry_format),
-                      mix_format_str, (intptr_t) *r, MUTT_FORMAT_ARROWCURSOR);
+  mutt_expando_format(buf->data, buf->dsize, 0, menu->win->state.cols,
+                      NONULL(c_mix_entry_format), mix_format_str, (intptr_t) *r,
+                      MUTT_FORMAT_ARROWCURSOR);
 }
 
 /**

--- a/mutt/state.h
+++ b/mutt/state.h
@@ -46,11 +46,11 @@ typedef uint16_t StateFlags;          ///< Flags for State->flags, e.g. #STATE_D
  */
 struct State
 {
-  FILE      *fp_in;   ///< File to read from
-  FILE      *fp_out;  ///< File to write to
-  char      *prefix;  ///< String to add to the beginning of each output line
-  StateFlags flags;   ///< Flags, e.g. #STATE_DISPLAY
-  int        wraplen; ///< Width to wrap lines to (when flags & #STATE_DISPLAY)
+  FILE       *fp_in;   ///< File to read from
+  FILE       *fp_out;  ///< File to write to
+  const char *prefix;  ///< String to add to the beginning of each output line
+  StateFlags  flags;   ///< Flags, e.g. #STATE_DISPLAY
+  int         wraplen; ///< Width to wrap lines to (when flags & #STATE_DISPLAY)
 };
 
 #define state_set_prefix(state)   ((state)->flags |= STATE_PENDINGPREFIX)

--- a/ncrypt/dlg_gpgme.c
+++ b/ncrypt/dlg_gpgme.c
@@ -541,7 +541,7 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
  *
  * @sa $pgp_entry_format, crypt_format_str()
  */
-static void crypt_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
+static void crypt_make_entry(struct Menu *menu, int line, struct Buffer *buf)
 {
   struct CryptKeyInfo **key_table = menu->mdata;
   struct CryptEntry entry = { 0 };
@@ -550,8 +550,9 @@ static void crypt_make_entry(struct Menu *menu, char *buf, size_t buflen, int li
   entry.num = line + 1;
 
   const char *const c_pgp_entry_format = cs_subset_string(NeoMutt->sub, "pgp_entry_format");
-  mutt_expando_format(buf, buflen, 0, menu->win->state.cols, NONULL(c_pgp_entry_format),
-                      crypt_format_str, (intptr_t) &entry, MUTT_FORMAT_ARROWCURSOR);
+  mutt_expando_format(buf->data, buf->dsize, 0, menu->win->state.cols,
+                      NONULL(c_pgp_entry_format), crypt_format_str,
+                      (intptr_t) &entry, MUTT_FORMAT_ARROWCURSOR);
 }
 
 /**

--- a/ncrypt/dlg_pgp.c
+++ b/ncrypt/dlg_pgp.c
@@ -441,7 +441,7 @@ static const char *pgp_entry_format_str(char *buf, size_t buflen, size_t col, in
  *
  * @sa $pgp_entry_format, pgp_entry_format_str()
  */
-static void pgp_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
+static void pgp_make_entry(struct Menu *menu, int line, struct Buffer *buf)
 {
   struct PgpUid **key_table = menu->mdata;
 
@@ -450,7 +450,7 @@ static void pgp_make_entry(struct Menu *menu, char *buf, size_t buflen, int line
   entry.num = line + 1;
 
   const char *const c_pgp_entry_format = cs_subset_string(NeoMutt->sub, "pgp_entry_format");
-  mutt_expando_format(buf, buflen, 0, menu->win->state.cols,
+  mutt_expando_format(buf->data, buf->dsize, 0, menu->win->state.cols,
                       NONULL(c_pgp_entry_format), pgp_entry_format_str,
                       (intptr_t) &entry, MUTT_FORMAT_ARROWCURSOR);
 }

--- a/ncrypt/dlg_smime.c
+++ b/ncrypt/dlg_smime.c
@@ -107,7 +107,7 @@ static char *smime_key_flags(KeyFlags flags)
 /**
  * smime_make_entry - Format an S/MIME Key for the Menu - Implements Menu::make_entry() - @ingroup menu_make_entry
  */
-static void smime_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
+static void smime_make_entry(struct Menu *menu, int line, struct Buffer *buf)
 {
   struct SmimeKey **table = menu->mdata;
   struct SmimeKey *key = table[line];
@@ -170,8 +170,8 @@ static void smime_make_entry(struct Menu *menu, char *buf, size_t buflen, int li
          Expired, Invalid, Revoked, Trusted, Unverified, Verified, and Unknown.  */
       truststate = _("Unknown   ");
   }
-  snprintf(buf, buflen, " 0x%s %s %s %-35.35s %s", key->hash,
-           smime_key_flags(key->flags), truststate, key->email, key->label);
+  buf_printf(buf, " 0x%s %s %s %-35.35s %s", key->hash,
+             smime_key_flags(key->flags), truststate, key->email, key->label);
 }
 
 /**

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1770,7 +1770,7 @@ int smime_class_verify_one(struct Body *b, struct State *state, const char *temp
 
   /* if we are decoding binary bodies, we don't want to prefix each
    * line with the prefix or else the data will get corrupted.  */
-  char *save_prefix = state->prefix;
+  const char *save_prefix = state->prefix;
   state->prefix = NULL;
 
   mutt_decode_attachment(b, state);

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -374,18 +374,17 @@ static const char *smime_command_format_str(char *buf, size_t buflen, size_t col
 /**
  * smime_command - Format an SMIME command string
  * @param buf    Buffer for the result
- * @param buflen Length of buffer
  * @param cctx   Data to pass to the formatter
  * @param fmt    printf-like formatting string
  *
  * @sa smime_command_format_str()
  */
-static void smime_command(char *buf, size_t buflen,
-                          struct SmimeCommandContext *cctx, const char *fmt)
+static void smime_command(struct Buffer *buf, struct SmimeCommandContext *cctx,
+                          const char *fmt)
 {
-  mutt_expando_format(buf, buflen, 0, buflen, NONULL(fmt), smime_command_format_str,
-                      (intptr_t) cctx, MUTT_FORMAT_NO_FLAGS);
-  mutt_debug(LL_DEBUG2, "%s\n", buf);
+  mutt_expando_format(buf->data, buf->dsize, 0, buf->dsize, NONULL(fmt),
+                      smime_command_format_str, (intptr_t) cctx, MUTT_FORMAT_NO_FLAGS);
+  mutt_debug(LL_DEBUG2, "%s\n", buf_string(buf));
 }
 
 /**
@@ -417,7 +416,6 @@ static pid_t smime_invoke(FILE **fp_smime_in, FILE **fp_smime_out, FILE **fp_smi
                           const char *intermediates, const char *format)
 {
   struct SmimeCommandContext cctx = { 0 };
-  char cmd[STR_COMMAND] = { 0 };
 
   if (!format || (*format == '\0'))
     return (pid_t) -1;
@@ -430,10 +428,13 @@ static pid_t smime_invoke(FILE **fp_smime_in, FILE **fp_smime_out, FILE **fp_smi
   cctx.certificates = certificates;
   cctx.intermediates = intermediates;
 
-  smime_command(cmd, sizeof(cmd), &cctx, format);
+  struct Buffer *cmd = buf_pool_get();
+  smime_command(cmd, &cctx, format);
 
-  return filter_create_fd(cmd, fp_smime_in, fp_smime_out, fp_smime_err,
-                          fp_smime_infd, fp_smime_outfd, fp_smime_errfd, EnvList);
+  pid_t pid = filter_create_fd(buf_string(cmd), fp_smime_in, fp_smime_out, fp_smime_err,
+                               fp_smime_infd, fp_smime_outfd, fp_smime_errfd, EnvList);
+  buf_pool_release(&cmd);
+  return pid;
 }
 
 /**

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -450,11 +450,11 @@ int dlg_pager(struct PagerView *pview)
         const char *const c_new_mail_command = cs_subset_string(NeoMutt->sub, "new_mail_command");
         if (c_new_mail_command)
         {
-          char cmd[1024] = { 0 };
-          menu_status_line(cmd, sizeof(cmd), shared, NULL, sizeof(cmd),
-                           NONULL(c_new_mail_command));
-          if (mutt_system(cmd) != 0)
-            mutt_error(_("Error running \"%s\""), cmd);
+          struct Buffer *cmd = buf_pool_get();
+          menu_status_line(cmd, shared, NULL, cmd->dsize, NONULL(c_new_mail_command));
+          if (mutt_system(buf_string(cmd)) != 0)
+            mutt_error(_("Error running \"%s\""), buf_string(cmd));
+          buf_pool_release(&cmd);
         }
       }
     }

--- a/pager/message.c
+++ b/pager/message.c
@@ -307,16 +307,16 @@ int external_pager(struct MailboxView *mv, struct Email *e, const char *command)
   if (!msg)
     return -1;
 
-  char buf[1024] = { 0 };
+  struct Buffer *buf = buf_pool_get();
   const char *const c_pager_format = cs_subset_string(NeoMutt->sub, "pager_format");
   const int screen_width = RootWindow->state.cols;
-  mutt_make_string(buf, sizeof(buf), screen_width, NONULL(c_pager_format), m,
-                   -1, e, MUTT_FORMAT_NO_FLAGS, _(ExtPagerProgress));
+  mutt_make_string(buf, screen_width, NONULL(c_pager_format), m, -1, e,
+                   MUTT_FORMAT_NO_FLAGS, _(ExtPagerProgress));
 
   struct Buffer *tempfile = buf_pool_get();
 
   CopyMessageFlags cmflags = MUTT_CM_DECODE | MUTT_CM_DISPLAY | MUTT_CM_CHARCONV;
-  int rc = email_to_file(msg, tempfile, m, e, buf, screen_width, &cmflags);
+  int rc = email_to_file(msg, tempfile, m, e, buf_string(buf), screen_width, &cmflags);
   if (rc < 0)
     goto cleanup;
 
@@ -346,6 +346,7 @@ int external_pager(struct MailboxView *mv, struct Email *e, const char *command)
   }
 
 cleanup:
+  buf_pool_release(&buf);
   mx_msg_close(m, &msg);
   buf_pool_release(&tempfile);
   return rc;

--- a/pattern/dlg_pattern.c
+++ b/pattern/dlg_pattern.c
@@ -113,10 +113,10 @@ static const char *pattern_format_str(char *buf, size_t buflen, size_t col, int 
   switch (op)
   {
     case 'd':
-      mutt_format_s(buf, buflen, prec, NONULL(entry->desc));
+      mutt_format(buf, buflen, prec, NONULL(entry->desc), false);
       break;
     case 'e':
-      mutt_format_s(buf, buflen, prec, NONULL(entry->expr));
+      mutt_format(buf, buflen, prec, NONULL(entry->expr), false);
       break;
     case 'n':
     {

--- a/pattern/dlg_pattern.c
+++ b/pattern/dlg_pattern.c
@@ -135,13 +135,14 @@ static const char *pattern_format_str(char *buf, size_t buflen, size_t col, int 
  *
  * @sa $pattern_format, pattern_format_str()
  */
-static void make_pattern_entry(struct Menu *menu, char *buf, size_t buflen, int num)
+static void make_pattern_entry(struct Menu *menu, int line, struct Buffer *buf)
 {
-  struct PatternEntry *entry = &((struct PatternEntry *) menu->mdata)[num];
+  struct PatternEntry *entry = &((struct PatternEntry *) menu->mdata)[line];
 
   const char *const c_pattern_format = cs_subset_string(NeoMutt->sub, "pattern_format");
-  mutt_expando_format(buf, buflen, 0, menu->win->state.cols, NONULL(c_pattern_format),
-                      pattern_format_str, (intptr_t) entry, MUTT_FORMAT_ARROWCURSOR);
+  mutt_expando_format(buf->data, buf->dsize, 0, menu->win->state.cols,
+                      NONULL(c_pattern_format), pattern_format_str,
+                      (intptr_t) entry, MUTT_FORMAT_ARROWCURSOR);
 }
 
 /**

--- a/postpone/dlg_postpone.c
+++ b/postpone/dlg_postpone.c
@@ -100,14 +100,15 @@ static const struct Mapping PostponedHelp[] = {
  *
  * @sa $index_format, index_format_str()
  */
-static void post_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
+static void post_make_entry(struct Menu *menu, int line, struct Buffer *buf)
 {
   struct MailboxView *mv = menu->mdata;
   struct Mailbox *m = mv->mailbox;
 
   const char *const c_index_format = cs_subset_string(NeoMutt->sub, "index_format");
-  mutt_make_string(buf, buflen, menu->win->state.cols, NONULL(c_index_format), m, -1,
-                   m->emails[line], MUTT_FORMAT_INDEX | MUTT_FORMAT_ARROWCURSOR, NULL);
+  mutt_make_string(buf->data, buf->dsize, menu->win->state.cols,
+                   NONULL(c_index_format), m, -1, m->emails[line],
+                   MUTT_FORMAT_INDEX | MUTT_FORMAT_ARROWCURSOR, NULL);
 }
 
 /**

--- a/postpone/dlg_postpone.c
+++ b/postpone/dlg_postpone.c
@@ -106,9 +106,8 @@ static void post_make_entry(struct Menu *menu, int line, struct Buffer *buf)
   struct Mailbox *m = mv->mailbox;
 
   const char *const c_index_format = cs_subset_string(NeoMutt->sub, "index_format");
-  mutt_make_string(buf->data, buf->dsize, menu->win->state.cols,
-                   NONULL(c_index_format), m, -1, m->emails[line],
-                   MUTT_FORMAT_INDEX | MUTT_FORMAT_ARROWCURSOR, NULL);
+  mutt_make_string(buf, menu->win->state.cols, NONULL(c_index_format), m, -1,
+                   m->emails[line], MUTT_FORMAT_INDEX | MUTT_FORMAT_ARROWCURSOR, NULL);
 }
 
 /**

--- a/send/send.c
+++ b/send/send.c
@@ -694,7 +694,7 @@ static const char *greeting_format_str(char *buf, size_t buflen, size_t col, int
   switch (op)
   {
     case 'n':
-      mutt_format_s(buf, buflen, prec, mutt_get_name(to));
+      mutt_format(buf, buflen, prec, mutt_get_name(to), false);
       break;
 
     case 'u':
@@ -708,19 +708,19 @@ static const char *greeting_format_str(char *buf, size_t buflen, size_t col, int
       {
         buf2[0] = '\0';
       }
-      mutt_format_s(buf, buflen, prec, buf2);
+      mutt_format(buf, buflen, prec, buf2, false);
       break;
 
     case 'v':
       if (to)
-        mutt_format_s(buf2, sizeof(buf2), prec, mutt_get_name(to));
+        mutt_format(buf2, sizeof(buf2), prec, mutt_get_name(to), false);
       else if (cc)
-        mutt_format_s(buf2, sizeof(buf2), prec, mutt_get_name(cc));
+        mutt_format(buf2, sizeof(buf2), prec, mutt_get_name(cc), false);
       else
         *buf2 = '\0';
       if ((p = strpbrk(buf2, " %@")))
         *p = '\0';
-      mutt_format_s(buf, buflen, prec, buf2);
+      mutt_format(buf, buflen, prec, buf2, false);
       break;
 
     default:

--- a/send/send.c
+++ b/send/send.c
@@ -456,13 +456,14 @@ void mutt_forward_intro(struct Email *e, FILE *fp, struct ConfigSubset *sub)
 
   const char *const c_attribution_locale = cs_subset_string(sub, "attribution_locale");
 
-  char buf[1024] = { 0 };
+  struct Buffer *buf = buf_pool_get();
   setlocale(LC_TIME, NONULL(c_attribution_locale));
-  mutt_make_string(buf, sizeof(buf), 0, c_forward_attribution_intro, NULL, -1,
-                   e, MUTT_FORMAT_NO_FLAGS, NULL);
+  mutt_make_string(buf, 0, c_forward_attribution_intro, NULL, -1, e,
+                   MUTT_FORMAT_NO_FLAGS, NULL);
   setlocale(LC_TIME, "");
-  fputs(buf, fp);
+  fputs(buf_string(buf), fp);
   fputs("\n\n", fp);
+  buf_pool_release(&buf);
 }
 
 /**
@@ -479,14 +480,15 @@ void mutt_forward_trailer(struct Email *e, FILE *fp, struct ConfigSubset *sub)
 
   const char *const c_attribution_locale = cs_subset_string(sub, "attribution_locale");
 
-  char buf[1024] = { 0 };
+  struct Buffer *buf = buf_pool_get();
   setlocale(LC_TIME, NONULL(c_attribution_locale));
-  mutt_make_string(buf, sizeof(buf), 0, c_forward_attribution_trailer, NULL, -1,
-                   e, MUTT_FORMAT_NO_FLAGS, NULL);
+  mutt_make_string(buf, 0, c_forward_attribution_trailer, NULL, -1, e,
+                   MUTT_FORMAT_NO_FLAGS, NULL);
   setlocale(LC_TIME, "");
   fputc('\n', fp);
-  fputs(buf, fp);
+  fputs(buf_string(buf), fp);
   fputc('\n', fp);
+  buf_pool_release(&buf);
 }
 
 /**
@@ -639,12 +641,13 @@ static void format_attribution(const char *s, struct Email *e, FILE *fp_out,
 
   const char *const c_attribution_locale = cs_subset_string(sub, "attribution_locale");
 
-  char buf[1024] = { 0 };
+  struct Buffer *buf = buf_pool_get();
   setlocale(LC_TIME, NONULL(c_attribution_locale));
-  mutt_make_string(buf, sizeof(buf), 0, s, NULL, -1, e, MUTT_FORMAT_NO_FLAGS, NULL);
+  mutt_make_string(buf, 0, s, NULL, -1, e, MUTT_FORMAT_NO_FLAGS, NULL);
   setlocale(LC_TIME, "");
-  fputs(buf, fp_out);
+  fputs(buf_string(buf), fp_out);
   fputc('\n', fp_out);
+  buf_pool_release(&buf);
 }
 
 /**
@@ -1052,11 +1055,11 @@ void mutt_make_forward_subject(struct Envelope *env, struct Email *e, struct Con
 
   const char *const c_forward_format = cs_subset_string(sub, "forward_format");
 
-  char buf[256] = { 0 };
+  struct Buffer *buf = buf_pool_get();
   /* set the default subject for the message. */
-  mutt_make_string(buf, sizeof(buf), 0, NONULL(c_forward_format), NULL, -1, e,
-                   MUTT_FORMAT_NO_FLAGS, NULL);
-  mutt_env_set_subject(env, buf);
+  mutt_make_string(buf, 0, NONULL(c_forward_format), NULL, -1, e, MUTT_FORMAT_NO_FLAGS, NULL);
+  mutt_env_set_subject(env, buf_string(buf));
+  buf_pool_release(&buf);
 }
 
 /**

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -395,7 +395,7 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
       size_t off = add_indent(indented, ilen, sbe);
       snprintf(indented + off, ilen - off, "%s",
                ((op == 'D') && sbe->mailbox->name) ? sbe->mailbox->name : sbe->box);
-      mutt_format_s(buf, buflen, prec, indented);
+      mutt_format(buf, buflen, prec, indented, false);
       break;
     }
 
@@ -535,20 +535,20 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
     case '!':
       if (m->msg_flagged == 0)
       {
-        mutt_format_s(buf, buflen, prec, "");
+        mutt_format(buf, buflen, prec, "", false);
       }
       else if (m->msg_flagged == 1)
       {
-        mutt_format_s(buf, buflen, prec, "!");
+        mutt_format(buf, buflen, prec, "!", false);
       }
       else if (m->msg_flagged == 2)
       {
-        mutt_format_s(buf, buflen, prec, "!!");
+        mutt_format(buf, buflen, prec, "!!", false);
       }
       else
       {
         snprintf(fmt, sizeof(fmt), "%d!", m->msg_flagged);
-        mutt_format_s(buf, buflen, prec, fmt);
+        mutt_format(buf, buflen, prec, fmt, false);
       }
       break;
   }

--- a/status.c
+++ b/status.c
@@ -472,7 +472,6 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
 /**
  * menu_status_line - Create the status line
  * @param[out] buf      Buffer in which to save string
- * @param[in]  buflen   Buffer length
  * @param[in]  shared   Shared Index data
  * @param[in]  menu     Current menu
  * @param[in]  cols     Maximum number of columns to use
@@ -480,11 +479,11 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
  *
  * @sa status_format_str()
  */
-void menu_status_line(char *buf, size_t buflen, struct IndexSharedData *shared,
+void menu_status_line(struct Buffer *buf, struct IndexSharedData *shared,
                       struct Menu *menu, int cols, const char *fmt)
 {
   struct MenuStatusLineData data = { shared, menu };
 
-  mutt_expando_format(buf, buflen, 0, cols, fmt, status_format_str,
+  mutt_expando_format(buf->data, buf->dsize, 0, cols, fmt, status_format_str,
                       (intptr_t) &data, MUTT_FORMAT_NO_FLAGS);
 }

--- a/status.h
+++ b/status.h
@@ -23,11 +23,10 @@
 #ifndef MUTT_STATUS_H
 #define MUTT_STATUS_H
 
-#include <stdio.h>
-
+struct Buffer;
 struct IndexSharedData;
 struct Menu;
 
-void menu_status_line(char *buf, size_t buflen, struct IndexSharedData *shared, struct Menu *menu, int cols, const char *fmt);
+void menu_status_line(struct Buffer *buf, struct IndexSharedData *shared, struct Menu *menu, int cols, const char *fmt);
 
 #endif /* MUTT_STATUS_H */


### PR DESCRIPTION
The job of the Menu and the Expandos is to assemble strings from lots of small pieces.

Currently, all these functions take `(char *buf, int buflen)`
They add to the `char` buffer, but they all need to check the length.
The natural solution is to use a `struct Buffer` that expands as needed.

This PR upgrades the `Menu` side to use `Buffer`s, but stops short of altering the Expando code.
That will be dealt with in the Expando refactor, #3944