### PR TITLE
Don't weed protected headers

### DIFF
--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1109,10 +1109,6 @@ int mutt_protected_headers_handler(struct Body *b_email, struct State *state)
     {
       const bool display = (state->flags & STATE_DISPLAY);
 
-      const bool c_weed = cs_subset_bool(NeoMutt->sub, "weed");
-      if (display && c_weed && mutt_matches_ignore("subject"))
-        return 0;
-
       state_mark_protected_header(state);
       const short c_wrap = cs_subset_number(NeoMutt->sub, "wrap");
       int wraplen = display ? mutt_window_wrap_cols(state->wraplen, c_wrap) : 0;


### PR DESCRIPTION
* **What does this PR do?**

Don't `weed` protected headers.

They are part of the crypto message, which means the sender considers
them part of the important data, and should not be carelessly weeded.

Cc: @nabijaczleweli , @flatcap 

* **Screenshots (if relevant)**

No.

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

      N/A.

   - All builds and tests are passing

      yes.

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

      n/a

   - Code follows the [style guide](https://neomutt.org/dev/code)

      yes.

* **What are the relevant issue numbers?**

    Link: <https://github.com/neomutt/neomutt/issues/4223>
    Link: <https://github.com/neomutt/neomutt/issues/4226>
<https://github.com/neomutt/neomutt/pull/4227>
