### PR TITLE
fix: cache naming

### DIFF
--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -376,6 +376,7 @@ static void hcache_per_folder(struct HeaderCache *hc, struct Buffer *hcpath,
   if (namer)
   {
     namer(hc->folder, hcfile);
+    mutt_encode_path(hcfile, buf_string(hcfile));
     buf_concat_path(hcpath, path, buf_string(hcfile));
   }
   else
@@ -392,11 +393,11 @@ static void hcache_per_folder(struct HeaderCache *hc, struct Buffer *hcpath,
     mutt_md5(buf_string(name), m);
     buf_reset(name);
     mutt_md5_toascii(m, name->data);
+    mutt_encode_path(name, buf_string(name));
     buf_printf(hcpath, "%s%s%s", path, slash ? "" : "/", buf_string(name));
     buf_pool_release(&name);
   }
 
-  mutt_encode_path(hcpath, buf_string(hcpath));
   create_hcache_dir(buf_string(hcpath));
   buf_pool_release(&hcfile);
 }

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -524,7 +524,6 @@ int nntp_newsrc_update(struct NntpAccountData *adata)
  */
 static void cache_expand(char *dst, size_t dstlen, struct ConnAccount *cac, const char *src)
 {
-  char *c = NULL;
   char file[PATH_MAX] = { 0 };
 
   /* server subdirectory */
@@ -534,19 +533,18 @@ static void cache_expand(char *dst, size_t dstlen, struct ConnAccount *cac, cons
   url_tostring(&url, file, sizeof(file), U_PATH);
   FREE(&url.path);
 
-  const char *const c_news_cache_dir = cs_subset_path(NeoMutt->sub, "news_cache_dir");
-  snprintf(dst, dstlen, "%s/%s", c_news_cache_dir, file);
-
   /* remove trailing slash */
-  c = dst + strlen(dst) - 1;
+  char *c = file + strlen(file) - 1;
   if (*c == '/')
     *c = '\0';
 
   struct Buffer *tmp = buf_pool_get();
-  buf_addstr(tmp, dst);
-  buf_expand_path(tmp);
-  mutt_encode_path(tmp, dst);
-  mutt_str_copy(dst, buf_string(tmp), dstlen);
+  buf_addstr(tmp, file);
+  mutt_encode_path(tmp, file);
+
+  const char *const c_news_cache_dir = cs_subset_path(NeoMutt->sub, "news_cache_dir");
+  snprintf(dst, dstlen, "%s/%s", c_news_cache_dir, buf_string(tmp));
+
   buf_pool_release(&tmp);
 }
 


### PR DESCRIPTION
The filename of a cache consists of two parts.

 - A config variable + mailbox path

Config: `$header_cache`, `$message_cache_dir` or `$news_cache_dir`

For filesystem compatibility, the mailbox path is converted to ASCII and some characters, such as `:` are replaced with `_`

It's important that only the mailbox path is converted and the user's config is left as-is.

---

This also fixes a difference in behaviour between the header and body caches.
They'd write to different directories, e.g.

- `imaps:dev-mail@flatcap.org`
- `imaps_dev-mail_flatcap.org`