### PR TITLE
mutt: fix copyright boilerplate in base64.h and filter.h

### DIFF
--- a/mutt/base64.h
+++ b/mutt/base64.h
@@ -3,11 +3,12 @@
  * Conversion to/from base64 encoding
  *
  * @authors
- * @copyright
  * Copyright (C) 2017-2018 Richard Russon <rich@flatcap.org>
- * Foundation, either version 2 of the License, or (at your option) any later
- * the terms of the GNU General Public License as published by the Free Software
+ *
+ * @copyright
  * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
  * version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT

--- a/mutt/filter.h
+++ b/mutt/filter.h
@@ -3,11 +3,12 @@
  * Pass files through external commands (filters)
  *
  * @authors
- * @copyright
  * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
- * Foundation, either version 2 of the License, or (at your option) any later
- * the terms of the GNU General Public License as published by the Free Software
+ *
+ * @copyright
  * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
  * version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT


### PR DESCRIPTION
* **What does this PR do?**
Fix copyright boilerplate.


* **Does this PR meet the acceptance criteria?**
Pretty minor changes to comment sections so I think we are okay.

* **What are the relevant issue numbers?**
Didn't create one, but this is the result of [overhauling debian/copyright](https://salsa.debian.org/charles/neomutt/-/commit/1783df0406b252575a45f43200194e247f5e15dc) to include the updated copyright boilerplates.