### PR TITLE
Zero-out mailbox counters on delete

### DIFF
--- a/core/mailbox.c
+++ b/core/mailbox.c
@@ -117,6 +117,14 @@ void mailbox_free(struct Mailbox **ptr)
   for (size_t i = 0; i < m->email_max; i++)
     email_free(&m->emails[i]);
 
+  m->email_max = 0;
+  m->msg_count = 0;
+  m->msg_deleted = 0;
+  m->msg_flagged = 0;
+  m->msg_new = 0;
+  m->msg_tagged = 0;
+  m->msg_unread = 0;
+
   if (m->mdata_free && m->mdata)
     m->mdata_free(&m->mdata);
 


### PR DESCRIPTION
I've just been hit by a crash when triggering the machinery (sourcing config files) to connect to an IMAP account after the connection dropped. As part of the machinery, there's an `alternates` command being triggered. This ends up with the following stack trace:

```
(gdb) bt
	#0  0x00000000002602b6 in mutt_alternates_reset (mv=0x6e1ca84c7d0) at alternates.c:80
	#1  0x00000000002a8f13 in index_altern_observer (nc=0x8209c3238) at index/index.c:231
	#2  0x00000000003c7883 in send (source=0x6e1ca8c69e0, current=0x6e1ca83b180, event_type=NT_ALTERN, event_subtype=1, event_data=0x0) at mutt/notify.c:132
	#3  0x00000000003c7935 in send (source=0x6e1ca8c69e0, current=0x6e1ca8c69e0, event_type=NT_ALTERN, event_subtype=1, event_data=0x0) at mutt/notify.c:140
	#4  0x00000000003c775d in notify_send (notify=0x6e1ca8c69e0, event_type=NT_ALTERN, event_subtype=1, event_data=0x0) at mutt/notify.c:176
	#5  0x0000000000260483 in parse_alternates (buf=0x6e1ca83b480, s=0x6e1ca83b380, data=0, err=0x6e1ca83b300) at alternates.c:116
```

In `mutt_alternates_reset`, we go over `m->msg_count`, but the current mailbox is blank, except for some counters. In particular, `msg_count` and the `emails` array clearly disagree:

```
(gdb) p *m
$3 = {pathbuf = {data = 0x0, dptr = 0x0, dsize = 0}, realpath = 0x0, name = 0x0, sub = 0x0, size = 12847, has_new = false, msg_count = 3,
  msg_unread = 2, msg_flagged = 0, msg_new = 2, msg_deleted = 0, msg_tagged = 0, emails = 0x0, email_max = 25, v2r = 0x0, vcount = 0,
  notified = false, type = MUTT_IMAP, newly_created = false, last_visited = {tv_sec = 1709195964, tv_nsec = 942447048}, last_checked = 1709196039,
  mx_ops = 0x237a00 <ImapCommands+32>, append = false, changed = true, dontwrite = false, first_check_stats_done = true, notify_user = true,
  peekonly = false, poll_new_mail = true, readonly = false, verbose = true, rights = 2022, compress_info = 0x0, id_hash = 0x0, subj_hash = 0x0,
  label_hash = 0x0, account = 0x0, opened = 0, visible = false, mdata = 0x0, mdata_free = 0x376b30 <__getCurrentRuneLocale+80>, notify = 0x0,
  gen = -1}
```
