### PR TITLE
expando: fix attach search

### DIFF
--- a/expando/expando.c
+++ b/expando/expando.c
@@ -113,8 +113,9 @@ int expando_render(const struct Expando *exp, const struct ExpandoRenderData *rd
   if (!exp || !exp->tree || !rdata)
     return 0;
 
+  // Give enough space for a long command line
   if (max_cols == -1)
-    max_cols = INT_MAX;
+    max_cols = 8192;
 
   struct ExpandoNode *root = exp->tree;
   return node_tree_render(root, rdata, buf, max_cols, data, flags);

--- a/menu/menu.c
+++ b/menu/menu.c
@@ -58,7 +58,7 @@ static int generic_search(struct Menu *menu, regex_t *rx, int line)
 {
   struct Buffer *buf = buf_pool_get();
 
-  menu->make_entry(menu, line, INT_MAX, buf);
+  menu->make_entry(menu, line, -1, buf);
   int rc = regexec(rx, buf->data, 0, NULL, 0);
   buf_pool_release(&buf);
 


### PR DESCRIPTION
Searching Attachments falls back to the default Menu search.
Menu search runs `make_entry()` on each row, giving it plenty of space.

Unfortunately, INT_MAX amount of space combined with padding led to some enormous strings.

Limit the space to 8KiB.

Fixes: #4231