### PR TITLE
test: remove unnecessary setting of TZ var

### DIFF
--- a/test/expando/node_conddate.c
+++ b/test/expando/node_conddate.c
@@ -52,8 +52,6 @@ static long test_d_num(const struct ExpandoNode *node, void *data, MuttFormatFla
 
 void test_expando_node_conddate(void)
 {
-  setenv("TZ", "UTC", 1); // Ensure dates are consistent
-
   // struct NodeCondDatePrivate *node_conddate_private_new(int count, char period);
   // void node_conddate_private_free(void **ptr);
   {


### PR DESCRIPTION
The same setting is already done in `test_init()`.

I also tried to remove the variable with `unsetenv("TZ")` but that didn't work. That might be because some code already called `tzset()` before the test code unsets the variable.
Or, quoting from tzset(3):

> If TZ does not appear in the environment, the best available
> approximation to local wall clock time, as specified by the
> tzfile(5)-format file #ifdef UNIFDEF_MOVE_LOCALTIME
> /var/db/timezone/localtime, #else /* !UNIFDEF_MOVE_LOCALTIME */
> /etc/localtime, #endif /* UNIFDEF_MOVE_LOCALTIME */ is used.
