### PR TITLE
mutt/string.c: Report an error and exit on ENOMEM

### DIFF
--- a/core/neomutt.c
+++ b/core/neomutt.c
@@ -29,6 +29,7 @@
 
 #include "config.h"
 #include <stddef.h>
+#include <errno.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "neomutt.h"
@@ -61,8 +62,8 @@ struct NeoMutt *neomutt_new(struct ConfigSet *cs)
 
   if (!n->time_c_locale)
   {
-    mutt_error(_("Out of memory")); // LCOV_EXCL_LINE
-    mutt_exit(1);                   // LCOV_EXCL_LINE
+    mutt_error("%s", strerror(errno)); // LCOV_EXCL_LINE
+    mutt_exit(1);                      // LCOV_EXCL_LINE
   }
 
   n->notify_timeout = notify_new();

--- a/imap/msn.c
+++ b/imap/msn.c
@@ -28,6 +28,7 @@
  */
 
 #include "config.h"
+#include <errno.h>
 #include <limits.h>
 #include <stdlib.h>
 #include "mutt/lib.h"
@@ -46,7 +47,7 @@ void imap_msn_reserve(struct MSNArray *msn, size_t num)
    * if msn_count is this big, we have a serious problem. */
   if (num >= (UINT_MAX / sizeof(struct Email *)))
   {
-    mutt_error(_("Out of memory"));
+    mutt_error("%s", strerror(ENOMEM));
     mutt_exit(1);
   }
 

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -35,6 +35,7 @@
  */
 
 #include "config.h"
+#include <errno.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -100,7 +101,7 @@ size_t buf_addstr_n(struct Buffer *buf, const char *s, size_t len)
   if (len > (SIZE_MAX - BufferStepSize))
   {
     // LCOV_EXCL_START
-    mutt_error(_("Out of memory"));
+    mutt_error("%s", strerror(ENOMEM));
     mutt_exit(1);
     // LCOV_EXCL_STOP
   }

--- a/mutt/memory.c
+++ b/mutt/memory.c
@@ -30,7 +30,9 @@
  */
 
 #include "config.h"
+#include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 #include "memory.h"
 #include "exit.h"
 #include "logging2.h"
@@ -55,8 +57,8 @@ void *mutt_mem_calloc(size_t nmemb, size_t size)
   void *p = calloc(nmemb, size);
   if (!p)
   {
-    mutt_error(_("Out of memory")); // LCOV_EXCL_LINE
-    mutt_exit(1);                   // LCOV_EXCL_LINE
+    mutt_error("%s", strerror(errno)); // LCOV_EXCL_LINE
+    mutt_exit(1);                      // LCOV_EXCL_LINE
   }
   return p;
 }
@@ -95,8 +97,8 @@ void *mutt_mem_malloc(size_t size)
   void *p = malloc(size);
   if (!p)
   {
-    mutt_error(_("Out of memory")); // LCOV_EXCL_LINE
-    mutt_exit(1);                   // LCOV_EXCL_LINE
+    mutt_error("%s", strerror(errno)); // LCOV_EXCL_LINE
+    mutt_exit(1);                      // LCOV_EXCL_LINE
   }
   return p;
 }
@@ -131,8 +133,8 @@ void mutt_mem_realloc(void *ptr, size_t size)
   void *r = realloc(*p, size);
   if (!r)
   {
-    mutt_error(_("Out of memory")); // LCOV_EXCL_LINE
-    mutt_exit(1);                   // LCOV_EXCL_LINE
+    mutt_error("%s", strerror(errno)); // LCOV_EXCL_LINE
+    mutt_exit(1);                      // LCOV_EXCL_LINE
   }
 
   *p = r;

--- a/mutt/signal.c
+++ b/mutt/signal.c
@@ -32,6 +32,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include "message.h"
 #include "signal2.h"
@@ -85,18 +86,16 @@ static void exit_print_int(int n)
   exit_print_int_recursive(n);
 }
 
+/**
+ * exit_print_string - AS-safe version of printf("%s", str)
+ * @param str String to be printed
+ */
 static void exit_print_string(const char *str)
 {
-  size_t len = 0;
-
   if (!str)
     return;
 
-  while (str[len])
-    len++;
-
-  if (len > 0)
-    write(1, str, len);
+  write(STDOUT_FILENO, str, strlen(str));
 }
 
 /**

--- a/mutt/signal.c
+++ b/mutt/signal.c
@@ -65,25 +65,33 @@ static sig_handler_t SegvHandler = mutt_sig_exit_handler;
 volatile sig_atomic_t SigInt;   ///< true after SIGINT is received
 volatile sig_atomic_t SigWinch; ///< true after SIGWINCH is received
 
-static void exit_print_int_recursive(int n)
+/**
+ * exit_print_uint - AS-safe version of printf("%u", n)
+ * @param n Number to be printed
+ */
+static void exit_print_uint(unsigned int n)
 {
   char digit;
 
   if (n > 9)
-    exit_print_int_recursive(n / 10);
+    exit_print_uint(n / 10);
 
   digit = '0' + (n % 10);
-  write(1, &digit, 1);
+  write(STDOUT_FILENO, &digit, 1);
 }
 
+/**
+ * exit_print_int - AS-safe version of printf("%d", n)
+ * @param n Number to be printed
+ */
 static void exit_print_int(int n)
 {
   if (n < 0)
   {
-    write(1, "-", 1);
+    write(STDOUT_FILENO, "-", 1);
     n = -n;
   }
-  exit_print_int_recursive(n);
+  exit_print_uint(n);
 }
 
 /**

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -31,6 +31,7 @@
 
 #include "config.h"
 #include <ctype.h>
+#include <errno.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -258,8 +259,8 @@ char *mutt_str_dup(const char *str)
   char *p = strdup(str);
   if (!p)
   {
-    mutt_error(_("Out of memory")); // LCOV_EXCL_LINE
-    mutt_exit(1);                   // LCOV_EXCL_LINE
+    mutt_error("%s", strerror(errno)); // LCOV_EXCL_LINE
+    mutt_exit(1);                      // LCOV_EXCL_LINE
   }
   return p;
 }
@@ -784,8 +785,8 @@ int mutt_str_asprintf(char **strp, const char *fmt, ...)
    * is undefined when the return code is -1.  */
   if (n < 0)
   {
-    mutt_error(_("Out of memory")); /* LCOV_EXCL_LINE */
-    mutt_exit(1);                   /* LCOV_EXCL_LINE */
+    mutt_error("%s", strerror(errno)); /* LCOV_EXCL_LINE */
+    mutt_exit(1);                      /* LCOV_EXCL_LINE */
   }
 
   if (n == 0)

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -255,7 +255,13 @@ char *mutt_str_dup(const char *str)
   if (!str || (*str == '\0'))
     return NULL;
 
-  return strdup(str);
+  char *p = strdup(str);
+  if (!p)
+  {
+    mutt_error(_("Out of memory")); // LCOV_EXCL_LINE
+    mutt_exit(1);                   // LCOV_EXCL_LINE
+  }
+  return p;
 }
 
 /**

--- a/mx.c
+++ b/mx.c
@@ -1216,7 +1216,7 @@ void mx_alloc_memory(struct Mailbox *m, int req_size)
   const size_t s = MAX(sizeof(struct Email *), sizeof(int));
   if ((req_size * s) < (m->email_max * s))
   {
-    mutt_error(_("Out of memory"));
+    mutt_error("%s", strerror(ENOMEM));
     mutt_exit(1);
   }
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -1908,12 +1908,6 @@ msgstr[1] ""
 msgid "No decryption engine available for message"
 msgstr ""
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Недостатъчно памет"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/ca.po
+++ b/po/ca.po
@@ -1961,12 +1961,6 @@ msgstr[1] ""
 msgid "No decryption engine available for message"
 msgstr "No hi ha cap mecanisme disponible per a desxifrar el missatge"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "No resta memòria."
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/cs.po
+++ b/po/cs.po
@@ -1861,12 +1861,6 @@ msgstr[2] "Vypočítaná délka nebyla správná o %ld bajtů"
 msgid "No decryption engine available for message"
 msgstr "Pro zprávu není k dispozici žádný dešifrovací nástroj"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Paměť vyčerpána"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/da.po
+++ b/po/da.po
@@ -1879,12 +1879,6 @@ msgstr[1] ""
 msgid "No decryption engine available for message"
 msgstr "Intet tilgængeligt dekrypteringsprogram til brev"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Ikke mere hukommelse"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/de.po
+++ b/po/de.po
@@ -1848,12 +1848,6 @@ msgstr[1] "Die Längenberechnung weicht um %ld Byte(s) ab"
 msgid "No decryption engine available for message"
 msgstr "Kein Entschlüsselungsmechanismus für Nachricht vorhanden"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Kein Speicher verfügbar"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/el.po
+++ b/po/el.po
@@ -1867,12 +1867,6 @@ msgstr[1] "Ο υπολογισμός μήκους ήταν λάθος για %ld
 msgid "No decryption engine available for message"
 msgstr "Δεν υπάρχει διάθεσιμη μηχανή αποκρυπτογράφησης για το μήνυμα"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Η μνήμη εξαντλήθηκε"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1841,12 +1841,6 @@ msgstr[1] "The length calculation was wrong by %ld bytes"
 msgid "No decryption engine available for message"
 msgstr "No decryption engine available for message"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Out of memory"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/eo.po
+++ b/po/eo.po
@@ -1874,12 +1874,6 @@ msgstr[1] ""
 msgid "No decryption engine available for message"
 msgstr "Nenia malĉifroproceduro estas disponata por mesaĝo"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Mankas sufiĉa memoro"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/es.po
+++ b/po/es.po
@@ -1847,12 +1847,6 @@ msgstr[1] "El cálculo de longitud fue incorrecto en los bytes %ld"
 msgid "No decryption engine available for message"
 msgstr "No existe un motor de descifrado disponible para el mensaje"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Sin memoria"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/et.po
+++ b/po/et.po
@@ -1904,12 +1904,6 @@ msgstr[1] ""
 msgid "No decryption engine available for message"
 msgstr ""
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Mälu on otsas"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/eu.po
+++ b/po/eu.po
@@ -1892,12 +1892,6 @@ msgstr[1] ""
 msgid "No decryption engine available for message"
 msgstr ""
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Memoriaz kanpo"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/fi.po
+++ b/po/fi.po
@@ -1867,12 +1867,6 @@ msgstr[1] "Pituuslaskelmat ovat pielessä %ld tavulla"
 msgid "No decryption engine available for message"
 msgstr "Viestille ei ole purkualgoritmia"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "muisti loppui"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1941,12 +1941,6 @@ msgstr[1] "Les temps de calcul étaient erronés de %ld octets."
 msgid "No decryption engine available for message"
 msgstr "Pas de moteur de déchiffrement disponible pour le message"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Plus de mémoire"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/ga.po
+++ b/po/ga.po
@@ -1908,12 +1908,6 @@ msgstr[4] ""
 msgid "No decryption engine available for message"
 msgstr ""
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Cuimhne ídithe"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/gl.po
+++ b/po/gl.po
@@ -1914,12 +1914,6 @@ msgstr[1] ""
 msgid "No decryption engine available for message"
 msgstr ""
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "¡Memoria agotada"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/hu.po
+++ b/po/hu.po
@@ -1846,12 +1846,6 @@ msgstr[1] "A méret számítás %ld bytettal eltér"
 msgid "No decryption engine available for message"
 msgstr "Nem elérhető dekódoló motor az üzenethez"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Elfogyott a memória"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/id.po
+++ b/po/id.po
@@ -1888,12 +1888,6 @@ msgstr[0] ""
 msgid "No decryption engine available for message"
 msgstr ""
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Buset, memory abis"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/it.po
+++ b/po/it.po
@@ -1892,12 +1892,6 @@ msgstr[1] ""
 msgid "No decryption engine available for message"
 msgstr ""
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Memoria esaurita"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1868,12 +1868,6 @@ msgstr[0] ""
 msgid "No decryption engine available for message"
 msgstr "利用できる復号化エンジンがない"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "メモリ不足"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/ko.po
+++ b/po/ko.po
@@ -1900,12 +1900,6 @@ msgstr[0] ""
 msgid "No decryption engine available for message"
 msgstr ""
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "메모리 부족"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/lt.po
+++ b/po/lt.po
@@ -1848,12 +1848,6 @@ msgstr[2] "Ilgio skaičiavimas suklydo %ld baitų"
 msgid "No decryption engine available for message"
 msgstr "Nėra iššifravimo mechanizmo laiškui"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Baigėsi atmintis"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -1845,12 +1845,6 @@ msgstr[1] "Lengden på utregningen er feil med %ld byte"
 msgid "No decryption engine available for message"
 msgstr "Ingen dekrypteringsmotor tilgjengelig for melding"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Gikk tom for minne"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/nl.po
+++ b/po/nl.po
@@ -1884,12 +1884,6 @@ msgstr[1] ""
 msgid "No decryption engine available for message"
 msgstr ""
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Onvoldoende geheugen"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1850,12 +1850,6 @@ msgstr[2] "Obliczenie długości pomyliło się o %ld bajtów"
 msgid "No decryption engine available for message"
 msgstr "Nieznany sposób odszyfrowania tej wiadomości"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Brak pamięci"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1847,12 +1847,6 @@ msgstr[1] "Cálculo de comprimento estava errado por %ld bytes"
 msgid "No decryption engine available for message"
 msgstr "Não há mecanismo disponível para desencriptar a mensagem"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Acabou a memória"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1868,12 +1868,6 @@ msgstr[2] ""
 msgid "No decryption engine available for message"
 msgstr "Нет доступного механизма расшифровки для сообщения"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Нехватка памяти"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/sk.po
+++ b/po/sk.po
@@ -1852,12 +1852,6 @@ msgstr[2] "Vypočítaná dľžka nebola správná o %ld bajtov"
 msgid "No decryption engine available for message"
 msgstr "Pre správu nebol nájdený dešifrovací program"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Nedostatok pamäte"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/sr.po
+++ b/po/sr.po
@@ -1847,12 +1847,6 @@ msgstr[2] "Рачунање дужине је погрешно за %ld бајт
 msgid "No decryption engine available for message"
 msgstr "Ниједан погон за дешифровање није доступан"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Нема меморије"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1892,12 +1892,6 @@ msgstr[1] ""
 msgid "No decryption engine available for message"
 msgstr ""
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Slut på minne"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/tr.po
+++ b/po/tr.po
@@ -1845,12 +1845,6 @@ msgstr[1] "Uzunluk hesaplaması %ld bayt ile yanlış"
 msgid "No decryption engine available for message"
 msgstr "İleti için bir şifre çözme işletkesi kullanılabilir değil"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Bellek yetersiz"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/uk.po
+++ b/po/uk.po
@@ -1853,12 +1853,6 @@ msgstr[2] "Обчислення довжини хибне на %ld байт"
 msgid "No decryption engine available for message"
 msgstr "Немає механізму розшифрування для листа"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "Не вистачає пам’яті"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1848,12 +1848,6 @@ msgstr[0] "长度计算错误，偏差 %ld 字节"
 msgid "No decryption engine available for message"
 msgstr "对于信件没有解密引擎"
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "内存不足"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1899,12 +1899,6 @@ msgstr[0] ""
 msgid "No decryption engine available for message"
 msgstr ""
 
-#: core/neomutt.c:64 imap/msn.c:49 mutt/buffer.c:103 mutt/buffer.c:352
-#: mutt/memory.c:58 mutt/memory.c:98 mutt/memory.c:134 mutt/string.c:836
-#: mx.c:1219
-msgid "Out of memory"
-msgstr "記憶體不足"
-
 #: editmsg.c:76
 #, c-format
 msgid "could not create temporary folder: %s"


### PR DESCRIPTION
* **What does this PR do?**

Report an error and exit on ENOMEM, instead of silently using a NULL.