### PR TITLE
config: add L10N support

### DIFF
--- a/compose/config.c
+++ b/compose/config.c
@@ -62,7 +62,8 @@ static const struct ExpandoDefinition ComposeFormatDef[] = {
  */
 static struct ConfigDef ComposeVars[] = {
   // clang-format off
-  { "compose_format", DT_EXPANDO, IP "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-", IP &ComposeFormatDef, NULL,
+  // L10N: $compose_format default format
+  { "compose_format", DT_EXPANDO|D_L10N_STRING, IP N_("-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"), IP &ComposeFormatDef, NULL,
     "printf-like format string for the Compose panel's status bar"
   },
   { "compose_show_user_headers", DT_BOOL, true, 0, NULL,

--- a/config/types.h
+++ b/config/types.h
@@ -54,6 +54,7 @@ enum ConfigTypeField
   D_B_ON_STARTUP = 5,              ///< May only be set at startup
   D_B_NOT_EMPTY,                   ///< Empty strings are not allowed
   D_B_SENSITIVE,                   ///< Contains sensitive value, e.g. password
+  D_B_L10N_STRING,                 ///< String can be localised
 
   D_B_CHARSET_SINGLE,              ///< Flag for charset_validator to allow only one charset
   D_B_CHARSET_STRICT,              ///< Flag for charset_validator to use strict char check
@@ -78,6 +79,7 @@ enum ConfigTypeField
 #define D_ON_STARTUP               (1 << D_B_ON_STARTUP)               ///< May only be set at startup
 #define D_NOT_EMPTY                (1 << D_B_NOT_EMPTY)                ///< Empty strings are not allowed
 #define D_SENSITIVE                (1 << D_B_SENSITIVE)                ///< Contains sensitive value, e.g. password
+#define D_L10N_STRING              (1 << D_B_L10N_STRING)              ///< String can be localised
 
 #define D_CHARSET_SINGLE           (1 << D_B_CHARSET_SINGLE)           ///< Flag for charset_validator to allow only one charset
 #define D_CHARSET_STRICT           (1 << D_B_CHARSET_STRICT)           ///< Flag for charset_validator to use strict char check

--- a/docs/config.c
+++ b/docs/config.c
@@ -3890,11 +3890,14 @@
 { "reply_regex", DT_REGEX, "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*" },
 /*
 ** .pp
-** A regular expression used to recognize reply messages when threading
-** and replying. The default value corresponds to the standard Latin "Re:"
-** prefix, the German "Aw:" or the Swedish "Sv:".  You can add your
-** own prefixes by swapping out or appending to that list.  For example:
-** \fC"^(re|se)"\fP or \fC"^(re|aw|se)"\fP.
+** A regular expression used to recognize reply messages when
+** threading and replying. The default value corresponds to the
+** standard Latin "Re:" prefix.
+** .pp
+** This value may have been localized by the translator for your
+** locale, adding other prefixes that are common in the locale. You
+** can add your own prefixes by appending inside \fC"^(re)"\fP.  For
+** example: \fC"^(re|sv)"\fP or \fC"^(re|aw|sv)"\fP.
 ** .pp
 ** The second parenthesized expression matches zero or more
 ** bracketed numbers following the prefix, such as \fC"Re[1]: "\fP.
@@ -3910,6 +3913,14 @@
 ** double quoted string.  If you use a single quoted string, you
 ** would have to type an actual tab character, and would need to
 ** convert the double-backslashes to single backslashes.
+** .pp
+** Note: the result of this regex match against the subject is
+** stored in the header cache.  Mutt isn't smart enough to
+** invalidate a header cache entry based on changing $$reply_regex,
+** so if you aren't seeing correct values in the index, try
+** temporarily turning off the header cache.  If that fixes the
+** problem, then once the variable is set to your liking, remove
+** your stale header cache files and turn the header cache back on.
 */
 
 { "reply_self", DT_BOOL, false },

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -710,7 +710,26 @@ static struct ConfigDef MainVars[] = {
   { "reflow_wrap", DT_NUMBER, 78, 0, NULL,
     "Maximum paragraph width for reformatting 'format=flowed' text"
   },
-  { "reply_regex", DT_REGEX, IP "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*", 0, NULL,
+  // L10N: $reply_regex default format
+  //
+  // This is a regular expression that matches reply subject lines.
+  // By default, it only matches an initial "Re: ", which is the
+  // standardized Latin prefix.
+  //
+  // However, many locales have other prefixes that are commonly used
+  // too, such as Aw in Germany.  To add other prefixes, modify the first
+  // parenthesized expression, such as:
+  //    "^(re|aw)
+  // you can add multiple values, for example:
+  //    "^(re|aw|sv)
+  //
+  // Important:
+  // - Use all lower case letters.
+  // - Don't remove the 're' prefix from the list of choices.
+  // - Please test the value you use inside Mutt.  A mistake here will break
+  //   NeoMutt's threading behavior.  Note: the header cache can interfere with
+  //   testing, so be sure to test with $header_cache unset.
+  { "reply_regex", DT_REGEX|D_L10N_STRING, IP N_("^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"), 0, NULL,
     "Regex to match message reply subjects like 're: '"
   },
   { "resolve", DT_BOOL, true, 0, NULL,
@@ -791,7 +810,8 @@ static struct ConfigDef MainVars[] = {
   { "status_chars", DT_MBTABLE, IP "-*%A", 0, NULL,
     "Indicator characters for the status bar"
   },
-  { "status_format", DT_EXPANDO, IP "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---", IP &StatusFormatDef, NULL,
+  // L10N: $status_format default format
+  { "status_format", DT_EXPANDO|D_L10N_STRING, IP N_("-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"), IP &StatusFormatDef, NULL,
     "printf-like format string for the index's status line"
   },
   { "status_on_top", DT_BOOL, false, 0, NULL,
@@ -827,10 +847,12 @@ static struct ConfigDef MainVars[] = {
   { "ts_enabled", DT_BOOL, false, 0, NULL,
     "Allow NeoMutt to set the terminal status line and icon"
   },
-  { "ts_icon_format", DT_EXPANDO, IP "M%<n?AIL&ail>", IP StatusFormatDefNoPadding, NULL,
+  // L10N: $ts_icon_format default format
+  { "ts_icon_format", DT_EXPANDO|D_L10N_STRING, IP N_("M%<n?AIL&ail>"), IP StatusFormatDefNoPadding, NULL,
     "printf-like format string for the terminal's icon title"
   },
-  { "ts_status_format", DT_EXPANDO, IP "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>", IP StatusFormatDefNoPadding, NULL,
+  // L10N: $ts_status_format default format
+  { "ts_status_format", DT_EXPANDO|D_L10N_STRING, IP N_("NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"), IP StatusFormatDefNoPadding, NULL,
     "printf-like format string for the terminal's status (window title)"
   },
   { "use_domain", DT_BOOL, true, 0, NULL,

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -729,7 +729,7 @@ static struct ConfigDef MainVars[] = {
   // - Please test the value you use inside Mutt.  A mistake here will break
   //   NeoMutt's threading behavior.  Note: the header cache can interfere with
   //   testing, so be sure to test with $header_cache unset.
-  { "reply_regex", DT_REGEX|D_L10N_STRING, IP N_("^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"), 0, NULL,
+  { "reply_regex", DT_REGEX|D_L10N_STRING, IP N_("^((re)(\\[[0-9]+\\])*:[ \t]*)*"), 0, NULL,
     "Regex to match message reply subjects like 're: '"
   },
   { "resolve", DT_BOOL, true, 0, NULL,

--- a/po/bg.po
+++ b/po/bg.po
@@ -8760,3 +8760,63 @@ msgstr "Опции при компилация:"
 #, fuzzy
 msgid "Devel options:"
 msgstr "Опции при компилация:"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -8911,3 +8911,63 @@ msgstr "Opcions de compilació:"
 #, fuzzy
 msgid "Devel options:"
 msgstr "Opcions de compilació:"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -8504,3 +8504,63 @@ msgstr "Volby pro vývoj:"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<řetěz nedefinován>"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/da.po
+++ b/po/da.po
@@ -8641,3 +8641,63 @@ msgstr "Tilvalg ved oversættelsen:"
 #, fuzzy
 msgid "Devel options:"
 msgstr "Tilvalg ved oversættelsen:"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -8469,3 +8469,63 @@ msgstr "Entwickleroptionen:"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<keine Kette definiert>"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -8710,3 +8710,63 @@ msgstr "Προκαθορισμένοι παράμετροι:"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<δεν έχει οριστεί αλυσίδα>"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1,9 +1,9 @@
 # English (British) messages for NeoMutt
 #
-# Copyright (c) 2016-2019 NeoMutt project.
+# Copyright (c) 2016-2024 NeoMutt project.
 # This file is distributed under the same license as the NeoMutt package.
 #
-# Richard Russon <rich@flatcap.org>, 2016-2021
+# Richard Russon <rich@flatcap.org>, 2016-2024
 #
 msgid ""
 msgstr ""
@@ -8452,3 +8452,63 @@ msgstr "Devel options:"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<no chain defined>"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr "M%<n?AIL&ail>"
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr "On %d, %n wrote:"
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr "----- Forwarded message from %f -----"
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr "----- End forwarded message -----"

--- a/po/eo.po
+++ b/po/eo.po
@@ -8596,3 +8596,63 @@ msgstr "Parametroj de la tradukaĵo:"
 #, fuzzy
 msgid "Devel options:"
 msgstr "Parametroj de la tradukaĵo:"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -8489,3 +8489,63 @@ msgstr "Opciones de Desarrollo:"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<ninguna cadena definida>"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/et.po
+++ b/po/et.po
@@ -8769,3 +8769,63 @@ msgstr "Kompileerimise võtmed:"
 #, fuzzy
 msgid "Devel options:"
 msgstr "Kompileerimise võtmed:"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/eu.po
+++ b/po/eu.po
@@ -8733,3 +8733,63 @@ msgstr "Konpilazio aukerak:"
 #, fuzzy
 msgid "Devel options:"
 msgstr "Konpilazio aukerak:"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -8509,3 +8509,63 @@ msgstr "Oletusasetukset:"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<ei ketjuja määritelty>"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -8783,3 +8783,63 @@ msgstr "Options par défaut :"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<aucune chaine définie"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/ga.po
+++ b/po/ga.po
@@ -8842,3 +8842,63 @@ msgstr "Roghanna tiomsaithe:"
 #, fuzzy
 msgid "Devel options:"
 msgstr "Roghanna tiomsaithe:"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -8832,3 +8832,63 @@ msgstr "Opcións de compilación:"
 #, fuzzy
 msgid "Devel options:"
 msgstr "Opcións de compilación:"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -8448,3 +8448,63 @@ msgstr "Fejlesztői opciók:"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<lánc nincs megadva>"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -8698,3 +8698,63 @@ msgstr "Opsi2 saat kompilasi:"
 #, fuzzy
 msgid "Devel options:"
 msgstr "Opsi2 saat kompilasi:"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -8726,3 +8726,63 @@ msgstr "Opzioni di compilazione:"
 #, fuzzy
 msgid "Devel options:"
 msgstr "Opzioni di compilazione:"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -8572,3 +8572,63 @@ msgstr "コンパイル時オプション:"
 #, fuzzy
 msgid "Devel options:"
 msgstr "コンパイル時オプション:"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -8735,3 +8735,63 @@ msgstr "컴파일 선택사항:"
 #, fuzzy
 msgid "Devel options:"
 msgstr "컴파일 선택사항:"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -8489,3 +8489,63 @@ msgstr "Derinimo parinktys:"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<nėra grandinės>"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -8452,3 +8452,63 @@ msgstr "Utviklervalg:"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<ingen kjede definert>"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -8693,3 +8693,63 @@ msgstr "Opties tijdens compileren:"
 #, fuzzy
 msgid "Devel options:"
 msgstr "Opties tijdens compileren:"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -8489,3 +8489,63 @@ msgstr "Opcje debugowania:"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<nie zdefiniowany łańcuch>"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8464,3 +8464,63 @@ msgstr "Opções de desenvolvimento:"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<cadeia indefinida>"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -8609,3 +8609,63 @@ msgstr "Параметры компиляции:"
 #, fuzzy
 msgid "Devel options:"
 msgstr "Параметры по умолчанию:"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/sk.po
+++ b/po/sk.po
@@ -8488,3 +8488,63 @@ msgstr "Vobľy pre vývoj:"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<nie je definovaný žiadny reťazec>"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -8495,3 +8495,63 @@ msgstr "Опције при изградњи:"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<ниједан ланац није задат>"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -8757,3 +8757,63 @@ msgstr "Kompileringsval:"
 #, fuzzy
 msgid "Devel options:"
 msgstr "Kompileringsval:"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -8468,3 +8468,63 @@ msgstr "Geliştirici seçenekleri:"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<tanımlı zincir yok>"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -8495,3 +8495,63 @@ msgstr "Параметри розробки:"
 
 #~ msgid "<no chain defined>"
 #~ msgstr "<не визначено ланки>"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8439,3 +8439,63 @@ msgstr "开发选项："
 
 #~ msgid "<no chain defined>"
 #~ msgstr "没有列表被定义"
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -8782,3 +8782,63 @@ msgstr "編譯選項："
 #, fuzzy
 msgid "Devel options:"
 msgstr "編譯選項："
+
+#. L10N: $compose_format default format
+#: compose/config.c:66
+msgid "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"
+msgstr ""
+
+#. L10N: $reply_regex default format
+#.
+#. This is a regular expression that matches reply subject lines.
+#. By default, it only matches an initial "Re: ", which is the
+#. standardized Latin prefix.
+#.
+#. However, many locales have other prefixes that are commonly used
+#. too, such as Aw in Germany.  To add other prefixes, modify the first
+#. parenthesized expression, such as:
+#. "^(re|aw)
+#. you can add multiple values, for example:
+#. "^(re|aw|sv)
+#.
+#. Important:
+#. - Use all lower case letters.
+#. - Don't remove the 're' prefix from the list of choices.
+#. - Please test the value you use inside Mutt.  A mistake here will break
+#. NeoMutt's threading behavior.  Note: the header cache can interfere with
+#. testing, so be sure to test with $header_cache unset.
+#: mutt_config.c:732
+msgid "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*"
+msgstr ""
+
+#. L10N: $status_format default format
+#: mutt_config.c:814
+msgid "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"
+msgstr ""
+
+#. L10N: $ts_icon_format default format
+#: mutt_config.c:851
+msgid "M%<n?AIL&ail>"
+msgstr ""
+
+#. L10N: $ts_status_format default format
+#: mutt_config.c:855
+msgid "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+msgstr ""
+
+#. L10N: $attribution_intro default format
+#: send/config.c:170
+#, c-format
+msgid "On %d, %n wrote:"
+msgstr ""
+
+#. L10N: $forward_attribution_intro default format
+#: send/config.c:237
+#, c-format
+msgid "----- Forwarded message from %f -----"
+msgstr ""
+
+#. L10N: $forward_attribution_trailer default format
+#: send/config.c:241
+msgid "----- End forwarded message -----"
+msgstr ""

--- a/send/config.c
+++ b/send/config.c
@@ -166,7 +166,8 @@ static struct ConfigDef SendVars[] = {
   { "attach_charset", DT_SLIST|D_SLIST_SEP_COLON|D_SLIST_ALLOW_EMPTY, 0, 0, charset_slist_validator,
     "When attaching files, use one of these character sets"
   },
-  { "attribution_intro", DT_EXPANDO, IP "On %d, %n wrote:", IP IndexFormatDefNoPadding, NULL,
+  // L10N: $attribution_intro default format
+  { "attribution_intro", DT_EXPANDO|D_L10N_STRING, IP N_("On %d, %n wrote:"), IP IndexFormatDefNoPadding, NULL,
     "Message to start a reply, 'On DATE, PERSON wrote:'"
   },
   { "attribution_locale", DT_STRING, 0, 0, NULL,
@@ -232,10 +233,12 @@ static struct ConfigDef SendVars[] = {
   { "forward_attachments", DT_QUAD, MUTT_ASKYES, 0, NULL,
     "Forward attachments when forwarding a message"
   },
-  { "forward_attribution_intro", DT_EXPANDO, IP "----- Forwarded message from %f -----", IP IndexFormatDefNoPadding, NULL,
+  // L10N: $forward_attribution_intro default format
+  { "forward_attribution_intro", DT_EXPANDO|D_L10N_STRING, IP N_("----- Forwarded message from %f -----"), IP IndexFormatDefNoPadding, NULL,
     "Prefix message for forwarded messages"
   },
-  { "forward_attribution_trailer", DT_EXPANDO, IP "----- End forwarded message -----", IP IndexFormatDefNoPadding, NULL,
+  // L10N: $forward_attribution_trailer default format
+  { "forward_attribution_trailer", DT_EXPANDO|D_L10N_STRING, IP N_("----- End forwarded message -----"), IP IndexFormatDefNoPadding, NULL,
     "Suffix message for forwarded messages"
   },
   { "forward_decrypt", DT_BOOL, true, 0, NULL,


### PR DESCRIPTION
## Overview

This PR introduces localisation to the config options (based on upstream feature).
It allows the translators to provide language specific defaults for the following config:

- `$attribution_intro`
- `$compose_format`
- `$forward_attribution_intro`
- `$forward_attribution_trailer`
- `$reply_regex`
- `$status_format`
- `$ts_icon_format`
- `$ts_status_format`

**Note**: In line with upstream Mutt, the default for `$reply_regex` has been changed to check for just `re:`

## Testing

- Update a translation, e.g. `po/pt_BR.po`
- Build NeoMutt
- Create a message dir, e.g. `mkdir -p pt_BR.UTF-8/LC_MESSAGES`
  The exact name may depend on your libc. It might be `.utf-8` in lower case.
  (`strace` may help)
- Set the text domain: `export TEXTDOMAINDIR="$(pwd)"`
- Run NeoMutt without config, `neomutt -n -F /dev/null`

/cc @neomutt/translators 