### PR TITLE
Protect more header fields

### DIFF
--- a/mutt/list.c
+++ b/mutt/list.c
@@ -265,3 +265,18 @@ size_t mutt_list_str_split(struct ListHead *head, const char *src, char sep)
 
   return count;
 }
+
+/**
+ * mutt_list_copy_tail - Copy a list into another list
+ * @param dst   Destination list
+ * @param src   Source list
+ */
+void mutt_list_copy_tail(struct ListHead *dst, const struct ListHead *src)
+{
+  const struct ListNode *np = NULL;
+
+  STAILQ_FOREACH(np, src, entries)
+  {
+    mutt_list_insert_tail(dst, mutt_str_dup(np->data));
+  }
+}

--- a/mutt/list.c
+++ b/mutt/list.c
@@ -30,6 +30,7 @@
 #include "config.h"
 #include <stdbool.h>
 #include "list.h"
+#include "buffer.h"
 #include "memory.h"
 #include "queue.h"
 #include "string2.h"
@@ -279,4 +280,28 @@ void mutt_list_copy_tail(struct ListHead *dst, const struct ListHead *src)
   {
     mutt_list_insert_tail(dst, mutt_str_dup(np->data));
   }
+}
+
+/**
+ * mutt_list_write - Write a list to a buffer
+ * @param h    List to write
+ * @param buf  Buffer for the list
+ *
+ * Elements separated by a space.  References, and In-Reply-To, use this
+ * format.
+ */
+size_t mutt_list_write(const struct ListHead *h, struct Buffer *buf)
+{
+  if (!buf || !h)
+    return 0;
+
+  struct ListNode *np = NULL;
+  STAILQ_FOREACH(np, h, entries)
+  {
+    buf_addstr(buf, np->data);
+    if (STAILQ_NEXT(np, entries))
+      buf_addstr(buf, " ");
+  }
+
+  return buf_len(buf);
 }

--- a/mutt/list.h
+++ b/mutt/list.h
@@ -26,6 +26,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include "buffer.h"
 #include "queue.h"
 
 /**
@@ -58,5 +59,6 @@ struct ListNode *mutt_list_insert_head (struct ListHead *h, char *s);
 struct ListNode *mutt_list_insert_tail (struct ListHead *h, char *s);
 bool             mutt_list_match       (const char *s, struct ListHead *h);
 size_t           mutt_list_str_split   (struct ListHead *head, const char *src, char sep);
+size_t           mutt_list_write       (const struct ListHead *h, struct Buffer *buf);
 
 #endif /* MUTT_MUTT_LIST_H */

--- a/mutt/list.h
+++ b/mutt/list.h
@@ -48,6 +48,7 @@ STAILQ_HEAD(ListHead, ListNode);
 typedef void (*list_free_t)(void **ptr);
 
 void             mutt_list_clear       (struct ListHead *h);
+void             mutt_list_copy_tail   (struct ListHead *dst, const struct ListHead *src);
 bool             mutt_list_equal       (const struct ListHead *ah, const struct ListHead *bh);
 struct ListNode *mutt_list_find        (const struct ListHead *h, const char *data);
 void             mutt_list_free        (struct ListHead *h);

--- a/mutt/slist.c
+++ b/mutt/slist.c
@@ -110,11 +110,7 @@ struct Slist *slist_dup(const struct Slist *list)
 
   struct Slist *list_new = slist_new(list->flags);
 
-  struct ListNode *np = NULL;
-  STAILQ_FOREACH(np, &list->head, entries)
-  {
-    mutt_list_insert_tail(&list_new->head, mutt_str_dup(np->data));
-  }
+  mutt_list_copy_tail(&list_new->head, &list->head);
   list_new->count = list->count;
   return list_new;
 }

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1124,6 +1124,63 @@ int mutt_protected_headers_handler(struct Body *b_email, struct State *state)
   const short c_wrap = cs_subset_number(NeoMutt->sub, "wrap");
   const int wraplen = display ? mutt_window_wrap_cols(state->wraplen, c_wrap) : 0;
   const CopyHeaderFlags chflags = display ? CH_DISPLAY : CH_NO_FLAGS;
+  struct Buffer *buf = buf_pool_get();
+
+  if (!display || !c_weed || !mutt_matches_ignore("return-path"))
+  {
+    mutt_addrlist_write(&b_email->mime_headers->return_path, buf, display);
+    mutt_write_one_header(state->fp_out, "Return-Path", buf_string(buf),
+                          state->prefix, wraplen, chflags, NeoMutt->sub);
+  }
+  if (!display || !c_weed || !mutt_matches_ignore("from"))
+  {
+    buf_reset(buf);
+    mutt_addrlist_write(&b_email->mime_headers->from, buf, display);
+    mutt_write_one_header(state->fp_out, "From", buf_string(buf), state->prefix,
+                          wraplen, chflags, NeoMutt->sub);
+  }
+  if (!display || !c_weed || !mutt_matches_ignore("to"))
+  {
+    buf_reset(buf);
+    mutt_addrlist_write(&b_email->mime_headers->to, buf, display);
+    mutt_write_one_header(state->fp_out, "To", buf_string(buf), state->prefix,
+                          wraplen, chflags, NeoMutt->sub);
+  }
+  if (!display || !c_weed || !mutt_matches_ignore("cc"))
+  {
+    buf_reset(buf);
+    mutt_addrlist_write(&b_email->mime_headers->cc, buf, display);
+    mutt_write_one_header(state->fp_out, "Cc", buf_string(buf), state->prefix,
+                          wraplen, chflags, NeoMutt->sub);
+  }
+  if (!display || !c_weed || !mutt_matches_ignore("sender"))
+  {
+    buf_reset(buf);
+    mutt_addrlist_write(&b_email->mime_headers->sender, buf, display);
+    mutt_write_one_header(state->fp_out, "Sender", buf_string(buf),
+                          state->prefix, wraplen, chflags, NeoMutt->sub);
+  }
+  if (!display || !c_weed || !mutt_matches_ignore("reply-to"))
+  {
+    buf_reset(buf);
+    mutt_addrlist_write(&b_email->mime_headers->reply_to, buf, display);
+    mutt_write_one_header(state->fp_out, "Reply-To", buf_string(buf),
+                          state->prefix, wraplen, chflags, NeoMutt->sub);
+  }
+  if (!display || !c_weed || !mutt_matches_ignore("mail-followup-to"))
+  {
+    buf_reset(buf);
+    mutt_addrlist_write(&b_email->mime_headers->mail_followup_to, buf, display);
+    mutt_write_one_header(state->fp_out, "Mail-Followup-To", buf_string(buf),
+                          state->prefix, wraplen, chflags, NeoMutt->sub);
+  }
+  if (!display || !c_weed || !mutt_matches_ignore("x-original-to"))
+  {
+    buf_reset(buf);
+    mutt_addrlist_write(&b_email->mime_headers->x_original_to, buf, display);
+    mutt_write_one_header(state->fp_out, "X-Original-To", buf_string(buf),
+                          state->prefix, wraplen, chflags, NeoMutt->sub);
+  }
 
   if (b_email->mime_headers->subject &&
       (!display || !c_weed || !mutt_matches_ignore("subject")))
@@ -1131,6 +1188,8 @@ int mutt_protected_headers_handler(struct Body *b_email, struct State *state)
     mutt_write_one_header(state->fp_out, "Subject", b_email->mime_headers->subject,
                           state->prefix, wraplen, chflags, NeoMutt->sub);
   }
+
+  buf_pool_release(&buf);
 
 blank:
   state_puts(state, "\n");

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -271,8 +271,15 @@ int mutt_protect(struct Email *e, char *keylist, bool postpone)
   {
     struct Envelope *protected_headers = mutt_env_new();
     mutt_env_set_subject(protected_headers, e->env->subject);
-    /* Note: if other headers get added, such as to, cc, then a call to
-     * mutt_env_to_intl() will need to be added here too. */
+    mutt_addrlist_copy(&protected_headers->return_path, &e->env->return_path, false);
+    mutt_addrlist_copy(&protected_headers->from, &e->env->from, false);
+    mutt_addrlist_copy(&protected_headers->to, &e->env->to, false);
+    mutt_addrlist_copy(&protected_headers->cc, &e->env->cc, false);
+    mutt_addrlist_copy(&protected_headers->sender, &e->env->sender, false);
+    mutt_addrlist_copy(&protected_headers->reply_to, &e->env->reply_to, false);
+    mutt_addrlist_copy(&protected_headers->mail_followup_to, &e->env->mail_followup_to, false);
+    mutt_addrlist_copy(&protected_headers->x_original_to, &e->env->x_original_to, false);
+    mutt_env_to_intl(protected_headers, NULL, NULL);
     mutt_prepare_envelope(protected_headers, 0, NeoMutt->sub);
 
     mutt_env_free(&e->body->mime_headers);

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -279,6 +279,8 @@ int mutt_protect(struct Email *e, char *keylist, bool postpone)
     mutt_addrlist_copy(&protected_headers->reply_to, &e->env->reply_to, false);
     mutt_addrlist_copy(&protected_headers->mail_followup_to, &e->env->mail_followup_to, false);
     mutt_addrlist_copy(&protected_headers->x_original_to, &e->env->x_original_to, false);
+    mutt_list_copy_tail(&protected_headers->references, &e->env->references);
+    mutt_list_copy_tail(&protected_headers->in_reply_to, &e->env->in_reply_to);
     mutt_env_to_intl(protected_headers, NULL, NULL);
     mutt_prepare_envelope(protected_headers, 0, NeoMutt->sub);
 

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1123,13 +1123,13 @@ int mutt_protected_headers_handler(struct Body *b_email, struct State *state)
   const bool c_weed = cs_subset_bool(NeoMutt->sub, "weed");
   const short c_wrap = cs_subset_number(NeoMutt->sub, "wrap");
   const int wraplen = display ? mutt_window_wrap_cols(state->wraplen, c_wrap) : 0;
+  const CopyHeaderFlags chflags = display ? CH_DISPLAY : CH_NO_FLAGS;
 
   if (b_email->mime_headers->subject &&
       (!display || !c_weed || !mutt_matches_ignore("subject")))
   {
-    mutt_write_one_header(state->fp_out, "Subject",
-                          b_email->mime_headers->subject, state->prefix, wraplen,
-                          display ? CH_DISPLAY : CH_NO_FLAGS, NeoMutt->sub);
+    mutt_write_one_header(state->fp_out, "Subject", b_email->mime_headers->subject,
+                          state->prefix, wraplen, chflags, NeoMutt->sub);
   }
 
 blank:

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1127,6 +1127,12 @@ int mutt_protected_headers_handler(struct Body *b_email, struct State *state)
   const CopyHeaderFlags chflags = display ? CH_DISPLAY : CH_NO_FLAGS;
   struct Buffer *buf = buf_pool_get();
 
+  if (b_email->mime_headers->date && (!display || !c_weed || !mutt_matches_ignore("date")))
+  {
+    mutt_write_one_header(state->fp_out, "Date", b_email->mime_headers->date,
+                          state->prefix, wraplen, chflags, NeoMutt->sub);
+  }
+
   if (!display || !c_weed || !mutt_matches_ignore("return-path"))
   {
     mutt_addrlist_write(&b_email->mime_headers->return_path, buf, display);

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -270,6 +270,7 @@ int mutt_protect(struct Email *e, char *keylist, bool postpone)
   if (c_crypt_protected_headers_write)
   {
     struct Envelope *protected_headers = mutt_env_new();
+    mutt_str_replace(&protected_headers->date, e->env->date);
     mutt_env_set_subject(protected_headers, e->env->subject);
     mutt_addrlist_copy(&protected_headers->return_path, &e->env->return_path, false);
     mutt_addrlist_copy(&protected_headers->from, &e->env->from, false);

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1189,6 +1189,21 @@ int mutt_protected_headers_handler(struct Body *b_email, struct State *state)
                           state->prefix, wraplen, chflags, NeoMutt->sub);
   }
 
+  if (!display || !c_weed || !mutt_matches_ignore("references"))
+  {
+    buf_reset(buf);
+    mutt_list_write(&b_email->mime_headers->references, buf);
+    mutt_write_one_header(state->fp_out, "References", buf_string(buf),
+                          state->prefix, wraplen, chflags, NeoMutt->sub);
+  }
+  if (!display || !c_weed || !mutt_matches_ignore("in-reply-to"))
+  {
+    buf_reset(buf);
+    mutt_list_write(&b_email->mime_headers->in_reply_to, buf);
+    mutt_write_one_header(state->fp_out, "In-Reply-To", buf_string(buf),
+                          state->prefix, wraplen, chflags, NeoMutt->sub);
+  }
+
   buf_pool_release(&buf);
 
 blank:

--- a/send/send.c
+++ b/send/send.c
@@ -997,13 +997,8 @@ int mutt_fetch_recips(struct Envelope *out, struct Envelope *in,
  */
 static void add_references(struct ListHead *head, struct Envelope *env)
 {
-  struct ListNode *np = NULL;
-
   struct ListHead *src = STAILQ_EMPTY(&env->references) ? &env->in_reply_to : &env->references;
-  STAILQ_FOREACH(np, src, entries)
-  {
-    mutt_list_insert_tail(head, mutt_str_dup(np->data));
-  }
+  mutt_list_copy_tail(head, src);
 }
 
 /**

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -391,7 +391,8 @@ LIST_OBJS	= test/list/common.o \
 		  test/list/mutt_list_insert_head.o \
 		  test/list/mutt_list_insert_tail.o \
 		  test/list/mutt_list_match.o \
-		  test/list/mutt_list_str_split.o
+		  test/list/mutt_list_str_split.o \
+		  test/list/mutt_list_write.o
 
 LOGGING_OBJS	= test/logging/log_disp_file.o \
 		  test/logging/log_disp_queue.o \

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -382,6 +382,7 @@ IMAP_OBJS	= test/imap/msg_set.o
 
 LIST_OBJS	= test/list/common.o \
 		  test/list/mutt_list_clear.o \
+		  test/list/mutt_list_copy_tail.o \
 		  test/list/mutt_list_equal.o \
 		  test/list/mutt_list_find.o \
 		  test/list/mutt_list_free.o \

--- a/test/list/mutt_list_copy_tail.c
+++ b/test/list/mutt_list_copy_tail.c
@@ -1,0 +1,64 @@
+/**
+ * @file
+ * Test code for mutt_list_copy_tail()
+ *
+ * @authors
+ * Copyright (C) 2019-2023, Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2024, Alejandro Colomar <alx@kernel.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include "mutt/lib.h"
+#include "common.h"
+
+void test_mutt_list_copy_tail(void)
+{
+  // void mutt_list_copy_tail(struct ListHead *dst, const struct ListHead *src);
+
+  {
+    static const char *expected_names[] = { "Zelda", "Mario", NULL };
+    static const char *copy_names[] = { "Zelda", "Mario", NULL };
+    struct ListHead start;
+    struct ListHead expected = test_list_create(expected_names, true);
+    struct ListHead copy = test_list_create(copy_names, true);
+    STAILQ_INIT(&start);
+    mutt_list_copy_tail(&start, &copy);
+    TEST_CHECK(mutt_list_equal(&start, &expected) == true);
+    mutt_list_free(&start);
+    mutt_list_free(&expected);
+    mutt_list_free(&copy);
+  }
+
+  {
+    static const char *start_names[] = { "Amy", "Beth", "Cathy", NULL };
+    static const char *expected_names[] = { "Amy",   "Beth",  "Cathy",
+                                            "Zelda", "Mario", NULL };
+    static const char *copy_names[] = { "Zelda", "Mario", NULL };
+    struct ListHead start = test_list_create(start_names, true);
+    struct ListHead expected = test_list_create(expected_names, true);
+    struct ListHead copy = test_list_create(copy_names, true);
+    mutt_list_copy_tail(&start, &copy);
+    TEST_CHECK(mutt_list_equal(&start, &expected) == true);
+    mutt_list_free(&start);
+    mutt_list_free(&expected);
+    mutt_list_free(&copy);
+  }
+}

--- a/test/list/mutt_list_write.c
+++ b/test/list/mutt_list_write.c
@@ -1,0 +1,66 @@
+/**
+ * @file
+ * Test code for mutt_list_write()
+ *
+ * @authors
+ * Copyright (C) 2019-2023, Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2024, Alejandro Colomar <alx@kernel.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include "mutt/lib.h"
+#include "common.h"
+#include "test_common.h"
+
+void test_mutt_list_write(void)
+{
+  // void mutt_list_write(const struct ListHead *h, struct Buffer *buf);
+
+  {
+    struct ListHead empty;
+    STAILQ_INIT(&empty);
+    struct Buffer *buf = buf_pool_get();
+    TEST_CHECK(mutt_list_write(NULL, buf) == 0);
+    TEST_CHECK(mutt_list_write(&empty, NULL) == 0);
+    buf_pool_release(&buf);
+  }
+
+  {
+    struct ListHead empty;
+    STAILQ_INIT(&empty);
+    struct Buffer *buf = buf_pool_get();
+    const char expected[] = "";
+    TEST_CHECK(mutt_list_write(&empty, buf) == strlen(expected));
+    TEST_CHECK_STR_EQ(buf_string(buf), expected);
+    buf_pool_release(&buf);
+  }
+
+  {
+    static const char *list_names[] = { "Amy", "Beth", "Cathy", NULL };
+    struct ListHead list = test_list_create(list_names, false);
+    struct Buffer *buf = buf_pool_get();
+    const char expected[] = "Amy Beth Cathy";
+    TEST_CHECK(mutt_list_write(&list, buf) == strlen(expected));
+    TEST_CHECK_STR_EQ(buf_string(buf), expected);
+    buf_pool_release(&buf);
+    mutt_list_clear(&list);
+  }
+}

--- a/test/main.c
+++ b/test/main.c
@@ -437,6 +437,7 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_mutt_list_insert_tail)                                \
   NEOMUTT_TEST_ITEM(test_mutt_list_match)                                      \
   NEOMUTT_TEST_ITEM(test_mutt_list_str_split)                                  \
+  NEOMUTT_TEST_ITEM(test_mutt_list_write)                                      \
                                                                                \
   /* logging */                                                                \
   NEOMUTT_TEST_ITEM(test_log_disp_file)                                        \

--- a/test/main.c
+++ b/test/main.c
@@ -427,6 +427,7 @@ void test_fini(void);
                                                                                \
   /* list */                                                                   \
   NEOMUTT_TEST_ITEM(test_mutt_list_clear)                                      \
+  NEOMUTT_TEST_ITEM(test_mutt_list_copy_tail)                                  \
   NEOMUTT_TEST_ITEM(test_mutt_list_equal)                                      \
   NEOMUTT_TEST_ITEM(test_mutt_list_find)                                       \
   NEOMUTT_TEST_ITEM(test_mutt_list_free)                                       \


### PR DESCRIPTION
* **What does this PR do?**

   Protect more header fields.

* **Screenshots (if relevant)**

```
--45wprh5a3u4z6yxp
Content-Type: text/plain; protected-headers=v1; charset=utf-8
Content-Disposition: inline
Content-Transfer-Encoding: quoted-printable
To: alx@kernel.es
Cc: foo@example.com
Subject: test protected to
MIME-Version: 1.0

asd

--=20
<https://www.alejandro-colomar.es/>

--45wprh5a3u4z6yxp
```

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

      Not yet.

   - All builds and tests are passing

      It works, partially.  It protects the headers when sending.  It doesn't read the protected headers in received mails, yet.

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

      N/A.  Maybe later I need to do something about it.

   - Code follows the [style guide](https://neomutt.org/dev/code)\
   
      I hope so.

* **What are the relevant issue numbers?**

   -  <https://github.com/neomutt/neomutt/issues/4223>
   -  <https://github.com/neomutt/neomutt/issues/4226>
