### PR TITLE
ncrypt/: Don't introduce spurious blank lines in protected blocks

### DIFF
--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1238,7 +1238,7 @@ int mutt_signed_handler(struct Body *b_email, struct State *state)
       top->badsig = !goodsig;
 
       /* Now display the signed body */
-      state_attach_puts(state, _("[-- The following data is signed --]\n\n"));
+      state_attach_puts(state, _("[-- The following data is signed --]\n"));
 
       mutt_protected_headers_handler(b_email, state);
 
@@ -1253,7 +1253,7 @@ int mutt_signed_handler(struct Body *b_email, struct State *state)
   rc = mutt_body_handler(b_email, state);
 
   if ((state->flags & STATE_DISPLAY) && (sigcnt != 0))
-    state_attach_puts(state, _("\n[-- End of signed data --]\n"));
+    state_attach_puts(state, _("[-- End of signed data --]\n"));
 
   return rc;
 }

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -2745,8 +2745,8 @@ int pgp_gpgme_encrypted_handler(struct Body *b, struct State *state)
     if (state->flags & STATE_DISPLAY)
     {
       state_attach_puts(state, is_signed ?
-                                   _("[-- The following data is PGP/MIME signed and encrypted --]\n\n") :
-                                   _("[-- The following data is PGP/MIME encrypted --]\n\n"));
+                                   _("[-- The following data is PGP/MIME signed and encrypted --]\n") :
+                                   _("[-- The following data is PGP/MIME encrypted --]\n"));
       mutt_protected_headers_handler(tattach, state);
     }
 
@@ -2781,7 +2781,6 @@ int pgp_gpgme_encrypted_handler(struct Body *b, struct State *state)
 
     if (state->flags & STATE_DISPLAY)
     {
-      state_puts(state, "\n");
       state_attach_puts(state, is_signed ?
                                    _("[-- End of PGP/MIME signed and encrypted data --]\n") :
                                    _("[-- End of PGP/MIME encrypted data --]\n"));
@@ -2839,8 +2838,8 @@ int smime_gpgme_application_handler(struct Body *b, struct State *state)
     if (state->flags & STATE_DISPLAY)
     {
       state_attach_puts(state, is_signed ?
-                                   _("[-- The following data is S/MIME signed --]\n\n") :
-                                   _("[-- The following data is S/MIME encrypted --]\n\n"));
+                                   _("[-- The following data is S/MIME signed --]\n") :
+                                   _("[-- The following data is S/MIME encrypted --]\n"));
       mutt_protected_headers_handler(tattach, state);
     }
 
@@ -2883,7 +2882,6 @@ int smime_gpgme_application_handler(struct Body *b, struct State *state)
 
     if (state->flags & STATE_DISPLAY)
     {
-      state_puts(state, "\n");
       state_attach_puts(state, is_signed ? _("[-- End of S/MIME signed data --]\n") :
                                            _("[-- End of S/MIME encrypted data --]\n"));
     }

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1269,7 +1269,7 @@ int pgp_class_encrypted_handler(struct Body *b, struct State *state)
   {
     if (state->flags & STATE_DISPLAY)
     {
-      state_attach_puts(state, _("[-- The following data is PGP/MIME encrypted --]\n\n"));
+      state_attach_puts(state, _("[-- The following data is PGP/MIME encrypted --]\n"));
       mutt_protected_headers_handler(tattach, state);
     }
 
@@ -1303,10 +1303,7 @@ int pgp_class_encrypted_handler(struct Body *b, struct State *state)
       b->goodsig |= tattach->goodsig;
 
     if (state->flags & STATE_DISPLAY)
-    {
-      state_puts(state, "\n");
       state_attach_puts(state, _("[-- End of PGP/MIME encrypted data --]\n"));
-    }
 
     mutt_body_free(&tattach);
     /* clear 'Invoking...' message, since there's no error */

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -2019,9 +2019,9 @@ static struct Body *smime_handle_entity(struct Body *b, struct State *state, FIL
   if (state->flags & STATE_DISPLAY)
   {
     if (type & SEC_ENCRYPT)
-      state_attach_puts(state, _("\n[-- End of S/MIME encrypted data. --]\n"));
+      state_attach_puts(state, _("[-- End of S/MIME encrypted data. --]\n"));
     else
-      state_attach_puts(state, _("\n[-- End of S/MIME signed data. --]\n"));
+      state_attach_puts(state, _("[-- End of S/MIME signed data. --]\n"));
   }
 
   if (type & SEC_SIGNOPAQUE)

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -2019,9 +2019,9 @@ static struct Body *smime_handle_entity(struct Body *b, struct State *state, FIL
   if (state->flags & STATE_DISPLAY)
   {
     if (type & SEC_ENCRYPT)
-      state_attach_puts(state, _("[-- End of S/MIME encrypted data. --]\n"));
+      state_attach_puts(state, _("[-- End of S/MIME encrypted data --]\n"));
     else
-      state_attach_puts(state, _("[-- End of S/MIME signed data. --]\n"));
+      state_attach_puts(state, _("[-- End of S/MIME signed data --]\n"));
   }
 
   if (type & SEC_SIGNOPAQUE)

--- a/po/bg.po
+++ b/po/bg.po
@@ -6364,10 +6364,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Следните данни са подписани --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6379,10 +6377,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Край на подписаните данни --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6659,18 +6655,14 @@ msgstr "[-- Грешка: не може да бъде създаден врем�
 #, fuzzy
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Следните данни са шифровани с PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Следните данни са шифровани с PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 #, fuzzy
@@ -6691,14 +6683,12 @@ msgstr "Писмото не може да бъде копирано."
 #, fuzzy
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr "[-- Следните данни са подписани със S/MIME --]\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 #, fuzzy
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr "[-- Следните данни са шифровани със S/MIME --]\n"
 
 #: ncrypt/crypt_gpgme.c:2883
@@ -7347,30 +7337,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Грешка: не може да бъде стартиран дъщерен OpenSSL процес --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Следните данни са шифровани със S/MIME --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Следните данни са подписани със S/MIME --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Край на шифрованите със S/MIME данни --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Край на подписаните със S/MIME данни --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/ca.po
+++ b/po/ca.po
@@ -6469,10 +6469,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Les dades següents es troben signades: --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6484,10 +6482,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Final de les dades signades. --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6769,18 +6765,14 @@ msgstr "[-- Error: No s’ha pogut crear un fitxer temporal. --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Les dades següents es troben signades i xifrades amb PGP/MIME: --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Les dades següents es troben xifrades amb PGP/MIME: --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6798,18 +6790,14 @@ msgstr "No s’ha pogut desxifrar el missatge PGP."
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Les dades següents es troben signades amb S/MIME: --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Les dades següents es troben xifrades amb S/MIME: --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7467,30 +7455,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Error: No s’ha pogut crear el subprocés OpenSSL. --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Les dades següents es troben xifrades amb S/MIME: --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Les dades següents es troben signades amb S/MIME: --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Final de les dades xifrades amb S/MIME. --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Final de les dades signades amb S/MIME. --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/cs.po
+++ b/po/cs.po
@@ -6201,10 +6201,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Následují podepsaná data --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6216,10 +6214,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Konec podepsaných dat --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6491,18 +6487,14 @@ msgstr "[-- Chyba: dočasný soubor nelze vytvořit --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Následující data jsou podepsána a zašifrována ve formátu PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Následující data jsou zašifrována ve formátu PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6520,18 +6512,14 @@ msgstr "PGP zprávu nelze dešifrovat"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Následující data jsou podepsaná pomocí S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Následující data jsou zašifrována pomocí S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7130,30 +7118,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Chyba: nelze spustit OpenSSL podproces --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Následující data jsou zašifrována pomocí S/MIME --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Následují data podepsaná pomocí S/MIME --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Konec dat zašifrovaných ve formátu S/MIME --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Konec dat podepsaných pomocí S/MIME --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/da.po
+++ b/po/da.po
@@ -6286,10 +6286,8 @@ msgstr "[-- Advarsel: %s/%s underskrifter kan ikke kontrolleres. --]\n"
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Følgende data er underskrevet --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6299,10 +6297,8 @@ msgstr "[-- Advarsel: Kan ikke finde nogen underskrifter. --]\n"
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Slut på underskrevne data --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6570,18 +6566,14 @@ msgstr "[-- Fejl: Kunne ikke oprette en midlertidig fil --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Følgende data er underskrevet og krypteret med PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Følgende data er PGP/MIME-krypteret --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6599,15 +6591,12 @@ msgstr "Kunne ikke dekryptere PGP-brev"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Følgende data er S/MIME-underskrevet --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr "[-- Følgende data er krypteret med S/MIME --]\n"
 
 #: ncrypt/crypt_gpgme.c:2883
@@ -7220,30 +7209,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Fejl: kan ikke skabe en OpenSSL-delproces --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Følgende data er S/MIME-krypteret --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Følgende data er S/MIME-underskrevet --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Slut på S/MIME-krypteret data --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Slut på S/MIME-underskrevne data --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/de.po
+++ b/po/de.po
@@ -6170,10 +6170,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Die folgenden Daten sind signiert --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6185,10 +6183,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Ende der signierten Daten --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6460,18 +6456,14 @@ msgstr "[-- Fehler: Konnte Temporärdatei nicht anlegen --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Die folgenden Daten sind PGP/MIME-signiert und -verschlüsselt --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Die folgenden Daten sind PGP/MIME-verschlüsselt --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6489,18 +6481,14 @@ msgstr "Konnte PGP-Nachricht nicht entschlüsseln"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Die folgenden Daten sind S/MIME signiert --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Die folgenden Daten sind S/MIME-verschlüsselt --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7098,30 +7086,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Fehler: Kann keinen OpenSSL-Unterprozess erzeugen --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Die folgenden Daten sind S/MIME-verschlüsselt --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Die folgenden Daten sind S/MIME-signiert --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Ende der S/MIME-verschlüsselten Daten --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Ende der S/MIME-signierten Daten --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/el.po
+++ b/po/el.po
@@ -6290,10 +6290,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Τα επόμενα δεδομένα είναι υπογεγραμμένα --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6305,10 +6303,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Τέλος υπογεγραμμένων δεδομένων --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6586,18 +6582,14 @@ msgstr "[-- Σφάλμα: αδυναμία δημιουργίας προσωρι
 #, fuzzy
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Τα επόμενα δεδομένα είναι κρυπτογραφημένα μέσω PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Τα επόμενα δεδομένα είναι κρυπτογραφημένα μέσω PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 #, fuzzy
@@ -6618,14 +6610,12 @@ msgstr "Αδυναμία αντιγραφής του μηνύματος."
 #, fuzzy
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr "[-- Τα επόμενα δεδομένα είναι υπογεγραμμένα με S/MIME --]\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 #, fuzzy
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr "[-- Τα επόμενα δεδομένα είναι κρυπτογραφημένα μέσω S/MIME --]\n"
 
 #: ncrypt/crypt_gpgme.c:2883
@@ -7276,30 +7266,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Σφάλμα: αδυναμία δημιουργίας υποδιεργασίας OpenSSL --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Τα επόμενα δεδομένα είναι κρυπτογραφημένα μέσω S/MIME --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Τα επόμενα δεδομένα είναι υπογεγραμμένα με S/MIME --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Τέλος δεδομένων κρυπτογραφημένων μέσω S/MIME --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Τέλος δεδομένων υπογεγραμμένων με S/MIME --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -6159,10 +6159,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- The following data is signed --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6174,10 +6172,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- End of signed data --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6449,18 +6445,14 @@ msgstr "[-- Error: could not create temporary file --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6478,18 +6470,14 @@ msgstr "Could not decrypt PGP message"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7087,30 +7075,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Error: unable to create OpenSSL subprocess --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- The following data is S/MIME encrypted --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- The following data is S/MIME signed --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/eo.po
+++ b/po/eo.po
@@ -6267,10 +6267,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- La sekvaj datenoj estas subskribitaj --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6282,10 +6280,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Fino de subskribitaj datenoj --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6553,18 +6549,14 @@ msgstr "[-- Eraro: ne eblas krei dumtempan dosieron --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- La sekvaj datenoj estas PGP/MIME-subskribitaj kaj -ĉifritaj --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- La sekvaj datenoj estas PGP/MIME-ĉifritaj --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6582,18 +6574,14 @@ msgstr "Ne eblis malĉifri PGP-mesaĝon"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- La sekvaj datenoj estas S/MIME-subskribitaj --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- La sekvaj datenoj estas S/MIME-ĉifritaj --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7204,30 +7192,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Eraro: ne eblas krei OpenSSL-subprocezon --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- La sekvaj datenoj estas S/MIME-ĉifritaj --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- La sekvaj datenoj estas S/MIME-subskribitaj --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Fino de S/MIME-ĉifritaj datenoj. --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Fino de S/MIME-subskribitaj datenoj. --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/es.po
+++ b/po/es.po
@@ -6193,10 +6193,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Los siguientes datos están firmados --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6208,10 +6206,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Fin de los datos firmados --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6479,18 +6475,14 @@ msgstr "[-- Error: no pudo crearse archivo temporal --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Los datos siguientes están cifrados y firmados con PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Los datos siguientes están cifrados y firmados con PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6508,18 +6500,14 @@ msgstr "No se pudo descifrar el mensaje PGP"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Los siguientes datos están firmados con S/MIME--]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Los datos siguientes están cifrados con S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7118,34 +7106,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Error: imposible crear subproceso OpenSSL --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr ""
-"[-- Los datos siguientes están cifrados con S/MIME --]\n"
-"\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr ""
-"[-- Los siguientes datos están firmados con S/MIME --]\n"
-"\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Fin de datos cifrados con S/MIME --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Fin de datos firmados con S/MIME. --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/et.po
+++ b/po/et.po
@@ -6370,10 +6370,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Järgnev info on allkirjastatud --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6385,10 +6383,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Allkirjastatud info lõpp --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6665,18 +6661,14 @@ msgstr "[-- Viga: ajutise faili loomine ebaõnnestus --]\n"
 #, fuzzy
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Järgneb PGP/MIME krüptitud info --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Järgneb PGP/MIME krüptitud info --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 #, fuzzy
@@ -6697,14 +6689,12 @@ msgstr "Teadet ei õnnestu kopeerida."
 #, fuzzy
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr "[-- Järgneb S/MIME allkirjastatud info --]\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 #, fuzzy
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr "[-- Järgneb S/MIME krüptitud info --]\n"
 
 #: ncrypt/crypt_gpgme.c:2883
@@ -7356,30 +7346,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Viga: ei õnnestu luua OpenSSL alamprotsessi --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Järgneb S/MIME krüptitud info --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Järgneb S/MIME allkirjastatud info --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME krüptitud info lõpp --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME Allkirjastatud info lõpp --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/eu.po
+++ b/po/eu.po
@@ -6353,10 +6353,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Hurrengo datuak sinaturik daude --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6368,10 +6366,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Sinatutako datuen amaiera --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6648,18 +6644,14 @@ msgstr "[-- Errorea: ezin da behin-behineko fitxategi sortu --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Hurrengo datuak PGP/MIME bidez sinatu eta enkriptaturik daude --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Hurrengo datuak PGP/MIME bidez enkriptaturik daude --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6677,18 +6669,14 @@ msgstr "Ezin da PGP mezua desenkriptatu"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- hurrengo datuak S/MIME bidez sinaturik daude --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- hurrengo datuak S/MIME bidez enkriptaturik daude --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7326,30 +7314,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Errorea: Ezin da OpenSSL azpiprozesua sortu--]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Honako datu hauek S/MIME enkriptatutik daude --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Hurrengo datu hauek S/MIME sinaturik daude --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME enkriptaturiko duen amaiera --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME sinatutako datuen amaiera. --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/fi.po
+++ b/po/fi.po
@@ -6207,10 +6207,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Seuraava data on allekirjoitettu --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6222,10 +6220,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Allekirjoitetun datan loppu --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6497,18 +6493,14 @@ msgstr "[-- Virhe: ei voitu luoda väliaikaistiedostoa --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Seuraava data on PGP/MIME-allekirjoitettu ja salattu --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Seuraava data on PGP/MIME-salattu --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6526,18 +6518,14 @@ msgstr "Ei voitu purkaa PGP-viestiä"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Seuraava data on S/MIME-allekirjoitettu --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Seuraava data on S/MIME-salattu --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7136,30 +7124,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Virhe: ei voitu luoda OpenSSL-prosessia --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Seuraava data on S/MIME-salattu --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Seuraava data on S/MIME-allekirjoitettu --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME-salatun datan loppu. --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME-allekirjoitetun datan loppu. --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/fr.po
+++ b/po/fr.po
@@ -6406,10 +6406,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Les données suivantes sont signées --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6421,10 +6419,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Fin des données signées --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6704,18 +6700,14 @@ msgstr "[-- Erreur : impossible de créer le fichier temporaire  --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Les données suivantes sont signées et chiffrées avec PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Les données suivantes sont chiffrées avec PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6733,18 +6725,14 @@ msgstr "Impossible de déchiffrer le message PGP"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Les données suivantes sont signées avec S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Les données suivantes sont chiffrées avec S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7364,30 +7352,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Erreur : impossible de créer le sous-processus OpenSSL  --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Les données suivantes sont chiffrées avec S/MIME --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Les données suivantes sont signées avec S/MIME --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Fin des données chiffrées avec S/MIME. --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Fin des données signées avec S/MIME. --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/ga.po
+++ b/po/ga.po
@@ -6423,10 +6423,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Is sínithe iad na sonraí seo a leanas --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6438,10 +6436,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Deireadh na sonraí sínithe --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6719,18 +6715,14 @@ msgstr "[-- Earráid: ní féidir comhad sealadach a chruthú --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Is sínithe agus criptithe le PGP/MIME iad na sonraí seo a leanas --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Is criptithe le PGP/MIME iad na sonraí seo a leanas --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6748,18 +6740,14 @@ msgstr "Níorbh fhéidir an teachtaireacht PGP a dhíchriptiú"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Is sínithe le S/MIME iad na sonraí seo a leanas --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Is criptithe le S/MIME iad na sonraí seo a leanas --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7400,30 +7388,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Earráid: ní féidir fo-phróiseas OpenSSL a chruthú --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Is criptithe mar S/MIME iad na sonraí seo a leanas --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Is sínithe mar S/MIME iad na sonraí seo a leanas --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Deireadh na sonraí criptithe mar S/MIME. --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Deireadh na sonraí sínithe mar S/MIME. --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/gl.po
+++ b/po/gl.po
@@ -6393,10 +6393,8 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Os datos a continuación están asinados --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6409,10 +6407,8 @@ msgstr ""
 #: ncrypt/crypt.c:1256
 #, fuzzy
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Fin dos datos asinados --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6695,18 +6691,14 @@ msgstr "[-- Erro: ¡non foi posible crea-lo ficheiro temporal --]\n"
 #, fuzzy
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Os datos a continuación están encriptados con PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Os datos a continuación están encriptados con PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 #, fuzzy
@@ -6732,19 +6724,15 @@ msgstr "Non foi posible copia-la mensaxe."
 #, fuzzy
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Os datos a continuación están asinados --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 #, fuzzy
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Os datos a continuación están encriptados con S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 #, fuzzy
@@ -7401,38 +7389,6 @@ msgstr "[-- Fin da saída OpenSSL --]\n"
 #, fuzzy
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Erro: ¡non foi posible crear subproceso OpenSSL --]\n"
-
-#: ncrypt/smime.c:1917
-#, fuzzy
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr ""
-"[-- Os datos a continuación están encriptados con S/MIME --]\n"
-"\n"
-
-#: ncrypt/smime.c:1921
-#, fuzzy
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr ""
-"[-- Os datos a continuación están asinados --]\n"
-"\n"
-
-#: ncrypt/smime.c:2021
-#, fuzzy
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Fin dos datos con encriptación S/MIME --]\n"
-
-#: ncrypt/smime.c:2023
-#, fuzzy
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Fin dos datos asinados --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/hu.po
+++ b/po/hu.po
@@ -6165,10 +6165,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- A következő adatok alá vannak írva --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6180,10 +6178,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Aláírt adat vége --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6455,18 +6451,14 @@ msgstr "[-- Hiba: nem lehet létrehozni az ideiglenes fájlt --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- A következő adat PGP/MIME-vel aláírt és titkosított --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- A következő adat PGP/MIME-vel titkosított --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6484,15 +6476,12 @@ msgstr "A PGP üzenetet nem tudtam dekódolni"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- A következő adat S/MIME-mal aláírva --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr "[-- A következő adat S/MIME-el titkosítva --]\n"
 
 #: ncrypt/crypt_gpgme.c:2883
@@ -7092,30 +7081,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Hiba: nem lehet létrehozni az OpenSSL alfolyamatot --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- A következő adat S/MIME-vel titkosított --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- A következő adatok S/MIME-vel alá vannak írva --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME titkosított adat vége. --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME aláírt adat vége --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/id.po
+++ b/po/id.po
@@ -6321,10 +6321,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Data berikut ini ditandatangani --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6336,10 +6334,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Akhir data yang ditandatangani --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6616,18 +6612,14 @@ msgstr "[-- Error: tidak bisa membuat file sementara --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Data berikut ditandatangani dan dienkripsi dg PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Data berikut dienkripsi dg PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6645,18 +6637,14 @@ msgstr "Tidak bisa mendekripsi surat PGP"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Data berikut ditandatangani dg S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Data berikut dienkripsi dg S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7291,30 +7279,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Error: tidak bisa membuat subproses utk OpenSSL --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Data berikut dienkripsi dg S/MIME --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Data berikut ditandatangani dg S/MIME --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Akhir data yang dienkripsi dg S/MIME. --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Akhir data yg ditandatangani dg S/MIME. --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/it.po
+++ b/po/it.po
@@ -6349,10 +6349,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- I seguenti dati sono firmati --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6364,10 +6362,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Fine dei dati firmati --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6639,18 +6635,14 @@ msgstr "[-- Errore: impossibile creare il file temporaneo --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- I seguenti dati sono firmati e cifrati con PGP/MIME  --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- I seguenti dati sono cifrati con PGP/MIME  --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6668,18 +6660,14 @@ msgstr "Impossibile decifrare il messaggio PGP"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- I seguenti dati sono firmati con S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- I seguenti dati sono cifrati con S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7316,30 +7304,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Errore: impossibile creare il sottoprocesso di OpenSSL --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- I seguenti dati sono cifrati con S/MIME --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- I seguenti dati sono firmati con S/MIME --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Fine dei dati cifrati con S/MIME --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Fine dei dati firmati com S/MIME. --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/ja.po
+++ b/po/ja.po
@@ -6255,10 +6255,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- 以下のデータは署名されている --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6270,10 +6268,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- 署名データ終了 --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6545,18 +6541,14 @@ msgstr "[-- エラー: 一時ファイルを作成できなかった --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- 以下のデータは PGP/MIME で署名および暗号化されている --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- 以下のデータは PGP/MIME で暗号化されている --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6574,18 +6566,14 @@ msgstr "PGP メッセージを復号化できなかった"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- 以下のデータは S/MIME で署名されている --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- 以下のデータは S/MIME で暗号化されている --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7190,30 +7178,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- エラー: OpenSSL 子プロセスを作成できなかった --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- 以下のデータは S/MIME で暗号化されている --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- 以下のデータは S/MIME で署名されている --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME 暗号化データ終了 --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME 署名データ終了 --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/ko.po
+++ b/po/ko.po
@@ -6335,10 +6335,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- 아래의 자료는 서명 되었음 --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6350,10 +6348,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- 서명 자료의 끝 --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6630,18 +6626,14 @@ msgstr "[-- 오류: 임시 파일을 만들 수가 없음 --]\n"
 #, fuzzy
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- 아래의 자료는 PGP/MIME 암호화 되었음 --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- 아래의 자료는 PGP/MIME 암호화 되었음 --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 #, fuzzy
@@ -6662,19 +6654,15 @@ msgstr "메일을 복사할 수 없음"
 #, fuzzy
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- 아래의 자료는 S/MIME 서명 되었음 --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 #, fuzzy
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- 아래의 자료는 S/MIME 암호화 되었음 --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 #, fuzzy
@@ -7323,34 +7311,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- 오류: OpenSSL 하부 프로세스를 생성할 수 없음 --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr ""
-"[-- 아래의 자료는 S/MIME 암호화 되었음 --]\n"
-"\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr ""
-"[-- 아래의 자료는 S/MIME 서명 되었음 --]\n"
-"\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME 암호화 자료 끝 --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME 서명 자료 끝 --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/lt.po
+++ b/po/lt.po
@@ -6186,10 +6186,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Toliau einantys duomenys yra pasirašyti --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6201,10 +6199,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Pasirašytų duomenų pabaiga --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6476,18 +6472,14 @@ msgstr "[-- Klaida: negalėjau sukurti laikinos bylos --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Toliau einantys duomenys yra užšifruoti ir pasirašyti su PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Toliau einantys duomenys yra užšifruoti su PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6505,18 +6497,14 @@ msgstr "Negalėjau iššifruoti PGP laiško"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Toliau einantys duomenys yra pasirašyti su S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Toliau einantys duomenys yra užšifruoti su S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7115,30 +7103,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Klaida: negaliu sukurti OpenSSL subproceso --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Toliau einantys duomenys yra užšifruoti su S/MIME --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Toliau einantys duomenys yra pasirašyti su S/MIME --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME užšifruotų duomenų pabaiga. --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME pasirašytų duomenų pabaiga. --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -6164,10 +6164,8 @@ msgstr "[-- Advarsel: %s/%s-signaturer kan ikke kontrolleres. --]\n"
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Følgende data er signert --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6177,10 +6175,8 @@ msgstr "[-- Advarsel: Finner ingen signaturer. --]\n"
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Slutt på signerte data --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6448,18 +6444,14 @@ msgstr "[-- Feil: kunne ikke opprette en midlertidig fil --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Følgende data er signert og kryptert med PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Følgende data er PGP/MIME-kryptert --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6477,15 +6469,12 @@ msgstr "Kunne ikke dekryptere PGP-melding"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Følgende data er S/MIME-signert --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr "[-- Følgende data er kryptert med S/MIME --]\n"
 
 #: ncrypt/crypt_gpgme.c:2883
@@ -7085,30 +7074,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Feil: kan ikke opprette en OpenSSL-underprosess --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Følgende data er S/MIME-kryptert --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Følgende data er S/MIME-signert --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Slutt på S/MIME-kryptert data --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Slutt på S/MIME-signert data --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/nl.po
+++ b/po/nl.po
@@ -6307,10 +6307,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- De volgende gegevens zijn ondertekend --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6322,10 +6320,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Einde van ondertekende gegevens --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6595,18 +6591,14 @@ msgstr "[-- Fout: Kon geen tijdelijk bestand aanmaken --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- De volgende gegevens zijn PGP/MIME-ondertekend en -versleuteld --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- De volgende gegevens zijn PGP/MIME-versleuteld --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6624,18 +6616,14 @@ msgstr "Kon PGP-gericht niet ontsleutelen"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- De volgende gegevens zijn S/MIME-ondertekend --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- De volgende gegevens zijn S/MIME-versleuteld --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7265,34 +7253,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Fout: Kan geen OpenSSL-subproces starten --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr ""
-"[-- De volgende gegevens zijn S/MIME versleuteld --]\n"
-"\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr ""
-"[-- De volgende gegevens zijn S/MIME ondertekend --]\n"
-"\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Einde van S/MIME versleutelde data --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Einde van S/MIME ondertekende gegevens --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/pl.po
+++ b/po/pl.po
@@ -6191,10 +6191,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Poniższe dane są podpisane --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6206,10 +6204,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Koniec podpisanych danych --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6481,18 +6477,14 @@ msgstr "[-- Błąd: nie można utworzyć pliku tymczasowego --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Następujące dane są podpisane i zaszyfrowane PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Następujące dane są zaszyfrowane PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6510,18 +6502,14 @@ msgstr "Odszyfrowanie listu PGP nie powiodło się"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Poniższe dane są podpisane S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Następujące dane są zaszyfrowane S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7121,30 +7109,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Błąd: nie można utworzyć podprocesu OpenSSL --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Następujące dane są zaszyfrowane S/MIME --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Poniższe dane są podpisane S/MIME --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Koniec danych zaszyfrowanych S/MIME. --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Koniec danych podpisanych S/MIME. --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -6166,10 +6166,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Os dados a seguir estão assinados --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6181,10 +6179,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Fim dos dados assinados --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6454,18 +6450,14 @@ msgstr "[-- Erro: não foi possível criar um arquivo temporário --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Os dados a seguir estão assinados e encriptados com PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Os dados a seguir estão encriptados com PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6483,18 +6475,14 @@ msgstr "Incapaz de desencriptar mensagem PGP"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Os dados a seguir estão assinados com S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Os dados a seguir estão encriptados com S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7093,30 +7081,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Erro: incapaz de criar subprocesso OpenSSL --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Os dados a seguir estão encriptados com S/MIME --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Os dados a seguir estão assinados com S/MIME --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Fim dos dados encriptados com S/MIME --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Fim dos dados assinados com S/MIME --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/ru.po
+++ b/po/ru.po
@@ -6262,10 +6262,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Начало подписанных данных --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6277,10 +6275,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Конец подписанных данных --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6552,18 +6548,14 @@ msgstr "[-- Ошибка: не удалось создать временный 
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Начало данных, подписанных и зашифрованных в формате PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Начало данных, зашифрованных в формате PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6581,18 +6573,14 @@ msgstr "Не удалось расшифровать PGP-сообщение"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Начало данных, подписанных в формате S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Начало данных, зашифрованных в формате S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7213,30 +7201,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Ошибка: не удалось создать OpenSSL-подпроцесс --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Начало данных, зашифрованных в формате S/MIME --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Начало данных, подписанных в формате S/MIME --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Конец данных, зашифрованных в формате S/MIME --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Конец данных, подписанных в формате S/MIME --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/sk.po
+++ b/po/sk.po
@@ -6187,10 +6187,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Nasledujúce dáta sú podpísané --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6202,10 +6200,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Koniec podpísaných dát --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6477,18 +6473,14 @@ msgstr "[-- Chyba: nemožno vytvoriť dočasný súbor --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Nasledujúce dáta sú šifrované a podpísané pomocou PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Nasledujúce dáta sú šifrované pomocou PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6506,18 +6498,14 @@ msgstr "Nemožno dešifrovať PGP správu"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Nasledujúce dáta sú podpísané pomocou S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Nasledujúce dáta sú šifrované pomocou S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7116,30 +7104,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Chyba: nemožno vytvoriť podproces OpenSSL --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Nasledujúce dáta sú šifrované pomocou S/MIME --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Nasledujúce dáta sú podpísané pomocou S/MIME --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Koniec dát šifrovaných pomocou S/MIME --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Koniec dát s podpísaných pomocou S/MIME --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/sr.po
+++ b/po/sr.po
@@ -6191,10 +6191,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Следећи подаци су потписани --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6206,10 +6204,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Крај потписаних података --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6481,18 +6477,14 @@ msgstr "[-- Грешка: не може се креирати привремен
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Следећи подаци су потписани и шифровани преко PGP/MIME-а --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Следећи подаци су шифровани преко PGP/MIME-а --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6510,18 +6502,14 @@ msgstr "Дешифровање PGP поруке није могуће"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Следећи подаци су потписани преко S/MIME-а--]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Следећи подаци су шифровани преко S/MIME-а --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7120,30 +7108,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Грешка: не може се креирати OpenSSL потпроцес --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Следећи подаци су шифровани преко S/MIME-а --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Следећи подаци су потписани преко S/MIME-а --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Крај података шифрованих преко S/MIME-а. --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Крај података потписаних преко S/MIME-а. --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/sv.po
+++ b/po/sv.po
@@ -6352,10 +6352,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Följande data är signerat --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6367,10 +6365,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Slut på signerat data --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6647,18 +6643,14 @@ msgstr "[-- Fel: kunde inte skapa tillfällig fil --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Följande data är PGP/MIME-signerad och krypterad --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Följande data är PGP/MIME-krypterad --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6676,18 +6668,14 @@ msgstr "Kunde inte avkryptera PGP-meddelande"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Följande data är S/MIME-signerad --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Följande data är S/MIME-krypterad --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7325,34 +7313,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Fel: kunde inte skapa OpenSSL-underprocess --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr ""
-"[-- Följande data är S/MIME-krypterad --]\n"
-"\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr ""
-"[-- Följande data är S/MIME-signerad --]\n"
-"\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Slut på S/MIME-krypterad data. --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Slut på S/MIME-signerad data. --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/tr.po
+++ b/po/tr.po
@@ -6170,10 +6170,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Aşağıdaki bilgi imzalıdır --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6185,10 +6183,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- İmzalı bilginin sonu --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6460,18 +6456,14 @@ msgstr "[-- Hata: Geçici dosya yaratılamadı --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Aşağıdaki bilgi PGP/MIME ile imzalanmış ve şifrelenmiştir --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Aşağıdaki bilgi PGP/MIME ile şifrelenmiştir --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6489,18 +6481,14 @@ msgstr "Şifrelenmiş PGP iletisi çözülemedi"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Aşağıdaki bilgi S/MIME ile imzalanmıştır --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Aşağıdaki bilgi S/MIME ile şifrelenmiştir --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7098,30 +7086,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Hata: OpenSSL alt süreci oluşturulamadı --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Aşağıdaki bilgi S/MIME ile şifrelenmiştir --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Aşağıdaki bilgi S/MIME ile imzalanmıştır --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME ile şifrelenmiş bilginin sonu --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME ile imzalanmış bilginin sonu --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/uk.po
+++ b/po/uk.po
@@ -6196,10 +6196,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- Наступні дані підписано --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6211,10 +6209,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- Кінець підписаних даних --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6484,18 +6480,14 @@ msgstr "[-- Помилка: не вийшло створити тимчасов�
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Наступні дані зашифровано і підписано PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Наступні дані зашифровано PGP/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6513,18 +6505,14 @@ msgstr "Не вийшло розшифрувати повідомлення PGP"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- Наступні дані підписано S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- Наступні дані зашифровано S/MIME --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7124,30 +7112,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- Помилка: неможливо створити підпроцес OpenSSL --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- Наступні дані зашифровано S/MIME --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- Наступні дані підписано S/MIME --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- Кінець даних, зашифрованих S/MIME --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- Кінець підписаних S/MIME даних --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -6152,10 +6152,8 @@ msgstr ""
 #: ncrypt/crypt.c:1241
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- 以下数据已签署 --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6167,10 +6165,8 @@ msgstr ""
 
 #: ncrypt/crypt.c:1256
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- 签署的数据结束 --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6442,18 +6438,14 @@ msgstr "[-- 错误：无法创建临时文件！ --]\n"
 #: ncrypt/crypt_gpgme.c:2744
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- 以下数据已由 PGP/MIME 签署并加密 --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- 以下数据已由 PGP/MIME 加密 --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 msgid "[-- End of PGP/MIME signed and encrypted data --]\n"
@@ -6471,18 +6463,14 @@ msgstr "无法解密 PGP 信件"
 #: ncrypt/crypt_gpgme.c:2838
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- 以下数据已由 S/MIME 签署 --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- 以下数据已由 S/MIME 加密 --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 msgid "[-- End of S/MIME signed data --]\n"
@@ -7080,30 +7068,6 @@ msgstr ""
 #: ncrypt/smime.c:1870 ncrypt/smime.c:1882
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- 错误：无法创建 OpenSSL 子进程！ --]\n"
-
-#: ncrypt/smime.c:1917
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr "[-- 以下数据已由 S/MIME 加密 --]\n"
-
-#: ncrypt/smime.c:1921
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr "[-- 以下数据已由 S/MIME 签署 --]\n"
-
-#: ncrypt/smime.c:2021
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME 加密数据结束 --]\n"
-
-#: ncrypt/smime.c:2023
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME 签署的数据结束 --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -6350,10 +6350,8 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[-- The following data is signed --]\n"
-"\n"
 msgstr ""
 "[-- 以下的資料已被簽署 --]\n"
-"\n"
 
 #: ncrypt/crypt.c:1249
 msgid ""
@@ -6366,10 +6364,8 @@ msgstr ""
 #: ncrypt/crypt.c:1256
 #, fuzzy
 msgid ""
-"\n"
 "[-- End of signed data --]\n"
 msgstr ""
-"\n"
 "[-- 簽署的資料結束 --]\n"
 
 #: ncrypt/crypt_gpgme.c:384
@@ -6652,18 +6648,14 @@ msgstr "[-- 錯誤：無法建立暫存檔！ --]\n"
 #, fuzzy
 msgid ""
 "[-- The following data is PGP/MIME signed and encrypted --]\n"
-"\n"
 msgstr ""
 "[-- 下面是 PGP/MIME 加密資料 --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2745 ncrypt/pgp.c:1272
 msgid ""
 "[-- The following data is PGP/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- 下面是 PGP/MIME 加密資料 --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2782
 #, fuzzy
@@ -6689,19 +6681,15 @@ msgstr "無法複制信件"
 #, fuzzy
 msgid ""
 "[-- The following data is S/MIME signed --]\n"
-"\n"
 msgstr ""
 "[-- 以下的資料已被簽署 --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2839
 #, fuzzy
 msgid ""
 "[-- The following data is S/MIME encrypted --]\n"
-"\n"
 msgstr ""
 "[-- 下面是 S/MIME 加密資料 --]\n"
-"\n"
 
 #: ncrypt/crypt_gpgme.c:2883
 #, fuzzy
@@ -7361,38 +7349,6 @@ msgstr ""
 #, fuzzy
 msgid "[-- Error: unable to create OpenSSL subprocess --]\n"
 msgstr "[-- 錯誤：無法建立 OpenSSL 子程序！ --]\n"
-
-#: ncrypt/smime.c:1917
-#, fuzzy
-msgid "[-- The following data is S/MIME encrypted --]\n"
-msgstr ""
-"[-- 下面是 S/MIME 加密資料 --]\n"
-"\n"
-
-#: ncrypt/smime.c:1921
-#, fuzzy
-msgid "[-- The following data is S/MIME signed --]\n"
-msgstr ""
-"[-- 以下的資料已被簽署 --]\n"
-"\n"
-
-#: ncrypt/smime.c:2021
-#, fuzzy
-msgid ""
-"\n"
-"[-- End of S/MIME encrypted data. --]\n"
-msgstr ""
-"\n"
-"[-- S/MIME 加密資料結束 --]\n"
-
-#: ncrypt/smime.c:2023
-#, fuzzy
-msgid ""
-"\n"
-"[-- End of S/MIME signed data. --]\n"
-msgstr ""
-"\n"
-"[-- 簽署的資料結束 --]\n"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
 #: ncrypt/smime.c:2158


### PR DESCRIPTION
These blank lines are not part of the signed and/or encrypted message. neomutt(1) was claiming so, which was incorrect.

Closes: <https://github.com/neomutt/neomutt/issues/4242>
Link: <https://github.com/neomutt/neomutt/pull/4221#issuecomment-2048251472>
Cc: @nabijaczleweli 

* **What does this PR do?**

Remove spurious blank lines in protected blocks.

* **Screenshots (if relevant)**

```
[-- Begin signature information --]
Good signature from: Alejandro Colomar <alx@alejandro-colomar.es>
                aka: Alejandro Colomar <alx@kernel.org>
                aka: Alejandro Colomar Andres <alx.manpages@gmail.com>
            created: Wed Apr 10 19:04:31 2024
[-- End signature information --]

[-- The following data is PGP/MIME signed and encrypted --]
Subject: REDACTED

Hi!

REDACTED

Have a lovely day!
Alex

--
<https://www.alejandro-colomar.es/>
[-- End of PGP/MIME signed and encrypted data --]
```

This is after the patch.  I won't paste again the before, as you already know it probably, and I already explained in the linked issue.

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

      I hope we don't need docs.

   - All builds and tests are passing

      Builds and works $here.

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

      N/ah.

   - Code follows the [style guide](https://neomutt.org/dev/code)

      Yep

* **What are the relevant issue numbers?**

    <https://github.com/neomutt/neomutt/issues/4242>
