### PR TITLE
Revert "ncrypt/crypt.c: Protect Date"

### DIFF
--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -271,8 +271,6 @@ int mutt_protect(struct Email *e, char *keylist, bool postpone)
   {
     const bool c_devel_security = cs_subset_bool(NeoMutt->sub, "devel_security");
     struct Envelope *protected_headers = mutt_env_new();
-    if (c_devel_security)
-      mutt_str_replace(&protected_headers->date, e->env->date);
     mutt_env_set_subject(protected_headers, e->env->subject);
     if (c_devel_security)
     {


### PR DESCRIPTION
This reverts commit 944e06904e8b3b088dbf58cc2f84bf7120af3539.

---

I thought I had tested that commit, but maybe I only tested the reading of the date field (generated with mutt(1)), and not the generation of it with neomutt(1)).  :|

Either that, or I broke it at some point.  But I tend to think that I forgot to test it properly.  Especially seeing that mutt(1) did a lot more work to get the date protected.  So, let's just not protect the date.  Anyway, the date of the PGP signature should be more useful than the date of the mail, and is simpler.

But it's weird, because I remember being surprised that it worked, since I was expecting it not to work.  Maybe I accidentally sent from mutt(1), and thought I had sent from neomutt(1), and that's why I thought it was working...

I only reverted the writing part, since the reading part works, and other MUAs protect the date, so it's good to read it if it's set.