### PR TITLE
$crypt_protected_headers_write: Change default to 'yes'

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -873,7 +873,7 @@
 ** (Crypto only)
 */
 
-{ "crypt_protected_headers_write", DT_BOOL, false },
+{ "crypt_protected_headers_write", DT_BOOL, true },
 /*
 ** .pp
 ** When set, NeoMutt will generate protected headers for signed and encrypted

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -13505,8 +13505,6 @@ set pgp_default_key = "1111111111111111111111111111111111111111"
 set crypt_autosign = yes
 <emphasis role="comment"># Encrypt mail if all recipients have valid public keys</emphasis>
 set crypt_opportunistic_encrypt = yes
-<emphasis role="comment"># Sign/encrypt protected headers (Subject)</emphasis>
-set crypt_protected_headers_write = yes
 <emphasis role="comment"># Self encrypt mail</emphasis>
 set crypt_self_encrypt = yes
 

--- a/ncrypt/config.c
+++ b/ncrypt/config.c
@@ -123,7 +123,7 @@ static struct ConfigDef NcryptVars[] = {
   { "crypt_protected_headers_subject", DT_STRING, IP "...", 0, NULL,
     "Use this as the subject for encrypted emails"
   },
-  { "crypt_protected_headers_write", DT_BOOL, false, 0, NULL,
+  { "crypt_protected_headers_write", DT_BOOL, true, 0, NULL,
     "Generate protected header (Memory Hole) for signed and encrypted emails"
   },
   { "crypt_timestamp", DT_BOOL, true, 0, NULL,


### PR DESCRIPTION
-  This is a cherry-pick of commit 1 from <https://github.com/neomutt/neomutt/pull/4248> (at v1e):

```
$ git range-diff neomutt/devel/security gh/cphwrite gh/cphw_def 
1:  dc32b3b11 = 1:  dc32b3b11 $crypt_protected_headers_write: Change default to 'yes'
2:  6863989c6 < -:  --------- $crypt_protected_headers_write: Remove variable
```