### PR TITLE
match folder-hook also against mailbox name (fixes #4201)

### DIFF
--- a/main.c
+++ b/main.c
@@ -1358,7 +1358,8 @@ main
       }
     }
 
-    mutt_folder_hook(buf_string(&folder), NULL);
+    struct Mailbox *m_cur = mailbox_find(buf_string(&folder));
+    mutt_folder_hook(buf_string(&folder), m_cur ? m_cur->name : NULL);
     mutt_startup_shutdown_hook(MUTT_STARTUP_HOOK);
     mutt_debug(LL_NOTIFY, "NT_GLOBAL_STARTUP\n");
     notify_send(NeoMutt->notify, NT_GLOBAL, NT_GLOBAL_STARTUP, NULL);


### PR DESCRIPTION
The folder hook run on startup only matched against the path. We can try to find a Mailbox with that path and also match against the name. Like we do when switching mailboxes.