### PR TITLE
only wrap after first address in header lines (fixes #4206)

### DIFF
--- a/address/address.c
+++ b/address/address.c
@@ -1149,7 +1149,7 @@ static size_t addrlist_write(const struct AddressList *al, struct Buffer *buf,
     // wrap if needed
     const size_t cur_len = buf_len(buf);
     cur_col += mutt_addr_write(buf, a, display);
-    if (cur_col > cols)
+    if ((cols > 0) && (cur_col > cols) && (a != TAILQ_FIRST(al)))
     {
       buf_insert(buf, cur_len, "\n\t");
       cur_col = 8;

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -21,6 +21,7 @@ ADDRESS_OBJS	= test/address/config_type.o \
 		  test/address/mutt_addrlist_to_local.o \
 		  test/address/mutt_addrlist_write.o \
 		  test/address/mutt_addrlist_write_list.o \
+		  test/address/mutt_addrlist_write_wrap.o \
 		  test/address/mutt_addr_cat.o \
 		  test/address/mutt_addr_cmp.o \
 		  test/address/mutt_addr_copy.o \

--- a/test/address/mutt_addrlist_write_wrap.c
+++ b/test/address/mutt_addrlist_write_wrap.c
@@ -1,0 +1,90 @@
+/**
+ * @file
+ * Test code for mutt_addrlist_write_wrap()
+ *
+ * @authors
+ * Copyright (C) 2024 Dennis Schön <mail@dennis-schoen.de>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "address/lib.h"
+#include "test_common.h"
+
+static const char *test_name(const char *str)
+{
+  if (!str)
+    return "[NULL]";
+  if (!*str)
+    return "[empty]";
+  return str;
+}
+
+struct TestCase
+{
+  const char *address_list;
+  const char *header;
+  size_t ret_num;
+  const char *expected;
+};
+
+// size_t mutt_addrlist_write_wrap(const struct AddressList *al, struct Buffer *buf, const char *header)
+void test_mutt_addrlist_write_wrap(void)
+{
+  static const struct TestCase tests[] = {
+    { NULL, NULL, 0, "" },
+    { "", "", 0, "" },
+    {
+        "foo@bar.com, sooooooooooooooooooooooooomthing@looooooooooooooooooooooooong.com, foo@bar.com",
+        "To",
+        97,
+        "To: foo@bar.com, \n\tsooooooooooooooooooooooooomthing@looooooooooooooooooooooooong.com, foo@bar.com",
+    },
+    {
+        "foo@bar.com,foo@bar.com,foo@bar.com,foo@bar.com,foo@bar.com,foo@bar.com,foo@bar.com",
+        "To",
+        95,
+        "To: foo@bar.com, foo@bar.com, foo@bar.com, foo@bar.com, foo@bar.com, \n\tfoo@bar.com, foo@bar.com",
+    },
+  };
+
+  {
+    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    {
+      TEST_CASE(test_name(tests[i].address_list));
+
+      struct AddressList al = { 0 };
+      if (tests[i].address_list)
+      {
+        struct AddressList parsed = TAILQ_HEAD_INITIALIZER(parsed);
+        mutt_addrlist_parse(&parsed, tests[i].address_list);
+        al = parsed;
+      }
+
+      struct Buffer *buf = buf_pool_get();
+      int buf_len = mutt_addrlist_write_wrap(&al, buf, tests[i].header);
+      TEST_CHECK(buf_len == tests[i].ret_num);
+      TEST_CHECK_STR_EQ(buf_string(buf), tests[i].expected);
+      buf_pool_release(&buf);
+      mutt_addrlist_clear(&al);
+    }
+  }
+}

--- a/test/main.c
+++ b/test/main.c
@@ -76,6 +76,7 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_mutt_addrlist_to_local)                               \
   NEOMUTT_TEST_ITEM(test_mutt_addrlist_write)                                  \
   NEOMUTT_TEST_ITEM(test_mutt_addrlist_write_list)                             \
+  NEOMUTT_TEST_ITEM(test_mutt_addrlist_write_wrap)                             \
                                                                                \
   /* array */                                                                  \
   NEOMUTT_TEST_ITEM(test_mutt_array_api)                                       \


### PR DESCRIPTION
Simpler version of https://github.com/neomutt/neomutt/pull/4239 without the refactoring.