### PR TITLE
mbox: fix sorting for mbox_resync()

### DIFF
--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -59,6 +59,7 @@
 #include "muttlib.h"
 #include "mx.h"
 #include "protos.h"
+#include "sort.h"
 
 /**
  * struct MUpdate - Store of new offsets, used by mutt_sync_mailbox()
@@ -1081,14 +1082,9 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
 
   /* sort message by their position in the mailbox on disk */
   const enum SortType c_sort = cs_subset_sort(NeoMutt->sub, "sort");
-  const unsigned char c_use_threads = cs_subset_enum(NeoMutt->sub, "use_threads");
   if (c_sort != SORT_ORDER)
   {
-    cs_subset_str_native_set(NeoMutt->sub, "sort", SORT_ORDER, NULL);
-    cs_subset_str_native_set(NeoMutt->sub, "use_threads", UT_FLAT, NULL);
-    mailbox_changed(m, NT_MAILBOX_RESORT);
-    cs_subset_str_native_set(NeoMutt->sub, "sort", c_sort, NULL);
-    cs_subset_str_native_set(NeoMutt->sub, "use_threads", c_use_threads, NULL);
+    mutt_sort_order(m);
     need_sort = true;
   }
 

--- a/sort.c
+++ b/sort.c
@@ -438,3 +438,19 @@ void mutt_sort_headers(struct MailboxView *mv, bool init)
 
   return;
 }
+
+/**
+ * mutt_sort_order - Sort emails by their disk order
+ * @param m Mailbox
+ */
+void mutt_sort_order(struct Mailbox *m)
+{
+  if (!m)
+    return;
+
+  struct EmailCompare cmp = { 0 };
+  cmp.type = mx_type(m);
+  cmp.sort = SORT_ORDER;
+  mutt_qsort_r((void *) m->emails, m->msg_count, sizeof(struct Email *),
+               compare_email_shim, &cmp);
+}

--- a/sort.h
+++ b/sort.h
@@ -52,6 +52,7 @@ int mutt_compare_emails(const struct Email *a, const struct Email *b,
                         enum MailboxType type, short sort, short sort_aux);
 
 void mutt_sort_headers(struct MailboxView *mv, bool init);
+void mutt_sort_order(struct Mailbox *m);
 
 const char *mutt_get_name(const struct Address *a);
 


### PR DESCRIPTION
Syncing an mbox requires the Mailbox to be in disk order.
This PR forcibly sorts them to fix `mbox_mbox_resync()`.

Fixes: #4210 

---

The Emails are shared by the GUI and the Backend (Mailbox proper).
Most of the time, the Emails are in the user's preferred order, e.g. "Thread"
When the Backends work on the Emails, they often want the array in a different order.

Typically, the behaviour is like this:
- User: sync mailbox
- Backend:
  - Sort Emails into **disk** order
  - Sync changes to disk
  - Sort Emails back into **user** order

Recent changes have started so separate the GUI parts from `struct Mailbox` (into `struct MailboxView`).
This means that the Backends can no longer restore the user's sort order.
Instead, they send a notification:
```c
mailbox_changed(m, NT_MAILBOX_RESORT);
```

This notification is observed by the `MailboxView` and acted upon.
This works, most of the time.

In the case of Postponed Emails, the Postponed Mailbox isn't being viewed by the user.
It doesn't have a `MailboxView` with GUI info.
The notification goes unnoticed and the Emails don't get sorted.

By forcibly sorting the Emails, `mbox_mbox_sync()` works again.