### PR TITLE
imap: add mailboxes more directly

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -718,6 +718,19 @@ static enum CommandResult mailbox_add(const char *folder, const char *mailbox,
 }
 
 /**
+ * mailbox_add_simple - Add a new Mailbox
+ * @param mailbox Mailbox to add
+ * @param err     Buffer for error messages
+ * @retval true Success
+ */
+bool mailbox_add_simple(const char *mailbox, struct Buffer *err)
+{
+  enum CommandResult rc = mailbox_add("", mailbox, NULL, TB_UNSET, TB_UNSET, err);
+
+  return (rc == MUTT_CMD_SUCCESS);
+}
+
+/**
  * parse_mailboxes - Parse the 'mailboxes' command - Implements Command::parse() - @ingroup command_parse
  *
  * This is also used by 'virtual-mailboxes'.

--- a/commands.h
+++ b/commands.h
@@ -24,6 +24,7 @@
 #define MUTT_COMMANDS_H
 
 #include "config.h"
+#include <stdbool.h>
 #include <stdint.h>
 #include "config/lib.h"
 #include "core/lib.h"
@@ -45,6 +46,7 @@ enum CommandResult parse_unsubscribe_from(struct Buffer *buf, struct Buffer *s, 
 
 enum CommandResult parse_rc_line_cwd(const char *line, char *cwd, struct Buffer *err);
 char *mutt_get_sourced_cwd(void);
+bool mailbox_add_simple(const char *mailbox, struct Buffer *err);
 
 int parse_grouplist(struct GroupList *gl, struct Buffer *buf, struct Buffer *s, struct Buffer *err);
 void source_stack_cleanup(void);


### PR DESCRIPTION
Shortcut IMAP's workflow when adding a Mailbox.

When `$imap_check_subscribed` is set, NeoMutt sends an `LSUB` command to the server.
The server responds with a list of "subscribed" Mailboxes.

The IMAP code used to create a fake `mailboxes NAME` command.
Now it skips that step and calls `mailbox_add()` (via a wrapper).

This removes the need to quote the Mailbox name, only for `parse_rc_line()` to dequote it.

---

- 35dd92fca create `mailbox_add_simple()` wrapper
- de6354027 imap: add mailboxes more directly
