### PR TITLE
hcache directory pollution

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1283,7 +1283,7 @@ int imap_complete(struct Buffer *buf, const char *path)
   int completions = 0;
   int rc;
 
-  if (imap_adata_find(path, &adata, &mdata) < 0)
+  if (imap_adata_find_nocache(path, &adata, &mdata) < 0)
   {
     buf_strcpy(buf, path);
     return complete_hosts(buf);

--- a/imap/mdata.c
+++ b/imap/mdata.c
@@ -70,7 +70,7 @@ struct ImapMboxData *imap_mdata_get(struct Mailbox *m)
  * @param name  Name for Mailbox
  * @retval ptr New ImapMboxData
  */
-struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char *name)
+struct ImapMboxData *imap_mdata_nocache_new(struct ImapAccountData *adata, const char *name)
 {
   char buf[1024] = { 0 };
   struct ImapMboxData *mdata = mutt_mem_calloc(1, sizeof(struct ImapMboxData));
@@ -88,6 +88,20 @@ struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char *n
   mdata->reopen &= IMAP_REOPEN_ALLOW;
 
   STAILQ_INIT(&mdata->flags);
+
+  return mdata;
+}
+
+/**
+ * imap_mdata_new - Allocate and initialise a new ImapMboxData structure and
+ * call cache function on it
+ * @param adata Imap Account data
+ * @param name  Name for Mailbox
+ * @retval ptr New ImapMboxData
+ */
+struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char *name)
+{
+  struct ImapMboxData *mdata = imap_mdata_nocache_new(adata, name);
 
 #ifdef USE_HCACHE
   imap_hcache_open(adata, mdata);

--- a/imap/mdata.h
+++ b/imap/mdata.h
@@ -67,5 +67,6 @@ struct ImapMboxData
 void                 imap_mdata_free(void **ptr);
 struct ImapMboxData *imap_mdata_get (struct Mailbox *m);
 struct ImapMboxData *imap_mdata_new (struct ImapAccountData *adata, const char* name);
+struct ImapMboxData *imap_mdata_nocache_new (struct ImapAccountData *adata, const char* name);
 
 #endif /* MUTT_IMAP_MDATA_H */

--- a/imap/private.h
+++ b/imap/private.h
@@ -189,6 +189,7 @@ int imap_login(struct ImapAccountData *adata);
 int imap_sync_message_for_copy(struct Mailbox *m, struct Email *e, struct Buffer *cmd, enum QuadOption *err_continue);
 bool imap_has_flag(struct ListHead *flag_list, const char *flag);
 int imap_adata_find(const char *path, struct ImapAccountData **adata, struct ImapMboxData **mdata);
+int imap_adata_find_nocache(const char *path, struct ImapAccountData **adata, struct ImapMboxData **mdata);
 
 /* auth.c */
 int imap_authenticate(struct ImapAccountData *adata);


### PR DESCRIPTION
Hcache directory get polluted by imap completion data.

To reproduce: have an imap dir with hcache enabled, type s to save mail to another mailbox (eg. mailbox)
type mailbox name but type it wrong eg. =maiz pres TAB for completion,
see maiz.hcache  and maiz.hache-lock created (8k each file)
same thing goes for each letter TAB press while completion is not complete.

* **What does this PR do?**

Add imap_adata_find_nocache() just for imap_completion() that basically is the same thing as imap_adata_find() without
any hcache calls.
The better approach would probably be to have a specific imap completion function that searches for a path.
However I'm unsure it's worth it.
There is another issue folded into this behavior, say when you want to save mail to an nonexistent mailbox type its name and say no to create mailbox dialog, you will end up with .hcache and .hcache-lock files once again however the impact is less visible.
