### PR TITLE
expando: fixes

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -430,12 +430,12 @@ $(PWD)/envelope:
 ###############################################################################
 # libexpando
 LIBEXPANDO=	libexpando.a
-LIBEXPANDOOBJS=	expando/config_type.o expando/expando.o expando/format.o \
-		expando/helpers.o expando/node.o expando/node_condbool.o \
-		expando/node_conddate.o expando/node_condition.o \
-		expando/node_container.o expando/node_expando.o \
-		expando/node_padding.o expando/node_text.o expando/parse.o \
-		expando/render.o
+LIBEXPANDOOBJS=	expando/config_type.o expando/expando.o expando/filter.o \
+		expando/format.o expando/helpers.o expando/node.o \
+		expando/node_condbool.o expando/node_conddate.o \
+		expando/node_condition.o expando/node_container.o \
+		expando/node_expando.o expando/node_padding.o \
+		expando/node_text.o expando/parse.o expando/render.o
 CLEANFILES+=	$(LIBEXPANDO) $(LIBEXPANDOOBJS)
 ALLOBJS+=	$(LIBEXPANDOOBJS)
 

--- a/alias/dlg_alias.c
+++ b/alias/dlg_alias.c
@@ -232,7 +232,7 @@ static int alias_make_entry(struct Menu *menu, int line, int max_cols, struct Bu
   }
 
   const struct Expando *c_alias_format = cs_subset_expando(mdata->sub, "alias_format");
-  return expando_render(c_alias_format, AliasRenderData, av,
+  return expando_filter(c_alias_format, AliasRenderData, av,
                         MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
 }
 

--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -242,7 +242,7 @@ static int query_make_entry(struct Menu *menu, int line, int max_cols, struct Bu
   }
 
   const struct Expando *c_query_format = cs_subset_expando(mdata->sub, "query_format");
-  return expando_render(c_query_format, QueryRenderData, av,
+  return expando_filter(c_query_format, QueryRenderData, av,
                         MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
 }
 

--- a/attach/dlg_attach.c
+++ b/attach/dlg_attach.c
@@ -475,7 +475,7 @@ static int attach_make_entry(struct Menu *menu, int line, int max_cols, struct B
   }
 
   const struct Expando *c_attach_format = cs_subset_expando(NeoMutt->sub, "attach_format");
-  return expando_render(c_attach_format, AttachRenderData, (actx->idx[actx->v2r[line]]),
+  return expando_filter(c_attach_format, AttachRenderData, (actx->idx[actx->v2r[line]]),
                         MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
 }
 

--- a/autocrypt/dlg_autocrypt.c
+++ b/autocrypt/dlg_autocrypt.c
@@ -206,7 +206,7 @@ static int autocrypt_make_entry(struct Menu *menu, int line, int max_cols, struc
   }
 
   const struct Expando *c_autocrypt_acct_format = cs_subset_expando(NeoMutt->sub, "autocrypt_acct_format");
-  return expando_render(c_autocrypt_acct_format, AutocryptRenderData, entry,
+  return expando_filter(c_autocrypt_acct_format, AutocryptRenderData, entry,
                         MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
 }
 

--- a/browser/dlg_browser.c
+++ b/browser/dlg_browser.c
@@ -976,19 +976,19 @@ static int folder_make_entry(struct Menu *menu, int line, int max_cols, struct B
   if (OptNews)
   {
     const struct Expando *c_group_index_format = cs_subset_expando(NeoMutt->sub, "group_index_format");
-    return expando_render(c_group_index_format, GroupIndexRenderData, &folder,
+    return expando_filter(c_group_index_format, GroupIndexRenderData, &folder,
                           MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
   }
 
   if (bstate->is_mailbox_list)
   {
     const struct Expando *c_mailbox_folder_format = cs_subset_expando(NeoMutt->sub, "mailbox_folder_format");
-    return expando_render(c_mailbox_folder_format, FolderRenderData, &folder,
+    return expando_filter(c_mailbox_folder_format, FolderRenderData, &folder,
                           MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
   }
 
   const struct Expando *c_folder_format = cs_subset_expando(NeoMutt->sub, "folder_format");
-  return expando_render(c_folder_format, FolderRenderData, &folder,
+  return expando_filter(c_folder_format, FolderRenderData, &folder,
                         MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
 }
 

--- a/compose/attach.c
+++ b/compose/attach.c
@@ -229,7 +229,7 @@ static int compose_make_entry(struct Menu *menu, int line, int max_cols, struct 
   }
 
   const struct Expando *c_attach_format = cs_subset_expando(sub, "attach_format");
-  return expando_render(c_attach_format, AttachRenderData, (actx->idx[actx->v2r[line]]),
+  return expando_filter(c_attach_format, AttachRenderData, (actx->idx[actx->v2r[line]]),
                         MUTT_FORMAT_STAT_FILE | MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
 }
 

--- a/compose/cbar.c
+++ b/compose/cbar.c
@@ -156,7 +156,7 @@ static int cbar_recalc(struct MuttWindow *win)
   struct ComposeSharedData *shared = win->parent->wdata;
 
   const struct Expando *c_compose_format = cs_subset_expando(shared->sub, "compose_format");
-  expando_render(c_compose_format, ComposeRenderData, shared,
+  expando_filter(c_compose_format, ComposeRenderData, shared,
                  MUTT_FORMAT_NO_FLAGS, win->state.cols, buf);
 
   struct ComposeBarData *cbar_data = win->wdata;

--- a/expando/filter.c
+++ b/expando/filter.c
@@ -1,0 +1,171 @@
+/**
+ * @file
+ * Expando filtering
+ *
+ * @authors
+ * Copyright (C) 2024 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page expando_filter Expando filtering
+ *
+ * Filter the rendered Expando through an external command.
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include "mutt/lib.h"
+#include "gui/lib.h"
+#include "expando.h"
+#include "globals.h"
+#include "node.h"
+#include "render.h"
+
+/**
+ * check_for_pipe - Should the Expando be piped to an external command?
+ * @param root Root Node
+ * @retval true Yes, pipe it
+ *
+ * - Check for a trailing | (pipe) character
+ * - Check the first Node is text
+ */
+bool check_for_pipe(struct ExpandoNode *root)
+{
+  if (!root)
+    return false;
+
+  struct ExpandoNode *first = node_first(root);
+  if (first->type != ENT_TEXT)
+    return false;
+
+  struct ExpandoNode *last = node_last(root);
+  if (!last || (last->type != ENT_TEXT))
+    return false;
+
+  if (!last->start || !last->end)
+    return false;
+
+  int len = last->end - last->start;
+  if (len < 1)
+    return false;
+
+  if (last->start[len - 1] != '|')
+    return false;
+
+  // Count any preceding backslashes
+  int count = 0;
+  for (int i = len - 2; i >= 0; i--)
+  {
+    if (last->start[i] == '\\')
+      count++;
+  }
+
+  // The pipe character is escaped with a backslash
+  if ((count % 2) != 0)
+    return false;
+
+  return true;
+}
+
+/**
+ * filter_text - Filter the text through an external command
+ * @param[in,out] buf Text
+ *
+ * The text is passed unchanged to the shell.
+ * The first line of any output (minus the newline) is stored back in buf.
+ */
+void filter_text(struct Buffer *buf)
+{
+  if (buf_is_empty(buf))
+    return;
+
+  // Trim the | (pipe) character
+  size_t len = buf_len(buf);
+  if (buf->data[len - 1] == '|')
+    buf->data[len - 1] = '\0';
+
+  mutt_debug(LL_DEBUG3, "execute: %s\n", buf_string(buf));
+  FILE *fp_filter = NULL;
+  pid_t pid = filter_create(buf_string(buf), NULL, &fp_filter, NULL, EnvList);
+  if (pid < 0)
+    return; // LCOV_EXCL_LINE
+
+  buf_reset(buf);
+  size_t n = fread(buf->data, 1, buf->dsize - 1, fp_filter);
+  mutt_file_fclose(&fp_filter);
+  buf_fix_dptr(buf);
+
+  int rc = filter_wait(pid);
+  if (rc != 0)
+    mutt_debug(LL_DEBUG1, "filter cmd exited code %d\n", rc);
+
+  if (n == 0)
+  {
+    mutt_debug(LL_DEBUG1, "error reading from filter: %s (errno=%d)\n",
+               strerror(errno), errno);
+    buf_reset(buf);
+    return;
+  }
+
+  char *nl = (char *) buf_find_char(buf, '\n');
+  if (nl)
+    *nl = '\0';
+  mutt_debug(LL_DEBUG3, "received: %s\n", buf_string(buf));
+}
+
+/**
+ * expando_filter - Render an Expando and run the result through a filter
+ * @param[in]  exp      Expando containing the expando tree
+ * @param[in]  rdata    Expando render data
+ * @param[in]  data     Callback data
+ * @param[in]  flags    Callback flags
+ * @param[in]  max_cols Number of screen columns (-1 means unlimited)
+ * @param[out] buf      Buffer in which to save string
+ * @retval obj Number of bytes written to buf and screen columns used
+ */
+int expando_filter(const struct Expando *exp, const struct ExpandoRenderData *rdata,
+                   void *data, MuttFormatFlags flags, int max_cols, struct Buffer *buf)
+{
+  if (!exp || !exp->tree)
+    return 0;
+
+  struct ExpandoNode *root = exp->tree;
+
+  bool is_pipe = check_for_pipe(root);
+  int old_cols = max_cols;
+  if (is_pipe)
+    max_cols = -1;
+
+  int rc = expando_render(exp, rdata, data, flags, max_cols, buf);
+
+  if (!is_pipe)
+    return rc;
+
+  filter_text(buf);
+
+  // Strictly truncate to size
+  size_t width = 0;
+  size_t bytes = mutt_wstr_trunc(buf_string(buf), buf_len(buf), old_cols, &width);
+  buf->data[bytes] = '\0';
+
+  return width;
+}

--- a/expando/filter.h
+++ b/expando/filter.h
@@ -1,0 +1,34 @@
+/**
+ * @file
+ * Expando filtering
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_EXPANDO_FILTER_H
+#define MUTT_EXPANDO_FILTER_H
+
+#include "render.h"
+
+struct Buffer;
+struct Expando;
+
+int expando_filter(const struct Expando *exp, const struct ExpandoRenderData *rdata,
+                   void *data, MuttFormatFlags flags, int max_cols, struct Buffer *buf);
+
+#endif /* MUTT_EXPANDO_FILTER_H */

--- a/expando/helpers.c
+++ b/expando/helpers.c
@@ -35,6 +35,7 @@
 #include "mutt/lib.h"
 #include "helpers.h"
 #include "definition.h"
+#include "mutt_thread.h"
 #include "render.h"
 
 /**
@@ -165,4 +166,35 @@ const char *skip_classic_expando(const char *str, const struct ExpandoDefinition
 
   str++;
   return str;
+}
+
+/**
+ * buf_lower_special - Convert to lowercase, excluding special characters
+ * @param buf String to lowercase
+ *
+ * The string is transformed in place.
+ */
+void buf_lower_special(struct Buffer *buf)
+{
+  if (!buf || !buf->data)
+    return;
+
+  char *p = buf->data;
+
+  while (*p)
+  {
+    if (*p == MUTT_SPECIAL_INDEX)
+    {
+      p += 2;
+      continue;
+    }
+    else if (*p < MUTT_TREE_MAX)
+    {
+      p++;
+      continue;
+    }
+
+    *p = tolower((unsigned char) *p);
+    p++;
+  }
 }

--- a/expando/helpers.h
+++ b/expando/helpers.h
@@ -24,6 +24,7 @@
 #ifndef MUTT_EXPANDO_HELPERS_H
 #define MUTT_EXPANDO_HELPERS_H
 
+struct Buffer;
 struct ExpandoDefinition;
 struct ExpandoRenderData;
 
@@ -33,5 +34,7 @@ const char *skip_until_classic_expando(const char *start);
 
 const struct ExpandoRenderData *find_get_number(const struct ExpandoRenderData *rdata, int did, int uid);
 const struct ExpandoRenderData *find_get_string(const struct ExpandoRenderData *rdata, int did, int uid);
+
+void buf_lower_special(struct Buffer *buf);
 
 #endif /* MUTT_EXPANDO_HELPERS_H */

--- a/expando/lib.h
+++ b/expando/lib.h
@@ -30,6 +30,7 @@
  * | :-------------------------------- | :------------------------------ |
  * | expando/config_type.c             | @subpage expando_config_type    |
  * | expando/expando.c                 | @subpage expando_expando        |
+ * | expando/filter.c                  | @subpage expando_filter         |
  * | expando/format.c                  | @subpage expando_format         |
  * | expando/helpers.c                 | @subpage expando_helpers        |
  * | expando/node.c                    | @subpage expando_node           |
@@ -51,6 +52,7 @@
 #include "definition.h"
 #include "domain.h"
 #include "expando.h"
+#include "filter.h"
 #include "format.h"
 #include "helpers.h"
 #include "node.h"

--- a/expando/node.c
+++ b/expando/node.c
@@ -146,3 +146,57 @@ void node_append(struct ExpandoNode **root, struct ExpandoNode *new_node)
 
   node->next = new_node;
 }
+
+/**
+ * node_first - First the first Node in a tree
+ * @param node Root Node
+ * @retval ptr First Node
+ */
+struct ExpandoNode *node_first(struct ExpandoNode *node)
+{
+  if (!node)
+    return NULL;
+
+  while (true)
+  {
+    struct ExpandoNode *first = node_get_child(node, 0);
+    if (!first)
+      break;
+
+    node = first;
+  }
+
+  return node;
+}
+
+/**
+ * node_last - Find the last Node in a tree
+ * @param node Root Node
+ * @retval ptr Last Node
+ */
+struct ExpandoNode *node_last(struct ExpandoNode *node)
+{
+  if (!node)
+    return NULL;
+
+  while (true)
+  {
+    if (node->next)
+    {
+      node = node->next;
+      continue;
+    }
+
+    size_t size = ARRAY_SIZE(&node->children);
+    if (size == 0)
+      break;
+
+    struct ExpandoNode *last = node_get_child(node, size - 1);
+    if (!last)
+      break; // LCOV_EXCL_LINE
+
+    node = last;
+  }
+
+  return node;
+}

--- a/expando/node.h
+++ b/expando/node.h
@@ -24,6 +24,7 @@
 #ifndef MUTT_EXPANDO_NODE_H
 #define MUTT_EXPANDO_NODE_H
 
+#include <stdbool.h>
 #include "mutt/lib.h"
 #include "format.h"
 #include "render.h"
@@ -54,8 +55,9 @@ struct ExpandoFormat
   int                max_cols;        ///< Maximum number of screen columns
   enum FormatJustify justification;   ///< Justification: left, centre, right
   char               leader;          ///< Leader character, 0 or space
-  const char         *start;          ///< Start of Expando specifier string
-  const char         *end;            ///< End of Expando specifier string
+  bool               lower;           ///< Display in lower case
+  const char        *start;           ///< Start of Expando specifier string
+  const char        *end;             ///< End of Expando specifier string
 };
 
 /**

--- a/expando/node.h
+++ b/expando/node.h
@@ -105,4 +105,7 @@ void                node_append   (struct ExpandoNode **root, struct ExpandoNode
 struct ExpandoNode *node_get_child(const struct ExpandoNode *node, int index);
 void                node_set_child(struct ExpandoNode *node, int index, struct ExpandoNode *child);
 
+struct ExpandoNode *node_first(struct ExpandoNode *node);
+struct ExpandoNode *node_last (struct ExpandoNode *node);
+
 #endif /* MUTT_EXPANDO_NODE_H */

--- a/expando/node_container.c
+++ b/expando/node_container.c
@@ -62,8 +62,9 @@ int node_container_render(const struct ExpandoNode *node,
 
   if (fmt)
   {
+    int min_cols = MIN(fmt->min_cols, max_cols);
     struct Buffer *tmp2 = buf_pool_get();
-    total_cols = format_string(tmp2, fmt->min_cols, fmt->max_cols, fmt->justification,
+    total_cols = format_string(tmp2, min_cols, max_cols, fmt->justification,
                                fmt->leader, buf_string(tmp), buf_len(tmp), true);
     if (fmt->lower)
       buf_lower_special(tmp2);

--- a/expando/node_container.c
+++ b/expando/node_container.c
@@ -34,6 +34,7 @@
 #include "mutt/lib.h"
 #include "node_container.h"
 #include "format.h"
+#include "helpers.h"
 #include "node.h"
 #include "render.h"
 
@@ -64,6 +65,8 @@ int node_container_render(const struct ExpandoNode *node,
     struct Buffer *tmp2 = buf_pool_get();
     total_cols = format_string(tmp2, fmt->min_cols, fmt->max_cols, fmt->justification,
                                fmt->leader, buf_string(tmp), buf_len(tmp), true);
+    if (fmt->lower)
+      buf_lower_special(tmp2);
     buf_addstr(buf, buf_string(tmp2));
     buf_pool_release(&tmp2);
   }

--- a/expando/node_expando.c
+++ b/expando/node_expando.c
@@ -217,6 +217,12 @@ struct ExpandoFormat *parse_format(const char *start, const char *end,
     start = end_ptr;
   }
 
+  if (*start == '_')
+  {
+    fmt->lower = true;
+    start++;
+  }
+
   return fmt;
 }
 
@@ -374,6 +380,8 @@ int node_expando_render(const struct ExpandoNode *node,
     total_cols += format_string(tmp, min_cols, max_cols, fmt->justification,
                                 fmt->leader, buf_string(buf_expando),
                                 buf_len(buf_expando), priv->has_tree);
+    if (fmt->lower)
+      buf_lower_special(tmp);
   }
   else
   {

--- a/expando/parse.c
+++ b/expando/parse.c
@@ -51,24 +51,26 @@
 static const char *skip_until_if_true_end(const char *start, char end_terminator)
 {
   int ctr = 0;
+  char prev = '\0';
   while (*start)
   {
-    if ((ctr == 0) && ((*start == end_terminator) || (*start == '&')))
+    if ((ctr == 0) && (((*start == end_terminator) && (prev != '%')) || (*start == '&')))
     {
       break;
     }
 
     // handle nested if-else-s
-    if (*start == '<')
+    if ((prev == '%') && (*start == '<'))
     {
       ctr++;
     }
 
-    if (*start == '>')
+    if ((*start == '>') && (prev != '%'))
     {
       ctr--;
     }
 
+    prev = *start;
     start++;
   }
 
@@ -84,24 +86,26 @@ static const char *skip_until_if_true_end(const char *start, char end_terminator
 static const char *skip_until_if_false_end(const char *start, char end_terminator)
 {
   int ctr = 0;
+  char prev = '\0';
   while (*start)
   {
-    if ((ctr == 0) && (*start == end_terminator))
+    if ((ctr == 0) && (*start == end_terminator) && (prev != '%'))
     {
       break;
     }
 
-    // handle nested if-esle-s
-    if (*start == '<')
+    // handle nested if-else-s
+    if ((prev == '%') && (*start == '<'))
     {
       ctr++;
     }
 
-    if (*start == '>')
+    if ((*start == '>') && (prev != '%'))
     {
       ctr--;
     }
 
+    prev = *start;
     start++;
   }
 

--- a/hdrline.c
+++ b/hdrline.c
@@ -498,7 +498,7 @@ void index_format_hook(const struct ExpandoNode *node, void *data,
   if (!exp)
     return;
 
-  expando_render(exp, IndexRenderData, data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+  expando_filter(exp, IndexRenderData, data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 }
 
 /**
@@ -1808,7 +1808,7 @@ int mutt_make_string(struct Buffer *buf, size_t max_cols,
   hfi.msg_in_pager = inpgr;
   hfi.pager_progress = progress;
 
-  return expando_render(exp, IndexRenderData, &hfi, flags, max_cols, buf);
+  return expando_filter(exp, IndexRenderData, &hfi, flags, max_cols, buf);
 }
 
 /**

--- a/history/dlg_history.c
+++ b/history/dlg_history.c
@@ -122,7 +122,7 @@ static int history_make_entry(struct Menu *menu, int line, int max_cols, struct 
   }
 
   const struct Expando *c_history_format = cs_subset_expando(NeoMutt->sub, "history_format");
-  return expando_render(c_history_format, HistoryRenderData, &h,
+  return expando_filter(c_history_format, HistoryRenderData, &h,
                         MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
 }
 

--- a/mixmaster/win_hosts.c
+++ b/mixmaster/win_hosts.c
@@ -173,7 +173,7 @@ static int mix_make_entry(struct Menu *menu, int line, int max_cols, struct Buff
   }
 
   const struct Expando *c_mix_entry_format = cs_subset_expando(NeoMutt->sub, "mix_entry_format");
-  return expando_render(c_mix_entry_format, MixRenderData, *r,
+  return expando_filter(c_mix_entry_format, MixRenderData, *r,
                         MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
 }
 

--- a/ncrypt/dlg_gpgme.c
+++ b/ncrypt/dlg_gpgme.c
@@ -554,7 +554,7 @@ static int crypt_make_entry(struct Menu *menu, int line, int max_cols, struct Bu
   }
 
   const struct Expando *c_pgp_entry_format = cs_subset_expando(NeoMutt->sub, "pgp_entry_format");
-  return expando_render(c_pgp_entry_format, PgpEntryGpgmeRenderData, &entry,
+  return expando_filter(c_pgp_entry_format, PgpEntryGpgmeRenderData, &entry,
                         MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
 }
 

--- a/ncrypt/dlg_pgp.c
+++ b/ncrypt/dlg_pgp.c
@@ -548,7 +548,7 @@ static int pgp_make_entry(struct Menu *menu, int line, int max_cols, struct Buff
   }
 
   const struct Expando *c_pgp_entry_format = cs_subset_expando(NeoMutt->sub, "pgp_entry_format");
-  return expando_render(c_pgp_entry_format, PgpEntryRenderData, &entry,
+  return expando_filter(c_pgp_entry_format, PgpEntryRenderData, &entry,
                         MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
 }
 

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -1146,7 +1146,7 @@ struct NntpAccountData *nntp_select_server(struct Mailbox *m, const char *server
   {
     const struct Expando *c_newsrc = cs_subset_expando(NeoMutt->sub, "newsrc");
     struct Buffer *buf = buf_pool_get();
-    expando_render(c_newsrc, NntpRenderData, adata, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+    expando_filter(c_newsrc, NntpRenderData, adata, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
     mutt_expand_path(buf->data, buf->dsize);
     adata->newsrc_file = buf_strdup(buf);
     buf_pool_release(&buf);

--- a/pattern/dlg_pattern.c
+++ b/pattern/dlg_pattern.c
@@ -145,7 +145,7 @@ static int pattern_make_entry(struct Menu *menu, int line, int max_cols, struct 
   }
 
   const struct Expando *c_pattern_format = cs_subset_expando(NeoMutt->sub, "pattern_format");
-  return expando_render(c_pattern_format, PatternRenderData, entry,
+  return expando_filter(c_pattern_format, PatternRenderData, entry,
                         MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
 }
 

--- a/send/send.c
+++ b/send/send.c
@@ -758,7 +758,7 @@ static void mutt_make_greeting(struct Email *e, FILE *fp_out, struct ConfigSubse
 
   struct Buffer *buf = buf_pool_get();
 
-  expando_render(c_greeting, GreetingRenderData, e, TOKEN_NO_FLAGS, buf->dsize, buf);
+  expando_filter(c_greeting, GreetingRenderData, e, TOKEN_NO_FLAGS, buf->dsize, buf);
 
   fputs(buf_string(buf), fp_out);
   fputc('\n', fp_out);

--- a/send/sendmail.c
+++ b/send/sendmail.c
@@ -311,7 +311,7 @@ int mutt_invoke_sendmail(struct Mailbox *m, struct AddressList *from,
     struct Buffer *cmd = buf_pool_get();
 
     const struct Expando *c_inews = cs_subset_expando(sub, "inews");
-    expando_render(c_inews, NntpRenderData, 0, MUTT_FORMAT_NO_FLAGS, cmd->dsize, cmd);
+    expando_filter(c_inews, NntpRenderData, 0, MUTT_FORMAT_NO_FLAGS, cmd->dsize, cmd);
     if (buf_is_empty(cmd))
     {
       i = nntp_post(m, msg);

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -590,7 +590,7 @@ static void make_sidebar_entry(char *buf, size_t buflen, int width,
 
   struct Buffer *tmp = buf_pool_get();
   const struct Expando *c_sidebar_format = cs_subset_expando(NeoMutt->sub, "sidebar_format");
-  expando_render(c_sidebar_format, SidebarRenderData, &sdata,
+  expando_filter(c_sidebar_format, SidebarRenderData, &sdata,
                  MUTT_FORMAT_NO_FLAGS, width, tmp);
   mutt_str_copy(buf, buf_string(tmp), buflen);
   buf_pool_release(&tmp);

--- a/status.c
+++ b/status.c
@@ -497,7 +497,7 @@ void menu_status_line(struct Buffer *buf, struct IndexSharedData *shared,
 {
   struct MenuStatusLineData data = { shared, menu };
 
-  expando_render(exp, StatusRenderData, &data, MUTT_FORMAT_NO_FLAGS, max_cols, buf);
+  expando_filter(exp, StatusRenderData, &data, MUTT_FORMAT_NO_FLAGS, max_cols, buf);
 }
 
 /**

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -258,6 +258,7 @@ EXPANDO_OBJS	= test/expando/colors_render.o \
 		  test/expando/empty_if_else.o \
 		  test/expando/empty_if_else_render.o \
 		  test/expando/expando.o \
+		  test/expando/filter.o \
 		  test/expando/format.o \
 		  test/expando/formatted_expando.o \
 		  test/expando/helpers.o \

--- a/test/expando/filter.c
+++ b/test/expando/filter.c
@@ -1,0 +1,165 @@
+/**
+ * @file
+ * Test Expando Filter
+ *
+ * @authors
+ * Copyright (C) 2024 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include <string.h>
+#include "mutt/lib.h"
+#include "email/lib.h"
+#include "expando/lib.h"
+#include "common.h" // IWYU pragma: keep
+#include "test_common.h"
+
+bool check_for_pipe(struct ExpandoNode *root);
+void filter_text(struct Buffer *buf);
+
+static void test_a(const struct ExpandoNode *node, void *data,
+                   MuttFormatFlags flags, int max_cols, struct Buffer *buf)
+{
+  buf_addstr(buf, "apple");
+}
+
+void test_expando_filter(void)
+{
+  // bool check_for_pipe(struct ExpandoNode *root);
+  {
+    static const struct Mapping tests[] = {
+      // clang-format off
+      { "|",           true  },
+      { "\\|",         false }, // one   backslash
+      { "\\\\|",       true  }, // two   backslashes
+      { "\\\\\\|",     false }, // three backslashes
+      { "\\\\\\\\|",   true  }, // four  backslashes
+      { "\\\\\\\\\\|", false }, // five  backslashes
+      // clang-format on
+    };
+    TEST_CHECK(!check_for_pipe(NULL));
+
+    struct ExpandoNode *node = node_new();
+    struct ExpandoNode *last = node_new();
+
+    node->next = last;
+
+    TEST_CHECK(!check_for_pipe(node));
+
+    node->type = ENT_TEXT;
+    TEST_CHECK(!check_for_pipe(node));
+
+    last->type = ENT_TEXT;
+    TEST_CHECK(!check_for_pipe(node));
+
+    const char *str = "hello|";
+    last->start = str + 5;
+    last->end = str;
+    TEST_CHECK(!check_for_pipe(node));
+
+    last->start = str;
+    last->end = str;
+    TEST_CHECK(!check_for_pipe(node));
+
+    last->start = str;
+    last->end = str + 5;
+    TEST_CHECK(!check_for_pipe(node));
+
+    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    {
+      str = tests[i].name;
+      TEST_CASE(str);
+      last->start = str;
+      size_t len = strlen(str);
+      last->end = last->start + len;
+      TEST_CHECK(check_for_pipe(node) == tests[i].value);
+    }
+
+    node_tree_free(&node);
+  }
+
+  // void filter_text(struct Buffer *buf);
+  {
+    struct Buffer *buf = buf_pool_get();
+
+    filter_text(NULL);
+    filter_text(buf);
+
+    // buf_strcpy(buf, "xyz-rst apple|"); // doesn't exist
+    // filter_text(buf);
+
+    buf_strcpy(buf, "false|");
+    filter_text(buf);
+
+    buf_strcpy(buf, "echo apple|");
+    filter_text(buf);
+
+    buf_pool_release(&buf);
+  }
+
+  // int expando_filter(const struct Expando *exp, const struct ExpandoRenderData *rdata, void *data, MuttFormatFlags flags, int max_cols, struct Buffer *buf);
+  {
+    const struct ExpandoDefinition TestFormatDef[] = {
+      // clang-format off
+      { "a", "from", ED_ENVELOPE, ED_ENV_FROM, E_TYPE_STRING, NULL },
+      { NULL, NULL, 0, -1, -1, NULL }
+      // clang-format on
+    };
+
+    const struct ExpandoRenderData TestRenderData[] = {
+      // clang-format off
+      { ED_ENVELOPE, ED_ENV_FROM, test_a, NULL },
+      { -1, -1, NULL, NULL },
+      // clang-format on
+    };
+
+    TEST_CHECK(expando_filter(NULL, NULL, NULL, MUTT_FORMAT_NO_FLAGS, 0, NULL) == 0);
+
+    struct Buffer *err = buf_pool_get();
+    struct Buffer *buf = buf_pool_get();
+    struct Expando *exp = NULL;
+    int rc;
+
+    const char *str = ">%a<";
+    exp = expando_parse(str, TestFormatDef, err);
+    TEST_CHECK(exp != NULL);
+    rc = expando_filter(exp, TestRenderData, NULL, MUTT_FORMAT_NO_FLAGS, -1, buf);
+    TEST_CHECK(rc == 7);
+    TEST_MSG("rc = %d", rc);
+    TEST_CHECK_STR_EQ(buf_string(buf), ">apple<");
+    expando_free(&exp);
+
+    str = "echo '>%a<'|";
+    buf_reset(buf);
+    exp = expando_parse(str, TestFormatDef, err);
+    TEST_CHECK(exp != NULL);
+    rc = expando_filter(exp, TestRenderData, NULL, MUTT_FORMAT_NO_FLAGS, -1, buf);
+    TEST_CHECK(rc == 7);
+    TEST_MSG("rc = %d", rc);
+    TEST_CHECK_STR_EQ(buf_string(buf), ">apple<");
+    expando_free(&exp);
+
+    buf_pool_release(&buf);
+    buf_pool_release(&err);
+  }
+
+  TEST_CHECK(true);
+}

--- a/test/expando/format.c
+++ b/test/expando/format.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <stddef.h>
 #include <limits.h>
+#include <stdbool.h>
 #include <string.h>
 #include "mutt/lib.h"
 #include "expando/lib.h"
@@ -39,6 +40,7 @@ struct TestCase
   char leader;
   int min_cols;
   int max_cols;
+  bool lower;
   enum FormatJustify justify;
 };
 
@@ -46,14 +48,21 @@ void test_expando_node_expando_format(void)
 {
   static const struct TestCase tests[] = {
     // clang-format off
-    { "5x",    ' ', 5, INT_MAX, JUSTIFY_RIGHT  },
-    { ".7x",   ' ', 0, 7,       JUSTIFY_RIGHT  },
-    { "5.7x",  ' ', 5, 7,       JUSTIFY_RIGHT  },
-    { "-5x",   ' ', 5, INT_MAX, JUSTIFY_LEFT   },
-    { "-.7x",  ' ', 0, 7,       JUSTIFY_LEFT   },
-    { "-5.7x", ' ', 5, 7,       JUSTIFY_LEFT   },
-    { "05x",   '0', 5, INT_MAX, JUSTIFY_RIGHT  },
-    { "=5x",   ' ', 5, INT_MAX, JUSTIFY_CENTER },
+    { "5x",      ' ', 5, INT_MAX, false, JUSTIFY_RIGHT  },
+    { ".7x",     ' ', 0, 7,       false, JUSTIFY_RIGHT  },
+    { "5.7x",    ' ', 5, 7,       false, JUSTIFY_RIGHT  },
+    { "-5x",     ' ', 5, INT_MAX, false, JUSTIFY_LEFT   },
+    { "-.7x",    ' ', 0, 7,       false, JUSTIFY_LEFT   },
+    { "-5.7x",   ' ', 5, 7,       false, JUSTIFY_LEFT   },
+    { "05x",     '0', 5, INT_MAX, false, JUSTIFY_RIGHT  },
+    { "=5x",     ' ', 5, INT_MAX, false, JUSTIFY_CENTER },
+    { "_x",      ' ', 0, INT_MAX, true,  JUSTIFY_RIGHT  },
+    { "5_x",     ' ', 5, INT_MAX, true,  JUSTIFY_RIGHT  },
+    { ".7_x",    ' ', 0, 7,       true,  JUSTIFY_RIGHT  },
+    { "5.7_x",   ' ', 5, 7,       true,  JUSTIFY_RIGHT  },
+    { "-5_x",    ' ', 5, INT_MAX, true,  JUSTIFY_LEFT   },
+    { "-.7_x",   ' ', 0, 7,       true,  JUSTIFY_LEFT   },
+    { "-5.7_x",  ' ', 5, 7,       true,  JUSTIFY_LEFT   },
     // clang-format on
   };
 
@@ -74,6 +83,7 @@ void test_expando_node_expando_format(void)
       TEST_CHECK(fmt->min_cols == tests[i].min_cols);
       TEST_CHECK(fmt->max_cols == tests[i].max_cols);
       TEST_CHECK(fmt->justification == tests[i].justify);
+      TEST_CHECK(fmt->lower == tests[i].lower);
       FREE(&fmt);
     }
   }

--- a/test/expando/node.c
+++ b/test/expando/node.c
@@ -104,4 +104,46 @@ void test_expando_node(void)
 
     node_free(&node);
   }
+
+  // struct ExpandoNode *node_first(struct ExpandoNode *node);
+  // struct ExpandoNode *node_last (struct ExpandoNode *node);
+  {
+    struct ExpandoNode *root = node_new();
+    struct ExpandoNode *child0 = node_new();
+    struct ExpandoNode *child1 = node_new();
+    struct ExpandoNode *child2 = node_new();
+    struct ExpandoNode *next0 = node_new();
+    struct ExpandoNode *next1 = node_new();
+    struct ExpandoNode *next2 = node_new();
+    struct ExpandoNode *n2child0 = node_new();
+    struct ExpandoNode *n2child1 = node_new();
+    struct ExpandoNode *n2child2 = node_new();
+
+    node_set_child(root, 0, child0);
+    node_set_child(root, 1, child1);
+    node_set_child(root, 2, child2);
+    root->next = next0;
+    next0->next = next1;
+    next1->next = next2;
+
+    node_set_child(next2, 0, n2child0);
+    node_set_child(next2, 1, n2child1);
+    node_set_child(next2, 2, n2child2);
+
+    struct ExpandoNode *node = NULL;
+
+    node = node_first(NULL);
+    TEST_CHECK(node == NULL);
+
+    node = node_first(root);
+    TEST_CHECK(node == child0);
+
+    node = node_last(NULL);
+    TEST_CHECK(node == NULL);
+
+    node = node_last(root);
+    TEST_CHECK(node == n2child2);
+
+    node_tree_free(&root);
+  }
 }

--- a/test/expando/node_container.c
+++ b/test/expando/node_container.c
@@ -102,7 +102,7 @@ void test_expando_node_container(void)
       // clang-format off
       { "ONEaaaONEbbbONEcccTW", 25 },
       { "ONEaaaONEbbbONE", 15 },
-      { "ONEaaaONEb     ", 10 },
+      { "ONEaaaONEb", 10 },
       { "", 0 },
       // clang-format on
     };
@@ -134,6 +134,16 @@ void test_expando_node_container(void)
     rc = node_tree_render(cont, TestRenderData, buf, 50, NULL, MUTT_FORMAT_NO_FLAGS);
     TEST_CHECK(rc == 50);
     TEST_CHECK_STR_EQ(buf_string(buf), "ONEaaaONEbbbONEcccTWOaaaTWObbbTWOcccTHREEaaaTHREEb");
+
+    fmt_str = "_-15.20x";
+    fmt_end = strchr(fmt_str, 'x');
+    cont->format = parse_format(fmt_str, fmt_end, &err);
+    buf_reset(buf);
+    rc = node_tree_render(cont, TestRenderData, buf, 20, NULL, MUTT_FORMAT_NO_FLAGS);
+    TEST_CHECK(rc == 20);
+    TEST_CHECK_STR_EQ(buf_string(buf), "oneaaaonebbboneccctw");
+
+    FREE(&cont->format);
 
     node_free(&cont);
     buf_pool_release(&buf);

--- a/test/expando/node_expando.c
+++ b/test/expando/node_expando.c
@@ -40,6 +40,8 @@ struct ExpandoNode *node_expando_parse(const char *str, const char **parsed_unti
                                        const struct ExpandoDefinition *defs,
                                        ExpandoParserFlags flags,
                                        struct ExpandoParseError *error);
+struct ExpandoFormat *parse_format(const char *start, const char *end,
+                                   struct ExpandoParseError *error);
 
 static long test_y_num(const struct ExpandoNode *node, void *data, MuttFormatFlags flags)
 {
@@ -200,10 +202,11 @@ void test_expando_node_expando(void)
     TEST_CHECK_STR_EQ(buf_string(buf), "hello");
     node_free(&node);
 
-    str = "%d";
+    str = "%_d";
     parsed_until = NULL;
     buf_reset(buf);
     node = node_expando_parse(str, &parsed_until, TestFormatDef, EP_NO_FLAGS, &err);
+    node->format = parse_format(str + 1, str + 2, &err);
     TEST_CHECK(node != NULL);
     node_expando_set_color(node, 42);
     rc = node_expando_render(node, TestRenderData, buf, 99, NULL, MUTT_FORMAT_NO_FLAGS);

--- a/test/expando/node_padding.c
+++ b/test/expando/node_padding.c
@@ -192,7 +192,7 @@ void test_expando_node_padding(void)
       { "%>X%c%d",              "<PAD:HARD_FILL:'X':|<EXP:'c'(ALIAS,FLAGS)><EXP:'d'(ALIAS,NAME)>>" },
       { "%a%>X%c",              "<PAD:HARD_FILL:'X':<EXP:'a'(ALIAS,ADDRESS)>|<EXP:'c'(ALIAS,FLAGS)>>" },
       { "%a%b%>X%c%d",          "<PAD:HARD_FILL:'X':<EXP:'a'(ALIAS,ADDRESS)><EXP:'b'(ALIAS,COMMENT)>|<EXP:'c'(ALIAS,FLAGS)><EXP:'d'(ALIAS,NAME)>>" },
-      { "%<a?%a%>X%b&%c%>X%d>", "<PAD:HARD_FILL:'X':<COND:<BOOL:'a':(ALIAS,ADDRESS)>|<PAD:HARD_FILL:'X':<EXP:'a'(ALIAS,ADDRESS)>|>|><TEXT:'X'><EXP:'b'(ALIAS,COMMENT)><TEXT:'&'><EXP:'c'(ALIAS,FLAGS)>|<EXP:'d'(ALIAS,NAME)><TEXT:'>'>>" },
+      { "%<a?%a%>X%b&%c%>X%d>", "<COND:<BOOL:'a':(ALIAS,ADDRESS)>|<PAD:HARD_FILL:'X':<EXP:'a'(ALIAS,ADDRESS)>|<EXP:'b'(ALIAS,COMMENT)>>|<PAD:HARD_FILL:'X':<EXP:'c'(ALIAS,FLAGS)>|<EXP:'d'(ALIAS,NAME)>>>" },
 
       { "%*X",                  "<PAD:SOFT_FILL:'X':|>" },
       { "%a%*X",                "<PAD:SOFT_FILL:'X':<EXP:'a'(ALIAS,ADDRESS)>|>" },

--- a/test/main.c
+++ b/test/main.c
@@ -295,6 +295,7 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_expando_empty_if_else)                                \
   NEOMUTT_TEST_ITEM(test_expando_empty_if_else_render)                         \
   NEOMUTT_TEST_ITEM(test_expando_expando)                                      \
+  NEOMUTT_TEST_ITEM(test_expando_filter)                                       \
   NEOMUTT_TEST_ITEM(test_expando_formatted_expando)                            \
   NEOMUTT_TEST_ITEM(test_expando_helpers)                                      \
   NEOMUTT_TEST_ITEM(test_expando_if_else_false_render)                         \


### PR DESCRIPTION
This PR fixes a few problems with the Expandos in the recent release.

- df6ee63d5 add lower-case operator
  Adding underscore before an expando letter, lowercases the field,
  e.g. `%30_s`

- b52ac1d27 fix conditional padding
  Using hard-padding `%>` in a conditional expando `%<...>` caused problems

- a6a503e8c fix container
  Some formats weren't handled correctly.
  The container node is used by the combined tree-subject in the Index

- df3c01124 add external filter
  Adding a pipe character (`|`) causes the field to be executed.
  e.g. `set sidebar_format = "sidebar.sh '%B'|"`

- e7b8e36e7 test: expando filter
  Unit tests

- 9bc780b69 enable external filter
  Enable the expando filter for lots of format strings.
 
Fixes: #4258 
Fixes: #4259 
