### PR TITLE
Change $crypt_protected_headers_write default to 'yes' and then set it in stone (remove it)

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -873,7 +873,7 @@
 ** (Crypto only)
 */
 
-{ "crypt_protected_headers_write", DT_BOOL, false },
+{ "crypt_protected_headers_write", DT_BOOL, true },
 /*
 ** .pp
 ** When set, NeoMutt will generate protected headers for signed and encrypted

--- a/docs/config.c
+++ b/docs/config.c
@@ -864,26 +864,11 @@
 { "crypt_protected_headers_subject", DT_STRING, "..." },
 /*
 ** .pp
-** When $$crypt_protected_headers_write is set, and the message is marked
-** for encryption, this will be substituted into the Subject field in the
-** message headers.
+** When the message is marked for encryption,
+** this will be substituted into the Subject field in the message headers.
 ** .pp
 ** To prevent a subject from being substituted, unset this variable, or set it
 ** to the empty string.
-** (Crypto only)
-*/
-
-{ "crypt_protected_headers_write", DT_BOOL, true },
-/*
-** .pp
-** When set, NeoMutt will generate protected headers for signed and encrypted
-** emails.
-** .pp
-** Protected headers are stored inside the encrypted or signed part of an
-** an email, to prevent disclosure or tampering.
-** For more information see https://github.com/autocrypt/protected-headers
-** .pp
-** Currently NeoMutt only supports the Subject header.
 ** (Crypto only)
 */
 

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -13475,8 +13475,6 @@ set pgp_default_key = "1111111111111111111111111111111111111111"
 set crypt_autosign = yes
 <emphasis role="comment"># Encrypt mail if all recipients have valid public keys</emphasis>
 set crypt_opportunistic_encrypt = yes
-<emphasis role="comment"># Sign/encrypt protected headers (Subject)</emphasis>
-set crypt_protected_headers_write = yes
 <emphasis role="comment"># Self encrypt mail</emphasis>
 set crypt_self_encrypt = yes
 

--- a/ncrypt/config.c
+++ b/ncrypt/config.c
@@ -123,9 +123,6 @@ static struct ConfigDef NcryptVars[] = {
   { "crypt_protected_headers_subject", DT_STRING, IP "...", 0, NULL,
     "Use this as the subject for encrypted emails"
   },
-  { "crypt_protected_headers_write", DT_BOOL, true, 0, NULL,
-    "Generate protected header (Memory Hole) for signed and encrypted emails"
-  },
   { "crypt_timestamp", DT_BOOL, true, 0, NULL,
     "Add a timestamp to PGP or SMIME output to prevent spoofing"
   },
@@ -202,6 +199,7 @@ static struct ConfigDef NcryptVars[] = {
 
   { "pgp_encrypt_self",   D_INTERNAL_DEPRECATED|DT_QUAD, 0, IP "2019-09-09" },
   { "smime_encrypt_self", D_INTERNAL_DEPRECATED|DT_QUAD, 0, IP "2019-09-09" },
+  { "crypt_protected_headers_write", D_INTERNAL_DEPRECATED|DT_BOOL, 0, IP "2024-04-08" },
 
   { NULL },
   // clang-format on

--- a/ncrypt/config.c
+++ b/ncrypt/config.c
@@ -123,7 +123,7 @@ static struct ConfigDef NcryptVars[] = {
   { "crypt_protected_headers_subject", DT_STRING, IP "...", 0, NULL,
     "Use this as the subject for encrypted emails"
   },
-  { "crypt_protected_headers_write", DT_BOOL, false, 0, NULL,
+  { "crypt_protected_headers_write", DT_BOOL, true, 0, NULL,
     "Generate protected header (Memory Hole) for signed and encrypted emails"
   },
   { "crypt_timestamp", DT_BOOL, true, 0, NULL,

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -266,19 +266,15 @@ int mutt_protect(struct Email *e, char *keylist, bool postpone)
       mutt_addr_free(&from);
   }
 
-  const bool c_crypt_protected_headers_write = cs_subset_bool(NeoMutt->sub, "crypt_protected_headers_write");
-  if (c_crypt_protected_headers_write)
-  {
-    struct Envelope *protected_headers = mutt_env_new();
-    mutt_env_set_subject(protected_headers, e->env->subject);
-    /* Note: if other headers get added, such as to, cc, then a call to
-     * mutt_env_to_intl() will need to be added here too. */
-    mutt_prepare_envelope(protected_headers, 0, NeoMutt->sub);
+  struct Envelope *protected_headers = mutt_env_new();
+  mutt_env_set_subject(protected_headers, e->env->subject);
+  /* Note: if other headers get added, such as to, cc, then a call to
+   * mutt_env_to_intl() will need to be added here too. */
+  mutt_prepare_envelope(protected_headers, 0, NeoMutt->sub);
 
-    mutt_env_free(&e->body->mime_headers);
-    e->body->mime_headers = protected_headers;
-    mutt_param_set(&e->body->parameter, "protected-headers", "v1");
-  }
+  mutt_env_free(&e->body->mime_headers);
+  e->body->mime_headers = protected_headers;
+  mutt_param_set(&e->body->parameter, "protected-headers", "v1");
 
 #ifdef USE_AUTOCRYPT
   /* A note about e->body->mime_headers.  If postpone or send
@@ -286,11 +282,6 @@ int mutt_protect(struct Email *e, char *keylist, bool postpone)
    * compose menu.  So despite the "robustness" code above and in the
    * gen_gossip_list function below, mime_headers will not be set when
    * entering mutt_protect().
-   *
-   * This is important to note because the user could toggle
-   * $crypt_protected_headers_write or $autocrypt off back in the
-   * compose menu.  We don't want mutt_rfc822_write_header() to write
-   * stale data from one option if the other is set.
    */
   const bool c_autocrypt = cs_subset_bool(NeoMutt->sub, "autocrypt");
   if (c_autocrypt && !postpone && (security & SEC_AUTOCRYPT))
@@ -1085,10 +1076,9 @@ static void crypt_fetch_signatures(struct Body ***b_sigs, struct Body *b, int *n
  */
 bool mutt_should_hide_protected_subject(struct Email *e)
 {
-  const bool c_crypt_protected_headers_write = cs_subset_bool(NeoMutt->sub, "crypt_protected_headers_write");
   const char *const c_crypt_protected_headers_subject =
       cs_subset_string(NeoMutt->sub, "crypt_protected_headers_subject");
-  if (c_crypt_protected_headers_write && (e->security & (SEC_ENCRYPT | SEC_AUTOCRYPT)) &&
+  if ((e->security & (SEC_ENCRYPT | SEC_AUTOCRYPT)) &&
       !(e->security & SEC_INLINE) && c_crypt_protected_headers_subject)
   {
     return true;

--- a/send/header.c
+++ b/send/header.c
@@ -895,13 +895,12 @@ int mutt_write_mime_header(struct Body *b, FILE *fp, struct ConfigSubset *sub)
   if (b->encoding != ENC_7BIT)
     fprintf(fp, "Content-Transfer-Encoding: %s\n", ENCODING(b->encoding));
 
-  const bool c_crypt_protected_headers_write = cs_subset_bool(sub, "crypt_protected_headers_write");
   bool c_autocrypt = false;
 #ifdef USE_AUTOCRYPT
   c_autocrypt = cs_subset_bool(sub, "autocrypt");
 #endif
 
-  if ((c_crypt_protected_headers_write || c_autocrypt) && b->mime_headers)
+  if (b->mime_headers)
   {
     mutt_rfc822_write_header(fp, b->mime_headers, NULL, MUTT_WRITE_HEADER_MIME,
                              false, false, sub);


### PR DESCRIPTION
Closes: <https://github.com/neomutt/neomutt/issues/4236>

Cc: @flatcap

Cherry-picked from <https://github.com/neomutt/neomutt/pull/4227/commits> (v2c):

```
$ git range-diff da56b5907^..gh/protect neomutt/devel/security..cphwrite 
 1:  da56b5907 <  -:  --------- ncrypt/crypt.c: Don't weed protected headers
 2:  b3e2fc80b <  -:  --------- ncrypt/crypt.c: Protect address lists in header fields
 3:  fab9c841e <  -:  --------- list: Add mutt_list_copy_tail()
 4:  3318db384 <  -:  --------- ncrypt/crypt.c: Protect In-Reply-To
 5:  adc7bdda7 <  -:  --------- ncrypt/crypt.c: Small refactor
 6:  843e39934 <  -:  --------- ncrypt/crypt.c: Read the protected header fields containing address lists
 7:  406417b42 <  -:  --------- Fix misspellings of X-Original-To
 8:  97dbe4c35 <  -:  --------- list: Add function to write lists wrapped to a buffer
 9:  335fbb42d <  -:  --------- ncrypt/crypt.c: Read the protected In-Reply-To header field
10:  a63efa0e2 =  1:  b6ad7887a $crypt_protected_headers_write: Change default to 'yes'
11:  165cc2b96 !  2:  2da88ecd6 $crypt_protected_headers_write: Remove variable
    @@ ncrypt/crypt.c: int mutt_protect(struct Email *e, char *keylist, bool postpone)
     -  {
     -    struct Envelope *protected_headers = mutt_env_new();
     -    mutt_env_set_subject(protected_headers, e->env->subject);
    --    mutt_list_copy_tail(&protected_headers->in_reply_to, &e->env->in_reply_to);
    --    mutt_addrlist_copy(&protected_headers->from, &e->env->from, false);
    --    mutt_addrlist_copy(&protected_headers->to, &e->env->to, false);
    --    mutt_addrlist_copy(&protected_headers->cc, &e->env->cc, false);
    --    mutt_addrlist_copy(&protected_headers->sender, &e->env->sender, false);
    --    mutt_addrlist_copy(&protected_headers->reply_to, &e->env->reply_to, false);
    --    mutt_addrlist_copy(&protected_headers->mail_followup_to, &e->env->mail_followup_to, false);
    --    mutt_addrlist_copy(&protected_headers->x_original_to, &e->env->x_original_to, false);
    --    mutt_env_to_intl(protected_headers, NULL, NULL);
    +-    /* Note: if other headers get added, such as to, cc, then a call to
    +-     * mutt_env_to_intl() will need to be added here too. */
     -    mutt_prepare_envelope(protected_headers, 0, NeoMutt->sub);
     +  struct Envelope *protected_headers = mutt_env_new();
     +  mutt_env_set_subject(protected_headers, e->env->subject);
    -+  mutt_list_copy_tail(&protected_headers->in_reply_to, &e->env->in_reply_to);
    -+  mutt_addrlist_copy(&protected_headers->from, &e->env->from, false);
    -+  mutt_addrlist_copy(&protected_headers->to, &e->env->to, false);
    -+  mutt_addrlist_copy(&protected_headers->cc, &e->env->cc, false);
    -+  mutt_addrlist_copy(&protected_headers->sender, &e->env->sender, false);
    -+  mutt_addrlist_copy(&protected_headers->reply_to, &e->env->reply_to, false);
    -+  mutt_addrlist_copy(&protected_headers->mail_followup_to, &e->env->mail_followup_to, false);
    -+  mutt_addrlist_copy(&protected_headers->x_original_to, &e->env->x_original_to, false);
    -+  mutt_env_to_intl(protected_headers, NULL, NULL);
    ++  /* Note: if other headers get added, such as to, cc, then a call to
    ++   * mutt_env_to_intl() will need to be added here too. */
     +  mutt_prepare_envelope(protected_headers, 0, NeoMutt->sub);
      
     -    mutt_env_free(&e->body->mime_headers);
12:  d0010ae8a <  -:  --------- docs: Add feature page for protected header fields
```