### PR TITLE
Don't special-case <stddef.h>

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,8 +13,6 @@ IncludeCategories:
     Priority:   -130
   - Regex:      '"acutest\.h"'
     Priority:   -120
-  - Regex:      '<stddef\.h>'
-    Priority:   -110
   - Regex:      '<.*>'
     Priority:   -100
 

--- a/address/address.h
+++ b/address/address.h
@@ -24,8 +24,8 @@
 #ifndef MUTT_ADDRESS_ADDRESS_H
 #define MUTT_ADDRESS_ADDRESS_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 

--- a/address/config_type.c
+++ b/address/config_type.c
@@ -35,9 +35,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <limits.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/alias/alias.c
+++ b/alias/alias.c
@@ -31,9 +31,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <pwd.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/alias/array.c
+++ b/alias/array.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "gui.h"
 

--- a/alias/config.c
+++ b/alias/config.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "expando/lib.h"

--- a/alias/functions.c
+++ b/alias/functions.c
@@ -31,8 +31,8 @@
 #ifdef _MAKEDOC
 #include "docs/makedoc_defs.h"
 #else
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "address/lib.h"

--- a/alias/lib.h
+++ b/alias/lib.h
@@ -43,8 +43,8 @@
 #ifndef MUTT_ALIAS_LIB_H
 #define MUTT_ALIAS_LIB_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "core/lib.h"
 #include "complete/lib.h"

--- a/alias/sort.c
+++ b/alias/sort.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "address/lib.h"
 #include "config/lib.h"

--- a/attach/cid.c
+++ b/attach/cid.c
@@ -28,8 +28,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 #include "email/lib.h"

--- a/attach/lib.c
+++ b/attach/lib.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "email/lib.h"
 

--- a/autocrypt/config.c
+++ b/autocrypt/config.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "private.h"
 #include "config/lib.h"
 #include "expando/lib.h"

--- a/autocrypt/db.c
+++ b/autocrypt/db.c
@@ -30,9 +30,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <sqlite3.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <sys/stat.h>
 #include "private.h"
 #include "mutt/lib.h"

--- a/autocrypt/gpgme.c
+++ b/autocrypt/gpgme.c
@@ -29,10 +29,10 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <gpg-error.h>
 #include <gpgme.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "private.h"
 #include "mutt/lib.h"
 #include "address/lib.h"

--- a/autocrypt/schema.c
+++ b/autocrypt/schema.c
@@ -28,8 +28,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <sqlite3.h>
+#include <stddef.h>
 #include "private.h"
 #include "mutt/lib.h"
 

--- a/browser/complete.c
+++ b/browser/complete.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <string.h>
 #include "mutt/lib.h"
 #include "core/lib.h"

--- a/browser/config.c
+++ b/browser/config.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "lib.h"

--- a/browser/sort.c
+++ b/browser/sort.c
@@ -28,8 +28,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <sys/stat.h>
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/color/command.c
+++ b/color/command.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/color/curses.c
+++ b/color/curses.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "gui/lib.h"
 #include "color.h"

--- a/color/merged.c
+++ b/color/merged.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "attr.h"
 #include "color.h"

--- a/color/parse_ansi.c
+++ b/color/parse_ansi.c
@@ -27,9 +27,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <ctype.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include "mutt/lib.h"
 #include "gui/lib.h"

--- a/color/parse_color.c
+++ b/color/parse_color.c
@@ -25,8 +25,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include "mutt/lib.h"
 #include "core/lib.h"

--- a/color/quoted.c
+++ b/color/quoted.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "core/lib.h"
 #include "quoted.h"

--- a/color/quoted.h
+++ b/color/quoted.h
@@ -24,8 +24,8 @@
 #define MUTT_COLOR_QUOTED_H
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "core/lib.h"
 #include "attr.h"
 #include "color.h"

--- a/color/regex.c
+++ b/color/regex.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/color/simple.c
+++ b/color/simple.c
@@ -28,8 +28,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "gui/lib.h"
 #include "attr.h"

--- a/complete/lib.h
+++ b/complete/lib.h
@@ -36,8 +36,8 @@
 #ifndef MUTT_COMPLETE_LIB_H
 #define MUTT_COMPLETE_LIB_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 // IWYU pragma: begin_keep
 #include "compapi.h"
 #include "data.h"

--- a/compose/attach.c
+++ b/compose/attach.c
@@ -57,8 +57,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "private.h"
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/compose/config.c
+++ b/compose/config.c
@@ -28,8 +28,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "expando/lib.h"

--- a/compress/lz4.c
+++ b/compress/lz4.c
@@ -30,9 +30,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <limits.h>
 #include <lz4.h>
+#include <stddef.h>
 #include "private.h"
 #include "mutt/lib.h"
 #include "lib.h"

--- a/config/bool.c
+++ b/config/bool.c
@@ -33,9 +33,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <limits.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "bool.h"

--- a/config/enum.c
+++ b/config/enum.c
@@ -31,8 +31,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "enum.h"

--- a/config/number.c
+++ b/config/number.c
@@ -34,8 +34,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "set.h"

--- a/config/path.c
+++ b/config/path.c
@@ -36,8 +36,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "set.h"

--- a/config/quad.c
+++ b/config/quad.c
@@ -36,8 +36,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "quad.h"

--- a/config/regex.c
+++ b/config/regex.c
@@ -35,8 +35,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "regex2.h"

--- a/config/slist.c
+++ b/config/slist.c
@@ -34,8 +34,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "set.h"

--- a/conn/config.c
+++ b/conn/config.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "config/lib.h"
 
 /**

--- a/conn/gsasl.c
+++ b/conn/gsasl.c
@@ -27,9 +27,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <gsasl.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "connaccount.h"
 #include "connection.h"

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -39,11 +39,11 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <errno.h>
 #include <netdb.h>
 #include <sasl/sasl.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/core/neomutt.c
+++ b/core/neomutt.c
@@ -28,9 +28,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <errno.h>
 #include <locale.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/core/neomutt.h
+++ b/core/neomutt.h
@@ -23,9 +23,9 @@
 #ifndef MUTT_CORE_NEOMUTT_H
 #define MUTT_CORE_NEOMUTT_H
 
-#include <stddef.h>
 #include <locale.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <sys/types.h>
 #include "account.h"
 #include "mailbox.h"

--- a/debug/lib.h
+++ b/debug/lib.h
@@ -41,8 +41,8 @@
 #ifndef MUTT_DEBUG_LIB_H
 #define MUTT_DEBUG_LIB_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <time.h>
 #include "mutt/lib.h"
 #include "email/lib.h"

--- a/debug/window.c
+++ b/debug/window.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "gui/lib.h"
 #include "lib.h"

--- a/editor/window.c
+++ b/editor/window.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <string.h>
 #include <wchar.h>
 #include "mutt/lib.h"

--- a/email/content.h
+++ b/email/content.h
@@ -24,8 +24,8 @@
 #ifndef MUTT_EMAIL_CONTENT_H
 #define MUTT_EMAIL_CONTENT_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 /**
  * struct Content - Info about an attachment

--- a/email/envelope.c
+++ b/email/envelope.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <string.h>
 #include "mutt/lib.h"
 #include "address/lib.h"

--- a/email/parameter.c
+++ b/email/parameter.c
@@ -28,8 +28,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "parameter.h"
 

--- a/email/tags.c
+++ b/email/tags.c
@@ -30,8 +30,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/enriched.c
+++ b/enriched.c
@@ -31,8 +31,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <wchar.h>
 #include <wctype.h>

--- a/expando/config_type.c
+++ b/expando/config_type.c
@@ -34,8 +34,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include "mutt/lib.h"

--- a/expando/filter.c
+++ b/expando/filter.c
@@ -27,9 +27,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>

--- a/expando/format.h
+++ b/expando/format.h
@@ -23,8 +23,8 @@
 #ifndef MUTT_EXPANDO_FORMAT_H
 #define MUTT_EXPANDO_FORMAT_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 /**
  * enum FormatJustify - Alignment for format_string()

--- a/expando/helpers.c
+++ b/expando/helpers.c
@@ -28,9 +28,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <ctype.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "helpers.h"
 #include "definition.h"

--- a/expando/node_container.c
+++ b/expando/node_container.c
@@ -28,8 +28,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "node_container.h"
 #include "format.h"

--- a/flags.c
+++ b/flags.c
@@ -31,8 +31,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/globals.c
+++ b/globals.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "menu/lib.h"
 

--- a/gui/curs_lib.h
+++ b/gui/curs_lib.h
@@ -24,8 +24,8 @@
 #ifndef MUTT_GUI_CURS_LIB_H
 #define MUTT_GUI_CURS_LIB_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "browser/lib.h"
 #include "key/lib.h"
 

--- a/gui/dialog.c
+++ b/gui/dialog.c
@@ -68,8 +68,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "dialog.h"
 #include "mutt_window.h"

--- a/gui/global.c
+++ b/gui/global.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "core/lib.h"

--- a/gui/msgcont.c
+++ b/gui/msgcont.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "msgcont.h"
 #include "mutt_window.h"

--- a/gui/msgwin.c
+++ b/gui/msgwin.c
@@ -83,8 +83,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <string.h>
 #include <wchar.h>
 #include "mutt/lib.h"

--- a/gui/resize.c
+++ b/gui/resize.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <fcntl.h>
+#include <stddef.h>
 #include <unistd.h>
 #include "mutt/lib.h"
 #include "mutt_curses.h"

--- a/hcache/config.c
+++ b/hcache/config.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/hcache/lib.h
+++ b/hcache/lib.h
@@ -67,8 +67,8 @@
 #ifndef MUTT_HCACHE_LIB_H
 #define MUTT_HCACHE_LIB_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "compress/lib.h"
 #include "store/lib.h"

--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <string.h>
 #include <sys/types.h>
 #include "mutt/lib.h"

--- a/help.c
+++ b/help.c
@@ -32,9 +32,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <limits.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 #include <wchar.h>

--- a/helpbar/config.c
+++ b/helpbar/config.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "config/lib.h"
 
 /**

--- a/helpbar/helpbar.c
+++ b/helpbar/helpbar.c
@@ -65,8 +65,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include "private.h"
 #include "mutt/lib.h"

--- a/history/config.c
+++ b/history/config.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "config/lib.h"
 #include "lib.h"
 #include "expando/lib.h"

--- a/imap/auth_gsasl.c
+++ b/imap/auth_gsasl.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <gsasl.h>
+#include <stddef.h>
 #include "private.h"
 #include "mutt/lib.h"
 #include "conn/lib.h"

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -29,10 +29,10 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <sasl/sasl.h>
 #include <sasl/saslutil.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 #include "private.h"

--- a/imap/config.c
+++ b/imap/config.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/imap/lib.h
+++ b/imap/lib.h
@@ -56,8 +56,8 @@
 #define MUTT_IMAP_LIB_H
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <sys/types.h>
 #include "core/lib.h"
 #include "external.h"

--- a/index/config.c
+++ b/index/config.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "config/lib.h"
 
 /**

--- a/index/index.c
+++ b/index/index.c
@@ -68,8 +68,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "email/lib.h"

--- a/key/get.c
+++ b/key/get.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <unistd.h>
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/mailcap.h
+++ b/mailcap.h
@@ -24,8 +24,8 @@
 #ifndef MUTT_MAILCAP_H
 #define MUTT_MAILCAP_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 struct Body;
 struct Buffer;

--- a/maildir/config.c
+++ b/maildir/config.c
@@ -28,9 +28,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <ctype.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 #include "mutt/lib.h"

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -30,8 +30,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "core/lib.h"
 #include "account.h"
 #include "mailbox.h"

--- a/maillist.h
+++ b/maillist.h
@@ -23,8 +23,8 @@
 #ifndef MUTT_MAILLIST_H
 #define MUTT_MAILLIST_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 struct Address;
 struct AddressList;

--- a/mbox/config.c
+++ b/mbox/config.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "config/lib.h"
 
 /**

--- a/menu/config.c
+++ b/menu/config.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "config/lib.h"
 
 /**

--- a/menu/draw.c
+++ b/menu/draw.c
@@ -28,8 +28,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <string.h>
 #include <wchar.h>
 #include "mutt/lib.h"

--- a/menu/functions.c
+++ b/menu/functions.c
@@ -28,8 +28,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/menu/move.c
+++ b/menu/move.c
@@ -49,8 +49,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "gui/lib.h"

--- a/menu/tagging.c
+++ b/menu/tagging.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"

--- a/mh/config.c
+++ b/mh/config.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "config/lib.h"
 
 /**

--- a/mixmaster/win_chain.c
+++ b/mixmaster/win_chain.c
@@ -44,8 +44,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 #include "mutt/lib.h"

--- a/mixmaster/win_hosts.c
+++ b/mixmaster/win_hosts.c
@@ -45,8 +45,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -26,8 +26,8 @@
 #ifndef MUTT_MUTT_BUFFER_H
 #define MUTT_MUTT_BUFFER_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 /**
  * struct Buffer - String manipulation buffer

--- a/mutt/list.h
+++ b/mutt/list.h
@@ -24,8 +24,8 @@
 #ifndef MUTT_MUTT_LIST_H
 #define MUTT_MUTT_LIST_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "queue.h"
 
 /**

--- a/mutt/md5.c
+++ b/mutt/md5.c
@@ -28,8 +28,8 @@
  */
 
 #include "config.h"
-#include <stddef.h> // IWYU pragma: keep
 #include <stdbool.h>
+#include <stddef.h> // IWYU pragma: keep
 #include <stdio.h>
 #include <string.h>
 #include "md5.h"

--- a/mutt/notify.c
+++ b/mutt/notify.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "notify.h"
 #include "logging2.h"
 #include "memory.h"

--- a/mutt/prex.c
+++ b/mutt/prex.c
@@ -28,8 +28,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "prex.h"
 #include "logging2.h"

--- a/mutt/random.c
+++ b/mutt/random.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <errno.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/mutt/signal.c
+++ b/mutt/signal.c
@@ -27,9 +27,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <signal.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/mutt/slist.h
+++ b/mutt/slist.h
@@ -23,8 +23,8 @@
 #ifndef MUTT_MUTT_SLIST_H
 #define MUTT_MUTT_SLIST_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "list.h"
 

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -33,8 +33,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include "mutt/lib.h"

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/mutt_signal.c
+++ b/mutt_signal.c
@@ -27,10 +27,10 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <errno.h>
 #include <signal.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"

--- a/ncrypt/config.c
+++ b/ncrypt/config.c
@@ -30,8 +30,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "private.h"
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/nntp/config.c
+++ b/nntp/config.c
@@ -28,8 +28,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "config/lib.h"
 #include "conn/lib.h"
 #include "expando/lib.h"

--- a/notmuch/config.c
+++ b/notmuch/config.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "private.h"
 #include "mutt/lib.h"

--- a/notmuch/lib.h
+++ b/notmuch/lib.h
@@ -42,8 +42,8 @@
 #ifndef MUTT_NOTMUCH_LIB_H
 #define MUTT_NOTMUCH_LIB_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "core/lib.h"
 #include "complete/lib.h"
 

--- a/notmuch/query.h
+++ b/notmuch/query.h
@@ -23,8 +23,8 @@
 #ifndef MUTT_NOTMUCH_QUERY_H
 #define MUTT_NOTMUCH_QUERY_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 /**
  * enum NmQueryType - Notmuch Query Types

--- a/notmuch/tag.c
+++ b/notmuch/tag.c
@@ -28,8 +28,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <ctype.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "tag.h"
 

--- a/pager/config.c
+++ b/pager/config.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "expando/lib.h"

--- a/pager/do_pager.c
+++ b/pager/do_pager.c
@@ -56,8 +56,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -30,9 +30,9 @@
 #ifdef _MAKEDOC
 #include "docs/makedoc_defs.h"
 #else
-#include <stddef.h>
 #include <inttypes.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include "mutt/lib.h"

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -61,8 +61,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <sys/stat.h>
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/pattern/config.c
+++ b/pattern/config.c
@@ -27,8 +27,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "private.h"
 #include "config/lib.h"
 #include "expando/lib.h"

--- a/pattern/dlg_pattern.c
+++ b/pattern/dlg_pattern.c
@@ -68,8 +68,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "private.h"
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/pattern/lib.h
+++ b/pattern/lib.h
@@ -44,8 +44,8 @@
 #define MUTT_PATTERN_LIB_H
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "mutt.h"

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -31,8 +31,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "private.h"
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/pop/config.c
+++ b/pop/config.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "private.h"
 #include "mutt/lib.h"

--- a/progress/window.h
+++ b/progress/window.h
@@ -23,9 +23,9 @@
 #ifndef MUTT_PROGRESS_WINDOW_H
 #define MUTT_PROGRESS_WINDOW_H
 
-#include <stddef.h>
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 struct MuttWindow;
 

--- a/send/config.c
+++ b/send/config.c
@@ -32,8 +32,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 #include "mutt/lib.h"

--- a/send/multipart.c
+++ b/send/multipart.c
@@ -28,8 +28,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "email/lib.h"
 #include "multipart.h"

--- a/sidebar/config.c
+++ b/sidebar/config.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "private.h"
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/sidebar/functions.c
+++ b/sidebar/functions.c
@@ -28,8 +28,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "private.h"
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/sidebar/observer.c
+++ b/sidebar/observer.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "private.h"
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/store/bdb.c
+++ b/store/bdb.c
@@ -29,11 +29,11 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <db.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/store/gdbm.c
+++ b/store/gdbm.c
@@ -29,9 +29,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <gdbm.h>
 #include <limits.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "lib.h"
 

--- a/store/lmdb.c
+++ b/store/lmdb.c
@@ -30,8 +30,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <lmdb.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "lib.h"

--- a/store/qdbm.c
+++ b/store/qdbm.c
@@ -29,9 +29,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <depot.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <villa.h>
 #include "mutt/lib.h"
 #include "lib.h"

--- a/store/rocksdb.c
+++ b/store/rocksdb.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <rocksdb/c.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "lib.h"
 

--- a/store/tdb.c
+++ b/store/tdb.c
@@ -29,8 +29,8 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <fcntl.h>
+#include <stddef.h>
 #include <tdb.h>
 #include "mutt/lib.h"
 #include "lib.h"

--- a/test/account/account_mailbox_add.c
+++ b/test/account/account_mailbox_add.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "config/lib.h"
 #include "core/lib.h"
 #include "test_common.h" // IWYU pragma: keep

--- a/test/account/account_mailbox_remove.c
+++ b/test/account/account_mailbox_remove.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "config/lib.h"
 #include "core/lib.h"
 #include "test_common.h" // IWYU pragma: keep

--- a/test/address/config_type.c
+++ b/test/address/config_type.c
@@ -25,9 +25,9 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <limits.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include "mutt/lib.h"

--- a/test/address/mutt_addr_copy.c
+++ b/test/address/mutt_addr_copy.c
@@ -25,8 +25,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "address/lib.h"
 #include "test_common.h"

--- a/test/address/mutt_addr_for_display.c
+++ b/test/address/mutt_addr_for_display.c
@@ -25,8 +25,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "address/lib.h"
 #include "config/lib.h"

--- a/test/address/mutt_addr_to_intl.c
+++ b/test/address/mutt_addr_to_intl.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "address/lib.h"
 
 void test_mutt_addr_to_intl(void)

--- a/test/address/mutt_addrlist_copy.c
+++ b/test/address/mutt_addrlist_copy.c
@@ -25,8 +25,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "address/lib.h"
 #include "test_common.h"

--- a/test/address/mutt_addrlist_parse.c
+++ b/test/address/mutt_addrlist_parse.c
@@ -25,8 +25,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "address/lib.h"
 #include "test_common.h"

--- a/test/address/mutt_addrlist_to_intl.c
+++ b/test/address/mutt_addrlist_to_intl.c
@@ -25,8 +25,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "address/lib.h"
 #include "config/lib.h"

--- a/test/address/mutt_addrlist_write.c
+++ b/test/address/mutt_addrlist_write.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "address/lib.h"
 #include "test_common.h"

--- a/test/array/mutt_array_api.c
+++ b/test/array/mutt_array_api.c
@@ -25,9 +25,9 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <math.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 
 struct Dummy

--- a/test/atoi/mutt_str_atol.c
+++ b/test/atoi/mutt_str_atol.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "test_common.h"
 

--- a/test/atoi/mutt_str_atoul.c
+++ b/test/atoi/mutt_str_atoul.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "test_common.h"
 

--- a/test/atoi/mutt_str_atoull.c
+++ b/test/atoi/mutt_str_atoull.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 
 struct TestValue

--- a/test/buffer/buf_copy.c
+++ b/test/buffer/buf_copy.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "test_common.h"
 

--- a/test/buffer/buf_rfind.c
+++ b/test/buffer/buf_rfind.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 
 struct RfindTest

--- a/test/charset/mutt_ch_check_charset.c
+++ b/test/charset/mutt_ch_check_charset.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 
 void test_mutt_ch_check_charset(void)

--- a/test/color/ansi.c
+++ b/test/color/ansi.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <string.h>
 #include "mutt/lib.h"
 #include "config/lib.h"

--- a/test/color/ansi_color_parse_single.c
+++ b/test/color/ansi_color_parse_single.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "gui/lib.h"

--- a/test/color/attr.c
+++ b/test/color/attr.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include "mutt/lib.h"

--- a/test/color/color_dump.c
+++ b/test/color/color_dump.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "config/lib.h"
 #include "core/lib.h"
 #include "gui/lib.h"

--- a/test/color/simple.c
+++ b/test/color/simple.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"

--- a/test/config/helpers.c
+++ b/test/config/helpers.c
@@ -25,8 +25,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"

--- a/test/convert/mutt_update_content_info.c
+++ b/test/convert/mutt_update_content_info.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "email/lib.h"
 #include "convert/lib.h"
 #include "convert_common.h"

--- a/test/date/mutt_date_make_date.c
+++ b/test/date/mutt_date_make_date.c
@@ -25,8 +25,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 
 void test_mutt_date_make_date(void)

--- a/test/envlist/envlist_set.c
+++ b/test/envlist/envlist_set.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "test_common.h"
 

--- a/test/envlist/envlist_unset.c
+++ b/test/envlist/envlist_unset.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "test_common.h"
 

--- a/test/expando/complex_if_else.c
+++ b/test/expando/complex_if_else.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
 #include "expando/lib.h"
 #include "common.h" // IWYU pragma: keep
 

--- a/test/expando/filter.c
+++ b/test/expando/filter.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <string.h>
 #include "mutt/lib.h"
 #include "email/lib.h"

--- a/test/expando/format.c
+++ b/test/expando/format.c
@@ -23,9 +23,9 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <limits.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <string.h>
 #include "mutt/lib.h"
 #include "expando/lib.h"

--- a/test/expando/formatted_expando.c
+++ b/test/expando/formatted_expando.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
 #include "expando/lib.h"
 #include "common.h" // IWYU pragma: keep
 

--- a/test/expando/new_if_else.c
+++ b/test/expando/new_if_else.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
 #include "expando/lib.h"
 #include "common.h" // IWYU pragma: keep
 

--- a/test/expando/node_expando.c
+++ b/test/expando/node_expando.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <string.h>
 #include "mutt/lib.h"
 #include "color/lib.h"

--- a/test/expando/old_if_else.c
+++ b/test/expando/old_if_else.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
 #include "expando/lib.h"
 #include "common.h" // IWYU pragma: keep
 

--- a/test/expando/serial.c
+++ b/test/expando/serial.c
@@ -21,9 +21,9 @@
  */
 
 #include "config.h"
-#include <stddef.h>
 #include <limits.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "debug/lib.h"

--- a/test/expando/validation.c
+++ b/test/expando/validation.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "expando/lib.h"
 #include "common.h" // IWYU pragma: keep

--- a/test/file/buf_quote_filename.c
+++ b/test/file/buf_quote_filename.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "common.h"
 #include "test_common.h"

--- a/test/file/mutt_file_sanitize_filename.c
+++ b/test/file/mutt_file_sanitize_filename.c
@@ -24,9 +24,9 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <locale.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "test_common.h"
 

--- a/test/gui/visible.c
+++ b/test/gui/visible.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "gui/lib.h"
 

--- a/test/history/mutt_hist_add.c
+++ b/test/history/mutt_hist_add.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "config/lib.h"
 #include "core/lib.h"
 #include "history/lib.h"

--- a/test/history/mutt_hist_save_scratch.c
+++ b/test/history/mutt_hist_save_scratch.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "config/lib.h"
 #include "core/lib.h"
 #include "history/lib.h"

--- a/test/history/mutt_hist_search.c
+++ b/test/history/mutt_hist_search.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "config/lib.h"
 #include "core/lib.h"
 #include "history/lib.h"

--- a/test/idna/mutt_idna_intl_to_local.c
+++ b/test/idna/mutt_idna_intl_to_local.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "address/lib.h"
 #include "config/lib.h"

--- a/test/idna/mutt_idna_local_to_intl.c
+++ b/test/idna/mutt_idna_local_to_intl.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "address/lib.h"
 #include "config/lib.h"

--- a/test/imap/msg_set.c
+++ b/test/imap/msg_set.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "imap/msg_set.h" // IWYU pragma: keep
 #include "imap/lib.h"

--- a/test/list/common.c
+++ b/test/list/common.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 
 struct ListHead test_list_create(const char *items[], bool copy)

--- a/test/list/mutt_list_clear.c
+++ b/test/list/mutt_list_clear.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "common.h"
 

--- a/test/list/mutt_list_equal.c
+++ b/test/list/mutt_list_equal.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "common.h"
 

--- a/test/list/mutt_list_find.c
+++ b/test/list/mutt_list_find.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "common.h"
 

--- a/test/list/mutt_list_free.c
+++ b/test/list/mutt_list_free.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "common.h"
 

--- a/test/list/mutt_list_free_type.c
+++ b/test/list/mutt_list_free_type.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "common.h"
 

--- a/test/list/mutt_list_insert_after.c
+++ b/test/list/mutt_list_insert_after.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "common.h"
 

--- a/test/list/mutt_list_insert_head.c
+++ b/test/list/mutt_list_insert_head.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "common.h"
 

--- a/test/list/mutt_list_insert_tail.c
+++ b/test/list/mutt_list_insert_tail.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "common.h"
 

--- a/test/list/mutt_list_match.c
+++ b/test/list/mutt_list_match.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "common.h"
 

--- a/test/logging/log_file_set_filename.c
+++ b/test/logging/log_file_set_filename.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 
 void test_log_file_set_filename(void)

--- a/test/mbyte/mutt_mb_width.c
+++ b/test/mbyte/mutt_mb_width.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 
 struct Test

--- a/test/memory/mutt_mem_calloc.c
+++ b/test/memory/mutt_mem_calloc.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 
 void test_mutt_mem_calloc(void)

--- a/test/memory/mutt_mem_malloc.c
+++ b/test/memory/mutt_mem_malloc.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "test_common.h"
 

--- a/test/neo/neomutt_account_add.c
+++ b/test/neo/neomutt_account_add.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "core/lib.h"
 
 void test_neomutt_account_add(void)

--- a/test/neo/neomutt_mailboxlist_get_all.c
+++ b/test/neo/neomutt_mailboxlist_get_all.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "core/lib.h"
 

--- a/test/parse/mutt_read_mime_header.c
+++ b/test/parse/mutt_read_mime_header.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "email/lib.h"
 
 void test_mutt_read_mime_header(void)

--- a/test/parse/parse_rc_line.c
+++ b/test/parse/parse_rc_line.c
@@ -25,8 +25,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "config/common.h" // IWYU pragma: keep

--- a/test/path/mutt_path_realpath.c
+++ b/test/path/mutt_path_realpath.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "test_common.h"

--- a/test/path/mutt_path_tidy.c
+++ b/test/path/mutt_path_tidy.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "test_common.h"
 

--- a/test/path/mutt_path_tidy_slash.c
+++ b/test/path/mutt_path_tidy_slash.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "test_common.h"
 

--- a/test/path/mutt_path_tilde.c
+++ b/test/path/mutt_path_tilde.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <pwd.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "test_common.h"
 

--- a/test/path/mutt_path_to_absolute.c
+++ b/test/path/mutt_path_to_absolute.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 #include "mutt/lib.h"

--- a/test/regex/mutt_regex_match.c
+++ b/test/regex/mutt_regex_match.c
@@ -26,8 +26,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "config/common.h" // IWYU pragma: keep
 #include "config/lib.h"

--- a/test/store/common.c
+++ b/test/store/common.c
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>  // IWYU pragma: keep
 #include "mutt/lib.h"
 #include "store/lib.h"
 #include "test_common.h"

--- a/test/store/gdbm.c
+++ b/test/store/gdbm.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "store/lib.h"
 #include "common.h" // IWYU pragma: keep

--- a/test/store/kc.c
+++ b/test/store/kc.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "store/lib.h"
 #include "common.h" // IWYU pragma: keep

--- a/test/store/lmdb.c
+++ b/test/store/lmdb.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "store/lib.h"
 #include "common.h" // IWYU pragma: keep

--- a/test/store/qdbm.c
+++ b/test/store/qdbm.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "store/lib.h"
 #include "common.h" // IWYU pragma: keep

--- a/test/store/rocksdb.c
+++ b/test/store/rocksdb.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "store/lib.h"
 #include "common.h" // IWYU pragma: keep

--- a/test/store/store.c
+++ b/test/store/store.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "store/lib.h"
 

--- a/test/store/tc.c
+++ b/test/store/tc.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "store/lib.h"
 #include "common.h" // IWYU pragma: keep

--- a/test/store/tdb.c
+++ b/test/store/tdb.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "store/lib.h"
 #include "common.h" // IWYU pragma: keep

--- a/test/string/mutt_str_is_ascii.c
+++ b/test/string/mutt_str_is_ascii.c
@@ -23,8 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 
 struct IsAsciiTest

--- a/test/tags/driver_tags_get.c
+++ b/test/tags/driver_tags_get.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "email/lib.h"
 #include "test_common.h"

--- a/test/tags/driver_tags_get_transformed.c
+++ b/test/tags/driver_tags_get_transformed.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "email/lib.h"
 #include "test_common.h"

--- a/test/tags/driver_tags_get_transformed_for.c
+++ b/test/tags/driver_tags_get_transformed_for.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "email/lib.h"
 #include "test_common.h"

--- a/test/tags/driver_tags_get_with_hidden.c
+++ b/test/tags/driver_tags_get_with_hidden.c
@@ -24,8 +24,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "email/lib.h"
 #include "test_common.h"


### PR DESCRIPTION
Fixes: ac6ef83f3229 ("fix: build of imap/auth_sasl.c")
Closes: <https://github.com/neomutt/neomutt/issues/4284>


Builds locally.  Let's see what CI has to say.

---

Revisions:

<details>
<summary>v2</summary>
v2 changes:

-  Workaround macOS violation of POSIX

```
$ git range-diff main neomutt/devel/stddef devel/stddef 
1:  8abe6e5e1 = 1:  8abe6e5e1 .clang-format: Don't special-case <stddef.h>
2:  bf134eaf0 = 2:  bf134eaf0 Sort include <stddef.h>
-:  --------- > 3:  469229425 test/store/common.c: Workaround macOS bug
3:  7066b19ff = 4:  3f3669fd4 .cirrus.yml: DO NOT MERGE: trigger CI on push to test these changes
```
</details>