### PR TITLE
ncrypt/crypt.c: Print a blank before the body area even if the header area is empty

### DIFF
--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1105,8 +1105,10 @@ int mutt_protected_headers_handler(struct Body *b_email, struct State *state)
   if (!cs_subset_bool(NeoMutt->sub, "crypt_protected_headers_read"))
     return 0;
 
+  state_mark_protected_header(state);
+
   if (!b_email->mime_headers)
-    return 0;
+    goto blank;
 
   const bool display = (state->flags & STATE_DISPLAY);
   const bool c_weed = cs_subset_bool(NeoMutt->sub, "weed");
@@ -1116,16 +1118,15 @@ int mutt_protected_headers_handler(struct Body *b_email, struct State *state)
   if (b_email->mime_headers->subject)
   {
     if (display && c_weed && mutt_matches_ignore("subject"))
-      return 0;
-
-    state_mark_protected_header(state);
+      goto blank;
 
     mutt_write_one_header(state->fp_out, "Subject",
                           b_email->mime_headers->subject, state->prefix, wraplen,
                           display ? CH_DISPLAY : CH_NO_FLAGS, NeoMutt->sub);
-    state_puts(state, "\n");
   }
 
+blank:
+  state_puts(state, "\n");
   return 0;
 }
 

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1108,17 +1108,17 @@ int mutt_protected_headers_handler(struct Body *b_email, struct State *state)
   if (!b_email->mime_headers)
     return 0;
 
+  const bool display = (state->flags & STATE_DISPLAY);
+  const bool c_weed = cs_subset_bool(NeoMutt->sub, "weed");
+  const short c_wrap = cs_subset_number(NeoMutt->sub, "wrap");
+  const int wraplen = display ? mutt_window_wrap_cols(state->wraplen, c_wrap) : 0;
+
   if (b_email->mime_headers->subject)
   {
-    const bool display = (state->flags & STATE_DISPLAY);
-
-    const bool c_weed = cs_subset_bool(NeoMutt->sub, "weed");
     if (display && c_weed && mutt_matches_ignore("subject"))
       return 0;
 
     state_mark_protected_header(state);
-    const short c_wrap = cs_subset_number(NeoMutt->sub, "wrap");
-    int wraplen = display ? mutt_window_wrap_cols(state->wraplen, c_wrap) : 0;
 
     mutt_write_one_header(state->fp_out, "Subject",
                           b_email->mime_headers->subject, state->prefix, wraplen,

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1105,25 +1105,25 @@ int mutt_protected_headers_handler(struct Body *b_email, struct State *state)
   if (!cs_subset_bool(NeoMutt->sub, "crypt_protected_headers_read"))
     return 0;
 
-  if (b_email->mime_headers)
+  if (!b_email->mime_headers)
+    return 0;
+
+  if (b_email->mime_headers->subject)
   {
-    if (b_email->mime_headers->subject)
-    {
-      const bool display = (state->flags & STATE_DISPLAY);
+    const bool display = (state->flags & STATE_DISPLAY);
 
-      const bool c_weed = cs_subset_bool(NeoMutt->sub, "weed");
-      if (display && c_weed && mutt_matches_ignore("subject"))
-        return 0;
+    const bool c_weed = cs_subset_bool(NeoMutt->sub, "weed");
+    if (display && c_weed && mutt_matches_ignore("subject"))
+      return 0;
 
-      state_mark_protected_header(state);
-      const short c_wrap = cs_subset_number(NeoMutt->sub, "wrap");
-      int wraplen = display ? mutt_window_wrap_cols(state->wraplen, c_wrap) : 0;
+    state_mark_protected_header(state);
+    const short c_wrap = cs_subset_number(NeoMutt->sub, "wrap");
+    int wraplen = display ? mutt_window_wrap_cols(state->wraplen, c_wrap) : 0;
 
-      mutt_write_one_header(state->fp_out, "Subject",
-                            b_email->mime_headers->subject, state->prefix, wraplen,
-                            display ? CH_DISPLAY : CH_NO_FLAGS, NeoMutt->sub);
-      state_puts(state, "\n");
-    }
+    mutt_write_one_header(state->fp_out, "Subject",
+                          b_email->mime_headers->subject, state->prefix, wraplen,
+                          display ? CH_DISPLAY : CH_NO_FLAGS, NeoMutt->sub);
+    state_puts(state, "\n");
   }
 
   return 0;

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1102,8 +1102,10 @@ bool mutt_should_hide_protected_subject(struct Email *e)
  */
 int mutt_protected_headers_handler(struct Body *b_email, struct State *state)
 {
-  const bool c_crypt_protected_headers_read = cs_subset_bool(NeoMutt->sub, "crypt_protected_headers_read");
-  if (c_crypt_protected_headers_read && b_email->mime_headers)
+  if (!cs_subset_bool(NeoMutt->sub, "crypt_protected_headers_read"))
+    return 0;
+
+  if (b_email->mime_headers)
   {
     if (b_email->mime_headers->subject)
     {

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1115,11 +1115,9 @@ int mutt_protected_headers_handler(struct Body *b_email, struct State *state)
   const short c_wrap = cs_subset_number(NeoMutt->sub, "wrap");
   const int wraplen = display ? mutt_window_wrap_cols(state->wraplen, c_wrap) : 0;
 
-  if (b_email->mime_headers->subject)
+  if (b_email->mime_headers->subject &&
+      (!display || !c_weed || !mutt_matches_ignore("subject")))
   {
-    if (display && c_weed && mutt_matches_ignore("subject"))
-      goto blank;
-
     mutt_write_one_header(state->fp_out, "Subject",
                           b_email->mime_headers->subject, state->prefix, wraplen,
                           display ? CH_DISPLAY : CH_NO_FLAGS, NeoMutt->sub);


### PR DESCRIPTION
Quoting RFC1521:
> Each part starts with an encapsulation boundary, and then contains a
> body part consisting of header area, a blank line, and a body area.
    
If the user has enabled $crypt_protected_headers_read, they want to see
the entire body part, which consists of a header area, a blank, and a
body area (well, from the headers they only want the important fields, ignoring the MIME metadata).  If there are no header fields in the header area, that's
irrelevant to the rest of it, and a blank is still meaningful (it shows
precisely that there are 0 header fields).
    
So, by having the blank line even if there are no header fields, we're
being more informative to the user, and more faithful about what the
contents of the original message are (and the code will be simpler when we have several protected fields).
    
Link: <https://datatracker.ietf.org/doc/html/rfc1521#section-7.2>
Link: <https://datatracker.ietf.org/doc/html/rfc2045#section-2.4>
Link: <https://github.com/neomutt/neomutt/issues/4242>
Link: <https://github.com/neomutt/neomutt/pull/4246>
Link: <https://github.com/neomutt/neomutt/pull/4243>
Link: <https://github.com/neomutt/neomutt/pull/4227>
Cc: @nabijaczleweli 
Cc: @flatcap 
Cc: @gahr 
