### PR TITLE
expando: allow newline

### DIFF
--- a/expando/format.c
+++ b/expando/format.c
@@ -143,6 +143,10 @@ int format_string(struct Buffer *buf, int min_cols, int max_cols, enum FormatJus
     {
       w = 1; /* hack */
     }
+    else if (iswspace(wc))
+    {
+      w = 1;
+    }
     else
     {
 #ifdef HAVE_ISWBLANK


### PR DESCRIPTION
Fix expandos to allow newlines `\n`.
Newlines were being treated as invalid and replaced with `?`s.

Some format strings, e.g. `$attribution_intro` need to allow `\n`.

e.g.
```sh
# Intro with blank line after
set attribution_intro = "On %d, %n wrote:\n"
```

Fixes: #4271