### PR TITLE
upgrade `assert()`

### DIFF
--- a/address/config_type.c
+++ b/address/config_type.c
@@ -36,7 +36,6 @@
 
 #include "config.h"
 #include <stddef.h>
-#include <assert.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -272,18 +271,18 @@ const struct ConfigSetType CstAddress = {
  */
 const struct Address *cs_subset_address(const struct ConfigSubset *sub, const char *name)
 {
-  assert(sub && name);
+  ASSERT(sub && name);
 
   struct HashElem *he = cs_subset_create_inheritance(sub, name);
-  assert(he);
+  ASSERT(he);
 
 #ifndef NDEBUG
   struct HashElem *he_base = cs_get_base(he);
-  assert(DTYPE(he_base->type) == DT_ADDRESS);
+  ASSERT(DTYPE(he_base->type) == DT_ADDRESS);
 #endif
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   return (const struct Address *) value;
 }

--- a/address/group.c
+++ b/address/group.c
@@ -30,7 +30,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include "group.h"
@@ -235,7 +234,7 @@ static void group_add_addrlist(struct Group *g, const struct AddressList *al)
     TAILQ_REMOVE(&al_new, a, entries);
     mutt_addrlist_append(&g->al, a);
   }
-  assert(TAILQ_EMPTY(&al_new));
+  ASSERT(TAILQ_EMPTY(&al_new));
 }
 
 /**

--- a/browser/dlg_browser.c
+++ b/browser/dlg_browser.c
@@ -74,7 +74,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <dirent.h>
 #include <errno.h>
 #include <grp.h>
@@ -226,7 +225,7 @@ void folder_date(const struct ExpandoNode *node, void *data,
     start++;
     len--;
   }
-  assert(len < sizeof(tmp2));
+  ASSERT(len < sizeof(tmp2));
   mutt_strn_copy(tmp2, start, len, sizeof(tmp2));
 
   if (use_c_locale)

--- a/color/attr.c
+++ b/color/attr.c
@@ -29,7 +29,6 @@
 
 #include "config.h"
 #include <stddef.h>
-#include <assert.h>
 #include <string.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
@@ -326,7 +325,7 @@ color_t color_xterm256_to_24bit(const color_t color)
     0x0000ff, 0xff00ff, 0x00ffff, 0xffffff,
   };
 
-  assert(color < 256);
+  ASSERT(color < 256);
 
   if (color < 0)
     return color;

--- a/config/helpers.c
+++ b/config/helpers.c
@@ -27,7 +27,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -47,18 +46,18 @@
  */
 bool cs_subset_bool(const struct ConfigSubset *sub, const char *name)
 {
-  assert(sub && name);
+  ASSERT(sub && name);
 
   struct HashElem *he = cs_subset_create_inheritance(sub, name);
-  assert(he);
+  ASSERT(he);
 
 #ifndef NDEBUG
   struct HashElem *he_base = cs_get_base(he);
-  assert(DTYPE(he_base->type) == DT_BOOL);
+  ASSERT(DTYPE(he_base->type) == DT_BOOL);
 #endif
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   return (bool) value;
 }
@@ -71,18 +70,18 @@ bool cs_subset_bool(const struct ConfigSubset *sub, const char *name)
  */
 unsigned char cs_subset_enum(const struct ConfigSubset *sub, const char *name)
 {
-  assert(sub && name);
+  ASSERT(sub && name);
 
   struct HashElem *he = cs_subset_create_inheritance(sub, name);
-  assert(he);
+  ASSERT(he);
 
 #ifndef NDEBUG
   struct HashElem *he_base = cs_get_base(he);
-  assert(DTYPE(he_base->type) == DT_ENUM);
+  ASSERT(DTYPE(he_base->type) == DT_ENUM);
 #endif
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   return (unsigned char) value;
 }
@@ -95,18 +94,18 @@ unsigned char cs_subset_enum(const struct ConfigSubset *sub, const char *name)
  */
 long cs_subset_long(const struct ConfigSubset *sub, const char *name)
 {
-  assert(sub && name);
+  ASSERT(sub && name);
 
   struct HashElem *he = cs_subset_create_inheritance(sub, name);
-  assert(he);
+  ASSERT(he);
 
 #ifndef NDEBUG
   struct HashElem *he_base = cs_get_base(he);
-  assert(DTYPE(he_base->type) == DT_LONG);
+  ASSERT(DTYPE(he_base->type) == DT_LONG);
 #endif
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   return (long) value;
 }
@@ -119,18 +118,18 @@ long cs_subset_long(const struct ConfigSubset *sub, const char *name)
  */
 struct MbTable *cs_subset_mbtable(const struct ConfigSubset *sub, const char *name)
 {
-  assert(sub && name);
+  ASSERT(sub && name);
 
   struct HashElem *he = cs_subset_create_inheritance(sub, name);
-  assert(he);
+  ASSERT(he);
 
 #ifndef NDEBUG
   struct HashElem *he_base = cs_get_base(he);
-  assert(DTYPE(he_base->type) == DT_MBTABLE);
+  ASSERT(DTYPE(he_base->type) == DT_MBTABLE);
 #endif
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   return (struct MbTable *) value;
 }
@@ -143,18 +142,18 @@ struct MbTable *cs_subset_mbtable(const struct ConfigSubset *sub, const char *na
  */
 short cs_subset_number(const struct ConfigSubset *sub, const char *name)
 {
-  assert(sub && name);
+  ASSERT(sub && name);
 
   struct HashElem *he = cs_subset_create_inheritance(sub, name);
-  assert(he);
+  ASSERT(he);
 
 #ifndef NDEBUG
   struct HashElem *he_base = cs_get_base(he);
-  assert(DTYPE(he_base->type) == DT_NUMBER);
+  ASSERT(DTYPE(he_base->type) == DT_NUMBER);
 #endif
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   return (short) value;
 }
@@ -168,18 +167,18 @@ short cs_subset_number(const struct ConfigSubset *sub, const char *name)
  */
 const char *cs_subset_path(const struct ConfigSubset *sub, const char *name)
 {
-  assert(sub && name);
+  ASSERT(sub && name);
 
   struct HashElem *he = cs_subset_create_inheritance(sub, name);
-  assert(he);
+  ASSERT(he);
 
 #ifndef NDEBUG
   struct HashElem *he_base = cs_get_base(he);
-  assert(DTYPE(he_base->type) == DT_PATH);
+  ASSERT(DTYPE(he_base->type) == DT_PATH);
 #endif
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   return (const char *) value;
 }
@@ -192,18 +191,18 @@ const char *cs_subset_path(const struct ConfigSubset *sub, const char *name)
  */
 enum QuadOption cs_subset_quad(const struct ConfigSubset *sub, const char *name)
 {
-  assert(sub && name);
+  ASSERT(sub && name);
 
   struct HashElem *he = cs_subset_create_inheritance(sub, name);
-  assert(he);
+  ASSERT(he);
 
 #ifndef NDEBUG
   struct HashElem *he_base = cs_get_base(he);
-  assert(DTYPE(he_base->type) == DT_QUAD);
+  ASSERT(DTYPE(he_base->type) == DT_QUAD);
 #endif
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   return (enum QuadOption) value;
 }
@@ -217,18 +216,18 @@ enum QuadOption cs_subset_quad(const struct ConfigSubset *sub, const char *name)
  */
 const struct Regex *cs_subset_regex(const struct ConfigSubset *sub, const char *name)
 {
-  assert(sub && name);
+  ASSERT(sub && name);
 
   struct HashElem *he = cs_subset_create_inheritance(sub, name);
-  assert(he);
+  ASSERT(he);
 
 #ifndef NDEBUG
   struct HashElem *he_base = cs_get_base(he);
-  assert(DTYPE(he_base->type) == DT_REGEX);
+  ASSERT(DTYPE(he_base->type) == DT_REGEX);
 #endif
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   return (const struct Regex *) value;
 }
@@ -242,18 +241,18 @@ const struct Regex *cs_subset_regex(const struct ConfigSubset *sub, const char *
  */
 const struct Slist *cs_subset_slist(const struct ConfigSubset *sub, const char *name)
 {
-  assert(sub && name);
+  ASSERT(sub && name);
 
   struct HashElem *he = cs_subset_create_inheritance(sub, name);
-  assert(he);
+  ASSERT(he);
 
 #ifndef NDEBUG
   struct HashElem *he_base = cs_get_base(he);
-  assert(DTYPE(he_base->type) == DT_SLIST);
+  ASSERT(DTYPE(he_base->type) == DT_SLIST);
 #endif
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   return (const struct Slist *) value;
 }
@@ -266,18 +265,18 @@ const struct Slist *cs_subset_slist(const struct ConfigSubset *sub, const char *
  */
 short cs_subset_sort(const struct ConfigSubset *sub, const char *name)
 {
-  assert(sub && name);
+  ASSERT(sub && name);
 
   struct HashElem *he = cs_subset_create_inheritance(sub, name);
-  assert(he);
+  ASSERT(he);
 
 #ifndef NDEBUG
   struct HashElem *he_base = cs_get_base(he);
-  assert(DTYPE(he_base->type) == DT_SORT);
+  ASSERT(DTYPE(he_base->type) == DT_SORT);
 #endif
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   return (short) value;
 }
@@ -291,18 +290,18 @@ short cs_subset_sort(const struct ConfigSubset *sub, const char *name)
  */
 const char *cs_subset_string(const struct ConfigSubset *sub, const char *name)
 {
-  assert(sub && name);
+  ASSERT(sub && name);
 
   struct HashElem *he = cs_subset_create_inheritance(sub, name);
-  assert(he);
+  ASSERT(he);
 
 #ifndef NDEBUG
   struct HashElem *he_base = cs_get_base(he);
-  assert(DTYPE(he_base->type) == DT_STRING);
+  ASSERT(DTYPE(he_base->type) == DT_STRING);
 #endif
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   return (const char *) value;
 }

--- a/conn/accountcmd.c
+++ b/conn/accountcmd.c
@@ -28,7 +28,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <stdio.h>
 #include <sys/types.h>
 #include "mutt/lib.h"
@@ -47,7 +46,7 @@
  */
 static void make_cmd(struct Buffer *buf, const struct ConnAccount *cac, const char *cmd)
 {
-  assert(buf && cac);
+  ASSERT(buf && cac);
 
   buf_addstr(buf, cmd);
   buf_add_printf(buf, " --hostname %s", cac->host);
@@ -57,7 +56,7 @@ static void make_cmd(struct Buffer *buf, const struct ConnAccount *cac, const ch
   }
 
   static const char *types[] = { "", "imap", "pop", "smtp", "nntp" };
-  assert(sizeof(types) / sizeof(*types) == MUTT_ACCT_TYPE_MAX);
+  ASSERT(sizeof(types) / sizeof(*types) == MUTT_ACCT_TYPE_MAX);
   if (cac->type != MUTT_ACCT_TYPE_NONE)
   {
     buf_add_printf(buf, " --type %s%c", types[cac->type],
@@ -74,7 +73,7 @@ static void make_cmd(struct Buffer *buf, const struct ConnAccount *cac, const ch
  */
 static MuttAccountFlags parse_one(struct ConnAccount *cac, char *line)
 {
-  assert(cac && line);
+  ASSERT(cac && line);
 
   const regmatch_t *match = mutt_prex_capture(PREX_ACCOUNT_CMD, line);
   if (!match)
@@ -132,7 +131,7 @@ static MuttAccountFlags parse_one(struct ConnAccount *cac, char *line)
  */
 static MuttAccountFlags call_cmd(struct ConnAccount *cac, const struct Buffer *cmd)
 {
-  assert(cac && cmd);
+  ASSERT(cac && cmd);
 
   MuttAccountFlags rc = MUTT_ACCT_NO_FLAGS;
 

--- a/conn/connaccount.c
+++ b/conn/connaccount.c
@@ -29,7 +29,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -262,7 +261,7 @@ char *mutt_account_getoauthbearer(struct ConnAccount *cac, bool xoauth2)
   FREE(&token);
 
   size_t encoded_len = oalen * 4 / 3 + 10;
-  assert(encoded_len < 6010); // Assure LGTM that we won't overflow
+  ASSERT(encoded_len < 6010); // Assure LGTM that we won't overflow
 
   char *encoded_token = mutt_mem_malloc(encoded_len);
   mutt_b64_encode(oauthbearer, oalen, encoded_token, encoded_len);

--- a/conn/getdomain.c
+++ b/conn/getdomain.c
@@ -30,7 +30,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <netdb.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -51,8 +50,8 @@
  */
 static struct addrinfo *mutt_getaddrinfo_a(const char *node, const struct addrinfo *hints)
 {
-  assert(node);
-  assert(hints);
+  ASSERT(node);
+  ASSERT(hints);
   struct addrinfo *result = NULL;
 
   /* Allow 0.1 seconds to get the FQDN (fully-qualified domain name).
@@ -102,8 +101,8 @@ static struct addrinfo *mutt_getaddrinfo_a(const char *node, const struct addrin
  */
 static struct addrinfo *mutt_getaddrinfo(const char *node, const struct addrinfo *hints)
 {
-  assert(node);
-  assert(hints);
+  ASSERT(node);
+  ASSERT(hints);
   struct addrinfo *result = NULL;
   mutt_debug(LL_DEBUG3, "before getaddrinfo\n");
   int rc = getaddrinfo(node, NULL, hints, &result);
@@ -124,7 +123,7 @@ static struct addrinfo *mutt_getaddrinfo(const char *node, const struct addrinfo
  */
 int getdnsdomainname(struct Buffer *result)
 {
-  assert(result);
+  ASSERT(result);
   int rc = -1;
 
 #if defined(HAVE_GETADDRINFO) || defined(HAVE_GETADDRINFO_A)

--- a/core/mailbox.c
+++ b/core/mailbox.c
@@ -29,7 +29,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <sys/stat.h>
 #include "config/lib.h"
 #include "email/lib.h"
@@ -298,7 +297,7 @@ static struct EmailGarbageCollector GC = { 0 };
  */
 void mailbox_gc_add(struct Email *e)
 {
-  assert(e);
+  ASSERT(e);
   if (GC.idx == mutt_array_size(GC.arr))
   {
     mailbox_gc_run();

--- a/debug/names_expando.c
+++ b/debug/names_expando.c
@@ -21,7 +21,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include "email/lib.h"
 #include "core/lib.h"
 #include "alias/gui.h"
@@ -528,7 +527,7 @@ const char *name_expando_uid(enum ExpandoDomain did, int uid)
     case ED_SMIME_CMD:
       return name_expando_uid_smime_cmd(uid);
     default:
-      assert(false);
+      ASSERT(false);
       return "UNKNOWN";
   }
 }

--- a/email/rfc2047.c
+++ b/email/rfc2047.c
@@ -31,7 +31,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <iconv.h>
@@ -201,7 +200,7 @@ static size_t try_block(const char *d, size_t dlen, const char *fromcode,
   if (fromcode)
   {
     iconv_t cd = mutt_ch_iconv_open(tocode, fromcode, MUTT_ICONV_NO_FLAGS);
-    assert(iconv_t_valid(cd));
+    ASSERT(iconv_t_valid(cd));
     ib = d;
     ibl = dlen;
     ob = buf;
@@ -209,8 +208,8 @@ static size_t try_block(const char *d, size_t dlen, const char *fromcode,
     if ((iconv(cd, (ICONV_CONST char **) &ib, &ibl, &ob, &obl) == ICONV_ILLEGAL_SEQ) ||
         (iconv(cd, NULL, NULL, &ob, &obl) == ICONV_ILLEGAL_SEQ))
     {
-      assert(errno == E2BIG);
-      assert(ib > d);
+      ASSERT(errno == E2BIG);
+      ASSERT(ib > d);
       return ((ib - d) == dlen) ? dlen : ib - d + 1;
     }
   }
@@ -226,7 +225,7 @@ static size_t try_block(const char *d, size_t dlen, const char *fromcode,
   for (char *p = buf; p < ob; p++)
   {
     unsigned char c = *p;
-    assert(strchr(MimeSpecials, '?'));
+    ASSERT(strchr(MimeSpecials, '?'));
     if ((c >= 0x7f) || (c < 0x20) || (*p == '_') ||
         ((c != ' ') && strchr(MimeSpecials, *p)))
     {
@@ -281,7 +280,7 @@ static size_t encode_block(char *str, char *buf, size_t buflen, const char *from
   }
 
   const iconv_t cd = mutt_ch_iconv_open(tocode, fromcode, MUTT_ICONV_NO_FLAGS);
-  assert(iconv_t_valid(cd));
+  ASSERT(iconv_t_valid(cd));
   const char *ib = buf;
   size_t ibl = buflen;
   char tmp[ENCWORD_LEN_MAX - ENCWORD_LEN_MIN + 1];
@@ -289,7 +288,7 @@ static size_t encode_block(char *str, char *buf, size_t buflen, const char *from
   size_t obl = sizeof(tmp) - strlen(tocode);
   const size_t n1 = iconv(cd, (ICONV_CONST char **) &ib, &ibl, &ob, &obl);
   const size_t n2 = iconv(cd, NULL, NULL, &ob, &obl);
-  assert((n1 != ICONV_ILLEGAL_SEQ) && (n2 != ICONV_ILLEGAL_SEQ));
+  ASSERT((n1 != ICONV_ILLEGAL_SEQ) && (n2 != ICONV_ILLEGAL_SEQ));
   return (*encoder)(str, tmp, ob - tmp, tocode);
 }
 
@@ -317,12 +316,12 @@ static size_t choose_block(char *d, size_t dlen, int col, const char *fromcode,
   size_t n = dlen;
   while (true)
   {
-    assert(n > 0);
+    ASSERT(n > 0);
     const size_t nn = try_block(d, n, fromcode, tocode, encoder, wlen);
     if ((nn == 0) && (((col + *wlen) <= (ENCWORD_LEN_MAX + 1)) || (n <= 1)))
       break;
     n = ((nn != 0) ? nn : n) - 1;
-    assert(n > 0);
+    ASSERT(n > 0);
     if (utf8)
       while ((n > 1) && CONTINUATION_BYTE(d[n]))
         n--;
@@ -368,7 +367,7 @@ static char *decode_word(const char *s, size_t len, enum ContentEncoding enc)
   const char *it = s;
   const char *end = s + len;
 
-  assert(*end == '\0');
+  ASSERT(*end == '\0');
 
   if (enc == ENC_QUOTED_PRINTABLE)
   {
@@ -408,7 +407,7 @@ static char *decode_word(const char *s, size_t len, enum ContentEncoding enc)
     return out;
   }
 
-  assert(0); /* The enc parameter has an invalid value */
+  ASSERT(0); /* The enc parameter has an invalid value */
   return NULL;
 }
 
@@ -572,7 +571,7 @@ static int encode(const char *d, size_t dlen, int col, const char *fromcode,
          * there is too much us-ascii stuff after it to use a single
          * encoded word. We add the next word to the encoded region
          * and try again. */
-        assert(t1 < (u + ulen));
+        ASSERT(t1 < (u + ulen));
         for (t1++; (t1 < (u + ulen)) && !HSPACE(*t1); t1++)
           ; // do nothing
 
@@ -591,7 +590,7 @@ static int encode(const char *d, size_t dlen, int col, const char *fromcode,
       mutt_mem_realloc(&buf, buflen);
     }
     r = encode_block(buf + bufpos, t, n, icode, tocode, encoder);
-    assert(r == wlen);
+    ASSERT(r == wlen);
     bufpos += wlen;
     memcpy(buf + bufpos, line_break, lb_len);
     bufpos += lb_len;
@@ -605,7 +604,7 @@ static int encode(const char *d, size_t dlen, int col, const char *fromcode,
   buflen = bufpos + wlen + (u + ulen - t1);
   mutt_mem_realloc(&buf, buflen + 1);
   r = encode_block(buf + bufpos, t, t1 - t, icode, tocode, encoder);
-  assert(r == wlen);
+  ASSERT(r == wlen);
   bufpos += wlen;
   memcpy(buf + bufpos, t1, u + ulen - t1);
 

--- a/expando/config_type.c
+++ b/expando/config_type.c
@@ -35,7 +35,6 @@
 
 #include "config.h"
 #include <stddef.h>
-#include <assert.h>
 #include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -357,18 +356,18 @@ const struct ConfigSetType CstExpando = {
  */
 const struct Expando *cs_subset_expando(const struct ConfigSubset *sub, const char *name)
 {
-  assert(sub && name);
+  ASSERT(sub && name);
 
   struct HashElem *he = cs_subset_create_inheritance(sub, name);
-  assert(he);
+  ASSERT(he);
 
 #ifndef NDEBUG
   struct HashElem *he_base = cs_get_base(he);
-  assert(DTYPE(he_base->type) == DT_EXPANDO);
+  ASSERT(DTYPE(he_base->type) == DT_EXPANDO);
 #endif
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   return (const struct Expando *) value;
 }

--- a/expando/helpers.c
+++ b/expando/helpers.c
@@ -29,7 +29,6 @@
 
 #include "config.h"
 #include <stddef.h>
-#include <assert.h>
 #include <ctype.h>
 #include <stdbool.h>
 #include "mutt/lib.h"
@@ -144,7 +143,7 @@ const char *skip_until_classic_expando(const char *start)
  */
 const char *skip_classic_expando(const char *str, const struct ExpandoDefinition *defs)
 {
-  assert(str);
+  ASSERT(str);
   if (*str == '\0')
     return str;
 

--- a/expando/node_condbool.c
+++ b/expando/node_condbool.c
@@ -28,7 +28,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "node_condbool.h"
@@ -112,7 +111,7 @@ int node_condbool_render(const struct ExpandoNode *node,
                          const struct ExpandoRenderData *rdata, struct Buffer *buf,
                          int max_cols, void *data, MuttFormatFlags flags)
 {
-  assert(node->type == ENT_CONDBOOL);
+  ASSERT(node->type == ENT_CONDBOOL);
 
   const struct ExpandoRenderData *rd_match = find_get_number(rdata, node->did, node->uid);
   if (rd_match)

--- a/expando/node_conddate.c
+++ b/expando/node_conddate.c
@@ -28,7 +28,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <ctype.h>
 #include <limits.h>
 #include <stdio.h>
@@ -76,10 +75,10 @@ int node_conddate_render(const struct ExpandoNode *node,
                          const struct ExpandoRenderData *rdata, struct Buffer *buf,
                          int max_cols, void *data, MuttFormatFlags flags)
 {
-  assert(node->type == ENT_CONDDATE);
+  ASSERT(node->type == ENT_CONDDATE);
 
   const struct ExpandoRenderData *rd_match = find_get_number(rdata, node->did, node->uid);
-  assert(rd_match && "Unknown UID");
+  ASSERT(rd_match && "Unknown UID");
 
   const long t_test = rd_match->get_number(node, data, flags);
 

--- a/expando/node_condition.c
+++ b/expando/node_condition.c
@@ -28,7 +28,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <stdbool.h>
 #include "mutt/lib.h"
 #include "node_condition.h"
@@ -42,7 +41,7 @@ static int node_condition_render(const struct ExpandoNode *node,
                                  const struct ExpandoRenderData *rdata, struct Buffer *buf,
                                  int max_cols, void *data, MuttFormatFlags flags)
 {
-  assert(node->type == ENT_CONDITION);
+  ASSERT(node->type == ENT_CONDITION);
 
   const struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
 
@@ -74,7 +73,7 @@ struct ExpandoNode *node_condition_new(struct ExpandoNode *condition,
                                        struct ExpandoNode *node_true,
                                        struct ExpandoNode *node_false)
 {
-  assert(condition);
+  ASSERT(condition);
 
   struct ExpandoNode *node = node_new();
 

--- a/expando/node_container.c
+++ b/expando/node_container.c
@@ -29,7 +29,6 @@
 
 #include "config.h"
 #include <stddef.h>
-#include <assert.h>
 #include <stdbool.h>
 #include "mutt/lib.h"
 #include "node_container.h"
@@ -45,7 +44,7 @@ int node_container_render(const struct ExpandoNode *node,
                           const struct ExpandoRenderData *rdata, struct Buffer *buf,
                           int max_cols, void *data, MuttFormatFlags flags)
 {
-  assert(node->type == ENT_CONTAINER);
+  ASSERT(node->type == ENT_CONTAINER);
 
   const struct ExpandoFormat *fmt = node->format;
   if (fmt)

--- a/expando/node_expando.c
+++ b/expando/node_expando.c
@@ -28,7 +28,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <ctype.h>
 #include <limits.h>
 #include <stdio.h>
@@ -333,7 +332,7 @@ struct ExpandoNode *node_expando_parse_enclosure(const char *str, const char **p
  */
 void add_color(struct Buffer *buf, enum ColorId cid)
 {
-  assert(cid < MT_COLOR_MAX);
+  ASSERT(cid < MT_COLOR_MAX);
 
   buf_addch(buf, MUTT_SPECIAL_INDEX);
   buf_addch(buf, cid);
@@ -346,7 +345,7 @@ int node_expando_render(const struct ExpandoNode *node,
                         const struct ExpandoRenderData *rdata, struct Buffer *buf,
                         int max_cols, void *data, MuttFormatFlags flags)
 {
-  assert(node->type == ENT_EXPANDO);
+  ASSERT(node->type == ENT_EXPANDO);
 
   struct Buffer *buf_expando = buf_pool_get();
 
@@ -358,7 +357,7 @@ int node_expando_render(const struct ExpandoNode *node,
   else
   {
     rd_match = find_get_number(rdata, node->did, node->uid);
-    assert(rd_match && "Unknown UID");
+    ASSERT(rd_match && "Unknown UID");
 
     const long num = rd_match->get_number(node, data, flags);
     buf_printf(buf_expando, "%ld", num);

--- a/expando/node_text.c
+++ b/expando/node_text.c
@@ -28,7 +28,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <stdbool.h>
 #include "node_text.h"
 #include "format.h"
@@ -44,7 +43,7 @@ static int node_text_render(const struct ExpandoNode *node,
                             const struct ExpandoRenderData *rdata, struct Buffer *buf,
                             int max_cols, void *data, MuttFormatFlags flags)
 {
-  assert(node->type == ENT_TEXT);
+  ASSERT(node->type == ENT_TEXT);
 
   const int num_bytes = node->end - node->start;
   return format_string(buf, 0, max_cols, JUSTIFY_LEFT, ' ', node->start, num_bytes, false);

--- a/expando/parse.c
+++ b/expando/parse.c
@@ -28,7 +28,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include "mutt/lib.h"
@@ -288,7 +287,7 @@ struct ExpandoNode *node_parse(const char *str, const char *end,
     }
   }
 
-  assert(false && "Internal parsing error"); // LCOV_EXCL_LINE
+  ASSERT(false && "Internal parsing error"); // LCOV_EXCL_LINE
   return NULL;
 }
 

--- a/external.c
+++ b/external.c
@@ -30,7 +30,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -548,7 +547,7 @@ bool mutt_select_sort(bool reverse)
   }
   else
   {
-    assert((c_sort & SORT_MASK) != SORT_THREADS); /* See index_config_observer() */
+    ASSERT((c_sort & SORT_MASK) != SORT_THREADS); /* See index_config_observer() */
     /* Preserve the value of $sort, and toggle whether we are threaded. */
     switch (c_use_threads)
     {
@@ -565,7 +564,7 @@ bool mutt_select_sort(bool reverse)
                                       reverse ? UT_FLAT : UT_THREADS, NULL);
         break;
       default:
-        assert(false);
+        ASSERT(false);
     }
   }
 

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -31,7 +31,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdbool.h>
@@ -235,7 +234,7 @@ static void *dump_email(struct HeaderCache *hc, const struct Email *e, int *off,
   d = serial_dump_uint32_t((uidvalidity != 0) ? uidvalidity : mutt_date_now(), d, off);
   d = serial_dump_int(hc->crc, d, off);
 
-  assert((size_t) *off == header_size());
+  ASSERT((size_t) *off == header_size());
 
   uint32_t packed = email_pack_flags(e);
   d = serial_dump_uint32_t(packed, d, off);
@@ -583,7 +582,7 @@ struct HCacheEntry hcache_fetch_email(struct HeaderCache *hc, const char *key,
   int off = 0;
   serial_restore_uint32_t(&hce.uidvalidity, data, &off);
   serial_restore_int(&hce.crc, data, &off);
-  assert((size_t) off == hlen);
+  ASSERT((size_t) off == hlen);
   if ((hce.crc != hc->crc) || ((uidvalidity != 0) && (uidvalidity != hce.uidvalidity)))
   {
     goto end;

--- a/hdrline.c
+++ b/hdrline.c
@@ -36,7 +36,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -341,7 +340,7 @@ void index_date_recv_local(const struct ExpandoNode *node, void *data,
     start++;
     len--;
   }
-  assert(len < sizeof(tmp2));
+  ASSERT(len < sizeof(tmp2));
   mutt_strn_copy(tmp2, start, len, sizeof(tmp2));
 
   if (use_c_locale)
@@ -397,7 +396,7 @@ void index_date_local(const struct ExpandoNode *node, void *data,
     start++;
     len--;
   }
-  assert(len < sizeof(tmp2));
+  ASSERT(len < sizeof(tmp2));
   mutt_strn_copy(tmp2, start, len, sizeof(tmp2));
 
   if (use_c_locale)
@@ -459,7 +458,7 @@ void index_date(const struct ExpandoNode *node, void *data,
     start++;
     len--;
   }
-  assert(len < sizeof(tmp2));
+  ASSERT(len < sizeof(tmp2));
   mutt_strn_copy(tmp2, start, len, sizeof(tmp2));
 
   if (use_c_locale)

--- a/imap/message.c
+++ b/imap/message.c
@@ -34,7 +34,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <ctype.h>
 #include <limits.h>
 #include <stdbool.h>
@@ -1013,7 +1012,7 @@ fail:
  */
 static int imap_verify_qresync(struct Mailbox *m)
 {
-  assert(m);
+  ASSERT(m);
   struct ImapAccountData *adata = imap_adata_get(m);
   struct ImapMboxData *mdata = imap_mdata_get(m);
   if (!adata || (adata->mailbox != m))

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -58,7 +58,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -354,7 +353,7 @@ int find_first_message(struct MailboxView *mv)
       reverse = !(c_sort & SORT_REVERSE);
       break;
     default:
-      assert(false);
+      ASSERT(false);
   }
 
   if (reverse || (m->vcount == 0))
@@ -511,7 +510,7 @@ static void update_index_unthreaded(struct MailboxView *mv, enum MxStatus check)
           mutt_pattern_exec(SLIST_FIRST(mv->limit_pattern),
                             MUTT_MATCH_FULL_ADDRESS, mv->mailbox, e, NULL))
       {
-        assert(mv->mailbox->vcount < mv->mailbox->msg_count);
+        ASSERT(mv->mailbox->vcount < mv->mailbox->msg_count);
         e->vnum = mv->mailbox->vcount;
         mv->mailbox->v2r[mv->mailbox->vcount] = i;
         e->visible = true;

--- a/mutt/prex.c
+++ b/mutt/prex.c
@@ -28,7 +28,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include "prex.h"
@@ -259,9 +258,9 @@ static struct PrexStorage *prex(enum Prex which)
     // clang-format on
   };
 
-  assert((which < PREX_MAX) && "Invalid 'which' argument");
+  ASSERT((which < PREX_MAX) && "Invalid 'which' argument");
   struct PrexStorage *h = &storage[which];
-  assert((which == h->which) && "Fix 'storage' array");
+  ASSERT((which == h->which) && "Fix 'storage' array");
   if (!h->re)
   {
 #ifdef HAVE_PCRE2
@@ -270,16 +269,16 @@ static struct PrexStorage *prex(enum Prex which)
     PCRE2_SIZE eoff = 0;
     h->re = pcre2_compile((PCRE2_SPTR8) h->str, PCRE2_ZERO_TERMINATED, opt,
                           &eno, &eoff, NULL);
-    assert(h->re && "Fix your RE");
+    ASSERT(h->re && "Fix your RE");
     h->mdata = pcre2_match_data_create_from_pattern(h->re, NULL);
     uint32_t ccount = 0;
     pcre2_pattern_info(h->re, PCRE2_INFO_CAPTURECOUNT, &ccount);
-    assert(((ccount + 1) == h->nmatches) && "Number of matches do not match (...)");
+    ASSERT(((ccount + 1) == h->nmatches) && "Number of matches do not match (...)");
     h->matches = mutt_mem_calloc(h->nmatches, sizeof(*h->matches));
 #else
     h->re = mutt_mem_calloc(1, sizeof(*h->re));
     const int rc = regcomp(h->re, h->str, REG_EXTENDED);
-    assert(rc == 0 && "Fix your RE");
+    ASSERT(rc == 0 && "Fix your RE");
     h->matches = mutt_mem_calloc(h->nmatches, sizeof(*h->matches));
 #endif
   }
@@ -325,7 +324,7 @@ regmatch_t *mutt_prex_capture(enum Prex which, const char *str)
   if (regexec(h->re, str, h->nmatches, h->matches, 0))
     return NULL;
 
-  assert((h->re->re_nsub == (h->nmatches - 1)) &&
+  ASSERT((h->re->re_nsub == (h->nmatches - 1)) &&
          "Regular expression and matches enum are out of sync");
 #endif
   return h->matches;

--- a/mutt/prex.c
+++ b/mutt/prex.c
@@ -34,6 +34,7 @@
 #include "prex.h"
 #include "logging2.h"
 #include "memory.h"
+#include "signal2.h"
 
 #ifdef HAVE_PCRE2
 #define PCRE2_CODE_UNIT_WIDTH 8

--- a/mutt/qsort_r.c
+++ b/mutt/qsort_r.c
@@ -30,10 +30,10 @@
 #include "config.h"
 #include <stddef.h>
 #include <stdlib.h>
+#include "mutt/lib.h"
 #include "qsort_r.h"
 
 #if !defined(HAVE_QSORT_S) && !defined(HAVE_QSORT_R)
-#include <assert.h>
 /// Original comparator in fallback implementation
 static sort_t GlobalCompar = NULL;
 /// Original opaque data in fallback implementation
@@ -74,7 +74,7 @@ void mutt_qsort_r(void *base, size_t nmemb, size_t size, sort_t compar, void *sd
   qsort_r(base, nmemb, size, compar, sdata);
 #else
   /* This fallback is not re-entrant. */
-  assert(!GlobalCompar && !GlobalData);
+  ASSERT(!GlobalCompar && !GlobalData);
   GlobalCompar = compar;
   GlobalData = sdata;
   qsort(base, nmemb, size, relay_compar);

--- a/mutt/signal.c
+++ b/mutt/signal.c
@@ -37,6 +37,8 @@
 #include "message.h"
 #include "signal2.h"
 
+int endwin(void);
+
 /// A set of signals used by mutt_sig_block(), mutt_sig_unblock()
 static sigset_t Sigset;
 /// A set of signals used by mutt_sig_block_system(), mutt_sig_unblock_system()
@@ -333,4 +335,18 @@ void mutt_sig_reset_child_signals(void)
   sigaction(SIGTERM, &sa, NULL);
   sigaction(SIGTSTP, &sa, NULL);
   sigaction(SIGCONT, &sa, NULL);
+}
+
+/**
+ * assertion_dump - Dump some debugging info before we stop the program
+ * @param file Source file
+ * @param line Line of source
+ * @param func Function
+ * @param cond Assertion condition
+ */
+void assertion_dump(const char *file, int line, const char *func, const char *cond)
+{
+  endwin();
+  show_backtrace();
+  printf("%s:%d:%s() -- assertion failed (%s)\n", file, line, func, cond);
 }

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -31,7 +31,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -753,7 +752,7 @@ static int compare_threads(const void *a, const void *b, void *sdata)
   const struct MuttThread *ta = *(struct MuttThread const *const *) a;
   const struct MuttThread *tb = *(struct MuttThread const *const *) b;
   const struct ThreadsContext *tctx = sdata;
-  assert(ta->parent == tb->parent);
+  ASSERT(ta->parent == tb->parent);
 
   /* If c_sort ties, remember we are building the thread array in
    * reverse from the index the mails had in the mailbox.  */
@@ -797,8 +796,8 @@ static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
   enum SortType c_sort_aux = cs_subset_sort(NeoMutt->sub, "sort_aux");
   if ((c_sort & SORT_MASK) == SORT_THREADS)
   {
-    assert(!(c_sort & SORT_REVERSE) != reverse);
-    assert(cs_subset_enum(NeoMutt->sub, "use_threads") == UT_UNSET);
+    ASSERT(!(c_sort & SORT_REVERSE) != reverse);
+    ASSERT(cs_subset_enum(NeoMutt->sub, "use_threads") == UT_UNSET);
     c_sort = c_sort_aux;
   }
   c_sort ^= SORT_REVERSE;
@@ -1043,7 +1042,7 @@ void mutt_sort_threads(struct ThreadsContext *tctx, bool init)
   struct MuttThread top = { 0 };
   struct ListNode *ref = NULL;
 
-  assert(m->msg_count > 0);
+  ASSERT(m->msg_count > 0);
   if (!tctx->hash)
     init = true;
 

--- a/ncrypt/dlg_gpgme.c
+++ b/ncrypt/dlg_gpgme.c
@@ -69,7 +69,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <gpgme.h>
 #include <locale.h>
 #include <stdbool.h>
@@ -320,7 +319,7 @@ void pgp_entry_gpgme_date(const struct ExpandoNode *node, void *data,
     len--;
   }
 
-  assert(len < sizeof(datestr));
+  ASSERT(len < sizeof(datestr));
   mutt_strn_copy(datestr, start, len, sizeof(datestr));
 
   struct tm tm = { 0 };

--- a/ncrypt/dlg_pgp.c
+++ b/ncrypt/dlg_pgp.c
@@ -68,7 +68,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <locale.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -289,7 +288,7 @@ void pgp_entry_pgp_date(const struct ExpandoNode *node, void *data,
     len--;
   }
 
-  assert(len < sizeof(datestr));
+  ASSERT(len < sizeof(datestr));
   mutt_strn_copy(datestr, start, len, sizeof(datestr));
 
   if (use_c_locale)

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -35,7 +35,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <inttypes.h>
 #include <stdbool.h>
 #include <string.h>
@@ -162,9 +161,9 @@ static const struct Mapping *pager_resolve_help_mapping(enum PagerMode mode, enu
     case PAGER_MODE_UNKNOWN:
     case PAGER_MODE_MAX:
     default:
-      assert(false); // something went really wrong
+      ASSERT(false); // something went really wrong
   }
-  assert(result);
+  ASSERT(result);
   return result;
 }
 
@@ -218,11 +217,11 @@ int dlg_pager(struct PagerView *pview)
   //===========================================================================
   // ACT 1 - Ensure sanity of the caller and determine the mode
   //===========================================================================
-  assert(pview);
-  assert((pview->mode > PAGER_MODE_UNKNOWN) && (pview->mode < PAGER_MODE_MAX));
-  assert(pview->pdata); // view can't exist in a vacuum
-  assert(pview->win_pager);
-  assert(pview->win_pbar);
+  ASSERT(pview);
+  ASSERT((pview->mode > PAGER_MODE_UNKNOWN) && (pview->mode < PAGER_MODE_MAX));
+  ASSERT(pview->pdata); // view can't exist in a vacuum
+  ASSERT(pview->win_pager);
+  ASSERT(pview->win_pbar);
 
   struct MuttWindow *dlg = dialog_find(pview->win_pager);
   struct IndexSharedData *shared = dlg->wdata;
@@ -234,10 +233,10 @@ int dlg_pager(struct PagerView *pview)
       // This case was previously identified by IsEmail macro
       // we expect data to contain email and not contain body
       // We also expect email to always belong to some mailbox
-      assert(shared->mailbox_view);
-      assert(shared->mailbox);
-      assert(shared->email);
-      assert(!pview->pdata->body);
+      ASSERT(shared->mailbox_view);
+      ASSERT(shared->mailbox);
+      ASSERT(shared->email);
+      ASSERT(!pview->pdata->body);
       break;
 
     case PAGER_MODE_ATTACH:
@@ -245,7 +244,7 @@ int dlg_pager(struct PagerView *pview)
       // macros, we expect data to contain:
       //  - body (viewing regular attachment)
       //  - fp and body->email in special case of viewing an attached email.
-      assert(pview->pdata->body);
+      ASSERT(pview->pdata->body);
       if (pview->pdata->fp && pview->pdata->body->email)
       {
         // Special case: attachment is a full-blown email message.
@@ -256,9 +255,9 @@ int dlg_pager(struct PagerView *pview)
 
     case PAGER_MODE_HELP:
     case PAGER_MODE_OTHER:
-      assert(!shared->mailbox_view);
-      assert(!shared->email);
-      assert(!pview->pdata->body);
+      ASSERT(!shared->mailbox_view);
+      ASSERT(!shared->email);
+      ASSERT(!pview->pdata->body);
       break;
 
     case PAGER_MODE_UNKNOWN:
@@ -267,7 +266,7 @@ int dlg_pager(struct PagerView *pview)
       // Unexpected mode. Catch fire and explode.
       // This *should* happen if mode is PAGER_MODE_ATTACH_E, since
       // we do not expect any caller to pass it to us.
-      assert(false);
+      ASSERT(false);
       break;
   }
 

--- a/pager/do_pager.c
+++ b/pager/do_pager.c
@@ -57,7 +57,6 @@
 
 #include "config.h"
 #include <stddef.h>
-#include <assert.h>
 #include <stdbool.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
@@ -122,10 +121,10 @@ static int dopager_window_observer(struct NotifyCallback *nc)
  */
 int mutt_do_pager(struct PagerView *pview, struct Email *e)
 {
-  assert(pview);
-  assert(pview->pdata);
-  assert(pview->pdata->fname);
-  assert((pview->mode == PAGER_MODE_ATTACH) ||
+  ASSERT(pview);
+  ASSERT(pview->pdata);
+  ASSERT(pview->pdata->fname);
+  ASSERT((pview->mode == PAGER_MODE_ATTACH) ||
          (pview->mode == PAGER_MODE_HELP) || (pview->mode == PAGER_MODE_OTHER));
 
   struct MuttWindow *dlg = mutt_window_new(WT_DLG_PAGER, MUTT_WIN_ORIENT_VERTICAL,

--- a/parse/set.c
+++ b/parse/set.c
@@ -29,7 +29,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include "mutt/lib.h"
@@ -59,7 +58,7 @@
  */
 static void command_set_expand_value(uint32_t type, struct Buffer *value)
 {
-  assert(value);
+  ASSERT(value);
   if (DTYPE(type) == DT_PATH)
   {
     if (type & (D_PATH_DIR | D_PATH_FILE))
@@ -101,8 +100,8 @@ static void command_set_expand_value(uint32_t type, struct Buffer *value)
 static enum CommandResult command_set_set(struct Buffer *name,
                                           struct Buffer *value, struct Buffer *err)
 {
-  assert(name);
-  assert(value);
+  ASSERT(name);
+  ASSERT(value);
   struct HashElem *he = cs_subset_lookup(NeoMutt->sub, name->data);
   if (!he)
   {
@@ -156,8 +155,8 @@ static enum CommandResult command_set_set(struct Buffer *name,
 static enum CommandResult command_set_increment(struct Buffer *name,
                                                 struct Buffer *value, struct Buffer *err)
 {
-  assert(name);
-  assert(value);
+  ASSERT(name);
+  ASSERT(value);
   struct HashElem *he = cs_subset_lookup(NeoMutt->sub, name->data);
   if (!he)
   {
@@ -211,8 +210,8 @@ static enum CommandResult command_set_increment(struct Buffer *name,
 static enum CommandResult command_set_decrement(struct Buffer *name,
                                                 struct Buffer *value, struct Buffer *err)
 {
-  assert(name);
-  assert(value);
+  ASSERT(name);
+  ASSERT(value);
   struct HashElem *he = cs_subset_lookup(NeoMutt->sub, name->data);
   if (!he)
   {
@@ -240,7 +239,7 @@ static enum CommandResult command_set_decrement(struct Buffer *name,
  */
 static enum CommandResult command_set_unset(struct Buffer *name, struct Buffer *err)
 {
-  assert(name);
+  ASSERT(name);
   struct HashElem *he = cs_subset_lookup(NeoMutt->sub, name->data);
   if (!he)
   {
@@ -279,7 +278,7 @@ static enum CommandResult command_set_unset(struct Buffer *name, struct Buffer *
  */
 static enum CommandResult command_set_reset(struct Buffer *name, struct Buffer *err)
 {
-  assert(name);
+  ASSERT(name);
   // Handle special "reset all" syntax
   if (mutt_str_equal(name->data, "all"))
   {
@@ -333,7 +332,7 @@ static enum CommandResult command_set_reset(struct Buffer *name, struct Buffer *
  */
 static enum CommandResult command_set_toggle(struct Buffer *name, struct Buffer *err)
 {
-  assert(name);
+  ASSERT(name);
   struct HashElem *he = cs_subset_lookup(NeoMutt->sub, name->data);
   if (!he)
   {
@@ -369,7 +368,7 @@ static enum CommandResult command_set_toggle(struct Buffer *name, struct Buffer 
  */
 static enum CommandResult command_set_query(struct Buffer *name, struct Buffer *err)
 {
-  assert(name);
+  ASSERT(name);
   // In the interactive case (outside of the initial parsing of neomuttrc) we
   // support additional syntax: "set" (no arguments) and "set all".
   // If not in interactive mode, we recognise them but do nothing.
@@ -573,15 +572,15 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
     // Each of inv, unset reset, query, equals implies that the others are not set.
     // If none of them are set, then we are dealing with a "set foo" command.
     // clang-format off
-    assert(!inv    || !(       unset || reset || query || equals          ));
-    assert(!unset  || !(inv ||          reset || query || equals          ));
-    assert(!reset  || !(inv || unset ||          query || equals          ));
-    assert(!query  || !(inv || unset || reset ||          equals          ));
-    assert(!equals || !(inv || unset || reset || query ||           prefix));
+    ASSERT(!inv    || !(       unset || reset || query || equals          ));
+    ASSERT(!unset  || !(inv ||          reset || query || equals          ));
+    ASSERT(!reset  || !(inv || unset ||          query || equals          ));
+    ASSERT(!query  || !(inv || unset || reset ||          equals          ));
+    ASSERT(!equals || !(inv || unset || reset || query ||           prefix));
     // clang-format on
-    assert(!(increment && decrement)); // only one of increment or decrement is set
-    assert(!(increment || decrement) || equals); // increment/decrement implies equals
-    assert(!inv || bool_or_quad); // inv (aka toggle) implies bool or quad
+    ASSERT(!(increment && decrement)); // only one of increment or decrement is set
+    ASSERT(!(increment || decrement) || equals); // increment/decrement implies equals
+    ASSERT(!inv || bool_or_quad); // inv (aka toggle) implies bool or quad
 
     enum CommandResult rc = MUTT_CMD_ERROR;
     if (query)

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -31,7 +31,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -113,7 +112,7 @@ static void print_crypt_pattern_op_error(int op)
  */
 static bool msg_search(struct Pattern *pat, struct Email *e, struct Message *msg)
 {
-  assert(msg);
+  ASSERT(msg);
 
   bool match = false;
 

--- a/question/question.c
+++ b/question/question.c
@@ -28,7 +28,6 @@
  */
 
 #include "config.h"
-#include <assert.h>
 #include <ctype.h>
 #include <langinfo.h>
 #include <limits.h>
@@ -344,10 +343,10 @@ enum QuadOption query_yesorno_help(const char *prompt, enum QuadOption def,
 {
   struct HashElem *he = cs_subset_create_inheritance(sub, name);
   struct HashElem *he_base = cs_get_base(he);
-  assert(DTYPE(he_base->type) == DT_BOOL);
+  ASSERT(DTYPE(he_base->type) == DT_BOOL);
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   struct ConfigDef *cdef = he_base->data;
   return mw_yesorno(prompt, def, cdef);
@@ -367,10 +366,10 @@ enum QuadOption query_quadoption(const char *prompt, struct ConfigSubset *sub, c
 {
   struct HashElem *he = cs_subset_create_inheritance(sub, name);
   struct HashElem *he_base = cs_get_base(he);
-  assert(DTYPE(he_base->type) == DT_QUAD);
+  ASSERT(DTYPE(he_base->type) == DT_QUAD);
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   if ((value == MUTT_YES) || (value == MUTT_NO))
     return value;

--- a/test/common.c
+++ b/test/common.c
@@ -316,3 +316,9 @@ bool subjrx_apply_mods(struct Envelope *env)
 {
   return false;
 }
+
+#ifdef USE_DEBUG_BACKTRACE
+void show_backtrace(void)
+{
+}
+#endif

--- a/test/config/myvar.c
+++ b/test/config/myvar.c
@@ -24,7 +24,6 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <assert.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -67,14 +66,14 @@ static struct ConfigDef Vars[] = {
  */
 const char *cs_subset_myvar(const struct ConfigSubset *sub, const char *name)
 {
-  assert(sub && name);
+  ASSERT(sub && name);
 
   struct HashElem *he = cs_subset_lookup(sub, name);
-  assert(he);
-  assert(DTYPE(he->type) == DT_MYVAR);
+  ASSERT(he);
+  ASSERT(DTYPE(he->type) == DT_MYVAR);
 
   intptr_t value = cs_subset_he_native_get(sub, he, NULL);
-  assert(value != INT_MIN);
+  ASSERT(value != INT_MIN);
 
   return (const char *) value;
 }

--- a/test/expando/colors_render.c
+++ b/test/expando/colors_render.c
@@ -23,7 +23,6 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <assert.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "gui/lib.h"
@@ -42,7 +41,7 @@ struct SimpleExpandoData
 static void simple_s(const struct ExpandoNode *node, void *data,
                      MuttFormatFlags flags, int max_cols, struct Buffer *buf)
 {
-  assert(node->type == ENT_EXPANDO);
+  ASSERT(node->type == ENT_EXPANDO);
 
   const struct SimpleExpandoData *sd = data;
   struct NodeExpandoPrivate *priv = node->ndata;
@@ -56,7 +55,7 @@ static void simple_s(const struct ExpandoNode *node, void *data,
 static void simple_C(const struct ExpandoNode *node, void *data,
                      MuttFormatFlags flags, int max_cols, struct Buffer *buf)
 {
-  assert(node->type == ENT_EXPANDO);
+  ASSERT(node->type == ENT_EXPANDO);
 
   const struct SimpleExpandoData *sd = data;
   struct NodeExpandoPrivate *priv = node->ndata;

--- a/test/expando/conditional_date_render.c
+++ b/test/expando/conditional_date_render.c
@@ -23,7 +23,6 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
@@ -46,7 +45,7 @@ static long cond_date_num(const struct ExpandoNode *node, void *data, MuttFormat
 static void cond_date(const struct ExpandoNode *node, void *data,
                       MuttFormatFlags flags, int max_cols, struct Buffer *buf)
 {
-  assert(node->type == ENT_EXPANDO);
+  ASSERT(node->type == ENT_EXPANDO);
 
   const struct CondDateData *dd = data;
   struct tm tm = mutt_date_localtime(dd->t);

--- a/test/expando/conditional_date_render2.c
+++ b/test/expando/conditional_date_render2.c
@@ -23,7 +23,6 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
@@ -46,7 +45,7 @@ static long cond_date_num(const struct ExpandoNode *node, void *data, MuttFormat
 static void cond_date(const struct ExpandoNode *node, void *data,
                       MuttFormatFlags flags, int max_cols, struct Buffer *buf)
 {
-  assert(node->type == ENT_EXPANDO || node->type == ENT_CONDDATE);
+  ASSERT(node->type == ENT_EXPANDO || node->type == ENT_CONDDATE);
 
   const struct CondDateData *dd = data;
   struct tm tm = mutt_date_localtime(dd->t);

--- a/test/expando/date_render.c
+++ b/test/expando/date_render.c
@@ -23,7 +23,6 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <assert.h>
 #include <limits.h>
 #include <stdio.h>
 #include <string.h>
@@ -41,7 +40,7 @@ struct SimpleDateData
 static void simple_date(const struct ExpandoNode *node, void *data,
                         MuttFormatFlags flags, int max_cols, struct Buffer *buf)
 {
-  assert(node->type == ENT_EXPANDO);
+  ASSERT(node->type == ENT_EXPANDO);
 
   const struct SimpleDateData *dd = data;
   struct tm tm = mutt_date_localtime(dd->t);

--- a/test/expando/empty_if_else_render.c
+++ b/test/expando/empty_if_else_render.c
@@ -23,7 +23,6 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <assert.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "expando/lib.h"
@@ -51,7 +50,7 @@ static void simple_c(const struct ExpandoNode *node, void *data,
 static void simple_f(const struct ExpandoNode *node, void *data,
                      MuttFormatFlags flags, int max_cols, struct Buffer *buf)
 {
-  assert(node->type == ENT_EXPANDO);
+  ASSERT(node->type == ENT_EXPANDO);
 
   const struct SimpleEmptyIfElseData *sd = data;
 

--- a/test/expando/if_else_false_render.c
+++ b/test/expando/if_else_false_render.c
@@ -23,7 +23,6 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <assert.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "expando/lib.h"
@@ -51,7 +50,7 @@ static void simple_c(const struct ExpandoNode *node, void *data,
 static void simple_t(const struct ExpandoNode *node, void *data,
                      MuttFormatFlags flags, int max_cols, struct Buffer *buf)
 {
-  assert(node->type == ENT_EXPANDO);
+  ASSERT(node->type == ENT_EXPANDO);
 
   const struct SimpleIfElseData *sd = data;
 
@@ -62,7 +61,7 @@ static void simple_t(const struct ExpandoNode *node, void *data,
 static void simple_f(const struct ExpandoNode *node, void *data,
                      MuttFormatFlags flags, int max_cols, struct Buffer *buf)
 {
-  assert(node->type == ENT_EXPANDO);
+  ASSERT(node->type == ENT_EXPANDO);
 
   const struct SimpleIfElseData *sd = data;
 

--- a/test/expando/if_else_true_render.c
+++ b/test/expando/if_else_true_render.c
@@ -23,7 +23,6 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <assert.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "expando/lib.h"
@@ -49,7 +48,7 @@ static void simple_c(const struct ExpandoNode *node, void *data,
 static void simple_t(const struct ExpandoNode *node, void *data,
                      MuttFormatFlags flags, int max_cols, struct Buffer *buf)
 {
-  assert(node->type == ENT_EXPANDO);
+  ASSERT(node->type == ENT_EXPANDO);
 
   const struct SimpleIfElseData *sd = data;
 
@@ -60,7 +59,7 @@ static void simple_t(const struct ExpandoNode *node, void *data,
 static void simple_f(const struct ExpandoNode *node, void *data,
                      MuttFormatFlags flags, int max_cols, struct Buffer *buf)
 {
-  assert(node->type == ENT_EXPANDO);
+  ASSERT(node->type == ENT_EXPANDO);
 
   const struct SimpleIfElseData *sd = data;
 

--- a/test/expando/serial.c
+++ b/test/expando/serial.c
@@ -22,7 +22,6 @@
 
 #include "config.h"
 #include <stddef.h>
-#include <assert.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -43,8 +42,8 @@ static void dump_node_condition(const struct ExpandoNode *node, struct Buffer *b
 {
   buf_addstr(buf, "<COND");
 
-  // assert(node->start);
-  // assert(node->end);
+  // ASSERT(node->start);
+  // ASSERT(node->end);
   // int len = node->end - node->start;
   // buf_add_printf(buf, ":'%.*s':", len, node->start);
 
@@ -60,7 +59,7 @@ static void dump_node_condition(const struct ExpandoNode *node, struct Buffer *b
   struct ExpandoNode *if_true_tree = node_get_child(node, ENC_TRUE);
   struct ExpandoNode *if_false_tree = node_get_child(node, ENC_FALSE);
 
-  assert(condition);
+  ASSERT(condition);
   buf_addstr(buf, ":");
   dump_node(condition, buf);
   buf_addstr(buf, "|");
@@ -75,15 +74,15 @@ static void dump_node_condbool(const struct ExpandoNode *node, struct Buffer *bu
 {
   buf_addstr(buf, "<BOOL");
 
-  assert(node->start);
-  assert(node->end);
+  ASSERT(node->start);
+  ASSERT(node->end);
   int len = node->end - node->start;
   buf_add_printf(buf, ":'%.*s':", len, node->start);
 
   dump_did_uid(node, buf);
 
-  assert(node->ndata == NULL);
-  assert(node->ndata_free == NULL);
+  ASSERT(node->ndata == NULL);
+  ASSERT(node->ndata_free == NULL);
 
   buf_addstr(buf, ">");
 }
@@ -92,15 +91,15 @@ static void dump_node_conddate(const struct ExpandoNode *node, struct Buffer *bu
 {
   buf_addstr(buf, "<DATE:");
 
-  // assert(node->start);
-  // assert(node->end);
+  // ASSERT(node->start);
+  // ASSERT(node->end);
   // int len = node->end - node->start;
   // buf_add_printf(buf, ":'%.*s':", len, node->start);
 
   dump_did_uid(node, buf);
 
-  assert(node->ndata);
-  assert(node->ndata_free);
+  ASSERT(node->ndata);
+  ASSERT(node->ndata_free);
   struct NodeCondDatePrivate *priv = node->ndata;
   buf_add_printf(buf, ":%d:%c", priv->count, priv->period);
 
@@ -138,17 +137,17 @@ static void dump_node_expando(const struct ExpandoNode *node, struct Buffer *buf
 {
   buf_addstr(buf, "<EXP:");
 
-  assert(node->start);
-  assert(node->end);
+  ASSERT(node->start);
+  ASSERT(node->end);
   int len = node->end - node->start;
   buf_add_printf(buf, "'%.*s'", len, node->start);
 
-  assert(node->did != 0);
-  assert(node->uid != 0);
+  ASSERT(node->did != 0);
+  ASSERT(node->uid != 0);
   dump_did_uid(node, buf);
 
-  assert(node->ndata);
-  assert(node->ndata_free);
+  ASSERT(node->ndata);
+  ASSERT(node->ndata_free);
 
   const struct ExpandoFormat *fmt = node->format;
   if (fmt)
@@ -174,8 +173,8 @@ static void dump_node_padding(const struct ExpandoNode *node, struct Buffer *buf
 {
   buf_addstr(buf, "<PAD:");
 
-  assert(node->ndata);
-  assert(node->ndata_free);
+  ASSERT(node->ndata);
+  ASSERT(node->ndata_free);
   struct NodePaddingPrivate *priv = node->ndata;
 
   struct ExpandoNode *left = node_get_child(node, ENP_LEFT);
@@ -185,8 +184,8 @@ static void dump_node_padding(const struct ExpandoNode *node, struct Buffer *buf
   pt += 4; // Skip "EPT_" prefix
   buf_add_printf(buf, "%s:", pt);
 
-  assert(node->start);
-  assert(node->end);
+  ASSERT(node->start);
+  ASSERT(node->end);
   int len = node->end - node->start;
   if (len > 0)
     buf_add_printf(buf, "'%.*s'", len, node->start);
@@ -211,8 +210,8 @@ static void dump_node_text(const struct ExpandoNode *node, struct Buffer *buf)
 {
   buf_addstr(buf, "<TEXT:");
 
-  assert(node->start);
-  assert(node->end);
+  ASSERT(node->start);
+  ASSERT(node->end);
   int len = node->end - node->start;
   buf_add_printf(buf, "'%.*s'", len, node->start);
 
@@ -260,7 +259,7 @@ static void dump_node(const struct ExpandoNode *node, struct Buffer *buf)
         dump_node_text(node, buf);
         break;
       default:
-        assert(false);
+        ASSERT(false);
     }
   }
 }

--- a/test/expando/simple_expando_render.c
+++ b/test/expando/simple_expando_render.c
@@ -23,7 +23,6 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <assert.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "expando/lib.h"
@@ -39,7 +38,7 @@ struct SimpleExpandoData
 static void simple_s(const struct ExpandoNode *node, void *data,
                      MuttFormatFlags flags, int max_cols, struct Buffer *buf)
 {
-  assert(node->type == ENT_EXPANDO);
+  ASSERT(node->type == ENT_EXPANDO);
 
   const struct SimpleExpandoData *sd = data;
 
@@ -50,7 +49,7 @@ static void simple_s(const struct ExpandoNode *node, void *data,
 static void simple_d(const struct ExpandoNode *node, void *data,
                      MuttFormatFlags flags, int max_cols, struct Buffer *buf)
 {
-  assert(node->type == ENT_EXPANDO);
+  ASSERT(node->type == ENT_EXPANDO);
 
   const struct SimpleExpandoData *sd = data;
 

--- a/test/expando/two_char_expando_render.c
+++ b/test/expando/two_char_expando_render.c
@@ -23,7 +23,6 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <assert.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "expando/lib.h"
@@ -39,7 +38,7 @@ struct SimpleData
 static void simple_ss(const struct ExpandoNode *node, void *data,
                       MuttFormatFlags flags, int max_cols, struct Buffer *buf)
 {
-  assert(node->type == ENT_EXPANDO);
+  ASSERT(node->type == ENT_EXPANDO);
 
   const struct SimpleData *sd = data;
 
@@ -50,7 +49,7 @@ static void simple_ss(const struct ExpandoNode *node, void *data,
 static void simple_dd(const struct ExpandoNode *node, void *data,
                       MuttFormatFlags flags, int max_cols, struct Buffer *buf)
 {
-  assert(node->type == ENT_EXPANDO);
+  ASSERT(node->type == ENT_EXPANDO);
 
   const struct SimpleData *sd = data;
 


### PR DESCRIPTION
Replace system `assert()` macro with a custom `ASSERT()` macro.

There are three distinct advantages to the new macro.

1. We can call `endwin()` to reset the screen mode.
2. A debugger will stop **ON** the macro, rather than about 6 levels beneath it.
3. You can continue running NeoMutt by stepping over the `ASSERT()`

---

Inspiration from Chris Wellons' https://nullprogram.com/blog/2022/06/26/

---

This PR upgrades `assert()` to reset the screen and optionally print a backtrace.
It works, if you enable `--debug-backtrace` and outputs:

```
NeoMutt 20240425-37-55fed8
Backtrace
    assertion_dump() ip = 21, sp = 7ffd651127a0
    op_print() ip = 4c, sp = 7ffd651127d0
    index_function_dispatcher() ip = 14e, sp = 7ffd65112820
    dlg_index() ip = b70, sp = 7ffd65112890
    main() ip = 2a41, sp = 7ffd65112950

index/functions.c:2080:op_print() -- assertion failed ((priv->menu->current % 2) == 1)
Illegal instruction (core dumped)
```

---

In the debugger, if you `j 2081` (jump to line 2081), NeoMutt will resume running.

```c
2075│ /**
2076│  * op_print - Print the current entry - Implements ::index_function_t - @ingroup index_function_api
2077│  */
2078│ static int op_print(struct IndexSharedData *shared, struct IndexPrivateData *priv, int op)
2079│ {
2080├─> ASSERT((priv->menu->current % 2) == 1);
2081│   struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
2082│   ea_add_tagged(&ea, shared->mailbox_view, shared->email, priv->tag_prefix);
2083│   mutt_print_message(shared->mailbox, &ea);
2084│   ARRAY_FREE(&ea);
2085│
2086│   /* in an IMAP folder index with imap_peek=no, printing could change
2087│    * new or old messages status to read. Redraw what's needed.  */
2088│   const bool c_imap_peek = cs_subset_bool(shared->sub, "imap_peek");
2089│   if ((shared->mailbox->type == MUTT_IMAP) && !c_imap_peek)
2090│   {
2091│     menu_queue_redraw(priv->menu, (priv->tag_prefix ? MENU_REDRAW_INDEX : MENU_REDRAW_CURRENT));
2092│   }
2093│
2094│   return FR_SUCCESS;
2095│ }
```