### PR TITLE
expando: don't render the condition node

### DIFF
--- a/expando/config_type.c
+++ b/expando/config_type.c
@@ -256,8 +256,8 @@ static int expando_string_plus_equals(const struct ConfigSet *cs, void *var,
 
   if (expando_equal(exp_new, exp_old))
   {
-    expando_free(&exp_new);
-    return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
+    expando_free(&exp_new);                 // LCOV_EXCL_LINE
+    return CSR_SUCCESS | CSR_SUC_NO_CHANGE; // LCOV_EXCL_LINE
   }
 
   if (cdef->validator)
@@ -272,10 +272,7 @@ static int expando_string_plus_equals(const struct ConfigSet *cs, void *var,
   }
 
   expando_destroy(cs, var, cdef);
-
   *(struct Expando **) var = exp_new;
-  if (!exp_new)
-    rc |= CSR_SUC_EMPTY;
 
   return rc;
 }

--- a/expando/expando.c
+++ b/expando/expando.c
@@ -78,20 +78,19 @@ struct Expando *expando_parse(const char *str, const struct ExpandoDefinition *d
   if (!str || !defs)
     return NULL;
 
-  struct Expando *exp = expando_new(str);
-
   struct ExpandoParseError error = { 0 };
   struct ExpandoNode *root = NULL;
 
-  node_tree_parse(&root, exp->string, defs, &error);
+  node_tree_parse(&root, str, defs, &error);
 
   if (error.position)
   {
     buf_strcpy(err, error.message);
-    expando_free(&exp);
+    node_tree_free(&root);
     return NULL;
   }
 
+  struct Expando *exp = expando_new(str);
   exp->tree = root;
   return exp;
 }

--- a/expando/helpers.c
+++ b/expando/helpers.c
@@ -143,7 +143,10 @@ const char *skip_until_classic_expando(const char *start)
  */
 const char *skip_classic_expando(const char *str, const struct ExpandoDefinition *defs)
 {
-  assert(*str != '\0');
+  assert(str);
+  if (*str == '\0')
+    return str;
+
   const struct ExpandoDefinition *definitions = defs;
 
   while (definitions && definitions->short_name)

--- a/expando/node_condition.c
+++ b/expando/node_condition.c
@@ -46,8 +46,11 @@ static int node_condition_render(const struct ExpandoNode *node,
 
   const struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
 
-  // Condition node won't use the buffer, they just return a bool
-  int rc = node_cond->render(node_cond, rdata, buf, max_cols, data, flags);
+  // Discard any text returned, just use the return value as a bool
+  struct Buffer *buf_cond = buf_pool_get();
+  int rc = node_cond->render(node_cond, rdata, buf_cond, max_cols, data, flags);
+  buf_pool_release(&buf_cond);
+
   if (rc == true)
   {
     const struct ExpandoNode *node_true = node_get_child(node, ENC_TRUE);

--- a/test/config/string.c
+++ b/test/config/string.c
@@ -415,12 +415,12 @@ static bool test_string_plus_equals(struct ConfigSubset *sub, struct Buffer *err
   static char *PlusTests[][3] = {
     // clang-format off
     // Initial,        Plus,     Result
-    { "",              "",       ""                   }, // Add nothing to various lists
+    { "",              "",       ""                   }, // Add nothing to various strings
     { "one",           "",       "one"                },
     { "one two",       "",       "one two"            },
     { "one two three", "",       "one two three"      },
 
-    { "",              "nine",   "nine"               }, // Add an item to various lists
+    { "",              "nine",   "nine"               }, // Add an item to various strings
     { "one",           " nine",   "one nine"           },
     { "one two",       " nine",   "one two nine"       },
     { "one two three", " nine",   "one two three nine" },

--- a/test/expando/helpers.c
+++ b/test/expando/helpers.c
@@ -133,5 +133,11 @@ void test_expando_helpers(void)
     end = skip_classic_expando(str + 1, TestFormatDef);
     TEST_CHECK(end != NULL);
     TEST_CHECK(*end == 'a');
+
+    str = "%";
+
+    end = skip_classic_expando(str + 1, TestFormatDef);
+    TEST_CHECK(end != NULL);
+    TEST_CHECK(*end == '\0');
   }
 }


### PR DESCRIPTION
Many expandos can be used as the test condition, e.g. `%<A?&%C>`
Here, `%A` should be tested but its value shouldn't be displayed.

Fixes: #4209