### PR TITLE
help: honour normal colour

### DIFF
--- a/gui/msgwin.c
+++ b/gui/msgwin.c
@@ -497,8 +497,11 @@ void msgwin_set_text(struct MuttWindow *win, const char *text, enum ColorId colo
   ARRAY_FREE(&wdata->chars);
   if (wdata->text)
   {
+    const struct AttrColor *ac_normal = simple_color_get(MT_COLOR_NORMAL);
     const struct AttrColor *ac_color = simple_color_get(color);
-    measure(&wdata->chars, buf_string(wdata->text), ac_color);
+    const struct AttrColor *ac_merge = merged_color_overlay(ac_normal, ac_color);
+
+    measure(&wdata->chars, buf_string(wdata->text), ac_merge);
   }
 
   mutt_debug(LL_DEBUG5, "MW SET: %zu, %s\n", buf_len(wdata->text),

--- a/pager/display.c
+++ b/pager/display.c
@@ -1317,7 +1317,10 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
     if (flags & MUTT_PAGER_STRIPES)
     {
       const enum ColorId cid = ((line_num % 2) == 0) ? MT_COLOR_STRIPE_ODD : MT_COLOR_STRIPE_EVEN;
-      mutt_curses_set_color_by_id(cid);
+      const struct AttrColor *ac_normal = simple_color_get(MT_COLOR_NORMAL);
+      const struct AttrColor *stripe_color = simple_color_get(cid);
+      const struct AttrColor *ac_eol = merged_color_overlay(ac_normal, stripe_color);
+      mutt_curses_set_color(ac_eol);
     }
     mutt_window_clrtoeol(win_pager);
   }

--- a/question/question.c
+++ b/question/question.c
@@ -69,21 +69,14 @@ int mw_multi_choice(const char *prompt, const char *letters)
 
   int choice = 0;
 
-  const struct AttrColor *ac_opts = NULL;
+  const struct AttrColor *ac_normal = simple_color_get(MT_COLOR_NORMAL);
+  const struct AttrColor *ac_prompt = merged_color_overlay(ac_normal,
+                                                           simple_color_get(MT_COLOR_PROMPT));
+
   if (simple_color_is_set(MT_COLOR_OPTIONS))
   {
-    const struct AttrColor *ac_base = simple_color_get(MT_COLOR_NORMAL);
-    ac_base = merged_color_overlay(ac_base, simple_color_get(MT_COLOR_PROMPT));
-
-    ac_opts = simple_color_get(MT_COLOR_OPTIONS);
-    ac_opts = merged_color_overlay(ac_base, ac_opts);
-  }
-
-  const struct AttrColor *ac_normal = simple_color_get(MT_COLOR_NORMAL);
-  const struct AttrColor *ac_prompt = simple_color_get(MT_COLOR_PROMPT);
-
-  if (ac_opts)
-  {
+    const struct AttrColor *ac_opts = merged_color_overlay(ac_prompt,
+                                                           simple_color_get(MT_COLOR_OPTIONS));
     char *cur = NULL;
 
     while ((cur = strchr(prompt, '(')))


### PR DESCRIPTION
When displaying the help page, remember to honour the `normal` colour.

Fixes: #4203

Steps to reproduce:
```sh
neomutt -F /dev/null -e 'color normal white blue' -e 'push ?'
```