### PR TITLE
expando: padding default to space

### DIFF
--- a/debug/graphviz.c
+++ b/debug/graphviz.c
@@ -1961,24 +1961,43 @@ void dot_format(FILE *fp, struct ExpandoFormat *fmt)
 
 void dot_expando_node_container(FILE *fp, struct ExpandoNode *node, struct ListHead *links)
 {
-  struct Buffer *buf = buf_pool_get();
   dot_object_header(fp, node, "Container", "#80ffff");
   // dot_type_string(fp, "type", "ENT_CONTAINER", true);
-
+  dot_type_number(fp, "children", ARRAY_SIZE(&node->children));
   dot_format(fp, node->format);
-
   dot_object_footer(fp);
 
   struct ExpandoNode **enp = NULL;
+  enp = ARRAY_FIRST(&node->children);
+  if (!enp)
+    return;
+
+  struct ExpandoNode *child = *enp;
+  dot_add_link(links, node, child, "Node->children", "children", false, "#80ff80");
+
+  char name[256] = { 0 };
+  struct Buffer *rank = buf_pool_get();
+  buf_addstr(rank, "{ rank=same ");
+
+  struct ExpandoNode *prev = NULL;
   ARRAY_FOREACH(enp, &node->children)
   {
-    struct ExpandoNode *child = *enp;
+    child = *enp;
 
     dot_expando_node(fp, child, links);
-    dot_add_link(links, node, child, "Node->child", "child", false, "#80ff80");
+    if (prev)
+    {
+      dot_add_link(links, prev, child, "Node->next", "next", false, "#80ff80");
+    }
+    prev = child;
+
+    dot_ptr_name(name, sizeof(name), child);
+    buf_add_printf(rank, "%s ", name);
   }
 
-  buf_pool_release(&buf);
+  buf_addstr(rank, "}");
+  mutt_list_insert_tail(links, buf_strdup(rank));
+  buf_pool_release(&rank);
 }
 
 void dot_expando_node_expando(FILE *fp, struct ExpandoNode *node, struct ListHead *links)
@@ -2031,57 +2050,36 @@ void dot_expando_node_unknown(FILE *fp, struct ExpandoNode *node, struct ListHea
 
 void dot_expando_node(FILE *fp, struct ExpandoNode *node, struct ListHead *links)
 {
-  struct Buffer *buf = buf_pool_get();
-
-  char name[256] = { 0 };
-  buf_addstr(buf, "{ rank=same ");
-
-  struct ExpandoNode *prev = NULL;
-  for (; node; node = node->next)
+  switch (node->type)
   {
-    switch (node->type)
-    {
-      case ENT_CONDITION:
-        dot_expando_node_condition(fp, node, links);
-        break;
-      case ENT_CONDBOOL:
-        dot_expando_node_conditional_bool(fp, node, links);
-        break;
-      case ENT_CONDDATE:
-        dot_expando_node_conditional_date(fp, node, links);
-        break;
-      case ENT_CONTAINER:
-        dot_expando_node_container(fp, node, links);
-        break;
-      case ENT_EMPTY:
-        dot_expando_node_empty(fp, node, links);
-        break;
-      case ENT_EXPANDO:
-        dot_expando_node_expando(fp, node, links);
-        break;
-      case ENT_PADDING:
-        dot_expando_node_pad(fp, node, links);
-        break;
-      case ENT_TEXT:
-        dot_expando_node_text(fp, node, links);
-        break;
-      default:
-        dot_expando_node_unknown(fp, node, links);
-        break;
-    }
-
-    if (prev)
-      dot_add_link(links, prev, node, "ExpandoNode->next", NULL, false, "#808080");
-    prev = node;
-
-    dot_ptr_name(name, sizeof(name), node);
-    buf_add_printf(buf, "%s ", name);
+    case ENT_CONDITION:
+      dot_expando_node_condition(fp, node, links);
+      break;
+    case ENT_CONDBOOL:
+      dot_expando_node_conditional_bool(fp, node, links);
+      break;
+    case ENT_CONDDATE:
+      dot_expando_node_conditional_date(fp, node, links);
+      break;
+    case ENT_CONTAINER:
+      dot_expando_node_container(fp, node, links);
+      break;
+    case ENT_EMPTY:
+      dot_expando_node_empty(fp, node, links);
+      break;
+    case ENT_EXPANDO:
+      dot_expando_node_expando(fp, node, links);
+      break;
+    case ENT_PADDING:
+      dot_expando_node_pad(fp, node, links);
+      break;
+    case ENT_TEXT:
+      dot_expando_node_text(fp, node, links);
+      break;
+    default:
+      dot_expando_node_unknown(fp, node, links);
+      break;
   }
-
-  buf_addstr(buf, "}");
-
-  mutt_list_insert_tail(links, buf_strdup(buf));
-  buf_pool_release(&buf);
 }
 
 void dump_graphviz_expando_node(struct ExpandoNode *node)

--- a/expando/expando.c
+++ b/expando/expando.c
@@ -32,6 +32,9 @@
 #include "mutt/lib.h"
 #include "expando.h"
 #include "node.h"
+#include "node_condition.h"
+#include "node_container.h"
+#include "node_padding.h"
 #include "parse.h"
 #include "render.h"
 
@@ -44,6 +47,7 @@ struct Expando *expando_new(const char *format)
 {
   struct Expando *exp = mutt_mem_calloc(1, sizeof(struct Expando));
   exp->string = mutt_str_dup(format);
+  exp->node = node_container_new();
   return exp;
 }
 
@@ -58,7 +62,7 @@ void expando_free(struct Expando **ptr)
 
   struct Expando *exp = *ptr;
 
-  node_tree_free(&exp->node);
+  node_free(&exp->node);
   FREE(&exp->string);
 
   FREE(ptr);
@@ -74,25 +78,35 @@ void expando_free(struct Expando **ptr)
 struct Expando *expando_parse(const char *str, const struct ExpandoDefinition *defs,
                               struct Buffer *err)
 {
-  if (!str || !defs)
+  if (!str || (*str == '\0') || !defs)
     return NULL;
 
   struct Expando *exp = expando_new(str);
 
   struct ExpandoParseError error = { 0 };
-  struct ExpandoNode *root = NULL;
+  const char *end = NULL;
+  const char *start = exp->string;
 
-  node_tree_parse(&root, exp->string, defs, &error);
+  while (*start)
+  {
+    struct ExpandoNode *node = node_parse(start, NULL, CON_NO_CONDITION, &end, defs, &error);
+    if (!node)
+      break;
+
+    node_add_child(exp->node, node);
+    start = end;
+  }
 
   if (error.position)
   {
     buf_strcpy(err, error.message);
-    node_tree_free(&root);
     expando_free(&exp);
     return NULL;
   }
 
-  exp->node = root;
+  node_padding_repad(&exp->node);
+  node_container_collapse_all(&exp->node);
+
   return exp;
 }
 

--- a/expando/node.h
+++ b/expando/node.h
@@ -68,7 +68,6 @@ struct ExpandoFormat
 struct ExpandoNode
 {
   enum ExpandoNodeType      type;        ///< Type of Node, e.g. #ENT_EXPANDO
-  struct ExpandoNode       *next;        ///< Linked list
   int                       did;         ///< Domain ID, e.g. #ED_EMAIL
   int                       uid;         ///< Unique ID, e.g. #ED_EMA_SIZE
 
@@ -97,11 +96,9 @@ struct ExpandoNode
 };
 
 struct ExpandoNode *node_new(void);
+void                node_free(struct ExpandoNode **ptr);
 
-void node_free     (struct ExpandoNode **ptr);
-void node_tree_free(struct ExpandoNode **ptr);
-
-void                node_append   (struct ExpandoNode **root, struct ExpandoNode *new_node);
+void                node_add_child(struct ExpandoNode *node, struct ExpandoNode *child);
 struct ExpandoNode *node_get_child(const struct ExpandoNode *node, int index);
 
 struct ExpandoNode *node_last (struct ExpandoNode *node);

--- a/expando/node_conddate.c
+++ b/expando/node_conddate.c
@@ -69,6 +69,93 @@ void node_conddate_private_free(void **ptr)
 }
 
 /**
+ * cutoff_number - Calculate the cutoff time for n units
+ * @param period Time period, from [ymwdHM]
+ * @param count  Number of time periods
+ * @retval num Cutoff time
+ *
+ * Calculate the cutoff time for, say, 3 months, or 2 hours.
+ */
+time_t cutoff_number(char period, int count)
+{
+  time_t t = mutt_date_now();
+  struct tm tm = { 0 };
+  localtime_r(&t, &tm);
+
+  switch (period)
+  {
+    case 'y':
+      tm.tm_year -= count;
+      break;
+
+    case 'm':
+      tm.tm_mon -= count;
+      break;
+
+    case 'w':
+      tm.tm_mday -= (7 * count);
+      break;
+
+    case 'd':
+      tm.tm_mday -= count;
+      break;
+
+    case 'H':
+      tm.tm_hour -= count;
+      break;
+
+    case 'M':
+      tm.tm_min -= count;
+      break;
+  }
+
+  return mktime(&tm);
+}
+
+/**
+ * cutoff_this - Calculcate the cutoff time of this unit
+ * @param period Time period, from [ymwdHM]
+ * @retval num Cutoff time
+ *
+ * Calculate the cutoff time of, say, this day (today), this month.
+ */
+time_t cutoff_this(char period)
+{
+  time_t t = mutt_date_now();
+  struct tm tm = { 0 };
+  localtime_r(&t, &tm);
+
+  switch (period)
+  {
+    case 'y':
+      tm.tm_mon = 0; // January
+      FALLTHROUGH;
+
+    case 'm':
+      tm.tm_mday = 1; // 1st of the month
+      FALLTHROUGH;
+
+    case 'd':
+      tm.tm_hour = 0; // Beginning of day (Midnight)
+      FALLTHROUGH;
+
+    case 'H':
+      tm.tm_min = 0; // Beginning of hour
+      FALLTHROUGH;
+
+    case 'M':
+      tm.tm_sec = 0; // Beginning of minute
+      break;
+
+    case 'w':
+      tm.tm_mday = 1;
+      break;
+  }
+
+  return mktime(&tm);
+}
+
+/**
  * node_conddate_render - Render a CondDate Node - Implements ExpandoNode::render() - @ingroup expando_render
  */
 int node_conddate_render(const struct ExpandoNode *node,
@@ -84,38 +171,11 @@ int node_conddate_render(const struct ExpandoNode *node,
 
   const struct NodeCondDatePrivate *priv = node->ndata;
 
-  time_t t = mutt_date_now();
-  struct tm tm = { 0 };
-  gmtime_r(&t, &tm);
-
-  switch (priv->period)
-  {
-    case 'y':
-      tm.tm_year -= priv->count;
-      break;
-
-    case 'm':
-      tm.tm_mon -= priv->count;
-      break;
-
-    case 'w':
-      tm.tm_mday -= (7 * priv->count);
-      break;
-
-    case 'd':
-      tm.tm_mday -= priv->count;
-      break;
-
-    case 'H':
-      tm.tm_hour -= priv->count;
-      break;
-
-    case 'M':
-      tm.tm_min -= priv->count;
-      break;
-  }
-
-  const time_t t_cutoff = mktime(&tm);
+  time_t t_cutoff;
+  if (priv->count == 0)
+    t_cutoff = cutoff_this(priv->period);
+  else
+    t_cutoff = cutoff_number(priv->period, priv->count);
 
   return (t_test > t_cutoff); // bool-ify
 }
@@ -148,7 +208,7 @@ struct ExpandoNode *node_conddate_new(int count, char period, int did, int uid)
 struct ExpandoNode *node_conddate_parse(const char *str, const char **parsed_until,
                                         int did, int uid, struct ExpandoParseError *err)
 {
-  int count = 1;
+  int count = 0;
   char period = '\0';
 
   if (isdigit(*str))

--- a/expando/node_container.c
+++ b/expando/node_container.c
@@ -92,3 +92,63 @@ struct ExpandoNode *node_container_new(void)
 
   return node;
 }
+
+/**
+ * node_container_collapse - Remove an unnecessary Container
+ * @param ptr Pointer to a Container
+ */
+void node_container_collapse(struct ExpandoNode **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct ExpandoNode *node = *ptr;
+
+  if (node->type != ENT_CONTAINER)
+    return;
+
+  struct ExpandoNode *child = NULL;
+  struct ExpandoNode **np = NULL;
+  size_t size = 0;
+  ARRAY_FOREACH(np, &node->children)
+  {
+    if (!np || !*np)
+      continue;
+
+    size++;
+    child = *np;
+  }
+
+  if (size > 1)
+    return;
+
+  if (size == 0)
+  {
+    node_free(ptr);
+    return;
+  }
+
+  ARRAY_FREE(&node->children);
+  node_free(ptr);
+  *ptr = child;
+}
+
+/**
+ * node_container_collapse_all - Remove unnecessary Containers
+ * @param ptr Pointer to the parent node
+ */
+void node_container_collapse_all(struct ExpandoNode **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct ExpandoNode *parent = *ptr;
+
+  struct ExpandoNode **np = NULL;
+  ARRAY_FOREACH(np, &parent->children)
+  {
+    node_container_collapse_all(np);
+  }
+
+  node_container_collapse(ptr);
+}

--- a/expando/node_container.h
+++ b/expando/node_container.h
@@ -26,4 +26,6 @@
 
 struct ExpandoNode *node_container_new(void);
 
+void node_container_collapse_all(struct ExpandoNode **ptr);
+
 #endif /* MUTT_EXPANDO_NODE_CONTAINER_H */

--- a/expando/node_padding.c
+++ b/expando/node_padding.c
@@ -35,7 +35,7 @@
 #include "node_padding.h"
 #include "definition.h"
 #include "node.h"
-#include "node_condition.h"
+#include "node_container.h"
 #include "parse.h"
 #include "render.h"
 
@@ -273,40 +273,55 @@ struct ExpandoNode *node_padding_parse(const char *str, int did, int uid,
 
 /**
  * node_padding_repad - Rearrange Padding in a tree of ExpandoNodes
- * @param parent Parent Node
+ * @param ptr Parent Node
  */
-void node_padding_repad(struct ExpandoNode **parent)
+void node_padding_repad(struct ExpandoNode **ptr)
 {
-  if (!parent || !*parent)
+  if (!ptr || !*ptr)
     return;
 
-  struct ExpandoNode *node = *parent;
-  struct ExpandoNode *prev = NULL;
-  for (; node; prev = node, node = node->next)
+  struct ExpandoNode *parent = *ptr;
+  struct ExpandoNode **np = NULL;
+  ARRAY_FOREACH(np, &parent->children)
   {
-    if (node->type == ENT_PADDING)
+    if (!np || !*np)
+      continue;
+
+    // Repad any children, recursively
+    node_padding_repad(np);
+
+    struct ExpandoNode *node = *np;
+    if (node->type != ENT_PADDING)
+      continue;
+
+    struct ExpandoNode *node_left = node_container_new();
+    struct ExpandoNode *node_right = node_container_new();
+
+    if (ARRAY_FOREACH_IDX > 0)
     {
-      if (node != *parent)
-        ARRAY_SET(&node->children, ENP_LEFT, *parent); // First sibling
-
-      ARRAY_SET(&node->children, ENP_RIGHT, node->next); // Sibling after Padding
-
-      if (prev)
-        prev->next = NULL;
-      node->next = NULL;
-      *parent = node;
-      return;
+      for (int i = 0; i < ARRAY_FOREACH_IDX; i++)
+      {
+        node_add_child(node_left, node_get_child(parent, i));
+      }
     }
 
-    if (node->type == ENT_CONDITION)
+    size_t count = ARRAY_SIZE(&parent->children);
+    if ((ARRAY_FOREACH_IDX + 1) < count)
     {
-      struct ExpandoNode **ptr = NULL;
-
-      ptr = ARRAY_GET(&node->children, ENC_TRUE);
-      node_padding_repad(ptr);
-
-      ptr = ARRAY_GET(&node->children, ENC_FALSE);
-      node_padding_repad(ptr);
+      for (int i = ARRAY_FOREACH_IDX + 1; i < count; i++)
+      {
+        node_add_child(node_right, node_get_child(parent, i));
+      }
     }
+
+    // All the children have been transferred
+    ARRAY_FREE(&parent->children);
+
+    node_add_child(node, node_left);
+    node_add_child(node, node_right);
+
+    node_add_child(parent, node);
+
+    break; // Only repad the first padding node
   }
 }

--- a/expando/node_padding.c
+++ b/expando/node_padding.c
@@ -265,7 +265,12 @@ struct ExpandoNode *node_padding_parse(const char *str, int did, int uid,
   }
   str++;
 
-  const size_t consumed = mutt_mb_charlen(str, NULL);
+  size_t consumed = mutt_mb_charlen(str, NULL);
+  if (consumed == 0)
+  {
+    str = " "; // Default to a space
+    consumed = 1;
+  }
 
   *parsed_until = str + consumed;
   return node_padding_new(pt, str, str + consumed);

--- a/expando/parse.c
+++ b/expando/parse.c
@@ -64,7 +64,7 @@ static const char *skip_until_if_true_end(const char *start, char end_terminator
       ctr++;
     }
 
-    if ((*start == '>') && (prev != '%'))
+    if ((ctr > 0) && (*start == '>') && (prev != '%'))
     {
       ctr--;
     }

--- a/expando/parse.c
+++ b/expando/parse.c
@@ -37,8 +37,8 @@
 #include "node.h"
 #include "node_condbool.h"
 #include "node_condition.h"
+#include "node_container.h"
 #include "node_expando.h"
-#include "node_padding.h"
 #include "node_text.h"
 
 /**
@@ -127,7 +127,10 @@ struct ExpandoNode *node_parse(const char *str, const char *end,
                                const struct ExpandoDefinition *defs,
                                struct ExpandoParseError *err)
 {
-  while (*str && (end ? (str <= end) : 1))
+  if (!str || (*str == '\0'))
+    return NULL;
+
+  while (*str && (end ? (str <= end) : true))
   {
     // %X -> expando
     // if there is condition like <X..., the `%` is implicit
@@ -186,7 +189,7 @@ struct ExpandoNode *node_parse(const char *str, const char *end,
         }
 
         const char *if_true_parsed = NULL;
-        struct ExpandoNode *node_true = NULL;
+        struct ExpandoNode *node_true = node_container_new();
 
         while (start_true < end_true)
         {
@@ -194,18 +197,14 @@ struct ExpandoNode *node_parse(const char *str, const char *end,
                                                 &if_true_parsed, defs, err);
           if (!node)
           {
+            node_free(&node_true);
             node_free(&node_cond);
             return NULL;
           }
 
-          node_append(&node_true, node);
+          node_add_child(node_true, node);
 
           start_true = if_true_parsed;
-        }
-
-        if ((start_true == end_true) && !node_true)
-        {
-          node_true = node_new();
         }
 
         if (only_true)
@@ -232,7 +231,7 @@ struct ExpandoNode *node_parse(const char *str, const char *end,
           }
 
           const char *if_false_parsed = NULL;
-          struct ExpandoNode *node_false = NULL;
+          struct ExpandoNode *node_false = node_container_new();
 
           while (start_false < end_false)
           {
@@ -241,18 +240,14 @@ struct ExpandoNode *node_parse(const char *str, const char *end,
             if (!node)
             {
               node_free(&node_true);
+              node_free(&node_false);
               node_free(&node_cond);
               return NULL;
             }
 
-            node_append(&node_false, node);
+            node_add_child(node_false, node);
 
             start_false = if_false_parsed;
-          }
-
-          if ((start_false == end_false) && !node_false)
-          {
-            node_false = node_new();
           }
 
           *parsed_until = end_false + 1;
@@ -289,36 +284,4 @@ struct ExpandoNode *node_parse(const char *str, const char *end,
 
   ASSERT(false && "Internal parsing error"); // LCOV_EXCL_LINE
   return NULL;
-}
-
-/**
- * node_tree_parse - Parse a format string into ExpandoNodes
- * @param[in,out] root   Parent ExpandoNode
- * @param[in]     string String to parse
- * @param[in]     defs   Expando definitions
- * @param[out]    err    Buffer for errors
- */
-void node_tree_parse(struct ExpandoNode **root, const char *string,
-                     const struct ExpandoDefinition *defs, struct ExpandoParseError *err)
-{
-  if (!string || !*string)
-  {
-    node_append(root, node_new());
-    return;
-  }
-
-  const char *end = NULL;
-  const char *start = string;
-
-  while (*start)
-  {
-    struct ExpandoNode *node = node_parse(start, NULL, CON_NO_CONDITION, &end, defs, err);
-    if (!node)
-      break;
-
-    node_append(root, node);
-    start = end;
-  }
-
-  node_padding_repad(root);
 }

--- a/expando/parse.h
+++ b/expando/parse.h
@@ -24,7 +24,8 @@
 #ifndef MUTT_EXPANDO_PARSER_H
 #define MUTT_EXPANDO_PARSER_H
 
-struct ExpandoNode;
+#include "node_condition.h"
+
 struct ExpandoDefinition;
 
 /**
@@ -36,6 +37,10 @@ struct ExpandoParseError
   const char *position;       ///< Position of error in original string
 };
 
-void node_tree_parse(struct ExpandoNode **root, const char *string, const struct ExpandoDefinition *defs, struct ExpandoParseError *err);
+struct ExpandoNode *node_parse(const char *str, const char *end,
+                               enum ExpandoConditionStart condition_start,
+                               const char **parsed_until,
+                               const struct ExpandoDefinition *defs,
+                               struct ExpandoParseError *err);
 
 #endif /* MUTT_EXPANDO_PARSER_H */

--- a/expando/render.c
+++ b/expando/render.c
@@ -45,15 +45,8 @@
 int node_render(const struct ExpandoNode *node, const struct ExpandoRenderData *rdata,
                 struct Buffer *buf, int max_cols, void *data, MuttFormatFlags flags)
 {
-  int total_cols = 0;
+  if (!node || !node->render)
+    return 0;
 
-  for (; node && (total_cols < max_cols); node = node->next)
-  {
-    if (!node->render)
-      continue;
-
-    total_cols += node->render(node, rdata, buf, max_cols - total_cols, data, flags);
-  }
-
-  return total_cols;
+  return node->render(node, rdata, buf, max_cols, data, flags);
 }

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -269,14 +269,14 @@ struct ExpandoNode *parse_subject(const char *str, int did, int uid,
 
   struct ExpandoNode *node_tree = node_expando_new(node_subj->start, node_subj->end,
                                                    NULL, ED_ENVELOPE, ED_ENV_THREAD_TREE);
-  node_tree->next = node_subj;
-
   // Move the formatting info to the container
   struct ExpandoNode *node_cont = node_container_new();
   node_cont->format = node_subj->format;
   node_subj->format = NULL;
 
-  ARRAY_ADD(&node_cont->children, node_tree);
+  node_add_child(node_cont, node_tree);
+  node_add_child(node_cont, node_subj);
+
   return node_cont;
 }
 

--- a/test/expando/colors_render.c
+++ b/test/expando/colors_render.c
@@ -69,11 +69,6 @@ static void simple_C(const struct ExpandoNode *node, void *data,
 void test_expando_colors_render(void)
 {
   {
-    const char *input = "%C - %s";
-
-    struct ExpandoNode *root = NULL;
-    struct ExpandoParseError err = { 0 };
-
     const struct ExpandoDefinition defs[] = {
       // clang-format off
       { "*", "padding-soft", ED_GLOBAL, ED_GLO_PADDING_SOFT, E_TYPE_STRING, node_padding_parse },
@@ -85,17 +80,18 @@ void test_expando_colors_render(void)
       // clang-format on
     };
 
-    node_tree_parse(&root, input, defs, &err);
+    const char *input = "%C - %s";
 
-    TEST_CHECK(err.position == NULL);
-    check_node_expando(get_nth_node(root, 0), "C", NULL);
-    check_node_text(get_nth_node(root, 1), " - ");
-    check_node_expando(get_nth_node(root, 2), "s", NULL);
+    struct Buffer *err = buf_pool_get();
 
-    const struct Expando exp = {
-      .string = input,
-      .node = root,
-    };
+    struct Expando *exp = expando_parse(input, defs, err);
+
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
+
+    check_node_expando(node_get_child(exp->node, 0), "C", NULL);
+    check_node_text(node_get_child(exp->node, 1), " - ");
+    check_node_expando(node_get_child(exp->node, 2), "s", NULL);
 
     const struct ExpandoRenderData render[] = {
       { 1, 0, simple_s },
@@ -119,22 +115,18 @@ void test_expando_colors_render(void)
     expected[15] = MT_COLOR_INDEX;
 
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_INDEX, buf->dsize, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_INDEX, buf->dsize, buf);
 
     const int expected_width = mutt_str_len(expected) - 8;
     TEST_CHECK(mutt_strwidth(expected) == expected_width);
     TEST_CHECK_STR_EQ(buf_string(buf), expected);
 
-    node_tree_free(&root);
+    expando_free(&exp);
     buf_pool_release(&buf);
+    buf_pool_release(&err);
   }
 
   {
-    const char *input = "%C %* %s";
-
-    struct ExpandoNode *root = NULL;
-    struct ExpandoParseError err = { 0 };
-
     const struct ExpandoDefinition defs[] = {
       // clang-format off
       { "*", "padding-soft", ED_GLOBAL, ED_GLO_PADDING_SOFT, E_TYPE_STRING, node_padding_parse },
@@ -146,25 +138,24 @@ void test_expando_colors_render(void)
       // clang-format on
     };
 
-    node_tree_parse(&root, input, defs, &err);
+    const char *input = "%C %* %s";
 
-    TEST_CHECK(err.position == NULL);
-    check_node_padding(root, " ", EPT_SOFT_FILL);
+    struct Buffer *err = buf_pool_get();
 
-    struct ExpandoNode *left = node_get_child(root, ENP_LEFT);
-    struct ExpandoNode *right = node_get_child(root, ENP_RIGHT);
+    struct Expando *exp = expando_parse(input, defs, err);
 
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
+    check_node_padding(exp->node, " ", EPT_SOFT_FILL);
+
+    struct ExpandoNode *left = node_get_child(exp->node, ENP_LEFT);
     TEST_CHECK(left != NULL);
+    struct ExpandoNode *right = node_get_child(exp->node, ENP_RIGHT);
     TEST_CHECK(right != NULL);
 
-    check_node_expando(get_nth_node(left, 0), "C", NULL);
-    check_node_text(get_nth_node(left, 1), " ");
-    check_node_expando(get_nth_node(right, 0), "s", NULL);
-
-    const struct Expando exp = {
-      .string = input,
-      .node = root,
-    };
+    check_node_expando(node_get_child(left, 0), "C", NULL);
+    check_node_text(node_get_child(left, 1), " ");
+    check_node_expando(right, "s", NULL);
 
     const struct ExpandoRenderData render[] = {
       { 1, 0, simple_s },
@@ -188,7 +179,7 @@ void test_expando_colors_render(void)
     expected[15] = MT_COLOR_INDEX;
 
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_INDEX, 8, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_INDEX, 8, buf);
 
     const int expected_width = mutt_str_len(expected) - 8;
     TEST_CHECK(mutt_strwidth(expected) == expected_width);
@@ -205,22 +196,18 @@ void test_expando_colors_render(void)
     expected2[13] = MT_COLOR_INDEX;
 
     buf_reset(buf);
-    expando_render(&exp, render, &data, MUTT_FORMAT_INDEX, 6, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_INDEX, 6, buf);
 
     const int expected_width2 = mutt_str_len(expected2) - 8;
     TEST_CHECK(mutt_strwidth(expected2) == expected_width2);
     TEST_CHECK_STR_EQ(buf_string(buf), expected2);
 
-    node_tree_free(&root);
+    expando_free(&exp);
     buf_pool_release(&buf);
+    buf_pool_release(&err);
   }
 
   {
-    const char *input = "%s %* %s";
-
-    struct ExpandoNode *root = NULL;
-    struct ExpandoParseError err = { 0 };
-
     const struct ExpandoDefinition defs[] = {
       // clang-format off
       { "*", "padding-soft", ED_GLOBAL, ED_GLO_PADDING_SOFT, E_TYPE_STRING, node_padding_parse },
@@ -232,25 +219,25 @@ void test_expando_colors_render(void)
       // clang-format on
     };
 
-    node_tree_parse(&root, input, defs, &err);
+    const char *input = "%s %* %s";
 
-    TEST_CHECK(err.position == NULL);
-    check_node_padding(root, " ", EPT_SOFT_FILL);
+    struct Buffer *err = buf_pool_get();
 
-    struct ExpandoNode *left = node_get_child(root, ENP_LEFT);
-    struct ExpandoNode *right = node_get_child(root, ENP_RIGHT);
+    struct Expando *exp = expando_parse(input, defs, err);
+
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
+    check_node_padding(exp->node, " ", EPT_SOFT_FILL);
+
+    struct ExpandoNode *left = node_get_child(exp->node, ENP_LEFT);
+    struct ExpandoNode *right = node_get_child(exp->node, ENP_RIGHT);
 
     TEST_CHECK(left != NULL);
     TEST_CHECK(right != NULL);
 
-    check_node_expando(get_nth_node(left, 0), "s", NULL);
-    check_node_text(get_nth_node(left, 1), " ");
-    check_node_expando(get_nth_node(right, 0), "s", NULL);
-
-    const struct Expando exp = {
-      .string = input,
-      .node = root,
-    };
+    check_node_expando(node_get_child(left, 0), "s", NULL);
+    check_node_text(node_get_child(left, 1), " ");
+    check_node_expando(right, "s", NULL);
 
     const struct ExpandoRenderData render[] = {
       { 1, 0, simple_s },
@@ -274,7 +261,7 @@ void test_expando_colors_render(void)
     expected[13] = MT_COLOR_INDEX;
 
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_INDEX, 6, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_INDEX, 6, buf);
 
     const int expected_width = mutt_str_len(expected) - 8;
     TEST_CHECK(mutt_strwidth(expected) == expected_width);
@@ -282,16 +269,12 @@ void test_expando_colors_render(void)
     // TEST_MSG("Expected: %s", expected);
     // TEST_MSG("Actual:   %s", buf_string(buf));
 
-    node_tree_free(&root);
+    expando_free(&exp);
     buf_pool_release(&buf);
+    buf_pool_release(&err);
   }
 
   {
-    const char *input = "%s %* %s";
-
-    struct ExpandoNode *root = NULL;
-    struct ExpandoParseError err = { 0 };
-
     const struct ExpandoDefinition defs[] = {
       // clang-format off
       { "*", "padding-soft", ED_GLOBAL, ED_GLO_PADDING_SOFT, E_TYPE_STRING, node_padding_parse },
@@ -303,25 +286,25 @@ void test_expando_colors_render(void)
       // clang-format on
     };
 
-    node_tree_parse(&root, input, defs, &err);
+    const char *input = "%s %* %s";
 
-    TEST_CHECK(err.position == NULL);
-    check_node_padding(root, " ", EPT_SOFT_FILL);
+    struct Buffer *err = buf_pool_get();
 
-    struct ExpandoNode *left = node_get_child(root, ENP_LEFT);
-    struct ExpandoNode *right = node_get_child(root, ENP_RIGHT);
+    struct Expando *exp = expando_parse(input, defs, err);
+
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
+    check_node_padding(exp->node, " ", EPT_SOFT_FILL);
+
+    struct ExpandoNode *left = node_get_child(exp->node, ENP_LEFT);
+    struct ExpandoNode *right = node_get_child(exp->node, ENP_RIGHT);
 
     TEST_CHECK(left != NULL);
     TEST_CHECK(right != NULL);
 
-    check_node_expando(get_nth_node(left, 0), "s", NULL);
-    check_node_text(get_nth_node(left, 1), " ");
-    check_node_expando(get_nth_node(right, 0), "s", NULL);
-
-    const struct Expando exp = {
-      .string = input,
-      .node = root,
-    };
+    check_node_expando(node_get_child(left, 0), "s", NULL);
+    check_node_text(node_get_child(left, 1), " ");
+    check_node_expando(right, "s", NULL);
 
     const struct ExpandoRenderData render[] = {
       { 1, 0, simple_s },
@@ -336,14 +319,15 @@ void test_expando_colors_render(void)
 
     char expected[] = "\x0e\x63Tá\x0e\x5b\x0e\x63Táéí\x0e\x5b";
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_INDEX, 6, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_INDEX, 6, buf);
 
     TEST_CHECK(mutt_strwidth(expected) == 6);
     // TEST_CHECK_STR_EQ(buf_string(buf), expected);
     // TEST_MSG("Expected: %s", expected);
     // TEST_MSG("Actual:   %s", buf_string(buf));
 
-    node_tree_free(&root);
+    expando_free(&exp);
     buf_pool_release(&buf);
+    buf_pool_release(&err);
   }
 }

--- a/test/expando/common.c
+++ b/test/expando/common.c
@@ -27,36 +27,6 @@
 #include "mutt/lib.h"
 #include "common.h"
 
-struct ExpandoNode *get_nth_node(struct ExpandoNode *node, int n)
-{
-  TEST_CHECK(node != NULL);
-
-  int i = 0;
-
-  while (node)
-  {
-    if (i++ == n)
-    {
-      return node;
-    }
-
-    node = node->next;
-  }
-
-  if (!TEST_CHECK(0))
-  {
-    TEST_MSG("Node is not found\n");
-  }
-
-  return NULL;
-}
-
-void check_node_empty(struct ExpandoNode *node)
-{
-  TEST_CHECK(node != NULL);
-  TEST_CHECK(node->type == ENT_EMPTY);
-}
-
 void check_node_text(struct ExpandoNode *node, const char *text)
 {
   TEST_CHECK(node != NULL);

--- a/test/expando/common.h
+++ b/test/expando/common.h
@@ -28,12 +28,10 @@
 void check_node_cond    (struct ExpandoNode *node);
 void check_node_condbool(struct ExpandoNode *node, const char *exp);
 void check_node_conddate(struct ExpandoNode *node, int count, char period);
-void check_node_empty   (struct ExpandoNode *node);
 void check_node_expando (struct ExpandoNode *node, const char *exp, const struct ExpandoFormat *fmt_expected);
 void check_node_padding (struct ExpandoNode *node, const char *pad_char, enum ExpandoPadType pad_type);
 void check_node_text    (struct ExpandoNode *node, const char *text);
 
-struct ExpandoNode *get_nth_node(struct ExpandoNode *node, int n);
 struct ExpandoNode *parse_date(const char *str, int did, int uid, ExpandoParserFlags flags, const char **parsed_until, struct ExpandoParseError *error);
 
 #endif /* TEST_EXPANDO_COMMON_H */

--- a/test/expando/complex_if_else.c
+++ b/test/expando/complex_if_else.c
@@ -38,16 +38,15 @@ void test_expando_complex_if_else(void)
     // clang-format on
   };
   const char *input = "if: %<l?pre %4lpost> if-else: %<l?pre %4lpost&pre %4cpost>";
-  struct ExpandoParseError err = { 0 };
-  struct ExpandoNode *root = NULL;
+  struct Buffer *err = buf_pool_get();
 
-  node_tree_parse(&root, input, TestFormatDef, &err);
+  struct Expando *exp = expando_parse(input, TestFormatDef, err);
 
-  TEST_CHECK(err.position == NULL);
-  check_node_text(get_nth_node(root, 0), "if: ");
+  TEST_CHECK(buf_is_empty(err));
+  check_node_text(node_get_child(exp->node, 0), "if: ");
 
   {
-    struct ExpandoNode *node = get_nth_node(root, 1);
+    struct ExpandoNode *node = node_get_child(exp->node, 1);
     check_node_cond(node);
 
     struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
@@ -62,17 +61,17 @@ void test_expando_complex_if_else(void)
     fmt.justification = JUSTIFY_RIGHT;
     fmt.leader = ' ';
 
-    check_node_text(get_nth_node(node_true, 0), "pre ");
-    check_node_expando(get_nth_node(node_true, 1), "l", &fmt);
-    check_node_text(get_nth_node(node_true, 2), "post");
+    check_node_text(node_get_child(node_true, 0), "pre ");
+    check_node_expando(node_get_child(node_true, 1), "l", &fmt);
+    check_node_text(node_get_child(node_true, 2), "post");
 
     TEST_CHECK(node_false == NULL);
   }
 
-  check_node_text(get_nth_node(root, 2), " if-else: ");
+  check_node_text(node_get_child(exp->node, 2), " if-else: ");
 
   {
-    struct ExpandoNode *node = get_nth_node(root, 3);
+    struct ExpandoNode *node = node_get_child(exp->node, 3);
     check_node_cond(node);
 
     struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
@@ -87,14 +86,15 @@ void test_expando_complex_if_else(void)
     fmt.justification = JUSTIFY_RIGHT;
     fmt.leader = ' ';
 
-    check_node_text(get_nth_node(node_true, 0), "pre ");
-    check_node_expando(get_nth_node(node_true, 1), "l", &fmt);
-    check_node_text(get_nth_node(node_true, 2), "post");
+    check_node_text(node_get_child(node_true, 0), "pre ");
+    check_node_expando(node_get_child(node_true, 1), "l", &fmt);
+    check_node_text(node_get_child(node_true, 2), "post");
 
-    check_node_text(get_nth_node(node_false, 0), "pre ");
-    check_node_expando(get_nth_node(node_false, 1), "c", &fmt);
-    check_node_text(get_nth_node(node_false, 2), "post");
+    check_node_text(node_get_child(node_false, 0), "pre ");
+    check_node_expando(node_get_child(node_false, 1), "c", &fmt);
+    check_node_text(node_get_child(node_false, 2), "post");
   }
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
 }

--- a/test/expando/conditional_date.c
+++ b/test/expando/conditional_date.c
@@ -31,28 +31,26 @@ void test_expando_conditional_date(void)
 {
   const char *input = "%<[1m?%[%d-%m-%Y]&%[%Y-%m-%d]>";
 
-  struct ExpandoNode *root = NULL;
-  struct ExpandoParseError err = { 0 };
+  struct Buffer *err = buf_pool_get();
 
   const struct ExpandoDefinition defs[] = {
     { "[", NULL, 1, 0, 0, parse_date },
     { NULL, NULL, 0, 0, 0, NULL },
   };
 
-  node_tree_parse(&root, input, defs, &err);
+  struct Expando *exp = expando_parse(input, defs, err);
+  TEST_CHECK(exp != NULL);
 
-  TEST_CHECK(err.position == NULL);
+  TEST_CHECK(buf_is_empty(err));
 
-  struct ExpandoNode *node = get_nth_node(root, 0);
-  check_node_cond(node);
-
-  struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
-  struct ExpandoNode *node_true = node_get_child(node, ENC_TRUE);
-  struct ExpandoNode *node_false = node_get_child(node, ENC_FALSE);
+  struct ExpandoNode *node_cond = node_get_child(exp->node, ENC_CONDITION);
+  struct ExpandoNode *node_true = node_get_child(exp->node, ENC_TRUE);
+  struct ExpandoNode *node_false = node_get_child(exp->node, ENC_FALSE);
 
   check_node_conddate(node_cond, 1, 'm');
   check_node_expando(node_true, "%d-%m-%Y", NULL);
   check_node_expando(node_false, "%Y-%m-%d", NULL);
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
 }

--- a/test/expando/conditional_date_render.c
+++ b/test/expando/conditional_date_render.c
@@ -62,35 +62,25 @@ static void cond_date(const struct ExpandoNode *node, void *data,
 
 void test_expando_conditional_date_render(void)
 {
-  struct ExpandoParseError err = { 0 };
-
   const char *input = "%<[1m?a&banana>";
-
-  struct ExpandoNode *root = NULL;
 
   const struct ExpandoDefinition defs[] = {
     { "[", NULL, 1, 2, 0, parse_date },
     { NULL, NULL, 0, 0, 0, NULL },
   };
 
-  node_tree_parse(&root, input, defs, &err);
-  TEST_CHECK(err.position == NULL);
+  struct Buffer *err = buf_pool_get();
 
-  struct ExpandoNode *node = get_nth_node(root, 0);
-  check_node_cond(node);
+  struct Expando *exp = expando_parse(input, defs, err);
+  TEST_CHECK(buf_is_empty(err));
 
-  struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
-  struct ExpandoNode *node_true = node_get_child(node, ENC_TRUE);
-  struct ExpandoNode *node_false = node_get_child(node, ENC_FALSE);
+  struct ExpandoNode *node_cond = node_get_child(exp->node, ENC_CONDITION);
+  struct ExpandoNode *node_true = node_get_child(exp->node, ENC_TRUE);
+  struct ExpandoNode *node_false = node_get_child(exp->node, ENC_FALSE);
 
   check_node_conddate(node_cond, 1, 'm');
   check_node_text(node_true, "a");
   check_node_text(node_false, "banana");
-
-  const struct Expando exp = {
-    .string = input,
-    .node = root,
-  };
 
   const struct ExpandoRenderData render[] = {
     { 1, 2, cond_date, cond_date_num },
@@ -104,7 +94,7 @@ void test_expando_conditional_date_render(void)
 
     char *expected = "a";
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
     TEST_CHECK_STR_EQ(buf_string(buf), expected);
     buf_pool_release(&buf);
@@ -117,11 +107,12 @@ void test_expando_conditional_date_render(void)
 
     char *expected = "banana";
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
     TEST_CHECK_STR_EQ(buf_string(buf), expected);
     buf_pool_release(&buf);
   }
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
 }

--- a/test/expando/conditional_date_render2.c
+++ b/test/expando/conditional_date_render2.c
@@ -62,35 +62,26 @@ static void cond_date(const struct ExpandoNode *node, void *data,
 
 void test_expando_conditional_date_render2(void)
 {
-  struct ExpandoParseError err = { 0 };
-
   const char *input = "%<[1m?%[%d-%m-%Y]&%[%Y-%m-%d]>";
-
-  struct ExpandoNode *root = NULL;
 
   const struct ExpandoDefinition defs[] = {
     { "[", NULL, 1, 2, 0, parse_date },
     { NULL, NULL, 0, 0, 0, NULL },
   };
 
-  node_tree_parse(&root, input, defs, &err);
-  TEST_CHECK(err.position == NULL);
+  struct Buffer *err = buf_pool_get();
 
-  struct ExpandoNode *node = get_nth_node(root, 0);
-  check_node_cond(node);
+  struct Expando *exp = expando_parse(input, defs, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
 
-  struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
-  struct ExpandoNode *node_true = node_get_child(node, ENC_TRUE);
-  struct ExpandoNode *node_false = node_get_child(node, ENC_FALSE);
+  struct ExpandoNode *node_cond = node_get_child(exp->node, ENC_CONDITION);
+  struct ExpandoNode *node_true = node_get_child(exp->node, ENC_TRUE);
+  struct ExpandoNode *node_false = node_get_child(exp->node, ENC_FALSE);
 
   check_node_conddate(node_cond, 1, 'm');
   check_node_expando(node_true, "%d-%m-%Y", NULL);
   check_node_expando(node_false, "%Y-%m-%d", NULL);
-
-  const struct Expando exp = {
-    .string = input,
-    .node = root,
-  };
 
   const struct ExpandoRenderData render[] = {
     { 1, 2, cond_date, cond_date_num },
@@ -107,7 +98,7 @@ void test_expando_conditional_date_render2(void)
     strftime(expected, sizeof(expected), "%d-%m-%Y", &tm);
 
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
     TEST_CHECK_STR_EQ(buf_string(buf), expected);
     buf_pool_release(&buf);
@@ -123,11 +114,12 @@ void test_expando_conditional_date_render2(void)
     strftime(expected, sizeof(expected), "%Y-%m-%d", &tm);
 
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
     TEST_CHECK_STR_EQ(buf_string(buf), expected);
     buf_pool_release(&buf);
   }
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
 }

--- a/test/expando/date_render.c
+++ b/test/expando/date_render.c
@@ -57,8 +57,6 @@ static void simple_date(const struct ExpandoNode *node, void *data,
 
 void test_expando_date_render(void)
 {
-  struct ExpandoParseError err = { 0 };
-
   struct SimpleDateData data = {
     .t = 1457341200,
   };
@@ -66,26 +64,21 @@ void test_expando_date_render(void)
   {
     const char *input = "%[%Y-%m-%d] date";
 
-    struct ExpandoNode *root = NULL;
-
     const struct ExpandoDefinition defs[] = {
       { "[", NULL, 1, 0, 0, parse_date },
       { NULL, NULL, 0, 0, 0, NULL },
     };
 
-    node_tree_parse(&root, input, defs, &err);
+    struct Buffer *err = buf_pool_get();
 
-    TEST_CHECK(err.position == NULL);
+    struct Expando *exp = expando_parse(input, defs, err);
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
 
-    check_node_expando(get_nth_node(root, 0), "%Y-%m-%d", NULL);
-    check_node_text(get_nth_node(root, 1), " date");
+    check_node_expando(node_get_child(exp->node, 0), "%Y-%m-%d", NULL);
+    check_node_text(node_get_child(exp->node, 1), " date");
 
     const char *expected = "2016-03-07 date";
-
-    const struct Expando exp = {
-      .string = input,
-      .node = root,
-    };
 
     const struct ExpandoRenderData render[] = {
       { 1, 0, simple_date },
@@ -93,27 +86,28 @@ void test_expando_date_render(void)
     };
 
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
     TEST_CHECK_STR_EQ(buf_string(buf), expected);
 
-    node_tree_free(&root);
+    expando_free(&exp);
     buf_pool_release(&buf);
+    buf_pool_release(&err);
   }
 
   {
     const char *input = "%-12[%Y-%m-%d]";
-
-    struct ExpandoNode *root = NULL;
 
     const struct ExpandoDefinition defs[] = {
       { "[", NULL, 1, 0, 0, parse_date },
       { NULL, NULL, 0, 0, 0, NULL },
     };
 
-    node_tree_parse(&root, input, defs, &err);
+    struct Buffer *err = buf_pool_get();
+    struct Expando *exp = expando_parse(input, defs, err);
 
-    TEST_CHECK(err.position == NULL);
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
 
     struct ExpandoFormat fmt = { 0 };
     fmt.min_cols = 12;
@@ -121,14 +115,9 @@ void test_expando_date_render(void)
     fmt.justification = JUSTIFY_LEFT;
     fmt.leader = ' ';
 
-    check_node_expando(get_nth_node(root, 0), "%Y-%m-%d", &fmt);
+    check_node_expando(exp->node, "%Y-%m-%d", &fmt);
 
     const char *expected = "2016-03-07  ";
-
-    const struct Expando exp = {
-      .string = input,
-      .node = root,
-    };
 
     const struct ExpandoRenderData render[] = {
       { 1, 0, simple_date },
@@ -136,11 +125,12 @@ void test_expando_date_render(void)
     };
 
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
     TEST_CHECK_STR_EQ(buf_string(buf), expected);
 
-    node_tree_free(&root);
+    expando_free(&exp);
+    buf_pool_release(&err);
     buf_pool_release(&buf);
   }
 }

--- a/test/expando/emoji_text.c
+++ b/test/expando/emoji_text.c
@@ -29,14 +29,19 @@
 
 void test_expando_emoji_text(void)
 {
+  const struct ExpandoDefinition defs[] = {
+    { NULL, NULL, 0, 0, 0, NULL },
+  };
+
   const char *input = "emoji text😀😀😀😀";
-  struct ExpandoParseError err = { 0 };
-  struct ExpandoNode *root = NULL;
+  struct Buffer *err = buf_pool_get();
 
-  node_tree_parse(&root, input, NULL, &err);
+  struct Expando *exp = expando_parse(input, defs, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
 
-  TEST_CHECK(err.position == NULL);
-  check_node_text(get_nth_node(root, 0), input);
+  check_node_text(exp->node, input);
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
 }

--- a/test/expando/empty.c
+++ b/test/expando/empty.c
@@ -32,11 +32,10 @@ void test_expando_empty(void)
   const char *input = "";
   struct ExpandoParseError err = { 0 };
   struct ExpandoNode *root = NULL;
+  const char *parsed_until = NULL;
 
-  node_tree_parse(&root, input, NULL, &err);
+  root = node_parse(input, NULL, CON_NO_CONDITION, &parsed_until, NULL, &err);
 
   TEST_CHECK(err.position == NULL);
-  check_node_empty(get_nth_node(root, 0));
-
-  node_tree_free(&root);
+  TEST_CHECK(root == NULL);
 }

--- a/test/expando/empty_if_else.c
+++ b/test/expando/empty_if_else.c
@@ -37,77 +37,68 @@ void test_expando_empty_if_else(void)
     { NULL, NULL, 0, -1, -1, NULL }
     // clang-format on
   };
-  struct ExpandoParseError err = { 0 };
+
+  struct Buffer *err = buf_pool_get();
 
   const char *input1 = "%<c?>";
-  struct ExpandoNode *root1 = NULL;
-  node_tree_parse(&root1, input1, TestFormatDef, &err);
-  TEST_CHECK(err.position == NULL);
-  {
-    struct ExpandoNode *node = get_nth_node(root1, 0);
-    check_node_cond(node);
+  struct Expando *exp = expando_parse(input1, TestFormatDef, err);
+  TEST_CHECK(exp != NULL);
 
-    struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
-    struct ExpandoNode *node_true = node_get_child(node, ENC_TRUE);
-    struct ExpandoNode *node_false = node_get_child(node, ENC_FALSE);
+  TEST_CHECK(buf_is_empty(err));
+  {
+    struct ExpandoNode *node_cond = node_get_child(exp->node, ENC_CONDITION);
+    struct ExpandoNode *node_true = node_get_child(exp->node, ENC_TRUE);
+    struct ExpandoNode *node_false = node_get_child(exp->node, ENC_FALSE);
 
     check_node_condbool(node_cond, "c");
-    check_node_empty(node_true);
+    TEST_CHECK(node_true == NULL);
     TEST_CHECK(node_false == NULL);
   }
-  node_tree_free(&root1);
+  expando_free(&exp);
 
   const char *input2 = "%<c?&>";
-  struct ExpandoNode *root2 = NULL;
-  node_tree_parse(&root2, input2, TestFormatDef, &err);
-  TEST_CHECK(err.position == NULL);
+  exp = expando_parse(input2, TestFormatDef, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
   {
-    struct ExpandoNode *node = get_nth_node(root2, 0);
-    check_node_cond(node);
-
-    struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
-    struct ExpandoNode *node_true = node_get_child(node, ENC_TRUE);
-    struct ExpandoNode *node_false = node_get_child(node, ENC_FALSE);
+    struct ExpandoNode *node_cond = node_get_child(exp->node, ENC_CONDITION);
+    struct ExpandoNode *node_true = node_get_child(exp->node, ENC_TRUE);
+    struct ExpandoNode *node_false = node_get_child(exp->node, ENC_FALSE);
 
     check_node_condbool(node_cond, "c");
-    check_node_empty(node_true);
-    check_node_empty(node_false);
+    TEST_CHECK(node_true == NULL);
+    TEST_CHECK(node_false == NULL);
   }
-  node_tree_free(&root2);
+  expando_free(&exp);
 
   const char *input3 = "%<c?%t&>";
-  struct ExpandoNode *root3 = NULL;
-  node_tree_parse(&root3, input3, TestFormatDef, &err);
-  TEST_CHECK(err.position == NULL);
+  exp = expando_parse(input3, TestFormatDef, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
   {
-    struct ExpandoNode *node = get_nth_node(root3, 0);
-    check_node_cond(node);
-
-    struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
-    struct ExpandoNode *node_true = node_get_child(node, ENC_TRUE);
-    struct ExpandoNode *node_false = node_get_child(node, ENC_FALSE);
+    struct ExpandoNode *node_cond = node_get_child(exp->node, ENC_CONDITION);
+    struct ExpandoNode *node_true = node_get_child(exp->node, ENC_TRUE);
+    struct ExpandoNode *node_false = node_get_child(exp->node, ENC_FALSE);
 
     check_node_condbool(node_cond, "c");
     check_node_expando(node_true, "t", NULL);
-    check_node_empty(node_false);
+    TEST_CHECK(node_false == NULL);
   }
-  node_tree_free(&root3);
+  expando_free(&exp);
 
   const char *input4 = "%<c?&%f>";
-  struct ExpandoNode *root4 = NULL;
-  node_tree_parse(&root4, input4, TestFormatDef, &err);
-  TEST_CHECK(err.position == NULL);
+  exp = expando_parse(input4, TestFormatDef, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
   {
-    struct ExpandoNode *node = get_nth_node(root4, 0);
-    check_node_cond(node);
-
-    struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
-    struct ExpandoNode *node_true = node_get_child(node, ENC_TRUE);
-    struct ExpandoNode *node_false = node_get_child(node, ENC_FALSE);
+    struct ExpandoNode *node_cond = node_get_child(exp->node, ENC_CONDITION);
+    struct ExpandoNode *node_true = node_get_child(exp->node, ENC_TRUE);
+    struct ExpandoNode *node_false = node_get_child(exp->node, ENC_FALSE);
 
     check_node_condbool(node_cond, "c");
-    check_node_empty(node_true);
+    TEST_CHECK(node_true == NULL);
     check_node_expando(node_false, "f", NULL);
   }
-  node_tree_free(&root4);
+  expando_free(&exp);
+  buf_pool_release(&err);
 }

--- a/test/expando/empty_if_else_render.c
+++ b/test/expando/empty_if_else_render.c
@@ -60,8 +60,6 @@ static void simple_f(const struct ExpandoNode *node, void *data,
 
 void test_expando_empty_if_else_render(void)
 {
-  struct ExpandoParseError err = { 0 };
-
   const char *input = "%<c?&%f>";
 
   const struct ExpandoDefinition defs[] = {
@@ -70,25 +68,19 @@ void test_expando_empty_if_else_render(void)
     { NULL, NULL, 0, 0, 0, NULL },
   };
 
-  struct ExpandoNode *root = NULL;
-  node_tree_parse(&root, input, defs, &err);
-  TEST_CHECK(err.position == NULL);
+  struct Buffer *err = buf_pool_get();
 
-  struct ExpandoNode *node = get_nth_node(root, 0);
-  check_node_cond(node);
+  struct Expando *exp = expando_parse(input, defs, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
 
-  struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
-  struct ExpandoNode *node_true = node_get_child(node, ENC_TRUE);
-  struct ExpandoNode *node_false = node_get_child(node, ENC_FALSE);
+  struct ExpandoNode *node_cond = node_get_child(exp->node, ENC_CONDITION);
+  struct ExpandoNode *node_true = node_get_child(exp->node, ENC_TRUE);
+  struct ExpandoNode *node_false = node_get_child(exp->node, ENC_FALSE);
 
   check_node_condbool(node_cond, "c");
-  check_node_empty(node_true);
+  TEST_CHECK(node_true == NULL);
   check_node_expando(node_false, "f", NULL);
-
-  const struct Expando exp = {
-    .string = input,
-    .node = root,
-  };
 
   const struct ExpandoRenderData render[] = {
     { 1, 0, simple_c },
@@ -102,7 +94,7 @@ void test_expando_empty_if_else_render(void)
   };
 
   struct Buffer *buf = buf_pool_get();
-  expando_render(&exp, render, &data1, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+  expando_render(exp, render, &data1, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
   const char *expected1 = "3";
   TEST_CHECK_STR_EQ(buf_string(buf), expected1);
@@ -113,11 +105,12 @@ void test_expando_empty_if_else_render(void)
   };
 
   buf_reset(buf);
-  expando_render(&exp, render, &data2, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+  expando_render(exp, render, &data2, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
   const char *expected2 = "";
   TEST_CHECK_STR_EQ(buf_string(buf), expected2);
 
-  node_tree_free(&root);
+  expando_free(&exp);
   buf_pool_release(&buf);
+  buf_pool_release(&err);
 }

--- a/test/expando/filter.c
+++ b/test/expando/filter.c
@@ -57,31 +57,33 @@ void test_expando_filter(void)
     };
     TEST_CHECK(!check_for_pipe(NULL));
 
-    struct ExpandoNode *node = node_new();
+    struct ExpandoNode *root = node_new();
+    struct ExpandoNode *first = node_new();
     struct ExpandoNode *last = node_new();
 
-    node->next = last;
+    node_add_child(root, first);
+    node_add_child(root, last);
 
-    TEST_CHECK(!check_for_pipe(node));
+    TEST_CHECK(!check_for_pipe(root));
 
-    node->type = ENT_TEXT;
-    TEST_CHECK(!check_for_pipe(node));
+    first->type = ENT_TEXT;
+    TEST_CHECK(!check_for_pipe(root));
 
     last->type = ENT_TEXT;
-    TEST_CHECK(!check_for_pipe(node));
+    TEST_CHECK(!check_for_pipe(root));
 
     const char *str = "hello|";
     last->start = str + 5;
     last->end = str;
-    TEST_CHECK(!check_for_pipe(node));
+    TEST_CHECK(!check_for_pipe(root));
 
     last->start = str;
     last->end = str;
-    TEST_CHECK(!check_for_pipe(node));
+    TEST_CHECK(!check_for_pipe(root));
 
     last->start = str;
     last->end = str + 5;
-    TEST_CHECK(!check_for_pipe(node));
+    TEST_CHECK(!check_for_pipe(root));
 
     for (size_t i = 0; i < mutt_array_size(tests); i++)
     {
@@ -90,10 +92,10 @@ void test_expando_filter(void)
       last->start = str;
       size_t len = strlen(str);
       last->end = last->start + len;
-      TEST_CHECK(check_for_pipe(node) == tests[i].value);
+      TEST_CHECK(check_for_pipe(root) == tests[i].value);
     }
 
-    node_tree_free(&node);
+    node_free(&root);
   }
 
   // void filter_text(struct Buffer *buf);

--- a/test/expando/formatted_expando.c
+++ b/test/expando/formatted_expando.c
@@ -37,14 +37,15 @@ void test_expando_formatted_expando(void)
     // clang-format on
   };
   const char *input = "%X %8X %-8X %08X %.8X %8.8X %-8.8X %=8X";
-  struct ExpandoParseError err = { 0 };
-  struct ExpandoNode *root = NULL;
 
-  node_tree_parse(&root, input, TestFormatDef, &err);
+  struct Buffer *err = buf_pool_get();
 
-  TEST_CHECK(err.position == NULL);
-  check_node_expando(get_nth_node(root, 0), "X", NULL);
-  check_node_text(get_nth_node(root, 1), " ");
+  struct Expando *exp = expando_parse(input, TestFormatDef, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
+
+  check_node_expando(node_get_child(exp->node, 0), "X", NULL);
+  check_node_text(node_get_child(exp->node, 1), " ");
 
   {
     struct ExpandoFormat fmt = { 0 };
@@ -52,8 +53,8 @@ void test_expando_formatted_expando(void)
     fmt.max_cols = INT_MAX;
     fmt.justification = JUSTIFY_RIGHT;
     fmt.leader = ' ';
-    check_node_expando(get_nth_node(root, 2), "X", &fmt);
-    check_node_text(get_nth_node(root, 3), " ");
+    check_node_expando(node_get_child(exp->node, 2), "X", &fmt);
+    check_node_text(node_get_child(exp->node, 3), " ");
   }
 
   {
@@ -62,8 +63,8 @@ void test_expando_formatted_expando(void)
     fmt.max_cols = INT_MAX;
     fmt.justification = JUSTIFY_LEFT;
     fmt.leader = ' ';
-    check_node_expando(get_nth_node(root, 4), "X", &fmt);
-    check_node_text(get_nth_node(root, 5), " ");
+    check_node_expando(node_get_child(exp->node, 4), "X", &fmt);
+    check_node_text(node_get_child(exp->node, 5), " ");
   }
 
   {
@@ -72,8 +73,8 @@ void test_expando_formatted_expando(void)
     fmt.max_cols = INT_MAX;
     fmt.justification = JUSTIFY_RIGHT;
     fmt.leader = '0';
-    check_node_expando(get_nth_node(root, 6), "X", &fmt);
-    check_node_text(get_nth_node(root, 7), " ");
+    check_node_expando(node_get_child(exp->node, 6), "X", &fmt);
+    check_node_text(node_get_child(exp->node, 7), " ");
   }
 
   {
@@ -82,8 +83,8 @@ void test_expando_formatted_expando(void)
     fmt.max_cols = 8;
     fmt.justification = JUSTIFY_RIGHT;
     fmt.leader = ' ';
-    check_node_expando(get_nth_node(root, 8), "X", &fmt);
-    check_node_text(get_nth_node(root, 9), " ");
+    check_node_expando(node_get_child(exp->node, 8), "X", &fmt);
+    check_node_text(node_get_child(exp->node, 9), " ");
   }
 
   {
@@ -92,8 +93,8 @@ void test_expando_formatted_expando(void)
     fmt.max_cols = 8;
     fmt.justification = JUSTIFY_RIGHT;
     fmt.leader = ' ';
-    check_node_expando(get_nth_node(root, 10), "X", &fmt);
-    check_node_text(get_nth_node(root, 11), " ");
+    check_node_expando(node_get_child(exp->node, 10), "X", &fmt);
+    check_node_text(node_get_child(exp->node, 11), " ");
   }
 
   {
@@ -102,8 +103,8 @@ void test_expando_formatted_expando(void)
     fmt.max_cols = 8;
     fmt.justification = JUSTIFY_LEFT;
     fmt.leader = ' ';
-    check_node_expando(get_nth_node(root, 12), "X", &fmt);
-    check_node_text(get_nth_node(root, 13), " ");
+    check_node_expando(node_get_child(exp->node, 12), "X", &fmt);
+    check_node_text(node_get_child(exp->node, 13), " ");
   }
 
   {
@@ -112,8 +113,9 @@ void test_expando_formatted_expando(void)
     fmt.max_cols = INT_MAX;
     fmt.justification = JUSTIFY_CENTER;
     fmt.leader = ' ';
-    check_node_expando(get_nth_node(root, 14), "X", &fmt);
+    check_node_expando(node_get_child(exp->node, 14), "X", &fmt);
   }
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
 }

--- a/test/expando/if_else_false_render.c
+++ b/test/expando/if_else_false_render.c
@@ -71,10 +71,6 @@ static void simple_f(const struct ExpandoNode *node, void *data,
 
 void test_expando_if_else_false_render(void)
 {
-  const char *input = "%<c?%t>%<c?%t&%f>";
-  struct ExpandoParseError err = { 0 };
-  struct ExpandoNode *root = NULL;
-
   const struct ExpandoDefinition defs[] = {
     { "c", NULL, 1, 0, 0, NULL },
     { "t", NULL, 1, 1, 0, NULL },
@@ -82,11 +78,15 @@ void test_expando_if_else_false_render(void)
     { NULL, NULL, 0, 0, 0, NULL },
   };
 
-  node_tree_parse(&root, input, defs, &err);
+  const char *input = "%<c?%t>%<c?%t&%f>";
+  struct Buffer *err = buf_pool_get();
 
-  TEST_CHECK(err.position == NULL);
+  struct Expando *exp = expando_parse(input, defs, err);
+
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
   {
-    struct ExpandoNode *node = get_nth_node(root, 0);
+    struct ExpandoNode *node = node_get_child(exp->node, 0);
     check_node_cond(node);
 
     struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
@@ -99,7 +99,7 @@ void test_expando_if_else_false_render(void)
   }
 
   {
-    struct ExpandoNode *node = get_nth_node(root, 1);
+    struct ExpandoNode *node = node_get_child(exp->node, 1);
     check_node_cond(node);
 
     struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
@@ -112,11 +112,6 @@ void test_expando_if_else_false_render(void)
   }
 
   const char *expected = "3";
-
-  const struct Expando exp = {
-    .string = input,
-    .node = root,
-  };
 
   const struct ExpandoRenderData render[] = {
     { 1, 0, simple_c },
@@ -134,11 +129,12 @@ void test_expando_if_else_false_render(void)
       .f = 3,
     };
 
-    expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
     TEST_CHECK_STR_EQ(buf_string(buf), expected);
   }
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
   buf_pool_release(&buf);
 }

--- a/test/expando/if_else_true_render.c
+++ b/test/expando/if_else_true_render.c
@@ -70,8 +70,6 @@ static void simple_f(const struct ExpandoNode *node, void *data,
 void test_expando_if_else_true_render(void)
 {
   const char *input = "%<c?%t>%<c?%t&%f>";
-  struct ExpandoParseError err = { 0 };
-  struct ExpandoNode *root = NULL;
 
   const struct ExpandoDefinition defs[] = {
     { "c", NULL, 1, 0, 0, NULL },
@@ -80,11 +78,13 @@ void test_expando_if_else_true_render(void)
     { NULL, NULL, 0, 0, 0, NULL },
   };
 
-  node_tree_parse(&root, input, defs, &err);
+  struct Buffer *err = buf_pool_get();
+  struct Expando *exp = expando_parse(input, defs, err);
 
-  TEST_CHECK(err.position == NULL);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
   {
-    struct ExpandoNode *node = get_nth_node(root, 0);
+    struct ExpandoNode *node = node_get_child(exp->node, 0);
     check_node_cond(node);
 
     struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
@@ -97,7 +97,7 @@ void test_expando_if_else_true_render(void)
   }
 
   {
-    struct ExpandoNode *node = get_nth_node(root, 1);
+    struct ExpandoNode *node = node_get_child(exp->node, 1);
     check_node_cond(node);
 
     struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
@@ -110,11 +110,6 @@ void test_expando_if_else_true_render(void)
   }
 
   const char *expected = "22";
-
-  const struct Expando exp = {
-    .string = input,
-    .node = root,
-  };
 
   const struct ExpandoRenderData render[] = {
     { 1, 0, simple_c },
@@ -130,10 +125,11 @@ void test_expando_if_else_true_render(void)
   };
 
   struct Buffer *buf = buf_pool_get();
-  expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+  expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
   TEST_CHECK_STR_EQ(buf_string(buf), expected);
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
   buf_pool_release(&buf);
 }

--- a/test/expando/nested_if_else.c
+++ b/test/expando/nested_if_else.c
@@ -41,23 +41,18 @@ void test_expando_nested_if_else(void)
     { NULL, NULL, 0, -1, -1, NULL }
     // clang-format on
   };
-  struct ExpandoParseError err = { 0 };
+  struct Buffer *err = buf_pool_get();
 
   {
     const char *input = "%<a?%<b?%c&%d>&%<e?%f&%g>>";
 
-    struct ExpandoNode *root = NULL;
+    struct Expando *exp = expando_parse(input, TestFormatDef, err);
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
 
-    node_tree_parse(&root, input, TestFormatDef, &err);
-
-    TEST_CHECK(err.position == NULL);
-
-    struct ExpandoNode *node = get_nth_node(root, 0);
-    check_node_cond(node);
-
-    struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
-    struct ExpandoNode *node_true = node_get_child(node, ENC_TRUE);
-    struct ExpandoNode *node_false = node_get_child(node, ENC_FALSE);
+    struct ExpandoNode *node_cond = node_get_child(exp->node, ENC_CONDITION);
+    struct ExpandoNode *node_true = node_get_child(exp->node, ENC_TRUE);
+    struct ExpandoNode *node_false = node_get_child(exp->node, ENC_FALSE);
 
     check_node_condbool(node_cond, "a");
 
@@ -83,24 +78,19 @@ void test_expando_nested_if_else(void)
     check_node_expando(node_true, "f", NULL);
     check_node_expando(node_false, "g", NULL);
 
-    node_tree_free(&root);
+    expando_free(&exp);
   }
 
   {
     const char *input = "%<a?%<b?%c&%d>&%<e?%f>>";
 
-    struct ExpandoNode *root = NULL;
+    struct Expando *exp = expando_parse(input, TestFormatDef, err);
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
 
-    node_tree_parse(&root, input, TestFormatDef, &err);
-
-    TEST_CHECK(err.position == NULL);
-
-    struct ExpandoNode *node = get_nth_node(root, 0);
-    check_node_cond(node);
-
-    struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
-    struct ExpandoNode *node_true = node_get_child(node, ENC_TRUE);
-    struct ExpandoNode *node_false = node_get_child(node, ENC_FALSE);
+    struct ExpandoNode *node_cond = node_get_child(exp->node, ENC_CONDITION);
+    struct ExpandoNode *node_true = node_get_child(exp->node, ENC_TRUE);
+    struct ExpandoNode *node_false = node_get_child(exp->node, ENC_FALSE);
 
     check_node_condbool(node_cond, "a");
 
@@ -126,24 +116,19 @@ void test_expando_nested_if_else(void)
     check_node_expando(node_true, "f", NULL);
     TEST_CHECK(node_false == NULL);
 
-    node_tree_free(&root);
+    expando_free(&exp);
   }
 
   {
     const char *input = "%<a?%<b?%c&%d>&%<e?&%f>>";
 
-    struct ExpandoNode *root = NULL;
+    struct Expando *exp = expando_parse(input, TestFormatDef, err);
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
 
-    node_tree_parse(&root, input, TestFormatDef, &err);
-
-    TEST_CHECK(err.position == NULL);
-
-    struct ExpandoNode *node = get_nth_node(root, 0);
-    check_node_cond(node);
-
-    struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
-    struct ExpandoNode *node_true = node_get_child(node, ENC_TRUE);
-    struct ExpandoNode *node_false = node_get_child(node, ENC_FALSE);
+    struct ExpandoNode *node_cond = node_get_child(exp->node, ENC_CONDITION);
+    struct ExpandoNode *node_true = node_get_child(exp->node, ENC_TRUE);
+    struct ExpandoNode *node_false = node_get_child(exp->node, ENC_FALSE);
 
     check_node_condbool(node_cond, "a");
 
@@ -166,27 +151,22 @@ void test_expando_nested_if_else(void)
     node_false = node_get_child(f, ENC_FALSE);
 
     check_node_condbool(node_cond, "e");
-    check_node_empty(node_true);
+    TEST_CHECK(node_true == NULL);
     check_node_expando(node_false, "f", NULL);
 
-    node_tree_free(&root);
+    expando_free(&exp);
   }
 
   {
     const char *input = "%<a?%<b?%c>&%<e?%f&%g>>";
 
-    struct ExpandoNode *root = NULL;
+    struct Expando *exp = expando_parse(input, TestFormatDef, err);
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
 
-    node_tree_parse(&root, input, TestFormatDef, &err);
-
-    TEST_CHECK(err.position == NULL);
-
-    struct ExpandoNode *node = get_nth_node(root, 0);
-    check_node_cond(node);
-
-    struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
-    struct ExpandoNode *node_true = node_get_child(node, ENC_TRUE);
-    struct ExpandoNode *node_false = node_get_child(node, ENC_FALSE);
+    struct ExpandoNode *node_cond = node_get_child(exp->node, ENC_CONDITION);
+    struct ExpandoNode *node_true = node_get_child(exp->node, ENC_TRUE);
+    struct ExpandoNode *node_false = node_get_child(exp->node, ENC_FALSE);
 
     check_node_condbool(node_cond, "a");
 
@@ -212,24 +192,19 @@ void test_expando_nested_if_else(void)
     check_node_expando(node_true, "f", NULL);
     check_node_expando(node_false, "g", NULL);
 
-    node_tree_free(&root);
+    expando_free(&exp);
   }
 
   {
     const char *input = "%<a?%<b?&%c>&%<e?%f&%g>>";
 
-    struct ExpandoNode *root = NULL;
+    struct Expando *exp = expando_parse(input, TestFormatDef, err);
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
 
-    node_tree_parse(&root, input, TestFormatDef, &err);
-
-    TEST_CHECK(err.position == NULL);
-
-    struct ExpandoNode *node = get_nth_node(root, 0);
-    check_node_cond(node);
-
-    struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
-    struct ExpandoNode *node_true = node_get_child(node, ENC_TRUE);
-    struct ExpandoNode *node_false = node_get_child(node, ENC_FALSE);
+    struct ExpandoNode *node_cond = node_get_child(exp->node, ENC_CONDITION);
+    struct ExpandoNode *node_true = node_get_child(exp->node, ENC_TRUE);
+    struct ExpandoNode *node_false = node_get_child(exp->node, ENC_FALSE);
 
     check_node_condbool(node_cond, "a");
 
@@ -244,7 +219,7 @@ void test_expando_nested_if_else(void)
     node_false = node_get_child(t, ENC_FALSE);
 
     check_node_condbool(node_cond, "b");
-    check_node_empty(node_true);
+    TEST_CHECK(node_true == NULL);
     check_node_expando(node_false, "c", NULL);
 
     node_cond = node_get_child(f, ENC_CONDITION);
@@ -255,6 +230,8 @@ void test_expando_nested_if_else(void)
     check_node_expando(node_true, "f", NULL);
     check_node_expando(node_false, "g", NULL);
 
-    node_tree_free(&root);
+    expando_free(&exp);
   }
+
+  buf_pool_release(&err);
 }

--- a/test/expando/nested_if_else_render.c
+++ b/test/expando/nested_if_else_render.c
@@ -62,8 +62,6 @@ static void nested_y(const struct ExpandoNode *node, void *data,
 void test_expando_nested_if_else_render(void)
 {
   const char *input = "%<x?%<y?XY&X>&%<y?Y&NONE>>";
-  struct ExpandoParseError err = { 0 };
-  struct ExpandoNode *root = NULL;
 
   const struct ExpandoDefinition defs[] = {
     { "x", NULL, 1, 0, 0, NULL },
@@ -71,16 +69,14 @@ void test_expando_nested_if_else_render(void)
     { NULL, NULL, 0, 0, 0, NULL },
   };
 
-  node_tree_parse(&root, input, defs, &err);
+  struct Buffer *err = buf_pool_get();
+  struct Expando *exp = expando_parse(input, defs, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
 
-  TEST_CHECK(err.position == NULL);
-
-  struct ExpandoNode *node = get_nth_node(root, 0);
-  check_node_cond(node);
-
-  struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
-  struct ExpandoNode *node_true = node_get_child(node, ENC_TRUE);
-  struct ExpandoNode *node_false = node_get_child(node, ENC_FALSE);
+  struct ExpandoNode *node_cond = node_get_child(exp->node, ENC_CONDITION);
+  struct ExpandoNode *node_true = node_get_child(exp->node, ENC_TRUE);
+  struct ExpandoNode *node_false = node_get_child(exp->node, ENC_FALSE);
 
   check_node_condbool(node_cond, "x");
 
@@ -106,11 +102,6 @@ void test_expando_nested_if_else_render(void)
   check_node_text(node_true, "Y");
   check_node_text(node_false, "NONE");
 
-  const struct Expando exp = {
-    .string = input,
-    .node = root,
-  };
-
   const struct ExpandoRenderData render[] = {
     { 1, 0, nested_x },
     { 1, 1, nested_y },
@@ -124,7 +115,7 @@ void test_expando_nested_if_else_render(void)
   };
 
   struct Buffer *buf = buf_pool_get();
-  expando_render(&exp, render, &data_X, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+  expando_render(exp, render, &data_X, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
   TEST_CHECK_STR_EQ(buf_string(buf), expected_X);
 
@@ -135,7 +126,7 @@ void test_expando_nested_if_else_render(void)
   };
 
   buf_reset(buf);
-  expando_render(&exp, render, &data_Y, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+  expando_render(exp, render, &data_Y, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
   TEST_CHECK_STR_EQ(buf_string(buf), expected_Y);
 
@@ -146,7 +137,7 @@ void test_expando_nested_if_else_render(void)
   };
 
   buf_reset(buf);
-  expando_render(&exp, render, &data_XY, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+  expando_render(exp, render, &data_XY, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
   TEST_CHECK_STR_EQ(buf_string(buf), expected_XY);
 
@@ -157,10 +148,11 @@ void test_expando_nested_if_else_render(void)
   };
 
   buf_reset(buf);
-  expando_render(&exp, render, &data_NONE, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+  expando_render(exp, render, &data_NONE, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
   TEST_CHECK_STR_EQ(buf_string(buf), expected_NONE);
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
   buf_pool_release(&buf);
 }

--- a/test/expando/new_if_else.c
+++ b/test/expando/new_if_else.c
@@ -38,16 +38,16 @@ void test_expando_new_if_else(void)
     // clang-format on
   };
   const char *input = "if: %<l?%4l>  if-else: %<l?%4l&%4c>";
-  struct ExpandoParseError err = { 0 };
-  struct ExpandoNode *root = NULL;
 
-  node_tree_parse(&root, input, TestFormatDef, &err);
+  struct Buffer *err = buf_pool_get();
+  struct Expando *exp = expando_parse(input, TestFormatDef, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
 
-  TEST_CHECK(err.position == NULL);
-  check_node_text(get_nth_node(root, 0), "if: ");
+  check_node_text(node_get_child(exp->node, 0), "if: ");
 
   {
-    struct ExpandoNode *node = get_nth_node(root, 1);
+    struct ExpandoNode *node = node_get_child(exp->node, 1);
     check_node_cond(node);
 
     struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
@@ -65,10 +65,10 @@ void test_expando_new_if_else(void)
     TEST_CHECK(node_false == NULL);
   }
 
-  check_node_text(get_nth_node(root, 2), "  if-else: ");
+  check_node_text(node_get_child(exp->node, 2), "  if-else: ");
 
   {
-    struct ExpandoNode *node = get_nth_node(root, 3);
+    struct ExpandoNode *node = node_get_child(exp->node, 3);
     check_node_cond(node);
 
     struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
@@ -86,5 +86,6 @@ void test_expando_new_if_else(void)
     check_node_expando(node_false, "c", &fmt);
   }
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
 }

--- a/test/expando/node.c
+++ b/test/expando/node.c
@@ -36,35 +36,21 @@ void test_expando_node(void)
     struct ExpandoNode *node = node_new();
     node_free(&node);
     node_free(NULL);
+
+    node_add_child(NULL, NULL);
   }
 
-  // void node_tree_free(struct ExpandoNode **ptr);
+  // void node_free(struct ExpandoNode **ptr);
   {
     struct ExpandoNode *first = node_new();
-    struct ExpandoNode *last = first;
 
     for (int i = 0; i < 5; i++)
     {
       struct ExpandoNode *node = node_new();
-      last->next = node;
-      last = node;
+      node_add_child(first, node);
     }
 
-    node_tree_free(&first);
-  }
-
-  // void node_append(struct ExpandoNode **root, struct ExpandoNode *new_node);
-  {
-    struct ExpandoNode *first = NULL;
-
-    for (int i = 0; i < 5; i++)
-    {
-      struct ExpandoNode *node = node_new();
-      node_append(&first, node);
-      TEST_CHECK(first != NULL);
-    }
-
-    node_tree_free(&first);
+    node_free(&first);
   }
 
   // struct ExpandoNode *node_get_child(const struct ExpandoNode *node, int index);
@@ -89,8 +75,8 @@ void test_expando_node(void)
     TEST_CHECK(node_get_child(node, 5) == NULL);
 
     TEST_CHECK(node_get_child(NULL, 0) == NULL);
-    TEST_CHECK(node_get_child(NULL, -1) == NULL);
-    TEST_CHECK(node_get_child(NULL, 10) == NULL);
+    TEST_CHECK(node_get_child(node, -1) == NULL);
+    TEST_CHECK(node_get_child(node, 10) == NULL);
 
     node_free(&node);
   }
@@ -101,23 +87,26 @@ void test_expando_node(void)
     struct ExpandoNode *child0 = node_new();
     struct ExpandoNode *child1 = node_new();
     struct ExpandoNode *child2 = node_new();
-    struct ExpandoNode *next0 = node_new();
-    struct ExpandoNode *next1 = node_new();
-    struct ExpandoNode *next2 = node_new();
-    struct ExpandoNode *n2child0 = node_new();
-    struct ExpandoNode *n2child1 = node_new();
-    struct ExpandoNode *n2child2 = node_new();
 
-    ARRAY_SET(&root->children, 0, child0);
-    ARRAY_SET(&root->children, 1, child1);
-    ARRAY_SET(&root->children, 2, child2);
-    root->next = next0;
-    next0->next = next1;
-    next1->next = next2;
+    node_add_child(root, child0);
+    node_add_child(root, child1);
+    node_add_child(root, child2);
 
-    ARRAY_SET(&next2->children, 0, n2child0);
-    ARRAY_SET(&next2->children, 1, n2child1);
-    ARRAY_SET(&next2->children, 2, n2child2);
+    struct ExpandoNode *child00 = node_new();
+    struct ExpandoNode *child01 = node_new();
+    struct ExpandoNode *child02 = node_new();
+
+    node_add_child(child0, child00);
+    node_add_child(child0, child01);
+    node_add_child(child0, child02);
+
+    struct ExpandoNode *child20 = node_new();
+    struct ExpandoNode *child21 = node_new();
+    struct ExpandoNode *child22 = node_new();
+
+    node_add_child(child2, child20);
+    node_add_child(child2, child21);
+    node_add_child(child2, child22);
 
     struct ExpandoNode *node = NULL;
 
@@ -125,8 +114,8 @@ void test_expando_node(void)
     TEST_CHECK(node == NULL);
 
     node = node_last(root);
-    TEST_CHECK(node == n2child2);
+    TEST_CHECK(node == child22);
 
-    node_tree_free(&root);
+    node_free(&root);
   }
 }

--- a/test/expando/node_padding.c
+++ b/test/expando/node_padding.c
@@ -172,35 +172,35 @@ void test_expando_node_padding(void)
   {
     static const char *TestStrings[][2] = {
       // clang-format off
-      { "",                     "<EMPTY>" },
+      { "",                     "" },
       { "%a",                   "<EXP:'a'(ALIAS,ADDRESS)>" },
-      { "%a%b",                 "<EXP:'a'(ALIAS,ADDRESS)><EXP:'b'(ALIAS,COMMENT)>" },
+      { "%a%b",                 "<CONT:<EXP:'a'(ALIAS,ADDRESS)><EXP:'b'(ALIAS,COMMENT)>>" },
 
       { "%|X",                  "<PAD:FILL_EOL:'X':|>" },
       { "%a%|X",                "<PAD:FILL_EOL:'X':<EXP:'a'(ALIAS,ADDRESS)>|>" },
-      { "%a%b%|X",              "<PAD:FILL_EOL:'X':<EXP:'a'(ALIAS,ADDRESS)><EXP:'b'(ALIAS,COMMENT)>|>" },
+      { "%a%b%|X",              "<PAD:FILL_EOL:'X':<CONT:<EXP:'a'(ALIAS,ADDRESS)><EXP:'b'(ALIAS,COMMENT)>>|>" },
       { "%|X%c",                "<PAD:FILL_EOL:'X':|<EXP:'c'(ALIAS,FLAGS)>>" },
-      { "%|X%c%d",              "<PAD:FILL_EOL:'X':|<EXP:'c'(ALIAS,FLAGS)><EXP:'d'(ALIAS,NAME)>>" },
+      { "%|X%c%d",              "<PAD:FILL_EOL:'X':|<CONT:<EXP:'c'(ALIAS,FLAGS)><EXP:'d'(ALIAS,NAME)>>>" },
       { "%a%|X%c",              "<PAD:FILL_EOL:'X':<EXP:'a'(ALIAS,ADDRESS)>|<EXP:'c'(ALIAS,FLAGS)>>" },
-      { "%a%b%|X%c%d",          "<PAD:FILL_EOL:'X':<EXP:'a'(ALIAS,ADDRESS)><EXP:'b'(ALIAS,COMMENT)>|<EXP:'c'(ALIAS,FLAGS)><EXP:'d'(ALIAS,NAME)>>" },
+      { "%a%b%|X%c%d",          "<PAD:FILL_EOL:'X':<CONT:<EXP:'a'(ALIAS,ADDRESS)><EXP:'b'(ALIAS,COMMENT)>>|<CONT:<EXP:'c'(ALIAS,FLAGS)><EXP:'d'(ALIAS,NAME)>>>" },
       { "%<a?%a%|X%b&%c%|X%d>", "<COND:<BOOL:'a':(ALIAS,ADDRESS)>|<PAD:FILL_EOL:'X':<EXP:'a'(ALIAS,ADDRESS)>|<EXP:'b'(ALIAS,COMMENT)>>|<PAD:FILL_EOL:'X':<EXP:'c'(ALIAS,FLAGS)>|<EXP:'d'(ALIAS,NAME)>>>" },
 
       { "%>X",                  "<PAD:HARD_FILL:'X':|>" },
       { "%a%>X",                "<PAD:HARD_FILL:'X':<EXP:'a'(ALIAS,ADDRESS)>|>" },
-      { "%a%b%>X",              "<PAD:HARD_FILL:'X':<EXP:'a'(ALIAS,ADDRESS)><EXP:'b'(ALIAS,COMMENT)>|>" },
+      { "%a%b%>X",              "<PAD:HARD_FILL:'X':<CONT:<EXP:'a'(ALIAS,ADDRESS)><EXP:'b'(ALIAS,COMMENT)>>|>" },
       { "%>X%c",                "<PAD:HARD_FILL:'X':|<EXP:'c'(ALIAS,FLAGS)>>" },
-      { "%>X%c%d",              "<PAD:HARD_FILL:'X':|<EXP:'c'(ALIAS,FLAGS)><EXP:'d'(ALIAS,NAME)>>" },
+      { "%>X%c%d",              "<PAD:HARD_FILL:'X':|<CONT:<EXP:'c'(ALIAS,FLAGS)><EXP:'d'(ALIAS,NAME)>>>" },
       { "%a%>X%c",              "<PAD:HARD_FILL:'X':<EXP:'a'(ALIAS,ADDRESS)>|<EXP:'c'(ALIAS,FLAGS)>>" },
-      { "%a%b%>X%c%d",          "<PAD:HARD_FILL:'X':<EXP:'a'(ALIAS,ADDRESS)><EXP:'b'(ALIAS,COMMENT)>|<EXP:'c'(ALIAS,FLAGS)><EXP:'d'(ALIAS,NAME)>>" },
+      { "%a%b%>X%c%d",          "<PAD:HARD_FILL:'X':<CONT:<EXP:'a'(ALIAS,ADDRESS)><EXP:'b'(ALIAS,COMMENT)>>|<CONT:<EXP:'c'(ALIAS,FLAGS)><EXP:'d'(ALIAS,NAME)>>>" },
       { "%<a?%a%>X%b&%c%>X%d>", "<COND:<BOOL:'a':(ALIAS,ADDRESS)>|<PAD:HARD_FILL:'X':<EXP:'a'(ALIAS,ADDRESS)>|<EXP:'b'(ALIAS,COMMENT)>>|<PAD:HARD_FILL:'X':<EXP:'c'(ALIAS,FLAGS)>|<EXP:'d'(ALIAS,NAME)>>>" },
 
       { "%*X",                  "<PAD:SOFT_FILL:'X':|>" },
       { "%a%*X",                "<PAD:SOFT_FILL:'X':<EXP:'a'(ALIAS,ADDRESS)>|>" },
-      { "%a%b%*X",              "<PAD:SOFT_FILL:'X':<EXP:'a'(ALIAS,ADDRESS)><EXP:'b'(ALIAS,COMMENT)>|>" },
+      { "%a%b%*X",              "<PAD:SOFT_FILL:'X':<CONT:<EXP:'a'(ALIAS,ADDRESS)><EXP:'b'(ALIAS,COMMENT)>>|>" },
       { "%*X%c",                "<PAD:SOFT_FILL:'X':|<EXP:'c'(ALIAS,FLAGS)>>" },
-      { "%*X%c%d",              "<PAD:SOFT_FILL:'X':|<EXP:'c'(ALIAS,FLAGS)><EXP:'d'(ALIAS,NAME)>>" },
+      { "%*X%c%d",              "<PAD:SOFT_FILL:'X':|<CONT:<EXP:'c'(ALIAS,FLAGS)><EXP:'d'(ALIAS,NAME)>>>" },
       { "%a%*X%c",              "<PAD:SOFT_FILL:'X':<EXP:'a'(ALIAS,ADDRESS)>|<EXP:'c'(ALIAS,FLAGS)>>" },
-      { "%a%b%*X%c%d",          "<PAD:SOFT_FILL:'X':<EXP:'a'(ALIAS,ADDRESS)><EXP:'b'(ALIAS,COMMENT)>|<EXP:'c'(ALIAS,FLAGS)><EXP:'d'(ALIAS,NAME)>>" },
+      { "%a%b%*X%c%d",          "<PAD:SOFT_FILL:'X':<CONT:<EXP:'a'(ALIAS,ADDRESS)><EXP:'b'(ALIAS,COMMENT)>>|<CONT:<EXP:'c'(ALIAS,FLAGS)><EXP:'d'(ALIAS,NAME)>>>" },
       { "%<a?%a%*X%b&%c%*X%d>", "<COND:<BOOL:'a':(ALIAS,ADDRESS)>|<PAD:SOFT_FILL:'X':<EXP:'a'(ALIAS,ADDRESS)>|<EXP:'b'(ALIAS,COMMENT)>>|<PAD:SOFT_FILL:'X':<EXP:'c'(ALIAS,FLAGS)>|<EXP:'d'(ALIAS,NAME)>>>" },
       // clang-format off
     };
@@ -221,6 +221,7 @@ void test_expando_node_padding(void)
       TEST_CASE(format);
 
       exp = expando_parse(format, TestFormatDef, err);
+
       TEST_CHECK(buf_is_empty(err));
       TEST_MSG(buf_string(err));
       expando_serialise(exp, buf);
@@ -459,6 +460,4 @@ void test_expando_node_padding(void)
     buf_pool_release(&buf);
     buf_pool_release(&err);
   }
-
 }
-

--- a/test/expando/old_if_else.c
+++ b/test/expando/old_if_else.c
@@ -38,16 +38,16 @@ void test_expando_old_if_else(void)
     // clang-format on
   };
   const char *input = "if: %?l?%4l?  if-else: %?l?%4l&%4c?";
-  struct ExpandoParseError err = { 0 };
-  struct ExpandoNode *root = NULL;
 
-  node_tree_parse(&root, input, TestFormatDef, &err);
+  struct Buffer *err = buf_pool_get();
+  struct Expando *exp = expando_parse(input, TestFormatDef, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
 
-  TEST_CHECK(err.position == NULL);
-  check_node_text(get_nth_node(root, 0), "if: ");
+  check_node_text(node_get_child(exp->node, 0), "if: ");
 
   {
-    struct ExpandoNode *node = get_nth_node(root, 1);
+    struct ExpandoNode *node = node_get_child(exp->node, 1);
     check_node_cond(node);
 
     struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
@@ -65,10 +65,10 @@ void test_expando_old_if_else(void)
     TEST_CHECK(node_false == NULL);
   }
 
-  check_node_text(get_nth_node(root, 2), "  if-else: ");
+  check_node_text(node_get_child(exp->node, 2), "  if-else: ");
 
   {
-    struct ExpandoNode *node = get_nth_node(root, 3);
+    struct ExpandoNode *node = node_get_child(exp->node, 3);
     check_node_cond(node);
 
     struct ExpandoNode *node_cond = node_get_child(node, ENC_CONDITION);
@@ -86,5 +86,6 @@ void test_expando_old_if_else(void)
     check_node_expando(node_false, "c", &fmt);
   }
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
 }

--- a/test/expando/padding.c
+++ b/test/expando/padding.c
@@ -39,24 +39,25 @@ void test_expando_padding(void)
   };
 
   const char *input = "%|A %>B %*C";
-  struct ExpandoParseError err = { 0 };
-  struct ExpandoNode *root = NULL;
 
-  node_tree_parse(&root, input, FormatDef, &err);
+  struct Buffer *err = buf_pool_get();
+  struct Expando *exp = expando_parse(input, FormatDef, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
 
-  TEST_CHECK(err.position == NULL);
-  check_node_padding(get_nth_node(root, 0), "A", EPT_FILL_EOL);
+  check_node_padding(exp->node, "A", EPT_FILL_EOL);
 
-  struct ExpandoNode *left = node_get_child(root, ENP_LEFT);
-  struct ExpandoNode *right = node_get_child(root, ENP_RIGHT);
+  struct ExpandoNode *left = node_get_child(exp->node, ENP_LEFT);
+  struct ExpandoNode *right = node_get_child(exp->node, ENP_RIGHT);
 
   TEST_CHECK(left == NULL);
   TEST_CHECK(right != NULL);
 
-  check_node_text(get_nth_node(right, 0), " ");
-  check_node_padding(get_nth_node(right, 1), "B", EPT_HARD_FILL);
-  check_node_text(get_nth_node(right, 2), " ");
-  check_node_padding(get_nth_node(right, 3), "C", EPT_SOFT_FILL);
+  check_node_text(node_get_child(right, 0), " ");
+  check_node_padding(node_get_child(right, 1), "B", EPT_HARD_FILL);
+  check_node_text(node_get_child(right, 2), " ");
+  check_node_padding(node_get_child(right, 3), "C", EPT_SOFT_FILL);
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
 }

--- a/test/expando/padding_render.c
+++ b/test/expando/padding_render.c
@@ -45,30 +45,25 @@ void test_expando_padding_render(void)
     // clang-format on
   };
 
-  struct ExpandoParseError err = { 0 };
+  struct Buffer *err = buf_pool_get();
 
   {
     const char *input = "text1%|-text2";
-    struct ExpandoNode *root = NULL;
 
-    node_tree_parse(&root, input, FormatDef, &err);
+    struct Expando *exp = expando_parse(input, FormatDef, err);
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
 
-    TEST_CHECK(err.position == NULL);
-    check_node_padding(root, "-", EPT_FILL_EOL);
+    check_node_padding(exp->node, "-", EPT_FILL_EOL);
 
-    struct ExpandoNode *left = node_get_child(root, ENP_LEFT);
-    struct ExpandoNode *right = node_get_child(root, ENP_RIGHT);
+    struct ExpandoNode *left = node_get_child(exp->node, ENP_LEFT);
+    struct ExpandoNode *right = node_get_child(exp->node, ENP_RIGHT);
 
     TEST_CHECK(left != NULL);
     TEST_CHECK(right != NULL);
 
     check_node_text(left, "text1");
     check_node_text(right, "text2");
-
-    const struct Expando exp = {
-      .string = input,
-      .node = root,
-    };
 
     const struct ExpandoRenderData render[] = {
       { -1, -1, NULL },
@@ -78,38 +73,32 @@ void test_expando_padding_render(void)
 
     const char *expected = "text1---";
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, 8, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, 8, buf);
 
     TEST_CHECK_STR_EQ(buf_string(buf), expected);
     TEST_MSG("Expected: %s", expected);
     TEST_MSG("Actual:   %s", buf_string(buf));
 
-    node_tree_free(&root);
+    expando_free(&exp);
+    buf_pool_release(&err);
     buf_pool_release(&buf);
   }
 
   {
     const char *input = "text1%|-text2";
-    struct ExpandoNode *root = NULL;
 
-    node_tree_parse(&root, input, FormatDef, &err);
+    struct Expando *exp = expando_parse(input, FormatDef, err);
 
-    TEST_CHECK(err.position == NULL);
-    check_node_padding(root, "-", EPT_FILL_EOL);
+    check_node_padding(exp->node, "-", EPT_FILL_EOL);
 
-    struct ExpandoNode *left = node_get_child(root, ENP_LEFT);
-    struct ExpandoNode *right = node_get_child(root, ENP_RIGHT);
+    struct ExpandoNode *left = node_get_child(exp->node, ENP_LEFT);
+    struct ExpandoNode *right = node_get_child(exp->node, ENP_RIGHT);
 
     TEST_CHECK(left != NULL);
     TEST_CHECK(right != NULL);
 
     check_node_text(left, "text1");
     check_node_text(right, "text2");
-
-    const struct Expando exp = {
-      .string = input,
-      .node = root,
-    };
 
     const struct ExpandoRenderData render[] = {
       { -1, -1, NULL },
@@ -119,36 +108,32 @@ void test_expando_padding_render(void)
 
     const char *expected = "text1--------";
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, 13, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, 13, buf);
 
     TEST_CHECK_STR_EQ(buf_string(buf), expected);
 
-    node_tree_free(&root);
+    expando_free(&exp);
+    buf_pool_release(&err);
     buf_pool_release(&buf);
   }
 
   {
     const char *input = "text1%>-text2";
-    struct ExpandoNode *root = NULL;
 
-    node_tree_parse(&root, input, FormatDef, &err);
+    struct Expando *exp = expando_parse(input, FormatDef, err);
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
 
-    TEST_CHECK(err.position == NULL);
-    check_node_padding(root, "-", EPT_HARD_FILL);
+    check_node_padding(exp->node, "-", EPT_HARD_FILL);
 
-    struct ExpandoNode *left = node_get_child(root, ENP_LEFT);
-    struct ExpandoNode *right = node_get_child(root, ENP_RIGHT);
+    struct ExpandoNode *left = node_get_child(exp->node, ENP_LEFT);
+    struct ExpandoNode *right = node_get_child(exp->node, ENP_RIGHT);
 
     TEST_CHECK(left != NULL);
     TEST_CHECK(right != NULL);
 
     check_node_text(left, "text1");
     check_node_text(right, "text2");
-
-    const struct Expando exp = {
-      .string = input,
-      .node = root,
-    };
 
     const struct ExpandoRenderData render[] = {
       { -1, -1, NULL },
@@ -158,37 +143,33 @@ void test_expando_padding_render(void)
 
     const char *expected = "text1tex";
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, 8, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, 8, buf);
     TEST_CHECK_STR_EQ(buf_string(buf), expected);
     TEST_MSG("Expected: %s", expected);
     TEST_MSG("Actual:   %s", buf_string(buf));
 
-    node_tree_free(&root);
+    expando_free(&exp);
+    buf_pool_release(&err);
     buf_pool_release(&buf);
   }
 
   {
     const char *input = "text1%>-text2";
-    struct ExpandoNode *root = NULL;
 
-    node_tree_parse(&root, input, FormatDef, &err);
+    struct Expando *exp = expando_parse(input, FormatDef, err);
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
 
-    TEST_CHECK(err.position == NULL);
-    check_node_padding(root, "-", EPT_HARD_FILL);
+    check_node_padding(exp->node, "-", EPT_HARD_FILL);
 
-    struct ExpandoNode *left = node_get_child(root, ENP_LEFT);
-    struct ExpandoNode *right = node_get_child(root, ENP_RIGHT);
+    struct ExpandoNode *left = node_get_child(exp->node, ENP_LEFT);
+    struct ExpandoNode *right = node_get_child(exp->node, ENP_RIGHT);
 
     TEST_CHECK(left != NULL);
     TEST_CHECK(right != NULL);
 
     check_node_text(left, "text1");
     check_node_text(right, "text2");
-
-    const struct Expando exp = {
-      .string = input,
-      .node = root,
-    };
 
     const struct ExpandoRenderData render[] = {
       { -1, -1, NULL },
@@ -198,38 +179,34 @@ void test_expando_padding_render(void)
 
     const char *expected = "text1---text2";
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, 13, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, 13, buf);
 
     TEST_CHECK_STR_EQ(buf_string(buf), expected);
     TEST_MSG("Expected: %s", expected);
     TEST_MSG("Actual:   %s", buf_string(buf));
 
-    node_tree_free(&root);
+    expando_free(&exp);
+    buf_pool_release(&err);
     buf_pool_release(&buf);
   }
 
   {
     const char *input = "text1%*-text2";
-    struct ExpandoNode *root = NULL;
 
-    node_tree_parse(&root, input, FormatDef, &err);
+    struct Expando *exp = expando_parse(input, FormatDef, err);
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
 
-    TEST_CHECK(err.position == NULL);
-    check_node_padding(root, "-", EPT_SOFT_FILL);
+    check_node_padding(exp->node, "-", EPT_SOFT_FILL);
 
-    struct ExpandoNode *left = node_get_child(root, ENP_LEFT);
-    struct ExpandoNode *right = node_get_child(root, ENP_RIGHT);
+    struct ExpandoNode *left = node_get_child(exp->node, ENP_LEFT);
+    struct ExpandoNode *right = node_get_child(exp->node, ENP_RIGHT);
 
     TEST_CHECK(left != NULL);
     TEST_CHECK(right != NULL);
 
     check_node_text(left, "text1");
     check_node_text(right, "text2");
-
-    const struct Expando exp = {
-      .string = input,
-      .node = root,
-    };
 
     const struct ExpandoRenderData render[] = {
       { -1, -1, NULL },
@@ -239,38 +216,34 @@ void test_expando_padding_render(void)
 
     const char *expected = "textext2";
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, 8, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, 8, buf);
 
     TEST_CHECK_STR_EQ(buf_string(buf), expected);
     TEST_MSG("Expected: %s", expected);
     TEST_MSG("Actual:   %s", buf_string(buf));
 
-    node_tree_free(&root);
+    expando_free(&exp);
+    buf_pool_release(&err);
     buf_pool_release(&buf);
   }
 
   {
     const char *input = "text1%*-text2";
-    struct ExpandoNode *root = NULL;
 
-    node_tree_parse(&root, input, FormatDef, &err);
+    struct Expando *exp = expando_parse(input, FormatDef, err);
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
 
-    TEST_CHECK(err.position == NULL);
-    check_node_padding(root, "-", EPT_SOFT_FILL);
+    check_node_padding(exp->node, "-", EPT_SOFT_FILL);
 
-    struct ExpandoNode *left = node_get_child(root, ENP_LEFT);
-    struct ExpandoNode *right = node_get_child(root, ENP_RIGHT);
+    struct ExpandoNode *left = node_get_child(exp->node, ENP_LEFT);
+    struct ExpandoNode *right = node_get_child(exp->node, ENP_RIGHT);
 
     TEST_CHECK(left != NULL);
     TEST_CHECK(right != NULL);
 
     check_node_text(left, "text1");
     check_node_text(right, "text2");
-
-    const struct Expando exp = {
-      .string = input,
-      .node = root,
-    };
 
     const struct ExpandoRenderData render[] = {
       { -1, -1, NULL },
@@ -280,38 +253,34 @@ void test_expando_padding_render(void)
 
     const char *expected = "text1---text2";
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, 13, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, 13, buf);
 
     TEST_CHECK_STR_EQ(buf_string(buf), expected);
     TEST_MSG("Expected: %s", expected);
     TEST_MSG("Actual:   %s", buf_string(buf));
 
-    node_tree_free(&root);
+    expando_free(&exp);
+    buf_pool_release(&err);
     buf_pool_release(&buf);
   }
 
   {
     const char *input = "text1%*-text2";
-    struct ExpandoNode *root = NULL;
 
-    node_tree_parse(&root, input, FormatDef, &err);
+    struct Expando *exp = expando_parse(input, FormatDef, err);
+    TEST_CHECK(exp != NULL);
+    TEST_CHECK(buf_is_empty(err));
 
-    TEST_CHECK(err.position == NULL);
-    check_node_padding(root, "-", EPT_SOFT_FILL);
+    check_node_padding(exp->node, "-", EPT_SOFT_FILL);
 
-    struct ExpandoNode *left = node_get_child(root, ENP_LEFT);
-    struct ExpandoNode *right = node_get_child(root, ENP_RIGHT);
+    struct ExpandoNode *left = node_get_child(exp->node, ENP_LEFT);
+    struct ExpandoNode *right = node_get_child(exp->node, ENP_RIGHT);
 
     TEST_CHECK(left != NULL);
     TEST_CHECK(right != NULL);
 
     check_node_text(left, "text1");
     check_node_text(right, "text2");
-
-    const struct Expando exp = {
-      .string = input,
-      .node = root,
-    };
 
     const struct ExpandoRenderData render[] = {
       { -1, -1, NULL },
@@ -321,13 +290,14 @@ void test_expando_padding_render(void)
 
     const char *expected = "text2";
     struct Buffer *buf = buf_pool_get();
-    expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, 5, buf);
+    expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, 5, buf);
 
     TEST_CHECK_STR_EQ(buf_string(buf), expected);
     TEST_MSG("Expected: %s", expected);
     TEST_MSG("Actual:   %s", buf_string(buf));
 
-    node_tree_free(&root);
+    expando_free(&exp);
+    buf_pool_release(&err);
     buf_pool_release(&buf);
   }
 }

--- a/test/expando/parse.c
+++ b/test/expando/parse.c
@@ -54,7 +54,7 @@ void test_expando_parser(void)
   static const char *TestStrings[][2] = {
     // clang-format off
     // Formatting
-    { "",       "<EMPTY>" },
+    { "",       "" },
     { "%X",     "<EXP:'X'(EMAIL,ATTACHMENT_COUNT)>" },
     { "%5X",    "<EXP:'X'(EMAIL,ATTACHMENT_COUNT):{5,MAX,RIGHT,' '}>" },
     { "%.7X",   "<EXP:'X'(EMAIL,ATTACHMENT_COUNT):{0,7,RIGHT,' '}>" },
@@ -65,19 +65,19 @@ void test_expando_parser(void)
     { "%05X",   "<EXP:'X'(EMAIL,ATTACHMENT_COUNT):{5,MAX,RIGHT,'0'}>" },
 
     // Conditional (old form)
-    { "%?X??",        "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>|<EMPTY>|>" },
-    { "%?X?&?",       "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>|<EMPTY>|<EMPTY>>" },
+    { "%?X??",        "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>||>" },
+    { "%?X?&?",       "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>||>" },
     { "%?X?AAA?",     "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>|<TEXT:'AAA'>|>" },
-    { "%?X?AAA&?",    "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>|<TEXT:'AAA'>|<EMPTY>>" },
-    { "%?X?&BBB?",    "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>|<EMPTY>|<TEXT:'BBB'>>" },
+    { "%?X?AAA&?",    "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>|<TEXT:'AAA'>|>" },
+    { "%?X?&BBB?",    "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>||<TEXT:'BBB'>>" },
     { "%?X?AAA&BBB?", "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>|<TEXT:'AAA'>|<TEXT:'BBB'>>" },
 
     // Conditional (new form)
-    { "%<X?>",        "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>|<EMPTY>|>" },
-    { "%<X?&>",       "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>|<EMPTY>|<EMPTY>>" },
+    { "%<X?>",        "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>||>" },
+    { "%<X?&>",       "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>||>" },
     { "%<X?AAA>",     "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>|<TEXT:'AAA'>|>" },
-    { "%<X?AAA&>",    "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>|<TEXT:'AAA'>|<EMPTY>>" },
-    { "%<X?&BBB>",    "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>|<EMPTY>|<TEXT:'BBB'>>" },
+    { "%<X?AAA&>",    "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>|<TEXT:'AAA'>|>" },
+    { "%<X?&BBB>",    "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>||<TEXT:'BBB'>>" },
     { "%<X?AAA&BBB>", "<COND:<BOOL:'X':(EMAIL,ATTACHMENT_COUNT)>|<TEXT:'AAA'>|<TEXT:'BBB'>>" },
 
     // Dates

--- a/test/expando/percent_sign_text.c
+++ b/test/expando/percent_sign_text.c
@@ -29,15 +29,22 @@
 
 void test_expando_percent_sign_text(void)
 {
+  static const struct ExpandoDefinition FormatDef[] = {
+    // clang-format off
+    { NULL, NULL, 0, -1, -1, NULL }
+    // clang-format on
+  };
+
   const char *input = "percent %%";
-  struct ExpandoParseError err = { 0 };
-  struct ExpandoNode *root = NULL;
 
-  node_tree_parse(&root, input, NULL, &err);
+  struct Buffer *err = buf_pool_get();
+  struct Expando *exp = expando_parse(input, FormatDef, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
 
-  TEST_CHECK(err.position == NULL);
-  check_node_text(get_nth_node(root, 0), "percent ");
-  check_node_text(get_nth_node(root, 1), "%");
+  check_node_text(node_get_child(exp->node, 0), "percent ");
+  check_node_text(node_get_child(exp->node, 1), "%");
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
 }

--- a/test/expando/serial.c
+++ b/test/expando/serial.c
@@ -112,6 +112,22 @@ static void dump_node_conddate(const struct ExpandoNode *node, struct Buffer *bu
   buf_addstr(buf, ">");
 }
 
+static void dump_node_container(const struct ExpandoNode *node, struct Buffer *buf)
+{
+  buf_addstr(buf, "<CONT:");
+
+  struct ExpandoNode **np = NULL;
+  ARRAY_FOREACH(np, &node->children)
+  {
+    if (!np || !*np)
+      continue;
+
+    dump_node(*np, buf);
+  }
+
+  buf_addstr(buf, ">");
+}
+
 static void dump_node_empty(const struct ExpandoNode *node, struct Buffer *buf)
 {
   buf_addstr(buf, "<EMPTY");
@@ -233,34 +249,34 @@ static void dump_node(const struct ExpandoNode *node, struct Buffer *buf)
   if (!node || !buf)
     return;
 
-  for (; node; node = node->next)
+  switch (node->type)
   {
-    switch (node->type)
-    {
-      case ENT_CONDITION:
-        dump_node_condition(node, buf);
-        break;
-      case ENT_CONDBOOL:
-        dump_node_condbool(node, buf);
-        break;
-      case ENT_CONDDATE:
-        dump_node_conddate(node, buf);
-        break;
-      case ENT_EMPTY:
-        dump_node_empty(node, buf);
-        break;
-      case ENT_EXPANDO:
-        dump_node_expando(node, buf);
-        break;
-      case ENT_PADDING:
-        dump_node_padding(node, buf);
-        break;
-      case ENT_TEXT:
-        dump_node_text(node, buf);
-        break;
-      default:
-        ASSERT(false);
-    }
+    case ENT_CONDITION:
+      dump_node_condition(node, buf);
+      break;
+    case ENT_CONDBOOL:
+      dump_node_condbool(node, buf);
+      break;
+    case ENT_CONDDATE:
+      dump_node_conddate(node, buf);
+      break;
+    case ENT_CONTAINER:
+      dump_node_container(node, buf);
+      break;
+    case ENT_EMPTY:
+      dump_node_empty(node, buf);
+      break;
+    case ENT_EXPANDO:
+      dump_node_expando(node, buf);
+      break;
+    case ENT_PADDING:
+      dump_node_padding(node, buf);
+      break;
+    case ENT_TEXT:
+      dump_node_text(node, buf);
+      break;
+    default:
+      ASSERT(false);
   }
 }
 

--- a/test/expando/simple_expando.c
+++ b/test/expando/simple_expando.c
@@ -37,15 +37,16 @@ void test_expando_simple_expando(void)
     // clang-format on
   };
   const char *input = "%a %b";
-  struct ExpandoParseError err = { 0 };
-  struct ExpandoNode *root = NULL;
 
-  node_tree_parse(&root, input, TestFormatDef, &err);
+  struct Buffer *err = buf_pool_get();
+  struct Expando *exp = expando_parse(input, TestFormatDef, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
 
-  TEST_CHECK(err.position == NULL);
-  check_node_expando(get_nth_node(root, 0), "a", NULL);
-  check_node_text(get_nth_node(root, 1), " ");
-  check_node_expando(get_nth_node(root, 2), "b", NULL);
+  check_node_expando(node_get_child(exp->node, 0), "a", NULL);
+  check_node_text(node_get_child(exp->node, 1), " ");
+  check_node_expando(node_get_child(exp->node, 2), "b", NULL);
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
 }

--- a/test/expando/simple_expando_render.c
+++ b/test/expando/simple_expando_render.c
@@ -59,10 +59,7 @@ static void simple_d(const struct ExpandoNode *node, void *data,
 
 void test_expando_simple_expando_render(void)
 {
-  const char *input = "%s - %d";
-
-  struct ExpandoNode *root = NULL;
-  struct ExpandoParseError err = { 0 };
+  const char *input = "%s - %d"; // Second space is: U+2002 EN SPACE
 
   const struct ExpandoDefinition defs[] = {
     { "s", NULL, 1, 0, 0, NULL },
@@ -70,19 +67,16 @@ void test_expando_simple_expando_render(void)
     { NULL, NULL, 0, 0, 0, NULL },
   };
 
-  node_tree_parse(&root, input, defs, &err);
+  struct Buffer *err = buf_pool_get();
+  struct Expando *exp = expando_parse(input, defs, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
 
-  TEST_CHECK(err.position == NULL);
-  check_node_expando(get_nth_node(root, 0), "s", NULL);
-  check_node_text(get_nth_node(root, 1), " - ");
-  check_node_expando(get_nth_node(root, 2), "d", NULL);
+  check_node_expando(node_get_child(exp->node, 0), "s", NULL);
+  check_node_text(node_get_child(exp->node, 1), " - ");
+  check_node_expando(node_get_child(exp->node, 2), "d", NULL);
 
-  const char *expected = "Test - 1";
-
-  const struct Expando exp = {
-    .string = input,
-    .node = root,
-  };
+  const char *expected = "Test - 1";
 
   const struct ExpandoRenderData render[] = {
     { 1, 0, simple_s },
@@ -96,10 +90,11 @@ void test_expando_simple_expando_render(void)
   };
 
   struct Buffer *buf = buf_pool_get();
-  expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+  expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
   TEST_CHECK_STR_EQ(buf_string(buf), expected);
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
   buf_pool_release(&buf);
 }

--- a/test/expando/simple_text.c
+++ b/test/expando/simple_text.c
@@ -29,14 +29,21 @@
 
 void test_expando_simple_text(void)
 {
+  const struct ExpandoDefinition defs[] = {
+    { "s", NULL, 1, 0, 0, NULL },
+    { "d", NULL, 1, 1, 0, NULL },
+    { NULL, NULL, 0, 0, 0, NULL },
+  };
+
   const char *input = "test text";
-  struct ExpandoParseError err = { 0 };
-  struct ExpandoNode *root = NULL;
 
-  node_tree_parse(&root, input, NULL, &err);
+  struct Buffer *err = buf_pool_get();
+  struct Expando *exp = expando_parse(input, defs, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
 
-  TEST_CHECK(err.position == NULL);
-  check_node_text(get_nth_node(root, 0), input);
+  check_node_text(exp->node, input);
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
 }

--- a/test/expando/two_char_expando.c
+++ b/test/expando/two_char_expando.c
@@ -30,8 +30,6 @@
 void test_expando_two_char_expando(void)
 {
   const char *input = "%cr %ab";
-  struct ExpandoParseError err = { 0 };
-  struct ExpandoNode *root = NULL;
 
   struct ExpandoDefinition defs[] = {
     { "cr", NULL, 0, 0, 0, NULL },
@@ -39,13 +37,16 @@ void test_expando_two_char_expando(void)
     { NULL, NULL, 0, 0, 0, NULL },
   };
 
-  node_tree_parse(&root, input, defs, &err);
+  struct Buffer *err = buf_pool_get();
+  struct Expando *exp = expando_parse(input, defs, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
 
-  TEST_CHECK(err.position == NULL);
-  check_node_expando(get_nth_node(root, 0), "cr", NULL);
-  check_node_text(get_nth_node(root, 1), " ");
-  check_node_expando(get_nth_node(root, 2), "a", NULL);
-  check_node_text(get_nth_node(root, 3), "b");
+  check_node_expando(node_get_child(exp->node, 0), "cr", NULL);
+  check_node_text(node_get_child(exp->node, 1), " ");
+  check_node_expando(node_get_child(exp->node, 2), "a", NULL);
+  check_node_text(node_get_child(exp->node, 3), "b");
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
 }

--- a/test/expando/two_char_expando_render.c
+++ b/test/expando/two_char_expando_render.c
@@ -61,28 +61,22 @@ void test_expando_two_char_expando_render(void)
 {
   const char *input = "%ss - %dd";
 
-  struct ExpandoNode *root = NULL;
-  struct ExpandoParseError err = { 0 };
-
   const struct ExpandoDefinition defs[] = {
     { "ss", NULL, 1, 0, 0, NULL },
     { "dd", NULL, 1, 1, 0, NULL },
     { NULL, NULL, 0, 0, 0, NULL },
   };
 
-  node_tree_parse(&root, input, defs, &err);
+  struct Buffer *err = buf_pool_get();
+  struct Expando *exp = expando_parse(input, defs, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
 
-  TEST_CHECK(err.position == NULL);
-  check_node_expando(get_nth_node(root, 0), "ss", NULL);
-  check_node_text(get_nth_node(root, 1), " - ");
-  check_node_expando(get_nth_node(root, 2), "dd", NULL);
+  check_node_expando(node_get_child(exp->node, 0), "ss", NULL);
+  check_node_text(node_get_child(exp->node, 1), " - ");
+  check_node_expando(node_get_child(exp->node, 2), "dd", NULL);
 
   const char *expected = "Test2 - 12";
-
-  const struct Expando exp = {
-    .string = input,
-    .node = root,
-  };
 
   const struct ExpandoRenderData render[] = {
     { 1, 0, simple_ss },
@@ -96,10 +90,11 @@ void test_expando_two_char_expando_render(void)
   };
 
   struct Buffer *buf = buf_pool_get();
-  expando_render(&exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+  expando_render(exp, render, &data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
 
   TEST_CHECK_STR_EQ(buf_string(buf), expected);
 
-  node_tree_free(&root);
+  expando_free(&exp);
+  buf_pool_release(&err);
   buf_pool_release(&buf);
 }

--- a/test/expando/unicode_padding.c
+++ b/test/expando/unicode_padding.c
@@ -39,12 +39,14 @@ void test_expando_unicode_padding(void)
   };
 
   const char *input = "%|😀";
-  struct ExpandoParseError err = { 0 };
-  struct ExpandoNode *root = NULL;
 
-  node_tree_parse(&root, input, FormatDef, &err);
+  struct Buffer *err = buf_pool_get();
+  struct Expando *exp = expando_parse(input, FormatDef, err);
+  TEST_CHECK(exp != NULL);
+  TEST_CHECK(buf_is_empty(err));
 
-  TEST_CHECK(err.position == NULL);
-  check_node_padding(get_nth_node(root, 0), "😀", EPT_FILL_EOL);
-  node_tree_free(&root);
+  check_node_padding(exp->node, "😀", EPT_FILL_EOL);
+
+  expando_free(&exp);
+  buf_pool_release(&err);
 }


### PR DESCRIPTION
If we can't parse the padding character, default to space for now.

This may fix #4270

If a format string ended in `%>`  (hard padding), but it omitted the padding character,
then NeoMutt would get stuck in a loop trying to pad out a string with `""` (nothing).