### PR TITLE
Add mutt_mem_reallocarray() and mutt_mem_mallocarray(), and some wrapper macros

### DIFF
--- a/address/address.c
+++ b/address/address.c
@@ -400,7 +400,7 @@ static bool add_addrspec(struct AddressList *al, const char *phrase,
  */
 struct Address *mutt_addr_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct Address));
+  return MUTT_MEM_CALLOC(1, struct Address);
 }
 
 /**

--- a/address/config_type.c
+++ b/address/config_type.c
@@ -51,7 +51,7 @@
  */
 struct Address *address_new(const char *addr)
 {
-  struct Address *a = mutt_mem_calloc(1, sizeof(*a));
+  struct Address *a = MUTT_MEM_CALLOC(1, struct Address);
   a->mailbox = buf_new(addr);
   return a;
 }
@@ -166,7 +166,7 @@ static struct Address *address_dup(struct Address *addr)
   if (!addr)
     return NULL; /* LCOV_EXCL_LINE */
 
-  struct Address *a = mutt_mem_calloc(1, sizeof(*a));
+  struct Address *a = MUTT_MEM_CALLOC(1, struct Address);
   a->personal = buf_dup(addr->personal);
   a->mailbox = buf_dup(addr->mailbox);
   return a;

--- a/address/group.c
+++ b/address/group.c
@@ -69,7 +69,7 @@ static void group_free(struct Group **ptr)
  */
 static struct Group *group_new(const char *pat)
 {
-  struct Group *g = mutt_mem_calloc(1, sizeof(struct Group));
+  struct Group *g = MUTT_MEM_CALLOC(1, struct Group);
 
   g->name = mutt_str_dup(pat);
   STAILQ_INIT(&g->rs);
@@ -190,7 +190,7 @@ void mutt_grouplist_add(struct GroupList *gl, struct Group *group)
     if (np->group == group)
       return;
   }
-  np = mutt_mem_calloc(1, sizeof(struct GroupNode));
+  np = MUTT_MEM_CALLOC(1, struct GroupNode);
   np->group = group;
   STAILQ_INSERT_TAIL(gl, np, entries);
 }

--- a/alias/alias.c
+++ b/alias/alias.c
@@ -659,7 +659,7 @@ bool mutt_addr_is_user(const struct Address *addr)
  */
 struct Alias *alias_new(void)
 {
-  struct Alias *a = mutt_mem_calloc(1, sizeof(struct Alias));
+  struct Alias *a = MUTT_MEM_CALLOC(1, struct Alias);
   TAILQ_INIT(&a->addr);
   STAILQ_INIT(&a->tags);
   return a;

--- a/attach/attach.c
+++ b/attach/attach.c
@@ -72,8 +72,8 @@ void mutt_actx_add_attach(struct AttachCtx *actx, struct AttachPtr *attach)
   if (actx->idxlen == actx->idxmax)
   {
     actx->idxmax += grow;
-    mutt_mem_realloc(&actx->idx, actx->idxmax * sizeof(struct AttachPtr *));
-    mutt_mem_realloc(&actx->v2r, actx->idxmax * sizeof(short));
+    mutt_mem_reallocarray(&actx->idx, actx->idxmax, sizeof(struct AttachPtr *));
+    mutt_mem_reallocarray(&actx->v2r, actx->idxmax, sizeof(short));
 
     memset(&actx->idx[actx->idxlen], 0, grow * sizeof(struct AttachPtr *));
     memset(&actx->v2r[actx->idxlen], 0, grow * sizeof(short));
@@ -99,8 +99,8 @@ void mutt_actx_ins_attach(struct AttachCtx *actx, struct AttachPtr *attach, int 
   if (actx->idxlen == actx->idxmax)
   {
     actx->idxmax += 5;
-    mutt_mem_realloc(&actx->idx, sizeof(struct AttachPtr *) * actx->idxmax);
-    mutt_mem_realloc(&actx->v2r, sizeof(short) * actx->idxmax);
+    mutt_mem_reallocarray(&actx->idx, actx->idxmax, sizeof(struct AttachPtr *));
+    mutt_mem_reallocarray(&actx->v2r, actx->idxmax, sizeof(short));
     for (int i = actx->idxlen; i < actx->idxmax; i++)
       actx->idx[i] = NULL;
   }
@@ -126,7 +126,7 @@ void mutt_actx_add_fp(struct AttachCtx *actx, FILE *fp_new)
   if (actx->fp_len == actx->fp_max)
   {
     actx->fp_max += 5;
-    mutt_mem_realloc(&actx->fp_idx, sizeof(FILE *) * actx->fp_max);
+    mutt_mem_reallocarray(&actx->fp_idx, actx->fp_max, sizeof(FILE *));
     for (int i = actx->fp_len; i < actx->fp_max; i++)
       actx->fp_idx[i] = NULL;
   }
@@ -147,7 +147,7 @@ void mutt_actx_add_body(struct AttachCtx *actx, struct Body *b)
   if (actx->body_len == actx->body_max)
   {
     actx->body_max += 5;
-    mutt_mem_realloc(&actx->body_idx, sizeof(struct Body *) * actx->body_max);
+    mutt_mem_reallocarray(&actx->body_idx, actx->body_max, sizeof(struct Body *));
     for (int i = actx->body_len; i < actx->body_max; i++)
       actx->body_idx[i] = NULL;
   }

--- a/attach/attach.c
+++ b/attach/attach.c
@@ -72,8 +72,8 @@ void mutt_actx_add_attach(struct AttachCtx *actx, struct AttachPtr *attach)
   if (actx->idxlen == actx->idxmax)
   {
     actx->idxmax += grow;
-    mutt_mem_reallocarray(&actx->idx, actx->idxmax, sizeof(struct AttachPtr *));
-    mutt_mem_reallocarray(&actx->v2r, actx->idxmax, sizeof(short));
+    MUTT_MEM_REALLOC(&actx->idx, actx->idxmax, struct AttachPtr *);
+    MUTT_MEM_REALLOC(&actx->v2r, actx->idxmax, short);
 
     memset(&actx->idx[actx->idxlen], 0, grow * sizeof(struct AttachPtr *));
     memset(&actx->v2r[actx->idxlen], 0, grow * sizeof(short));
@@ -99,8 +99,8 @@ void mutt_actx_ins_attach(struct AttachCtx *actx, struct AttachPtr *attach, int 
   if (actx->idxlen == actx->idxmax)
   {
     actx->idxmax += 5;
-    mutt_mem_reallocarray(&actx->idx, actx->idxmax, sizeof(struct AttachPtr *));
-    mutt_mem_reallocarray(&actx->v2r, actx->idxmax, sizeof(short));
+    MUTT_MEM_REALLOC(&actx->idx, actx->idxmax, struct AttachPtr *);
+    MUTT_MEM_REALLOC(&actx->v2r, actx->idxmax, short);
     for (int i = actx->idxlen; i < actx->idxmax; i++)
       actx->idx[i] = NULL;
   }
@@ -126,7 +126,7 @@ void mutt_actx_add_fp(struct AttachCtx *actx, FILE *fp_new)
   if (actx->fp_len == actx->fp_max)
   {
     actx->fp_max += 5;
-    mutt_mem_reallocarray(&actx->fp_idx, actx->fp_max, sizeof(FILE *));
+    MUTT_MEM_REALLOC(&actx->fp_idx, actx->fp_max, FILE *);
     for (int i = actx->fp_len; i < actx->fp_max; i++)
       actx->fp_idx[i] = NULL;
   }
@@ -147,7 +147,7 @@ void mutt_actx_add_body(struct AttachCtx *actx, struct Body *b)
   if (actx->body_len == actx->body_max)
   {
     actx->body_max += 5;
-    mutt_mem_reallocarray(&actx->body_idx, actx->body_max, sizeof(struct Body *));
+    MUTT_MEM_REALLOC(&actx->body_idx, actx->body_max, struct Body *);
     for (int i = actx->body_len; i < actx->body_max; i++)
       actx->body_idx[i] = NULL;
   }

--- a/attach/attach.c
+++ b/attach/attach.c
@@ -39,7 +39,7 @@
  */
 struct AttachPtr *mutt_aptr_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct AttachPtr));
+  return MUTT_MEM_CALLOC(1, struct AttachPtr);
 }
 
 /**
@@ -188,7 +188,7 @@ void mutt_actx_entries_free(struct AttachCtx *actx)
  */
 struct AttachCtx *mutt_actx_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct AttachCtx));
+  return MUTT_MEM_CALLOC(1, struct AttachCtx);
 }
 
 /**

--- a/attach/attachments.c
+++ b/attach/attachments.c
@@ -83,7 +83,7 @@ static void attachmatch_free(struct AttachMatch **ptr)
  */
 static struct AttachMatch *attachmatch_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct AttachMatch));
+  return MUTT_MEM_CALLOC(1, struct AttachMatch);
 }
 
 /**

--- a/attach/attachments.c
+++ b/attach/attachments.c
@@ -350,7 +350,7 @@ static enum CommandResult parse_attach_list(struct Buffer *buf, struct Buffer *s
     }
 
     len = strlen(a->minor);
-    tmpminor = mutt_mem_mallocarray(len + 3, sizeof(char));
+    tmpminor = MUTT_MEM_MALLOC(len + 3, char);
     strcpy(&tmpminor[1], a->minor);
     tmpminor[0] = '^';
     tmpminor[len + 1] = '$';

--- a/attach/attachments.c
+++ b/attach/attachments.c
@@ -350,7 +350,7 @@ static enum CommandResult parse_attach_list(struct Buffer *buf, struct Buffer *s
     }
 
     len = strlen(a->minor);
-    tmpminor = mutt_mem_malloc(len + 3);
+    tmpminor = mutt_mem_mallocarray(len + 3, sizeof(char));
     strcpy(&tmpminor[1], a->minor);
     tmpminor[0] = '^';
     tmpminor[len + 1] = '$';

--- a/attach/cid.c
+++ b/attach/cid.c
@@ -67,7 +67,7 @@ struct CidMap *cid_map_new(const char *cid, const char *filename)
   if (!cid || !filename)
     return NULL;
 
-  struct CidMap *cid_map = mutt_mem_calloc(1, sizeof(struct CidMap));
+  struct CidMap *cid_map = MUTT_MEM_CALLOC(1, struct CidMap);
 
   cid_map->cid = mutt_str_dup(cid);
   cid_map->fname = mutt_str_dup(filename);

--- a/attach/private_data.c
+++ b/attach/private_data.c
@@ -49,7 +49,5 @@ void attach_private_data_free(struct Menu *menu, void **ptr)
  */
 struct AttachPrivateData *attach_private_data_new(void)
 {
-  struct AttachPrivateData *priv = mutt_mem_calloc(1, sizeof(struct AttachPrivateData));
-
-  return priv;
+  return MUTT_MEM_CALLOC(1, struct AttachPrivateData);
 }

--- a/autocrypt/db.c
+++ b/autocrypt/db.c
@@ -237,7 +237,7 @@ static char *strdup_column_text(sqlite3_stmt *stmt, int index)
  */
 struct AutocryptAccount *mutt_autocrypt_db_account_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct AutocryptAccount));
+  return MUTT_MEM_CALLOC(1, struct AutocryptAccount);
 }
 
 /**
@@ -527,7 +527,7 @@ cleanup:
  */
 struct AutocryptPeer *mutt_autocrypt_db_peer_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct AutocryptPeer));
+  return MUTT_MEM_CALLOC(1, struct AutocryptPeer);
 }
 
 /**
@@ -748,7 +748,7 @@ cleanup:
  */
 struct AutocryptPeerHistory *mutt_autocrypt_db_peer_history_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct AutocryptPeerHistory));
+  return MUTT_MEM_CALLOC(1, struct AutocryptPeerHistory);
 }
 
 /**
@@ -829,7 +829,7 @@ cleanup:
  */
 struct AutocryptGossipHistory *mutt_autocrypt_db_gossip_history_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct AutocryptGossipHistory));
+  return MUTT_MEM_CALLOC(1, struct AutocryptGossipHistory);
 }
 
 /**

--- a/autocrypt/db.c
+++ b/autocrypt/db.c
@@ -491,7 +491,7 @@ int mutt_autocrypt_db_account_get_all(struct AutocryptAccount ***accounts, int *
     if (results_count == results_len)
     {
       results_len += 5;
-      mutt_mem_reallocarray(&results, results_len, sizeof(struct AutocryptAccount *));
+      MUTT_MEM_REALLOC(&results, results_len, struct AutocryptAccount *);
     }
 
     struct AutocryptAccount *account = mutt_autocrypt_db_account_new();

--- a/autocrypt/db.c
+++ b/autocrypt/db.c
@@ -491,7 +491,7 @@ int mutt_autocrypt_db_account_get_all(struct AutocryptAccount ***accounts, int *
     if (results_count == results_len)
     {
       results_len += 5;
-      mutt_mem_realloc(&results, results_len * sizeof(struct AutocryptAccount *));
+      mutt_mem_reallocarray(&results, results_len, sizeof(struct AutocryptAccount *));
     }
 
     struct AutocryptAccount *account = mutt_autocrypt_db_account_new();

--- a/autocrypt/dlg_autocrypt.c
+++ b/autocrypt/dlg_autocrypt.c
@@ -243,7 +243,7 @@ bool populate_menu(struct Menu *menu)
   if (mutt_autocrypt_db_account_get_all(&accounts, &num_accounts) < 0)
     return false;
 
-  struct AccountEntry *entries = mutt_mem_calloc(num_accounts, sizeof(struct AccountEntry));
+  struct AccountEntry *entries = MUTT_MEM_CALLOC(num_accounts, struct AccountEntry);
   menu->mdata = entries;
   menu->mdata_free = autocrypt_menu_free;
   menu->max = num_accounts;

--- a/bcache/bcache.c
+++ b/bcache/bcache.c
@@ -150,7 +150,7 @@ struct BodyCache *mutt_bcache_open(struct ConnAccount *account, const char *mail
   if (!account)
     return NULL;
 
-  struct BodyCache *bcache = mutt_mem_calloc(1, sizeof(struct BodyCache));
+  struct BodyCache *bcache = MUTT_MEM_CALLOC(1, struct BodyCache);
   if (bcache_path(account, mailbox, bcache) < 0)
   {
     mutt_bcache_close(&bcache);

--- a/browser/complete.c
+++ b/browser/complete.c
@@ -95,7 +95,7 @@ enum FunctionRetval complete_file_mbox(struct EnterWindowData *wdata, int op)
   if (mutt_complete(wdata->cd, wdata->buffer) == 0)
   {
     wdata->templen = wdata->state->lastchar;
-    mutt_mem_realloc(&wdata->tempbuf, wdata->templen * sizeof(wchar_t));
+    mutt_mem_reallocarray(&wdata->tempbuf, wdata->templen, sizeof(wchar_t));
     if (wdata->tempbuf)
       wmemcpy(wdata->tempbuf, wdata->state->wbuf, wdata->templen);
   }
@@ -134,7 +134,7 @@ enum FunctionRetval complete_file_simple(struct EnterWindowData *wdata, int op)
   if (mutt_complete(wdata->cd, wdata->buffer) == 0)
   {
     wdata->templen = wdata->state->lastchar - i;
-    mutt_mem_realloc(&wdata->tempbuf, wdata->templen * sizeof(wchar_t));
+    mutt_mem_reallocarray(&wdata->tempbuf, wdata->templen, sizeof(wchar_t));
     if (wdata->tempbuf)
       wmemcpy(wdata->tempbuf, wdata->state->wbuf + i, wdata->templen);
   }

--- a/browser/complete.c
+++ b/browser/complete.c
@@ -95,7 +95,7 @@ enum FunctionRetval complete_file_mbox(struct EnterWindowData *wdata, int op)
   if (mutt_complete(wdata->cd, wdata->buffer) == 0)
   {
     wdata->templen = wdata->state->lastchar;
-    mutt_mem_reallocarray(&wdata->tempbuf, wdata->templen, sizeof(wchar_t));
+    MUTT_MEM_REALLOC(&wdata->tempbuf, wdata->templen, wchar_t);
     if (wdata->tempbuf)
       wmemcpy(wdata->tempbuf, wdata->state->wbuf, wdata->templen);
   }
@@ -134,7 +134,7 @@ enum FunctionRetval complete_file_simple(struct EnterWindowData *wdata, int op)
   if (mutt_complete(wdata->cd, wdata->buffer) == 0)
   {
     wdata->templen = wdata->state->lastchar - i;
-    mutt_mem_reallocarray(&wdata->tempbuf, wdata->templen, sizeof(wchar_t));
+    MUTT_MEM_REALLOC(&wdata->tempbuf, wdata->templen, wchar_t);
     if (wdata->tempbuf)
       wmemcpy(wdata->tempbuf, wdata->state->wbuf + i, wdata->templen);
   }

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -602,7 +602,7 @@ static int op_exit(struct BrowserPrivateData *priv, int op)
     if (priv->menu->num_tagged)
     {
       *priv->numfiles = priv->menu->num_tagged;
-      tfiles = mutt_mem_calloc(*priv->numfiles, sizeof(char *));
+      tfiles = MUTT_MEM_CALLOC(*priv->numfiles, char *);
       size_t j = 0;
       struct FolderFile *ff = NULL;
       ARRAY_FOREACH(ff, &priv->state.entry)
@@ -621,7 +621,7 @@ static int op_exit(struct BrowserPrivateData *priv, int op)
     else if (!buf_is_empty(priv->file)) /* no tagged entries. return selected entry */
     {
       *priv->numfiles = 1;
-      tfiles = mutt_mem_calloc(*priv->numfiles, sizeof(char *));
+      tfiles = MUTT_MEM_CALLOC(*priv->numfiles, char *);
       buf_expand_path(priv->file);
       tfiles[0] = buf_strdup(priv->file);
       *priv->files = tfiles;

--- a/browser/private_data.c
+++ b/browser/private_data.c
@@ -54,7 +54,7 @@ void browser_private_data_free(struct BrowserPrivateData **ptr)
  */
 struct BrowserPrivateData *browser_private_data_new(void)
 {
-  struct BrowserPrivateData *priv = mutt_mem_calloc(1, sizeof(struct BrowserPrivateData));
+  struct BrowserPrivateData *priv = MUTT_MEM_CALLOC(1, struct BrowserPrivateData);
 
   priv->old_last_dir = buf_pool_get();
   priv->prefix = buf_pool_get();

--- a/color/attr.c
+++ b/color/attr.c
@@ -89,7 +89,7 @@ void attr_color_free(struct AttrColor **ptr)
  */
 struct AttrColor *attr_color_new(void)
 {
-  struct AttrColor *ac = mutt_mem_calloc(1, sizeof(*ac));
+  struct AttrColor *ac = MUTT_MEM_CALLOC(1, struct AttrColor);
 
   ac->fg.color = COLOR_DEFAULT;
   ac->fg.type = CT_SIMPLE;

--- a/color/curses.c
+++ b/color/curses.c
@@ -170,7 +170,7 @@ struct CursesColor *curses_color_new(color_t fg, color_t bg)
   if (index == 0)
     return NULL;
 
-  struct CursesColor *cc_new = mutt_mem_calloc(1, sizeof(*cc_new));
+  struct CursesColor *cc_new = MUTT_MEM_CALLOC(1, struct CursesColor);
   NumCursesColors++;
   color_debug(LL_DEBUG5, "CursesColor %p\n", (void *) cc_new);
   cc_new->fg = fg;

--- a/color/quoted.c
+++ b/color/quoted.c
@@ -232,7 +232,7 @@ void qstyle_free_tree(struct QuoteStyle **quote_list)
  */
 static struct QuoteStyle *qstyle_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct QuoteStyle));
+  return MUTT_MEM_CALLOC(1, struct QuoteStyle);
 }
 
 /**

--- a/color/regex.c
+++ b/color/regex.c
@@ -150,9 +150,7 @@ void regex_color_free(struct RegexColorList *list, struct RegexColor **ptr)
  */
 struct RegexColor *regex_color_new(void)
 {
-  struct RegexColor *rcol = mutt_mem_calloc(1, sizeof(*rcol));
-
-  return rcol;
+  return MUTT_MEM_CALLOC(1, struct RegexColor);
 }
 
 /**

--- a/complete/data.c
+++ b/complete/data.c
@@ -70,10 +70,10 @@ void completion_data_free(struct CompletionData **ptr)
  */
 struct CompletionData *completion_data_new(void)
 {
-  struct CompletionData *cd = mutt_mem_calloc(1, sizeof(struct CompletionData));
+  struct CompletionData *cd = MUTT_MEM_CALLOC(1, struct CompletionData);
 
   cd->match_list_len = 512;
-  cd->match_list = mutt_mem_calloc(cd->match_list_len, sizeof(char *));
+  cd->match_list = MUTT_MEM_CALLOC(cd->match_list_len, const char *);
 
   return cd;
 }

--- a/complete/helpers.c
+++ b/complete/helpers.c
@@ -58,7 +58,7 @@ void matches_ensure_morespace(struct CompletionData *cd, int new_size)
 
   new_size = ROUND_UP(new_size + 2, 512);
 
-  mutt_mem_reallocarray(&cd->match_list, new_size, sizeof(char *));
+  MUTT_MEM_REALLOC(&cd->match_list, new_size, const char *);
   memset(&cd->match_list[cd->match_list_len], 0, new_size - cd->match_list_len);
 
   cd->match_list_len = new_size;

--- a/complete/helpers.c
+++ b/complete/helpers.c
@@ -58,7 +58,7 @@ void matches_ensure_morespace(struct CompletionData *cd, int new_size)
 
   new_size = ROUND_UP(new_size + 2, 512);
 
-  mutt_mem_realloc(&cd->match_list, new_size * sizeof(char *));
+  mutt_mem_reallocarray(&cd->match_list, new_size, sizeof(char *));
   memset(&cd->match_list[cd->match_list_len], 0, new_size - cd->match_list_len);
 
   cd->match_list_len = new_size;

--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -252,7 +252,7 @@ static struct CompressInfo *set_compress_info(struct Mailbox *m)
   const char *c = mutt_find_hook(MUTT_CLOSE_HOOK, mailbox_path(m));
   const char *a = mutt_find_hook(MUTT_APPEND_HOOK, mailbox_path(m));
 
-  struct CompressInfo *ci = mutt_mem_calloc(1, sizeof(struct CompressInfo));
+  struct CompressInfo *ci = MUTT_MEM_CALLOC(1, struct CompressInfo);
   m->compress_info = ci;
 
   ci->cmd_open = validate_compress_expando(o);

--- a/compose/attach_data.c
+++ b/compose/attach_data.c
@@ -53,7 +53,7 @@ void attach_data_free(struct Menu *menu, void **ptr)
  */
 struct ComposeAttachData *attach_data_new(struct Email *e)
 {
-  struct ComposeAttachData *attach_data = mutt_mem_calloc(1, sizeof(struct ComposeAttachData));
+  struct ComposeAttachData *attach_data = MUTT_MEM_CALLOC(1, struct ComposeAttachData);
 
   attach_data->actx = mutt_actx_new();
   attach_data->actx->email = e;

--- a/compose/cbar_data.c
+++ b/compose/cbar_data.c
@@ -51,5 +51,5 @@ void cbar_data_free(struct MuttWindow *win, void **ptr)
  */
 struct ComposeBarData *cbar_data_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct ComposeBarData));
+  return MUTT_MEM_CALLOC(1, struct ComposeBarData);
 }

--- a/compose/shared_data.c
+++ b/compose/shared_data.c
@@ -47,7 +47,5 @@ void compose_shared_data_free(struct MuttWindow *win, void **ptr)
  */
 struct ComposeSharedData *compose_shared_data_new(void)
 {
-  struct ComposeSharedData *shared = mutt_mem_calloc(1, sizeof(struct ComposeSharedData));
-
-  return shared;
+  return MUTT_MEM_CALLOC(1, struct ComposeSharedData);
 }

--- a/compress/lz4.c
+++ b/compress/lz4.c
@@ -70,7 +70,7 @@ void lz4_cdata_free(struct Lz4ComprData **ptr)
  */
 static struct Lz4ComprData *lz4_cdata_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct Lz4ComprData));
+  return MUTT_MEM_CALLOC(1, struct Lz4ComprData);
 }
 
 /**
@@ -80,7 +80,7 @@ static ComprHandle *compr_lz4_open(short level)
 {
   struct Lz4ComprData *cdata = lz4_cdata_new();
 
-  cdata->buf = mutt_mem_calloc(1, LZ4_compressBound(1024 * 32));
+  cdata->buf = mutt_mem_calloc(LZ4_compressBound(1024 * 32), 1);
 
   if ((level < MIN_COMP_LEVEL) || (level > MAX_COMP_LEVEL))
   {

--- a/compress/zlib.c
+++ b/compress/zlib.c
@@ -70,7 +70,7 @@ void zlib_cdata_free(struct ZlibComprData **ptr)
  */
 static struct ZlibComprData *zlib_cdata_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct ZlibComprData));
+  return MUTT_MEM_CALLOC(1, struct ZlibComprData);
 }
 
 /**
@@ -80,7 +80,7 @@ static ComprHandle *compr_zlib_open(short level)
 {
   struct ZlibComprData *cdata = zlib_cdata_new();
 
-  cdata->buf = mutt_mem_calloc(1, compressBound(1024 * 32));
+  cdata->buf = mutt_mem_calloc(compressBound(1024 * 32), 1);
 
   if ((level < MIN_COMP_LEVEL) || (level > MAX_COMP_LEVEL))
   {

--- a/compress/zstd.c
+++ b/compress/zstd.c
@@ -72,7 +72,7 @@ void zstd_cdata_free(struct ZstdComprData **ptr)
  */
 static struct ZstdComprData *zstd_cdata_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct ZstdComprData));
+  return MUTT_MEM_CALLOC(1, struct ZstdComprData);
 }
 
 /**
@@ -82,7 +82,7 @@ static ComprHandle *compr_zstd_open(short level)
 {
   struct ZstdComprData *cdata = zstd_cdata_new();
 
-  cdata->buf = mutt_mem_calloc(1, ZSTD_compressBound(1024 * 128));
+  cdata->buf = mutt_mem_calloc(ZSTD_compressBound(1024 * 128), 1);
   cdata->cctx = ZSTD_createCCtx();
   cdata->dctx = ZSTD_createDCtx();
 

--- a/config/mbtable.c
+++ b/config/mbtable.c
@@ -74,13 +74,13 @@ struct MbTable *mbtable_parse(const char *s)
   if (!slen)
     return NULL;
 
-  t = mutt_mem_calloc(1, sizeof(struct MbTable));
+  t = MUTT_MEM_CALLOC(1, struct MbTable);
 
   t->orig_str = mutt_str_dup(s);
   /* This could be more space efficient.  However, being used on tiny
    * strings (`$to_chars` and `$status_chars`), the overhead is not great. */
-  t->chars = mutt_mem_calloc(slen, sizeof(char *));
-  t->segmented_str = mutt_mem_calloc(slen * 2, sizeof(char));
+  t->chars = MUTT_MEM_CALLOC(slen, char *);
+  t->segmented_str = MUTT_MEM_CALLOC(slen * 2, char);
   d = t->segmented_str;
 
   while (slen && (k = mbrtowc(NULL, s, slen, &mbstate)))
@@ -205,7 +205,7 @@ static struct MbTable *mbtable_dup(struct MbTable *table)
   if (!table)
     return NULL; /* LCOV_EXCL_LINE */
 
-  struct MbTable *m = mutt_mem_calloc(1, sizeof(*m));
+  struct MbTable *m = MUTT_MEM_CALLOC(1, struct MbTable);
   m->orig_str = mutt_str_dup(table->orig_str);
   return m;
 }

--- a/config/regex.c
+++ b/config/regex.c
@@ -105,9 +105,9 @@ struct Regex *regex_new(const char *str, uint32_t flags, struct Buffer *err)
     return NULL;
 
   int rflags = 0;
-  struct Regex *reg = mutt_mem_calloc(1, sizeof(struct Regex));
+  struct Regex *reg = MUTT_MEM_CALLOC(1, struct Regex);
 
-  reg->regex = mutt_mem_calloc(1, sizeof(regex_t));
+  reg->regex = MUTT_MEM_CALLOC(1, regex_t);
   reg->pattern = mutt_str_dup(str);
 
   /* Should we use smart case matching? */

--- a/config/set.c
+++ b/config/set.c
@@ -126,7 +126,7 @@ static struct HashElem *create_synonym(const struct ConfigSet *cs,
  */
 struct ConfigSet *cs_new(size_t size)
 {
-  struct ConfigSet *cs = mutt_mem_calloc(1, sizeof(*cs));
+  struct ConfigSet *cs = MUTT_MEM_CALLOC(1, struct ConfigSet);
 
   cs->hash = mutt_hash_new(size, MUTT_HASH_NO_FLAGS);
   mutt_hash_set_destructor(cs->hash, cs_hashelem_free, (intptr_t) cs);
@@ -318,7 +318,7 @@ bool cs_register_variables(const struct ConfigSet *cs, struct ConfigDef vars[])
 struct HashElem *cs_create_variable(const struct ConfigSet *cs,
                                     struct ConfigDef *cdef, struct Buffer *err)
 {
-  struct ConfigDef *cdef_copy = mutt_mem_calloc(1, sizeof(struct ConfigDef));
+  struct ConfigDef *cdef_copy = MUTT_MEM_CALLOC(1, struct ConfigDef);
   cdef_copy->name = mutt_str_dup(cdef->name);
   cdef_copy->type = cdef->type | D_INTERNAL_FREE_CONFIGDEF;
   cdef_copy->initial = cdef->initial;
@@ -354,7 +354,7 @@ struct HashElem *cs_inherit_variable(const struct ConfigSet *cs,
   if (DTYPE(he_parent->type) == DT_MYVAR)
     return NULL;
 
-  struct Inheritance *i = mutt_mem_calloc(1, sizeof(*i));
+  struct Inheritance *i = MUTT_MEM_CALLOC(1, struct Inheritance);
   i->parent = he_parent;
   i->name = mutt_str_dup(name);
 

--- a/config/subset.c
+++ b/config/subset.c
@@ -81,7 +81,7 @@ struct HashElem **get_elem_list(struct ConfigSet *cs)
   if (!cs)
     return NULL;
 
-  struct HashElem **he_list = mutt_mem_calloc(1024, sizeof(struct HashElem *));
+  struct HashElem **he_list = MUTT_MEM_CALLOC(1024, struct HashElem *);
   size_t index = 0;
 
   struct HashWalkState walk = { 0 };
@@ -152,7 +152,7 @@ void cs_subset_free(struct ConfigSubset **ptr)
 struct ConfigSubset *cs_subset_new(const char *name, struct ConfigSubset *sub_parent,
                                    struct Notify *not_parent)
 {
-  struct ConfigSubset *sub = mutt_mem_calloc(1, sizeof(*sub));
+  struct ConfigSubset *sub = MUTT_MEM_CALLOC(1, struct ConfigSubset);
 
   if (sub_parent)
   {

--- a/conn/connaccount.c
+++ b/conn/connaccount.c
@@ -263,7 +263,7 @@ char *mutt_account_getoauthbearer(struct ConnAccount *cac, bool xoauth2)
   size_t encoded_len = oalen * 4 / 3 + 10;
   ASSERT(encoded_len < 6010); // Assure LGTM that we won't overflow
 
-  char *encoded_token = mutt_mem_malloc(encoded_len);
+  char *encoded_token = mutt_mem_mallocarray(encoded_len, sizeof(char));
   mutt_b64_encode(oauthbearer, oalen, encoded_token, encoded_len);
 
   return encoded_token;

--- a/conn/connaccount.c
+++ b/conn/connaccount.c
@@ -263,7 +263,7 @@ char *mutt_account_getoauthbearer(struct ConnAccount *cac, bool xoauth2)
   size_t encoded_len = oalen * 4 / 3 + 10;
   ASSERT(encoded_len < 6010); // Assure LGTM that we won't overflow
 
-  char *encoded_token = mutt_mem_mallocarray(encoded_len, sizeof(char));
+  char *encoded_token = MUTT_MEM_MALLOC(encoded_len, char);
   mutt_b64_encode(oauthbearer, oalen, encoded_token, encoded_len);
 
   return encoded_token;

--- a/conn/gnutls.c
+++ b/conn/gnutls.c
@@ -245,7 +245,7 @@ static int tls_compare_certificates(const gnutls_datum_t *peercert)
     return 0;
 
   b64_data.size = st.st_size;
-  b64_data_data = mutt_mem_calloc(1, b64_data.size + 1);
+  b64_data_data = MUTT_MEM_CALLOC(b64_data.size + 1, unsigned char);
   b64_data.data = b64_data_data;
 
   FILE *fp = mutt_file_fopen(c_certificate_file, "r");
@@ -729,7 +729,7 @@ static void tls_get_client_cert(struct Connection *conn)
                                      0, NULL, &cnlen);
   if (((rc >= 0) || (rc == GNUTLS_E_SHORT_MEMORY_BUFFER)) && (cnlen > 0))
   {
-    cn = mutt_mem_calloc(1, cnlen);
+    cn = MUTT_MEM_CALLOC(cnlen, char);
     if (gnutls_x509_crt_get_dn_by_oid(clientcrt, GNUTLS_OID_X520_COMMON_NAME, 0,
                                       0, cn, &cnlen) < 0)
     {
@@ -871,7 +871,7 @@ static int tls_set_priority(struct TlsSockData *data)
  */
 static int tls_negotiate(struct Connection *conn)
 {
-  struct TlsSockData *data = mutt_mem_calloc(1, sizeof(struct TlsSockData));
+  struct TlsSockData *data = MUTT_MEM_CALLOC(1, struct TlsSockData);
   conn->sockdata = data;
   int err = gnutls_certificate_allocate_credentials(&data->xcred);
   if (err < 0)

--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -1206,7 +1206,7 @@ static int ssl_setup(struct Connection *conn)
 {
   int maxbits = 0;
 
-  conn->sockdata = mutt_mem_calloc(1, sizeof(struct SslSockData));
+  conn->sockdata = MUTT_MEM_CALLOC(1, struct SslSockData);
 
   sockdata(conn)->sctx = SSL_CTX_new(SSLv23_client_method());
   if (!sockdata(conn)->sctx)

--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -316,7 +316,7 @@ static void ssl_dprint_err_stack(void)
   long buflen = BIO_get_mem_data(bio, &buf);
   if (buflen > 0)
   {
-    char *output = mutt_mem_mallocarray(buflen + 1, sizeof(char));
+    char *output = MUTT_MEM_MALLOC(buflen + 1, char);
     memcpy(output, buf, buflen);
     output[buflen] = '\0';
     mutt_debug(LL_DEBUG1, "SSL error stack: %s\n", output);
@@ -781,7 +781,7 @@ static int check_host(X509 *x509cert, const char *hostname, char *err, size_t er
       goto out;
     }
     bufsize++; /* space for the terminal nul char */
-    buf = mutt_mem_mallocarray((size_t) bufsize, sizeof(char));
+    buf = MUTT_MEM_MALLOC((size_t) bufsize, char);
     if (X509_NAME_get_text_by_NID(x509_subject, NID_commonName, buf, bufsize) == -1)
     {
       if (err && errlen)

--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -316,7 +316,7 @@ static void ssl_dprint_err_stack(void)
   long buflen = BIO_get_mem_data(bio, &buf);
   if (buflen > 0)
   {
-    char *output = mutt_mem_malloc(buflen + 1);
+    char *output = mutt_mem_mallocarray(buflen + 1, sizeof(char));
     memcpy(output, buf, buflen);
     output[buflen] = '\0';
     mutt_debug(LL_DEBUG1, "SSL error stack: %s\n", output);
@@ -781,7 +781,7 @@ static int check_host(X509 *x509cert, const char *hostname, char *err, size_t er
       goto out;
     }
     bufsize++; /* space for the terminal nul char */
-    buf = mutt_mem_malloc((size_t) bufsize);
+    buf = mutt_mem_mallocarray((size_t) bufsize, sizeof(char));
     if (X509_NAME_get_text_by_NID(x509_subject, NID_commonName, buf, bufsize) == -1)
     {
       if (err && errlen)

--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -781,7 +781,7 @@ static int check_host(X509 *x509cert, const char *hostname, char *err, size_t er
       goto out;
     }
     bufsize++; /* space for the terminal nul char */
-    buf = MUTT_MEM_MALLOC((size_t) bufsize, char);
+    buf = MUTT_MEM_MALLOC(bufsize, char);
     if (X509_NAME_get_text_by_NID(x509_subject, NID_commonName, buf, bufsize) == -1)
     {
       if (err && errlen)

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -740,7 +740,7 @@ int mutt_sasl_interact(sasl_interact_t *interaction)
  */
 void mutt_sasl_setup_conn(struct Connection *conn, sasl_conn_t *saslconn)
 {
-  struct SaslSockData *sasldata = mutt_mem_mallocarray(1, sizeof(struct SaslSockData));
+  struct SaslSockData *sasldata = MUTT_MEM_MALLOC(1, struct SaslSockData);
   /* work around sasl_getprop aliasing issues */
   const void *tmp = NULL;
 

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -740,7 +740,7 @@ int mutt_sasl_interact(sasl_interact_t *interaction)
  */
 void mutt_sasl_setup_conn(struct Connection *conn, sasl_conn_t *saslconn)
 {
-  struct SaslSockData *sasldata = mutt_mem_malloc(sizeof(struct SaslSockData));
+  struct SaslSockData *sasldata = mutt_mem_mallocarray(1, sizeof(struct SaslSockData));
   /* work around sasl_getprop aliasing issues */
   const void *tmp = NULL;
 

--- a/conn/socket.c
+++ b/conn/socket.c
@@ -271,7 +271,7 @@ int mutt_socket_readln_d(char *buf, size_t buflen, struct Connection *conn, int 
  */
 struct Connection *mutt_socket_new(enum ConnectionType type)
 {
-  struct Connection *conn = mutt_mem_calloc(1, sizeof(struct Connection));
+  struct Connection *conn = MUTT_MEM_CALLOC(1, struct Connection);
   conn->fd = -1;
 
   if (type == MUTT_CONNECTION_TUNNEL)

--- a/conn/tunnel.c
+++ b/conn/tunnel.c
@@ -60,7 +60,7 @@ static int tunnel_socket_open(struct Connection *conn)
 {
   int pin[2], pout[2];
 
-  struct TunnelSockData *tunnel = mutt_mem_mallocarray(1, sizeof(struct TunnelSockData));
+  struct TunnelSockData *tunnel = MUTT_MEM_MALLOC(1, struct TunnelSockData);
   conn->sockdata = tunnel;
 
   const char *const c_tunnel = cs_subset_string(NeoMutt->sub, "tunnel");

--- a/conn/tunnel.c
+++ b/conn/tunnel.c
@@ -60,7 +60,7 @@ static int tunnel_socket_open(struct Connection *conn)
 {
   int pin[2], pout[2];
 
-  struct TunnelSockData *tunnel = mutt_mem_malloc(sizeof(struct TunnelSockData));
+  struct TunnelSockData *tunnel = mutt_mem_mallocarray(1, sizeof(struct TunnelSockData));
   conn->sockdata = tunnel;
 
   const char *const c_tunnel = cs_subset_string(NeoMutt->sub, "tunnel");

--- a/conn/zstrm.c
+++ b/conn/zstrm.c
@@ -290,7 +290,7 @@ static int zstrm_write(struct Connection *conn, const char *buf, size_t count)
  */
 void mutt_zstrm_wrap_conn(struct Connection *conn)
 {
-  struct ZstrmContext *zctx = mutt_mem_calloc(1, sizeof(struct ZstrmContext));
+  struct ZstrmContext *zctx = MUTT_MEM_CALLOC(1, struct ZstrmContext);
 
   /* store wrapped stream as next stream */
   zctx->next_conn.fd = conn->fd;

--- a/conn/zstrm.c
+++ b/conn/zstrm.c
@@ -311,10 +311,10 @@ void mutt_zstrm_wrap_conn(struct Connection *conn)
 
   /* allocate/setup (de)compression buffers */
   zctx->read.len = 8192;
-  zctx->read.buf = mutt_mem_mallocarray(zctx->read.len, sizeof(char));
+  zctx->read.buf = MUTT_MEM_MALLOC(zctx->read.len, char);
   zctx->read.pos = 0;
   zctx->write.len = 8192;
-  zctx->write.buf = mutt_mem_mallocarray(zctx->write.len, sizeof(char));
+  zctx->write.buf = MUTT_MEM_MALLOC(zctx->write.len, char);
   zctx->write.pos = 0;
 
   /* initialise zlib for inflate and deflate for RFC4978 */

--- a/conn/zstrm.c
+++ b/conn/zstrm.c
@@ -311,10 +311,10 @@ void mutt_zstrm_wrap_conn(struct Connection *conn)
 
   /* allocate/setup (de)compression buffers */
   zctx->read.len = 8192;
-  zctx->read.buf = mutt_mem_malloc(zctx->read.len);
+  zctx->read.buf = mutt_mem_mallocarray(zctx->read.len, sizeof(char));
   zctx->read.pos = 0;
   zctx->write.len = 8192;
-  zctx->write.buf = mutt_mem_malloc(zctx->write.len);
+  zctx->write.buf = mutt_mem_mallocarray(zctx->write.len, sizeof(char));
   zctx->write.pos = 0;
 
   /* initialise zlib for inflate and deflate for RFC4978 */

--- a/convert/content_info.c
+++ b/convert/content_info.c
@@ -222,7 +222,7 @@ struct Content *mutt_get_content_info(const char *fname, struct Body *b,
     return NULL;
   }
 
-  info = mutt_mem_calloc(1, sizeof(struct Content));
+  info = MUTT_MEM_CALLOC(1, struct Content);
 
   const char *const c_charset = cc_charset();
   if (b && (b->type == TYPE_TEXT) && (!b->noconv && !b->force_charset))

--- a/convert/convert.c
+++ b/convert/convert.c
@@ -74,10 +74,10 @@ size_t mutt_convert_file_to(FILE *fp, const char *fromcode, struct Slist const *
     return -1;
 
   int ncodes = tocodes->count;
-  iconv_t *cd = mutt_mem_calloc(ncodes, sizeof(iconv_t));
-  size_t *score = mutt_mem_calloc(ncodes, sizeof(size_t));
-  struct ContentState *states = mutt_mem_calloc(ncodes, sizeof(struct ContentState));
-  struct Content *infos = mutt_mem_calloc(ncodes, sizeof(struct Content));
+  iconv_t *cd = MUTT_MEM_CALLOC(ncodes, iconv_t);
+  size_t *score = MUTT_MEM_CALLOC(ncodes, size_t);
+  struct ContentState *states = MUTT_MEM_CALLOC(ncodes, struct ContentState);
+  struct Content *infos = MUTT_MEM_CALLOC(ncodes, struct Content);
 
   struct ListNode *np = NULL;
   int ni = 0;
@@ -222,7 +222,7 @@ size_t mutt_convert_file_from_to(FILE *fp, const struct Slist *fromcodes,
   struct ListNode *np = NULL;
 
   /* Copy them */
-  tcode = mutt_mem_calloc(tocodes->count, sizeof(char *));
+  tcode = MUTT_MEM_CALLOC(tocodes->count, char *);
   np = NULL;
   cn = 0;
   STAILQ_FOREACH(np, &tocodes->head, entries)

--- a/copy.c
+++ b/copy.c
@@ -346,7 +346,7 @@ int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end,
       {
         size_t blen = mutt_str_len(buf);
 
-        mutt_mem_reallocarray(&this_one, this_one_len + blen + 1, sizeof(char));
+        MUTT_MEM_REALLOC(&this_one, this_one_len + blen + 1, char);
         mutt_strn_copy(this_one + this_one_len, buf, blen, blen + 1);
         this_one_len += blen;
       }

--- a/copy.c
+++ b/copy.c
@@ -346,7 +346,7 @@ int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end,
       {
         size_t blen = mutt_str_len(buf);
 
-        mutt_mem_realloc(&this_one, this_one_len + blen + 1);
+        mutt_mem_reallocarray(&this_one, this_one_len + blen + 1, sizeof(char));
         mutt_strn_copy(this_one + this_one_len, buf, blen, blen + 1);
         this_one_len += blen;
       }

--- a/core/account.c
+++ b/core/account.c
@@ -46,7 +46,7 @@ struct Account *account_new(const char *name, struct ConfigSubset *sub)
   if (!sub)
     return NULL;
 
-  struct Account *a = mutt_mem_calloc(1, sizeof(struct Account));
+  struct Account *a = MUTT_MEM_CALLOC(1, struct Account);
 
   STAILQ_INIT(&a->mailboxes);
   a->notify = notify_new();
@@ -73,7 +73,7 @@ bool account_mailbox_add(struct Account *a, struct Mailbox *m)
     a->type = m->type;
 
   m->account = a;
-  struct MailboxNode *np = mutt_mem_calloc(1, sizeof(*np));
+  struct MailboxNode *np = MUTT_MEM_CALLOC(1, struct MailboxNode);
   np->mailbox = m;
   STAILQ_INSERT_TAIL(&a->mailboxes, np, entries);
   mailbox_set_subset(m, a->sub);

--- a/core/mailbox.c
+++ b/core/mailbox.c
@@ -67,14 +67,14 @@ int mailbox_gen(void)
  */
 struct Mailbox *mailbox_new(void)
 {
-  struct Mailbox *m = mutt_mem_calloc(1, sizeof(struct Mailbox));
+  struct Mailbox *m = MUTT_MEM_CALLOC(1, struct Mailbox);
 
   buf_init(&m->pathbuf);
   m->notify = notify_new();
 
   m->email_max = 25;
-  m->emails = mutt_mem_calloc(m->email_max, sizeof(struct Email *));
-  m->v2r = mutt_mem_calloc(m->email_max, sizeof(int));
+  m->emails = MUTT_MEM_CALLOC(m->email_max, struct Email *);
+  m->v2r = MUTT_MEM_CALLOC(m->email_max, int);
   m->gen = mailbox_gen();
   m->notify_user = true;
   m->poll_new_mail = true;

--- a/core/message.c
+++ b/core/message.c
@@ -52,5 +52,5 @@ void message_free(struct Message **ptr)
  */
 struct Message *message_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct Message));
+  return MUTT_MEM_CALLOC(1, struct Message);
 }

--- a/core/neomutt.c
+++ b/core/neomutt.c
@@ -52,7 +52,7 @@ struct NeoMutt *neomutt_new(struct ConfigSet *cs)
   if (!cs)
     return NULL;
 
-  struct NeoMutt *n = mutt_mem_calloc(1, sizeof(*NeoMutt));
+  struct NeoMutt *n = MUTT_MEM_CALLOC(1, struct NeoMutt);
 
   TAILQ_INIT(&n->accounts);
   n->notify = notify_new();
@@ -205,7 +205,7 @@ size_t neomutt_mailboxlist_get_all(struct MailboxList *head, struct NeoMutt *n,
 
     STAILQ_FOREACH(mn, &a->mailboxes, entries)
     {
-      struct MailboxNode *mn2 = mutt_mem_calloc(1, sizeof(*mn2));
+      struct MailboxNode *mn2 = MUTT_MEM_CALLOC(1, struct MailboxNode);
       mn2->mailbox = mn->mailbox;
       STAILQ_INSERT_TAIL(head, mn2, entries);
       count++;

--- a/editor/functions.c
+++ b/editor/functions.c
@@ -150,7 +150,7 @@ void replace_part(struct EnterState *es, size_t from, const char *buf)
     if (es->curpos + savelen > es->wbuflen)
     {
       es->wbuflen = es->curpos + savelen;
-      mutt_mem_reallocarray(&es->wbuf, es->wbuflen, sizeof(wchar_t));
+      MUTT_MEM_REALLOC(&es->wbuf, es->wbuflen, wchar_t);
     }
 
     /* Restore suffix */

--- a/editor/functions.c
+++ b/editor/functions.c
@@ -137,7 +137,7 @@ void replace_part(struct EnterState *es, size_t from, const char *buf)
 
   if (savelen)
   {
-    savebuf = mutt_mem_calloc(savelen, sizeof(wchar_t));
+    savebuf = MUTT_MEM_CALLOC(savelen, wchar_t);
     wmemcpy(savebuf, es->wbuf + es->curpos, savelen);
   }
 

--- a/editor/functions.c
+++ b/editor/functions.c
@@ -150,7 +150,7 @@ void replace_part(struct EnterState *es, size_t from, const char *buf)
     if (es->curpos + savelen > es->wbuflen)
     {
       es->wbuflen = es->curpos + savelen;
-      mutt_mem_realloc(&es->wbuf, es->wbuflen * sizeof(wchar_t));
+      mutt_mem_reallocarray(&es->wbuf, es->wbuflen, sizeof(wchar_t));
     }
 
     /* Restore suffix */

--- a/editor/state.c
+++ b/editor/state.c
@@ -73,7 +73,7 @@ void enter_state_resize(struct EnterState *es, size_t num)
  */
 struct EnterState *enter_state_new(void)
 {
-  struct EnterState *es = mutt_mem_calloc(1, sizeof(struct EnterState));
+  struct EnterState *es = MUTT_MEM_CALLOC(1, struct EnterState);
 
   enter_state_resize(es, 1);
 

--- a/editor/state.c
+++ b/editor/state.c
@@ -60,7 +60,7 @@ void enter_state_resize(struct EnterState *es, size_t num)
     return;
 
   num = ROUND_UP(num + 4, 128);
-  mutt_mem_reallocarray(&es->wbuf, num, sizeof(wchar_t));
+  MUTT_MEM_REALLOC(&es->wbuf, num, wchar_t);
 
   wmemset(es->wbuf + es->wbuflen, 0, num - es->wbuflen);
 

--- a/editor/state.c
+++ b/editor/state.c
@@ -60,7 +60,7 @@ void enter_state_resize(struct EnterState *es, size_t num)
     return;
 
   num = ROUND_UP(num + 4, 128);
-  mutt_mem_realloc(&es->wbuf, num * sizeof(wchar_t));
+  mutt_mem_reallocarray(&es->wbuf, num, sizeof(wchar_t));
 
   wmemset(es->wbuf + es->wbuflen, 0, num - es->wbuflen);
 

--- a/editor/window.c
+++ b/editor/window.c
@@ -150,7 +150,7 @@ bool self_insert(struct EnterWindowData *wdata, int ch)
     if (wdata->state->lastchar >= wdata->state->wbuflen)
     {
       wdata->state->wbuflen = wdata->state->lastchar + 20;
-      mutt_mem_realloc(&wdata->state->wbuf, wdata->state->wbuflen * sizeof(wchar_t));
+      mutt_mem_reallocarray(&wdata->state->wbuf, wdata->state->wbuflen, sizeof(wchar_t));
     }
     memmove(wdata->state->wbuf + wdata->state->curpos + 1,
             wdata->state->wbuf + wdata->state->curpos,

--- a/editor/window.c
+++ b/editor/window.c
@@ -137,7 +137,7 @@ bool self_insert(struct EnterWindowData *wdata, int ch)
       {
         char **tfiles = NULL;
         *cdata->numfiles = 1;
-        tfiles = mutt_mem_calloc(*cdata->numfiles, sizeof(char *));
+        tfiles = MUTT_MEM_CALLOC(*cdata->numfiles, char *);
         buf_expand_path_regex(wdata->buffer, false);
         tfiles[0] = buf_strdup(wdata->buffer);
         *cdata->files = tfiles;

--- a/editor/window.c
+++ b/editor/window.c
@@ -150,7 +150,7 @@ bool self_insert(struct EnterWindowData *wdata, int ch)
     if (wdata->state->lastchar >= wdata->state->wbuflen)
     {
       wdata->state->wbuflen = wdata->state->lastchar + 20;
-      mutt_mem_reallocarray(&wdata->state->wbuf, wdata->state->wbuflen, sizeof(wchar_t));
+      MUTT_MEM_REALLOC(&wdata->state->wbuf, wdata->state->wbuflen, wchar_t);
     }
     memmove(wdata->state->wbuf + wdata->state->curpos + 1,
             wdata->state->wbuf + wdata->state->curpos,

--- a/email/body.c
+++ b/email/body.c
@@ -43,7 +43,7 @@
  */
 struct Body *mutt_body_new(void)
 {
-  struct Body *p = mutt_mem_calloc(1, sizeof(struct Body));
+  struct Body *p = MUTT_MEM_CALLOC(1, struct Body);
 
   p->disposition = DISP_ATTACH;
   p->use_disp = true;

--- a/email/email.c
+++ b/email/email.c
@@ -78,7 +78,7 @@ struct Email *email_new(void)
 {
   static size_t sequence = 0;
 
-  struct Email *e = mutt_mem_calloc(1, sizeof(struct Email));
+  struct Email *e = MUTT_MEM_CALLOC(1, struct Email);
   STAILQ_INIT(&e->tags);
   e->visible = true;
   e->sequence = sequence++;

--- a/email/envelope.c
+++ b/email/envelope.c
@@ -45,7 +45,7 @@
  */
 struct Envelope *mutt_env_new(void)
 {
-  struct Envelope *env = mutt_mem_calloc(1, sizeof(struct Envelope));
+  struct Envelope *env = MUTT_MEM_CALLOC(1, struct Envelope);
   TAILQ_INIT(&env->return_path);
   TAILQ_INIT(&env->from);
   TAILQ_INIT(&env->to);
@@ -94,7 +94,7 @@ void mutt_env_set_subject(struct Envelope *env, const char *subj)
  */
 struct AutocryptHeader *mutt_autocrypthdr_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct AutocryptHeader));
+  return MUTT_MEM_CALLOC(1, struct AutocryptHeader);
 }
 
 /**

--- a/email/parameter.c
+++ b/email/parameter.c
@@ -39,7 +39,7 @@
  */
 struct Parameter *mutt_param_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct Parameter));
+  return MUTT_MEM_CALLOC(1, struct Parameter);
 }
 
 /**

--- a/email/rfc2047.c
+++ b/email/rfc2047.c
@@ -587,7 +587,7 @@ static int encode(const char *d, size_t dlen, int col, const char *fromcode,
     if ((bufpos + wlen + lb_len) > buflen)
     {
       buflen = bufpos + wlen + lb_len;
-      mutt_mem_realloc(&buf, buflen);
+      mutt_mem_reallocarray(&buf, buflen, sizeof(char));
     }
     r = encode_block(buf + bufpos, t, n, icode, tocode, encoder);
     ASSERT(r == wlen);
@@ -602,7 +602,7 @@ static int encode(const char *d, size_t dlen, int col, const char *fromcode,
 
   /* Add last encoded word and us-ascii suffix to buffer. */
   buflen = bufpos + wlen + (u + ulen - t1);
-  mutt_mem_realloc(&buf, buflen + 1);
+  mutt_mem_reallocarray(&buf, buflen + 1, sizeof(char));
   r = encode_block(buf + bufpos, t, t1 - t, icode, tocode, encoder);
   ASSERT(r == wlen);
   bufpos += wlen;

--- a/email/rfc2047.c
+++ b/email/rfc2047.c
@@ -396,7 +396,7 @@ static char *decode_word(const char *s, size_t len, enum ContentEncoding enc)
   else if (enc == ENC_BASE64)
   {
     const int olen = 3 * len / 4 + 1;
-    char *out = mutt_mem_mallocarray(olen, sizeof(char));
+    char *out = MUTT_MEM_MALLOC(olen, char);
     int dlen = mutt_b64_decode(it, out, olen);
     if (dlen == -1)
     {
@@ -544,7 +544,7 @@ static int encode(const char *d, size_t dlen, int col, const char *fromcode,
 
   /* Initialise the output buffer with the us-ascii prefix. */
   buflen = 2 * ulen;
-  buf = mutt_mem_mallocarray(buflen, sizeof(char));
+  buf = MUTT_MEM_MALLOC(buflen, char);
   bufpos = t0 - u;
   memcpy(buf, u, t0 - u);
 

--- a/email/rfc2047.c
+++ b/email/rfc2047.c
@@ -587,7 +587,7 @@ static int encode(const char *d, size_t dlen, int col, const char *fromcode,
     if ((bufpos + wlen + lb_len) > buflen)
     {
       buflen = bufpos + wlen + lb_len;
-      mutt_mem_reallocarray(&buf, buflen, sizeof(char));
+      MUTT_MEM_REALLOC(&buf, buflen, char);
     }
     r = encode_block(buf + bufpos, t, n, icode, tocode, encoder);
     ASSERT(r == wlen);
@@ -602,7 +602,7 @@ static int encode(const char *d, size_t dlen, int col, const char *fromcode,
 
   /* Add last encoded word and us-ascii suffix to buffer. */
   buflen = bufpos + wlen + (u + ulen - t1);
-  mutt_mem_reallocarray(&buf, buflen + 1, sizeof(char));
+  MUTT_MEM_REALLOC(&buf, buflen + 1, char);
   r = encode_block(buf + bufpos, t, t1 - t, icode, tocode, encoder);
   ASSERT(r == wlen);
   bufpos += wlen;

--- a/email/rfc2047.c
+++ b/email/rfc2047.c
@@ -396,7 +396,7 @@ static char *decode_word(const char *s, size_t len, enum ContentEncoding enc)
   else if (enc == ENC_BASE64)
   {
     const int olen = 3 * len / 4 + 1;
-    char *out = mutt_mem_malloc(olen);
+    char *out = mutt_mem_mallocarray(olen, sizeof(char));
     int dlen = mutt_b64_decode(it, out, olen);
     if (dlen == -1)
     {
@@ -544,7 +544,7 @@ static int encode(const char *d, size_t dlen, int col, const char *fromcode,
 
   /* Initialise the output buffer with the us-ascii prefix. */
   buflen = 2 * ulen;
-  buf = mutt_mem_malloc(buflen);
+  buf = mutt_mem_mallocarray(buflen, sizeof(char));
   bufpos = t0 - u;
   memcpy(buf, u, t0 - u);
 

--- a/email/rfc2231.c
+++ b/email/rfc2231.c
@@ -211,7 +211,7 @@ static void join_continuations(struct ParameterList *pl, struct Rfc2231Parameter
 
       const size_t vl = strlen(par->value);
 
-      mutt_mem_realloc(&value, l + vl + 1);
+      mutt_mem_reallocarray(&value, l + vl + 1, sizeof(char));
       strcpy(value + l, par->value);
       l += vl;
 

--- a/email/rfc2231.c
+++ b/email/rfc2231.c
@@ -211,7 +211,7 @@ static void join_continuations(struct ParameterList *pl, struct Rfc2231Parameter
 
       const size_t vl = strlen(par->value);
 
-      mutt_mem_reallocarray(&value, l + vl + 1, sizeof(char));
+      MUTT_MEM_REALLOC(&value, l + vl + 1, char);
       strcpy(value + l, par->value);
       l += vl;
 

--- a/email/rfc2231.c
+++ b/email/rfc2231.c
@@ -133,7 +133,7 @@ static void decode_one(char *dest, char *src)
  */
 static struct Rfc2231Parameter *parameter_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct Rfc2231Parameter));
+  return MUTT_MEM_CALLOC(1, struct Rfc2231Parameter);
 }
 
 /**

--- a/email/tags.c
+++ b/email/tags.c
@@ -63,7 +63,7 @@ void tag_free(struct Tag **ptr)
  */
 struct Tag *tag_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct Tag));
+  return MUTT_MEM_CALLOC(1, struct Tag);
 }
 
 /**

--- a/email/url.c
+++ b/email/url.c
@@ -77,7 +77,7 @@ static bool parse_query_string(struct UrlQueryList *list, char *src)
     if ((url_pct_decode(key) < 0) || (url_pct_decode(val) < 0))
       return false;
 
-    struct UrlQuery *qs = mutt_mem_calloc(1, sizeof(struct UrlQuery));
+    struct UrlQuery *qs = MUTT_MEM_CALLOC(1, struct UrlQuery);
     qs->name = key;
     qs->value = val;
     STAILQ_INSERT_TAIL(list, qs, entries);
@@ -112,7 +112,7 @@ static enum UrlScheme get_scheme(const char *src, const regmatch_t *match)
  */
 static struct Url *url_new(void)
 {
-  struct Url *url = mutt_mem_calloc(1, sizeof(struct Url));
+  struct Url *url = MUTT_MEM_CALLOC(1, struct Url);
   STAILQ_INIT(&url->query_strings);
   return url;
 }

--- a/enriched.c
+++ b/enriched.c
@@ -282,7 +282,10 @@ static void enriched_putwc(wchar_t c, struct EnrichedState *enriched)
     if (enriched->tag_level[RICH_COLOR])
     {
       if ((enriched->param_used + 1) >= enriched->param_len)
-        MUTT_MEM_REALLOC(&enriched->param, (enriched->param_len += 256), wchar_t);
+      {
+        enriched->param_len += 256;
+        MUTT_MEM_REALLOC(&enriched->param, enriched->param_len, wchar_t);
+      }
 
       enriched->param[enriched->param_used++] = c;
     }

--- a/enriched.c
+++ b/enriched.c
@@ -489,8 +489,8 @@ int text_enriched_handler(struct Body *b_email, struct State *state)
                              state->wraplen - 4 :
                              72;
   enriched.line_max = enriched.wrap_margin * 4;
-  enriched.line = mutt_mem_calloc((enriched.line_max + 1), sizeof(wchar_t));
-  enriched.param = mutt_mem_calloc(256, sizeof(wchar_t));
+  enriched.line = MUTT_MEM_CALLOC(enriched.line_max + 1, wchar_t);
+  enriched.param = MUTT_MEM_CALLOC(256, wchar_t);
 
   enriched.param_len = 256;
   enriched.param_used = 0;

--- a/enriched.c
+++ b/enriched.c
@@ -255,7 +255,7 @@ static void enriched_flush(struct EnrichedState *enriched, bool wrap)
     if (enriched->line_used > enriched->line_max)
     {
       enriched->line_max = enriched->line_used;
-      mutt_mem_reallocarray(&enriched->line, enriched->line_max + 1, sizeof(wchar_t));
+      MUTT_MEM_REALLOC(&enriched->line, enriched->line_max + 1, wchar_t);
     }
     wcscat(enriched->line, enriched->buffer);
     enriched->line_len += enriched->word_len;
@@ -282,8 +282,7 @@ static void enriched_putwc(wchar_t c, struct EnrichedState *enriched)
     if (enriched->tag_level[RICH_COLOR])
     {
       if ((enriched->param_used + 1) >= enriched->param_len)
-        mutt_mem_reallocarray(&enriched->param, (enriched->param_len += 256),
-                              sizeof(wchar_t));
+        MUTT_MEM_REALLOC(&enriched->param, (enriched->param_len += 256), wchar_t);
 
       enriched->param[enriched->param_used++] = c;
     }
@@ -294,7 +293,7 @@ static void enriched_putwc(wchar_t c, struct EnrichedState *enriched)
   if ((enriched->buf_len < (enriched->buf_used + 3)) || !enriched->buffer)
   {
     enriched->buf_len += 1024;
-    mutt_mem_reallocarray(&enriched->buffer, enriched->buf_len + 1, sizeof(wchar_t));
+    MUTT_MEM_REALLOC(&enriched->buffer, enriched->buf_len + 1, wchar_t);
   }
 
   if ((!enriched->tag_level[RICH_NOFILL] && iswspace(c)) || (c == (wchar_t) '\0'))
@@ -357,7 +356,7 @@ static void enriched_puts(const char *s, struct EnrichedState *enriched)
   if ((enriched->buf_len < (enriched->buf_used + mutt_str_len(s))) || !enriched->buffer)
   {
     enriched->buf_len += 1024;
-    mutt_mem_reallocarray(&enriched->buffer, enriched->buf_len + 1, sizeof(wchar_t));
+    MUTT_MEM_REALLOC(&enriched->buffer, enriched->buf_len + 1, wchar_t);
   }
   c = s;
   while (*c)

--- a/enriched.c
+++ b/enriched.c
@@ -255,7 +255,7 @@ static void enriched_flush(struct EnrichedState *enriched, bool wrap)
     if (enriched->line_used > enriched->line_max)
     {
       enriched->line_max = enriched->line_used;
-      mutt_mem_realloc(&enriched->line, (enriched->line_max + 1) * sizeof(wchar_t));
+      mutt_mem_reallocarray(&enriched->line, enriched->line_max + 1, sizeof(wchar_t));
     }
     wcscat(enriched->line, enriched->buffer);
     enriched->line_len += enriched->word_len;
@@ -282,7 +282,8 @@ static void enriched_putwc(wchar_t c, struct EnrichedState *enriched)
     if (enriched->tag_level[RICH_COLOR])
     {
       if ((enriched->param_used + 1) >= enriched->param_len)
-        mutt_mem_realloc(&enriched->param, (enriched->param_len += 256) * sizeof(wchar_t));
+        mutt_mem_reallocarray(&enriched->param, (enriched->param_len += 256),
+                              sizeof(wchar_t));
 
       enriched->param[enriched->param_used++] = c;
     }
@@ -293,7 +294,7 @@ static void enriched_putwc(wchar_t c, struct EnrichedState *enriched)
   if ((enriched->buf_len < (enriched->buf_used + 3)) || !enriched->buffer)
   {
     enriched->buf_len += 1024;
-    mutt_mem_realloc(&enriched->buffer, (enriched->buf_len + 1) * sizeof(wchar_t));
+    mutt_mem_reallocarray(&enriched->buffer, enriched->buf_len + 1, sizeof(wchar_t));
   }
 
   if ((!enriched->tag_level[RICH_NOFILL] && iswspace(c)) || (c == (wchar_t) '\0'))
@@ -356,7 +357,7 @@ static void enriched_puts(const char *s, struct EnrichedState *enriched)
   if ((enriched->buf_len < (enriched->buf_used + mutt_str_len(s))) || !enriched->buffer)
   {
     enriched->buf_len += 1024;
-    mutt_mem_realloc(&enriched->buffer, (enriched->buf_len + 1) * sizeof(wchar_t));
+    mutt_mem_reallocarray(&enriched->buffer, enriched->buf_len + 1, sizeof(wchar_t));
   }
   c = s;
   while (*c)

--- a/envelope/wdata.c
+++ b/envelope/wdata.c
@@ -50,7 +50,7 @@ void env_wdata_free(struct MuttWindow *win, void **ptr)
  */
 struct EnvelopeWindowData *env_wdata_new(void)
 {
-  struct EnvelopeWindowData *wdata = mutt_mem_calloc(1, sizeof(struct EnvelopeWindowData));
+  struct EnvelopeWindowData *wdata = MUTT_MEM_CALLOC(1, struct EnvelopeWindowData);
 
 #ifdef USE_AUTOCRYPT
   wdata->autocrypt_rec = AUTOCRYPT_REC_OFF;

--- a/expando/expando.c
+++ b/expando/expando.c
@@ -48,7 +48,7 @@ struct ExpandoDefinition;
  */
 struct Expando *expando_new(const char *format)
 {
-  struct Expando *exp = mutt_mem_calloc(1, sizeof(struct Expando));
+  struct Expando *exp = MUTT_MEM_CALLOC(1, struct Expando);
   exp->string = mutt_str_dup(format);
   exp->node = node_container_new();
   return exp;

--- a/expando/node.c
+++ b/expando/node.c
@@ -38,7 +38,7 @@
  */
 struct ExpandoNode *node_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct ExpandoNode));
+  return MUTT_MEM_CALLOC(1, struct ExpandoNode);
 }
 
 /**

--- a/expando/node_conddate.c
+++ b/expando/node_conddate.c
@@ -48,7 +48,7 @@
  */
 struct NodeCondDatePrivate *node_conddate_private_new(int count, char period)
 {
-  struct NodeCondDatePrivate *priv = mutt_mem_calloc(1, sizeof(struct NodeCondDatePrivate));
+  struct NodeCondDatePrivate *priv = MUTT_MEM_CALLOC(1, struct NodeCondDatePrivate);
 
   priv->count = count;
   priv->period = period;

--- a/expando/node_expando.c
+++ b/expando/node_expando.c
@@ -48,7 +48,7 @@
  */
 struct NodeExpandoPrivate *node_expando_private_new(void)
 {
-  struct NodeExpandoPrivate *priv = mutt_mem_calloc(1, sizeof(struct NodeExpandoPrivate));
+  struct NodeExpandoPrivate *priv = MUTT_MEM_CALLOC(1, struct NodeExpandoPrivate);
 
   // NOTE(g0mb4): Expando definition should contain this
   priv->color = -1;
@@ -141,7 +141,7 @@ struct ExpandoFormat *parse_format(const char *str, const char **parsed_until,
 
   const char *start = str;
 
-  struct ExpandoFormat *fmt = mutt_mem_calloc(1, sizeof(struct ExpandoFormat));
+  struct ExpandoFormat *fmt = MUTT_MEM_CALLOC(1, struct ExpandoFormat);
 
   fmt->leader = ' ';
   fmt->justification = JUSTIFY_RIGHT;

--- a/expando/node_padding.c
+++ b/expando/node_padding.c
@@ -46,7 +46,7 @@
  */
 struct NodePaddingPrivate *node_padding_private_new(enum ExpandoPadType pad_type)
 {
-  struct NodePaddingPrivate *priv = mutt_mem_calloc(1, sizeof(struct NodePaddingPrivate));
+  struct NodePaddingPrivate *priv = MUTT_MEM_CALLOC(1, struct NodePaddingPrivate);
 
   priv->pad_type = pad_type;
 

--- a/gui/msgwin_wdata.c
+++ b/gui/msgwin_wdata.c
@@ -59,7 +59,7 @@ void msgwin_wdata_free(struct MuttWindow *win, void **ptr)
  */
 struct MsgWinWindowData *msgwin_wdata_new(void)
 {
-  struct MsgWinWindowData *wdata = mutt_mem_calloc(1, sizeof(struct MsgWinWindowData));
+  struct MsgWinWindowData *wdata = MUTT_MEM_CALLOC(1, struct MsgWinWindowData);
 
   wdata->text = buf_new(NULL);
 

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -181,7 +181,7 @@ void window_set_visible(struct MuttWindow *win, bool visible)
 struct MuttWindow *mutt_window_new(enum WindowType type, enum MuttWindowOrientation orient,
                                    enum MuttWindowSize size, int cols, int rows)
 {
-  struct MuttWindow *win = mutt_mem_calloc(1, sizeof(struct MuttWindow));
+  struct MuttWindow *win = MUTT_MEM_CALLOC(1, struct MuttWindow);
 
   win->type = type;
   win->orient = orient;

--- a/gui/sbar.c
+++ b/gui/sbar.c
@@ -193,7 +193,7 @@ static void sbar_wdata_free(struct MuttWindow *win, void **ptr)
  */
 static struct SBarPrivateData *sbar_data_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct SBarPrivateData));
+  return MUTT_MEM_CALLOC(1, struct SBarPrivateData);
 }
 
 /**

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -117,7 +117,7 @@ static void hcache_free(struct HeaderCache **ptr)
  */
 static struct HeaderCache *hcache_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct HeaderCache));
+  return MUTT_MEM_CALLOC(1, struct HeaderCache);
 }
 
 /**

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -229,7 +229,7 @@ static void *dump_email(struct HeaderCache *hc, const struct Email *e, int *off,
   bool convert = !CharsetIsUtf8;
 
   *off = 0;
-  unsigned char *d = mutt_mem_mallocarray(4096, sizeof(unsigned char));
+  unsigned char *d = MUTT_MEM_MALLOC(4096, unsigned char);
 
   d = serial_dump_uint32_t((uidvalidity != 0) ? uidvalidity : mutt_date_now(), d, off);
   d = serial_dump_int(hc->crc, d, off);
@@ -410,7 +410,7 @@ static char *get_foldername(const char *folder)
 {
   /* if the folder is local, canonify the path to ensure equivalent paths share
    * the hcache */
-  char *p = mutt_mem_mallocarray(PATH_MAX + 1, sizeof(char));
+  char *p = MUTT_MEM_MALLOC(PATH_MAX + 1, char);
   if (!realpath(folder, p))
     mutt_str_replace(&p, folder);
 
@@ -692,7 +692,7 @@ int hcache_store_email(struct HeaderCache *hc, const char *key, size_t keylen,
       return -1;
     }
 
-    char *whole = mutt_mem_mallocarray(hlen + clen, sizeof(char));
+    char *whole = MUTT_MEM_MALLOC(hlen + clen, char);
     memcpy(whole, data, hlen);
     memcpy(whole + hlen, cdata, clen);
 

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -229,7 +229,7 @@ static void *dump_email(struct HeaderCache *hc, const struct Email *e, int *off,
   bool convert = !CharsetIsUtf8;
 
   *off = 0;
-  unsigned char *d = mutt_mem_malloc(4096);
+  unsigned char *d = mutt_mem_mallocarray(4096, sizeof(unsigned char));
 
   d = serial_dump_uint32_t((uidvalidity != 0) ? uidvalidity : mutt_date_now(), d, off);
   d = serial_dump_int(hc->crc, d, off);
@@ -410,7 +410,7 @@ static char *get_foldername(const char *folder)
 {
   /* if the folder is local, canonify the path to ensure equivalent paths share
    * the hcache */
-  char *p = mutt_mem_malloc(PATH_MAX + 1);
+  char *p = mutt_mem_mallocarray(PATH_MAX + 1, sizeof(char));
   if (!realpath(folder, p))
     mutt_str_replace(&p, folder);
 
@@ -692,7 +692,7 @@ int hcache_store_email(struct HeaderCache *hc, const char *key, size_t keylen,
       return -1;
     }
 
-    char *whole = mutt_mem_malloc(hlen + clen);
+    char *whole = mutt_mem_mallocarray(hlen + clen, sizeof(char));
     memcpy(whole, data, hlen);
     memcpy(whole + hlen, cdata, clen);
 

--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -210,7 +210,7 @@ void serial_restore_char(char **c, const unsigned char *d, int *off, bool conver
     return;
   }
 
-  *c = mutt_mem_malloc(size);
+  *c = mutt_mem_mallocarray(size, sizeof(char));
   memcpy(*c, d + *off, size);
   if (convert && !mutt_str_is_ascii(*c, size))
   {

--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -210,7 +210,7 @@ void serial_restore_char(char **c, const unsigned char *d, int *off, bool conver
     return;
   }
 
-  *c = mutt_mem_mallocarray(size, sizeof(char));
+  *c = MUTT_MEM_MALLOC(size, char);
   memcpy(*c, d + *off, size);
   if (convert && !mutt_str_is_ascii(*c, size))
   {

--- a/helpbar/wdata.c
+++ b/helpbar/wdata.c
@@ -38,7 +38,7 @@
  */
 struct HelpbarWindowData *helpbar_wdata_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct HelpbarWindowData));
+  return MUTT_MEM_CALLOC(1, struct HelpbarWindowData);
 }
 
 /**

--- a/history/history.c
+++ b/history/history.c
@@ -139,7 +139,7 @@ static void init_history(struct History *h)
 
   const short c_history = cs_subset_number(NeoMutt->sub, "history");
   if (c_history != 0)
-    h->hist = mutt_mem_calloc(c_history + 1, sizeof(char *));
+    h->hist = MUTT_MEM_CALLOC(c_history + 1, char *);
 
   h->cur = 0;
   h->last = 0;
@@ -686,7 +686,7 @@ void mutt_hist_save_scratch(enum HistoryClass hclass, const char *str)
 void mutt_hist_complete(char *buf, size_t buflen, enum HistoryClass hclass)
 {
   const short c_history = cs_subset_number(NeoMutt->sub, "history");
-  char **matches = mutt_mem_calloc(c_history, sizeof(char *));
+  char **matches = MUTT_MEM_CALLOC(c_history, char *);
   int match_count = mutt_hist_search(buf, hclass, matches);
   if (match_count)
   {

--- a/hook.c
+++ b/hook.c
@@ -115,7 +115,7 @@ static void hook_free(struct Hook **ptr)
  */
 static struct Hook *hook_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct Hook));
+  return MUTT_MEM_CALLOC(1, struct Hook);
 }
 
 /**
@@ -357,7 +357,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
   else if (~data & MUTT_GLOBAL_HOOK) /* NOT a global hook */
   {
     /* Hooks not allowing full patterns: Check syntax of regex */
-    rx = mutt_mem_calloc(1, sizeof(regex_t));
+    rx = MUTT_MEM_CALLOC(1, regex_t);
     int rc2 = REG_COMP(rx, buf_string(pattern), ((data & MUTT_CRYPT_HOOK) ? REG_ICASE : 0));
     if (rc2 != 0)
     {
@@ -537,7 +537,7 @@ static enum CommandResult mutt_parse_idxfmt_hook(struct Buffer *buf, struct Buff
 
   if (!hl)
   {
-    hl = mutt_mem_calloc(1, sizeof(*hl));
+    hl = MUTT_MEM_CALLOC(1, struct HookList);
     TAILQ_INIT(hl);
     mutt_hash_insert(IdxFmtHooks, buf_string(name), hl);
   }

--- a/imap/adata.c
+++ b/imap/adata.c
@@ -97,7 +97,7 @@ void imap_adata_free(void **ptr)
  */
 struct ImapAccountData *imap_adata_new(struct Account *a)
 {
-  struct ImapAccountData *adata = mutt_mem_calloc(1, sizeof(struct ImapAccountData));
+  struct ImapAccountData *adata = MUTT_MEM_CALLOC(1, struct ImapAccountData);
   adata->account = a;
 
   static unsigned char new_seqid = 'a';
@@ -105,7 +105,7 @@ struct ImapAccountData *imap_adata_new(struct Account *a)
   adata->seqid = new_seqid;
   const short c_imap_pipeline_depth = cs_subset_number(NeoMutt->sub, "imap_pipeline_depth");
   adata->cmdslots = c_imap_pipeline_depth + 2;
-  adata->cmds = mutt_mem_calloc(adata->cmdslots, sizeof(*adata->cmds));
+  adata->cmds = MUTT_MEM_CALLOC(adata->cmdslots, struct ImapCommand);
 
   if (++new_seqid > 'z')
     new_seqid = 'a';

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -169,7 +169,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
         if (len > bufsize)
         {
           bufsize = len;
-          mutt_mem_realloc(&buf, bufsize);
+          mutt_mem_reallocarray(&buf, bufsize, sizeof(char));
         }
         /* For sasl_decode64, the fourth parameter, outmax, doesn't
          * include space for the trailing null */
@@ -204,7 +204,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
       if ((olen * 2) > bufsize)
       {
         bufsize = olen * 2;
-        mutt_mem_realloc(&buf, bufsize);
+        mutt_mem_reallocarray(&buf, bufsize, sizeof(char));
       }
       if (sasl_encode64(pc, olen, buf, bufsize, &olen) != SASL_OK)
       {

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -126,7 +126,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
   mutt_message(_("Authenticating (%s)..."), mech);
 
   bufsize = MAX((olen * 2), 1024);
-  buf = mutt_mem_mallocarray(bufsize, sizeof(char));
+  buf = MUTT_MEM_MALLOC(bufsize, char);
 
   snprintf(buf, bufsize, "AUTHENTICATE %s", mech);
   if ((adata->capabilities & IMAP_CAP_SASL_IR) && client_start)

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -169,7 +169,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
         if (len > bufsize)
         {
           bufsize = len;
-          mutt_mem_reallocarray(&buf, bufsize, sizeof(char));
+          MUTT_MEM_REALLOC(&buf, bufsize, char);
         }
         /* For sasl_decode64, the fourth parameter, outmax, doesn't
          * include space for the trailing null */
@@ -204,7 +204,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
       if ((olen * 2) > bufsize)
       {
         bufsize = olen * 2;
-        mutt_mem_reallocarray(&buf, bufsize, sizeof(char));
+        MUTT_MEM_REALLOC(&buf, bufsize, char);
       }
       if (sasl_encode64(pc, olen, buf, bufsize, &olen) != SASL_OK)
       {

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -126,7 +126,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
   mutt_message(_("Authenticating (%s)..."), mech);
 
   bufsize = MAX((olen * 2), 1024);
-  buf = mutt_mem_malloc(bufsize);
+  buf = mutt_mem_mallocarray(bufsize, sizeof(char));
 
   snprintf(buf, bufsize, "AUTHENTICATE %s", mech);
   if ((adata->capabilities & IMAP_CAP_SASL_IR) && client_start)

--- a/imap/command.c
+++ b/imap/command.c
@@ -1149,7 +1149,7 @@ int imap_cmd_step(struct ImapAccountData *adata)
   {
     if (len == adata->blen)
     {
-      mutt_mem_realloc(&adata->buf, adata->blen + IMAP_CMD_BUFSIZE);
+      mutt_mem_reallocarray(&adata->buf, adata->blen + IMAP_CMD_BUFSIZE, sizeof(char));
       adata->blen = adata->blen + IMAP_CMD_BUFSIZE;
       mutt_debug(LL_DEBUG3, "grew buffer to %zu bytes\n", adata->blen);
     }
@@ -1175,7 +1175,7 @@ int imap_cmd_step(struct ImapAccountData *adata)
   /* don't let one large string make cmd->buf hog memory forever */
   if ((adata->blen > IMAP_CMD_BUFSIZE) && (len <= IMAP_CMD_BUFSIZE))
   {
-    mutt_mem_realloc(&adata->buf, IMAP_CMD_BUFSIZE);
+    mutt_mem_reallocarray(&adata->buf, IMAP_CMD_BUFSIZE, sizeof(char));
     adata->blen = IMAP_CMD_BUFSIZE;
     mutt_debug(LL_DEBUG3, "shrank buffer to %zu bytes\n", adata->blen);
   }

--- a/imap/command.c
+++ b/imap/command.c
@@ -1149,7 +1149,7 @@ int imap_cmd_step(struct ImapAccountData *adata)
   {
     if (len == adata->blen)
     {
-      mutt_mem_reallocarray(&adata->buf, adata->blen + IMAP_CMD_BUFSIZE, sizeof(char));
+      MUTT_MEM_REALLOC(&adata->buf, adata->blen + IMAP_CMD_BUFSIZE, char);
       adata->blen = adata->blen + IMAP_CMD_BUFSIZE;
       mutt_debug(LL_DEBUG3, "grew buffer to %zu bytes\n", adata->blen);
     }
@@ -1175,7 +1175,7 @@ int imap_cmd_step(struct ImapAccountData *adata)
   /* don't let one large string make cmd->buf hog memory forever */
   if ((adata->blen > IMAP_CMD_BUFSIZE) && (len <= IMAP_CMD_BUFSIZE))
   {
-    mutt_mem_reallocarray(&adata->buf, IMAP_CMD_BUFSIZE, sizeof(char));
+    MUTT_MEM_REALLOC(&adata->buf, IMAP_CMD_BUFSIZE, char);
     adata->blen = IMAP_CMD_BUFSIZE;
     mutt_debug(LL_DEBUG3, "shrank buffer to %zu bytes\n", adata->blen);
   }

--- a/imap/edata.c
+++ b/imap/edata.c
@@ -56,7 +56,7 @@ void imap_edata_free(void **ptr)
  */
 struct ImapEmailData *imap_edata_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct ImapEmailData));
+  return MUTT_MEM_CALLOC(1, struct ImapEmailData);
 }
 
 /**

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1578,7 +1578,7 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
 #endif
 
   /* presort here to avoid doing 10 resorts in imap_exec_msg_set */
-  emails = mutt_mem_mallocarray(m->msg_count, sizeof(struct Email *));
+  emails = MUTT_MEM_MALLOC(m->msg_count, struct Email *);
   memcpy(emails, m->emails, m->msg_count * sizeof(struct Email *));
   mutt_qsort_r(emails, m->msg_count, sizeof(struct Email *), imap_sort_email_uid, NULL);
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1578,7 +1578,7 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
 #endif
 
   /* presort here to avoid doing 10 resorts in imap_exec_msg_set */
-  emails = mutt_mem_malloc(m->msg_count * sizeof(struct Email *));
+  emails = mutt_mem_mallocarray(m->msg_count, sizeof(struct Email *));
   memcpy(emails, m->emails, m->msg_count * sizeof(struct Email *));
   mutt_qsort_r(emails, m->msg_count, sizeof(struct Email *), imap_sort_email_uid, NULL);
 

--- a/imap/mdata.c
+++ b/imap/mdata.c
@@ -74,7 +74,7 @@ struct ImapMboxData *imap_mdata_get(struct Mailbox *m)
 struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char *name)
 {
   char buf[1024] = { 0 };
-  struct ImapMboxData *mdata = mutt_mem_calloc(1, sizeof(struct ImapMboxData));
+  struct ImapMboxData *mdata = MUTT_MEM_CALLOC(1, struct ImapMboxData);
 
   imap_fix_path_with_delim(adata->delim, name, buf, sizeof(buf));
   if (buf[0] == '\0')

--- a/imap/utf7.c
+++ b/imap/utf7.c
@@ -107,7 +107,7 @@ static char *utf7_to_utf8(const char *u7, size_t u7len, char **u8, size_t *u8len
 {
   int b, ch, k;
 
-  char *buf = mutt_mem_malloc(u7len + u7len / 8 + 1);
+  char *buf = mutt_mem_mallocarray(u7len + u7len / 8 + 1, sizeof(char));
   char *p = buf;
   int pair1 = 0;
 
@@ -257,7 +257,7 @@ static char *utf8_to_utf7(const char *u8, size_t u8len, char **u7, size_t *u7len
 
   /* In the worst case we convert 2 chars to 7 chars. For example:
    * "\x10&\x10&..." -> "&ABA-&-&ABA-&-...".  */
-  char *buf = mutt_mem_malloc((u8len / 2) * 7 + 6);
+  char *buf = mutt_mem_mallocarray((u8len / 2) * 7 + 6, sizeof(char));
   char *p = buf;
 
   while (u8len)

--- a/imap/utf7.c
+++ b/imap/utf7.c
@@ -225,7 +225,7 @@ static char *utf7_to_utf8(const char *u7, size_t u7len, char **u8, size_t *u8len
   if (u8len)
     *u8len = p - buf;
 
-  mutt_mem_reallocarray(&buf, p - buf, sizeof(char));
+  MUTT_MEM_REALLOC(&buf, p - buf, char);
   if (u8)
     *u8 = buf;
   return buf;
@@ -379,7 +379,7 @@ static char *utf8_to_utf7(const char *u8, size_t u8len, char **u7, size_t *u7len
   *p++ = '\0';
   if (u7len)
     *u7len = p - buf;
-  mutt_mem_reallocarray(&buf, p - buf, sizeof(char));
+  MUTT_MEM_REALLOC(&buf, p - buf, char);
   if (u7)
     *u7 = buf;
   return buf;

--- a/imap/utf7.c
+++ b/imap/utf7.c
@@ -225,7 +225,7 @@ static char *utf7_to_utf8(const char *u7, size_t u7len, char **u8, size_t *u8len
   if (u8len)
     *u8len = p - buf;
 
-  mutt_mem_realloc(&buf, p - buf);
+  mutt_mem_reallocarray(&buf, p - buf, sizeof(char));
   if (u8)
     *u8 = buf;
   return buf;
@@ -379,7 +379,7 @@ static char *utf8_to_utf7(const char *u8, size_t u8len, char **u7, size_t *u7len
   *p++ = '\0';
   if (u7len)
     *u7len = p - buf;
-  mutt_mem_realloc(&buf, p - buf);
+  mutt_mem_reallocarray(&buf, p - buf, sizeof(char));
   if (u7)
     *u7 = buf;
   return buf;

--- a/imap/utf7.c
+++ b/imap/utf7.c
@@ -107,7 +107,7 @@ static char *utf7_to_utf8(const char *u7, size_t u7len, char **u8, size_t *u8len
 {
   int b, ch, k;
 
-  char *buf = mutt_mem_mallocarray(u7len + u7len / 8 + 1, sizeof(char));
+  char *buf = MUTT_MEM_MALLOC(u7len + u7len / 8 + 1, char);
   char *p = buf;
   int pair1 = 0;
 
@@ -257,7 +257,7 @@ static char *utf8_to_utf7(const char *u8, size_t u8len, char **u7, size_t *u7len
 
   /* In the worst case we convert 2 chars to 7 chars. For example:
    * "\x10&\x10&..." -> "&ABA-&-&ABA-&-...".  */
-  char *buf = mutt_mem_mallocarray((u8len / 2) * 7 + 6, sizeof(char));
+  char *buf = MUTT_MEM_MALLOC((u8len / 2) * 7 + 6, char);
   char *p = buf;
 
   while (u8len)

--- a/imap/util.c
+++ b/imap/util.c
@@ -561,8 +561,8 @@ int imap_mxcmp(const char *mx1, const char *mx2)
     return 0;
   }
 
-  b1 = mutt_mem_malloc(strlen(mx1) + 1);
-  b2 = mutt_mem_malloc(strlen(mx2) + 1);
+  b1 = mutt_mem_mallocarray(strlen(mx1) + 1, sizeof(char));
+  b2 = mutt_mem_mallocarray(strlen(mx2) + 1, sizeof(char));
 
   imap_fix_path(mx1, b1, strlen(mx1) + 1);
   imap_fix_path(mx2, b2, strlen(mx2) + 1);

--- a/imap/util.c
+++ b/imap/util.c
@@ -561,8 +561,8 @@ int imap_mxcmp(const char *mx1, const char *mx2)
     return 0;
   }
 
-  b1 = mutt_mem_mallocarray(strlen(mx1) + 1, sizeof(char));
-  b2 = mutt_mem_mallocarray(strlen(mx2) + 1, sizeof(char));
+  b1 = MUTT_MEM_MALLOC(strlen(mx1) + 1, char);
+  b2 = MUTT_MEM_MALLOC(strlen(mx2) + 1, char);
 
   imap_fix_path(mx1, b1, strlen(mx1) + 1);
   imap_fix_path(mx2, b2, strlen(mx2) + 1);

--- a/imap/util.c
+++ b/imap/util.c
@@ -1128,7 +1128,7 @@ struct SeqsetIterator *mutt_seqset_iterator_new(const char *seqset)
   if (!seqset || (*seqset == '\0'))
     return NULL;
 
-  struct SeqsetIterator *iter = mutt_mem_calloc(1, sizeof(struct SeqsetIterator));
+  struct SeqsetIterator *iter = MUTT_MEM_CALLOC(1, struct SeqsetIterator);
   iter->full_seqset = mutt_str_dup(seqset);
   iter->eostr = strchr(iter->full_seqset, '\0');
   iter->substr_cur = iter->substr_end = iter->full_seqset;

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -422,7 +422,7 @@ static void update_index_threaded(struct MailboxView *mv, enum MxStatus check, i
   if ((check != MX_STATUS_REOPENED) && (oldcount > 0) &&
       (lmt || c_uncollapse_new) && (num_new > 0))
   {
-    save_new = mutt_mem_malloc(num_new * sizeof(struct Email *));
+    save_new = mutt_mem_mallocarray(num_new, sizeof(struct Email *));
     for (int i = oldcount; i < m->msg_count; i++)
       save_new[i - oldcount] = m->emails[i];
   }

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -975,7 +975,7 @@ void mutt_draw_statusline(struct MuttWindow *win, int max_cols, const char *buf,
       if (!found)
       {
         chunks++;
-        mutt_mem_reallocarray(&syntax, chunks, sizeof(struct StatusSyntax));
+        MUTT_MEM_REALLOC(&syntax, chunks, struct StatusSyntax);
       }
 
       i = chunks - 1;

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -422,7 +422,7 @@ static void update_index_threaded(struct MailboxView *mv, enum MxStatus check, i
   if ((check != MX_STATUS_REOPENED) && (oldcount > 0) &&
       (lmt || c_uncollapse_new) && (num_new > 0))
   {
-    save_new = mutt_mem_mallocarray(num_new, sizeof(struct Email *));
+    save_new = MUTT_MEM_MALLOC(num_new, struct Email *);
     for (int i = oldcount; i < m->msg_count; i++)
       save_new[i - oldcount] = m->emails[i];
   }

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -975,7 +975,7 @@ void mutt_draw_statusline(struct MuttWindow *win, int max_cols, const char *buf,
       if (!found)
       {
         chunks++;
-        mutt_mem_realloc(&syntax, chunks * sizeof(struct StatusSyntax));
+        mutt_mem_reallocarray(&syntax, chunks, sizeof(struct StatusSyntax));
       }
 
       i = chunks - 1;

--- a/index/ibar.c
+++ b/index/ibar.c
@@ -319,7 +319,7 @@ static void ibar_data_free(struct MuttWindow *win, void **ptr)
 static struct IBarPrivateData *ibar_data_new(struct IndexSharedData *shared,
                                              struct IndexPrivateData *priv)
 {
-  struct IBarPrivateData *ibar_data = mutt_mem_calloc(1, sizeof(struct IBarPrivateData));
+  struct IBarPrivateData *ibar_data = MUTT_MEM_CALLOC(1, struct IBarPrivateData);
 
   ibar_data->shared = shared;
   ibar_data->priv = priv;

--- a/index/private_data.c
+++ b/index/private_data.c
@@ -48,7 +48,7 @@ void index_private_data_free(struct MuttWindow *win, void **ptr)
  */
 struct IndexPrivateData *index_private_data_new(struct IndexSharedData *shared)
 {
-  struct IndexPrivateData *priv = mutt_mem_calloc(1, sizeof(struct IndexPrivateData));
+  struct IndexPrivateData *priv = MUTT_MEM_CALLOC(1, struct IndexPrivateData);
 
   priv->shared = shared;
   priv->oldcount = -1;

--- a/index/shared_data.c
+++ b/index/shared_data.c
@@ -306,7 +306,7 @@ void index_shared_data_free(struct MuttWindow *win, void **ptr)
  */
 struct IndexSharedData *index_shared_data_new(void)
 {
-  struct IndexSharedData *shared = mutt_mem_calloc(1, sizeof(struct IndexSharedData));
+  struct IndexSharedData *shared = MUTT_MEM_CALLOC(1, struct IndexSharedData);
 
   shared->notify = notify_new();
   shared->sub = NeoMutt->sub;

--- a/key/lib.c
+++ b/key/lib.c
@@ -149,9 +149,9 @@ void mutt_keymap_free(struct Keymap **ptr)
  */
 struct Keymap *alloc_keys(size_t len, keycode_t *keys)
 {
-  struct Keymap *p = mutt_mem_calloc(1, sizeof(struct Keymap));
+  struct Keymap *p = MUTT_MEM_CALLOC(1, struct Keymap);
   p->len = len;
-  p->keys = mutt_mem_calloc(len, sizeof(keycode_t));
+  p->keys = MUTT_MEM_CALLOC(len, keycode_t);
   memcpy(p->keys, keys, len * sizeof(keycode_t));
   return p;
 }

--- a/mailcap.c
+++ b/mailcap.c
@@ -444,7 +444,7 @@ static bool rfc1524_mailcap_parse(struct Body *b, const char *filename, const ch
  */
 struct MailcapEntry *mailcap_entry_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct MailcapEntry));
+  return MUTT_MEM_CALLOC(1, struct MailcapEntry);
 }
 
 /**

--- a/maildir/edata.c
+++ b/maildir/edata.c
@@ -52,8 +52,7 @@ void maildir_edata_free(void **ptr)
  */
 struct MaildirEmailData *maildir_edata_new(void)
 {
-  struct MaildirEmailData *edata = mutt_mem_calloc(1, sizeof(struct MaildirEmailData));
-  return edata;
+  return MUTT_MEM_CALLOC(1, struct MaildirEmailData);
 }
 
 /**

--- a/maildir/mdata.c
+++ b/maildir/mdata.c
@@ -48,8 +48,7 @@ void maildir_mdata_free(void **ptr)
  */
 struct MaildirMboxData *maildir_mdata_new(void)
 {
-  struct MaildirMboxData *mdata = mutt_mem_calloc(1, sizeof(struct MaildirMboxData));
-  return mdata;
+  return MUTT_MEM_CALLOC(1, struct MaildirMboxData);
 }
 
 /**

--- a/maildir/mdemail.c
+++ b/maildir/mdemail.c
@@ -38,7 +38,7 @@
  */
 struct MdEmail *maildir_entry_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct MdEmail));
+  return MUTT_MEM_CALLOC(1, struct MdEmail);
 }
 
 /**

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -94,7 +94,7 @@ static void mbox_adata_free(void **ptr)
  */
 static struct MboxAccountData *mbox_adata_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct MboxAccountData));
+  return MUTT_MEM_CALLOC(1, struct MboxAccountData);
 }
 
 /**
@@ -1166,8 +1166,8 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
     offset -= (sizeof(MMDF_SEP) - 1);
 
   /* allocate space for the new offsets */
-  new_offset = mutt_mem_calloc(m->msg_count - first, sizeof(struct MUpdate));
-  old_offset = mutt_mem_calloc(m->msg_count - first, sizeof(struct MUpdate));
+  new_offset = MUTT_MEM_CALLOC(m->msg_count - first, struct MUpdate);
+  old_offset = MUTT_MEM_CALLOC(m->msg_count - first, struct MUpdate);
 
   if (m->verbose)
   {

--- a/menu/menu.c
+++ b/menu/menu.c
@@ -135,7 +135,7 @@ void menu_free(struct Menu **ptr)
  */
 struct Menu *menu_new(enum MenuType type, struct MuttWindow *win, struct ConfigSubset *sub)
 {
-  struct Menu *menu = mutt_mem_calloc(1, sizeof(struct Menu));
+  struct Menu *menu = MUTT_MEM_CALLOC(1, struct Menu);
 
   menu->type = type;
   menu->redraw = MENU_REDRAW_FULL;

--- a/mh/mdata.c
+++ b/mh/mdata.c
@@ -48,8 +48,7 @@ void mh_mdata_free(void **ptr)
  */
 struct MhMboxData *mh_mdata_new(void)
 {
-  struct MhMboxData *mdata = mutt_mem_calloc(1, sizeof(struct MhMboxData));
-  return mdata;
+  return MUTT_MEM_CALLOC(1, struct MhMboxData);
 }
 
 /**

--- a/mh/mhemail.c
+++ b/mh/mhemail.c
@@ -38,7 +38,7 @@
  */
 struct MhEmail *mh_entry_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct MhEmail));
+  return MUTT_MEM_CALLOC(1, struct MhEmail);
 }
 
 /**

--- a/mh/sequence.c
+++ b/mh/sequence.c
@@ -54,7 +54,7 @@ static void mh_seq_alloc(struct MhSequences *mhs, int i)
 
   const int newmax = i + 128;
   int j = mhs->flags ? mhs->max + 1 : 0;
-  mutt_mem_realloc(&mhs->flags, sizeof(mhs->flags[0]) * (newmax + 1));
+  mutt_mem_reallocarray(&mhs->flags, newmax + 1, sizeof(mhs->flags[0]));
   while (j <= newmax)
     mhs->flags[j++] = 0;
 

--- a/mh/sequence.c
+++ b/mh/sequence.c
@@ -54,7 +54,7 @@ static void mh_seq_alloc(struct MhSequences *mhs, int i)
 
   const int newmax = i + 128;
   int j = mhs->flags ? mhs->max + 1 : 0;
-  mutt_mem_reallocarray(&mhs->flags, newmax + 1, sizeof(mhs->flags[0]));
+  MUTT_MEM_REALLOC(&mhs->flags, newmax + 1, MhSeqFlags);
   while (j <= newmax)
     mhs->flags[j++] = 0;
 

--- a/monitor.c
+++ b/monitor.c
@@ -127,7 +127,7 @@ static void mutt_poll_fd_add(int fd, short events)
     if (PollFdsCount == PollFdsLen)
     {
       PollFdsLen += 2;
-      mutt_mem_realloc(&PollFds, PollFdsLen * sizeof(struct pollfd));
+      mutt_mem_reallocarray(&PollFds, PollFdsLen, sizeof(struct pollfd));
     }
     PollFdsCount++;
     PollFds[i].fd = fd;

--- a/monitor.c
+++ b/monitor.c
@@ -127,7 +127,7 @@ static void mutt_poll_fd_add(int fd, short events)
     if (PollFdsCount == PollFdsLen)
     {
       PollFdsLen += 2;
-      mutt_mem_reallocarray(&PollFds, PollFdsLen, sizeof(struct pollfd));
+      MUTT_MEM_REALLOC(&PollFds, PollFdsLen, struct pollfd);
     }
     PollFdsCount++;
     PollFds[i].fd = fd;

--- a/monitor.c
+++ b/monitor.c
@@ -216,7 +216,7 @@ static void monitor_check_cleanup(void)
  */
 static struct Monitor *monitor_new(struct MonitorInfo *info, int descriptor)
 {
-  struct Monitor *monitor = mutt_mem_calloc(1, sizeof(struct Monitor));
+  struct Monitor *monitor = MUTT_MEM_CALLOC(1, struct Monitor);
   monitor->type = info->type;
   monitor->st_dev = info->st_dev;
   monitor->st_ino = info->st_ino;

--- a/mutt/array.h
+++ b/mutt/array.h
@@ -189,8 +189,8 @@
 #define ARRAY_RESERVE(head, num)                                               \
   (((head)->capacity > (num)) ?                                                \
        (head)->capacity :                                                      \
-       ((mutt_mem_realloc(                                                     \
-         &(head)->entries, ((num) + ARRAY_HEADROOM) * ARRAY_ELEM_SIZE(head))), \
+       ((mutt_mem_reallocarray(                                                \
+         &(head)->entries, (num) + ARRAY_HEADROOM, ARRAY_ELEM_SIZE(head))),    \
         (memset((head)->entries + (head)->capacity, 0,                         \
                 ((num) + ARRAY_HEADROOM - (head)->capacity) *                  \
                 ARRAY_ELEM_SIZE(head))),                                       \

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -360,7 +360,7 @@ void buf_alloc(struct Buffer *buf, size_t new_size)
 
   buf->dsize = ROUND_UP(new_size + 1, BufferStepSize);
 
-  mutt_mem_realloc(&buf->data, buf->dsize);
+  mutt_mem_reallocarray(&buf->data, buf->dsize, sizeof(char));
   buf->dptr = buf->data + offset;
 
   // Ensures that initially NULL buf->data is properly terminated

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -360,7 +360,7 @@ void buf_alloc(struct Buffer *buf, size_t new_size)
 
   buf->dsize = ROUND_UP(new_size + 1, BufferStepSize);
 
-  mutt_mem_reallocarray(&buf->data, buf->dsize, sizeof(char));
+  MUTT_MEM_REALLOC(&buf->data, buf->dsize, char);
   buf->dptr = buf->data + offset;
 
   // Ensures that initially NULL buf->data is properly terminated

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -303,7 +303,7 @@ bool buf_is_empty(const struct Buffer *buf)
  */
 struct Buffer *buf_new(const char *str)
 {
-  struct Buffer *buf = mutt_mem_calloc(1, sizeof(struct Buffer));
+  struct Buffer *buf = MUTT_MEM_CALLOC(1, struct Buffer);
 
   if (str)
     buf_addstr(buf, str);

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -932,29 +932,26 @@ bool mutt_ch_check_charset(const char *cs, bool strict)
  */
 struct FgetConv *mutt_ch_fgetconv_open(FILE *fp, const char *from, const char *to, uint8_t flags)
 {
-  struct FgetConv *fc = NULL;
   iconv_t cd = ICONV_T_INVALID;
 
   if (from && to)
     cd = mutt_ch_iconv_open(to, from, flags);
 
+  struct FgetConv *fc = MUTT_MEM_CALLOC(1, struct FgetConv);
+  fc->fp = fp;
+  fc->cd = cd;
+
   if (iconv_t_valid(cd))
   {
     static const char *repls[] = { "\357\277\275", "?", 0 };
 
-    fc = MUTT_MEM_MALLOC(1, struct FgetConv);
     fc->p = fc->bufo;
     fc->ob = fc->bufo;
     fc->ib = fc->bufi;
     fc->ibl = 0;
     fc->inrepls = mutt_ch_is_utf8(to) ? repls : repls + 1;
   }
-  else
-  {
-    fc = MUTT_MEM_MALLOC(1, struct FgetConvNot);
-  }
-  fc->fp = fp;
-  fc->cd = cd;
+
   return fc;
 }
 

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -344,7 +344,7 @@ int mutt_ch_convert_nonmime_string(const struct Slist *const assumed_charset,
   {
     char const *c = np->data;
     size_t n = mutt_str_len(c);
-    char *fromcode = mutt_mem_mallocarray(n + 1, sizeof(char));
+    char *fromcode = MUTT_MEM_MALLOC(n + 1, char);
     mutt_str_copy(fromcode, c, n + 1);
     char *s = mutt_strn_dup(u, ulen);
     int m = mutt_ch_convert_string(&s, fromcode, charset, MUTT_ICONV_NO_FLAGS);
@@ -804,7 +804,7 @@ int mutt_ch_check(const char *s, size_t slen, const char *from, const char *to)
     return -1;
 
   size_t outlen = MB_LEN_MAX * slen;
-  char *out = mutt_mem_mallocarray(outlen + 1, sizeof(char));
+  char *out = MUTT_MEM_MALLOC(outlen + 1, char);
   char *saved_out = out;
 
   const size_t convlen = iconv(cd, (ICONV_CONST char **) &s, &slen, &out, &outlen);
@@ -865,7 +865,7 @@ int mutt_ch_convert_string(char **ps, const char *from, const char *to, uint8_t 
     return -1;
   }
   size_t obl = MB_LEN_MAX * ibl;
-  char *buf = mutt_mem_mallocarray(obl + 1, sizeof(char));
+  char *buf = MUTT_MEM_MALLOC(obl + 1, char);
   char *ob = buf;
 
   mutt_ch_iconv(cd, &ib, &ibl, &ob, &obl, inrepls, outrepl, &rc);
@@ -942,7 +942,7 @@ struct FgetConv *mutt_ch_fgetconv_open(FILE *fp, const char *from, const char *t
   {
     static const char *repls[] = { "\357\277\275", "?", 0 };
 
-    fc = mutt_mem_mallocarray(1, sizeof(struct FgetConv));
+    fc = MUTT_MEM_MALLOC(1, struct FgetConv);
     fc->p = fc->bufo;
     fc->ob = fc->bufo;
     fc->ib = fc->bufi;
@@ -951,7 +951,7 @@ struct FgetConv *mutt_ch_fgetconv_open(FILE *fp, const char *from, const char *t
   }
   else
   {
-    fc = mutt_mem_mallocarray(1, sizeof(struct FgetConvNot));
+    fc = MUTT_MEM_MALLOC(1, struct FgetConvNot);
   }
   fc->fp = fp;
   fc->cd = cd;

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -268,7 +268,7 @@ static const struct MimeNames PreferredMimeNames[] = {
  */
 static struct Lookup *lookup_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct Lookup));
+  return MUTT_MEM_CALLOC(1, struct Lookup);
 }
 
 /**
@@ -512,7 +512,7 @@ bool mutt_ch_lookup_add(enum LookupType type, const char *pat,
   if (!pat || !replace)
     return false;
 
-  regex_t *rx = mutt_mem_calloc(1, sizeof(regex_t));
+  regex_t *rx = MUTT_MEM_CALLOC(1, regex_t);
   int rc = REG_COMP(rx, pat, REG_ICASE);
   if (rc != 0)
   {

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -344,7 +344,7 @@ int mutt_ch_convert_nonmime_string(const struct Slist *const assumed_charset,
   {
     char const *c = np->data;
     size_t n = mutt_str_len(c);
-    char *fromcode = mutt_mem_malloc(n + 1);
+    char *fromcode = mutt_mem_mallocarray(n + 1, sizeof(char));
     mutt_str_copy(fromcode, c, n + 1);
     char *s = mutt_strn_dup(u, ulen);
     int m = mutt_ch_convert_string(&s, fromcode, charset, MUTT_ICONV_NO_FLAGS);
@@ -804,7 +804,7 @@ int mutt_ch_check(const char *s, size_t slen, const char *from, const char *to)
     return -1;
 
   size_t outlen = MB_LEN_MAX * slen;
-  char *out = mutt_mem_malloc(outlen + 1);
+  char *out = mutt_mem_mallocarray(outlen + 1, sizeof(char));
   char *saved_out = out;
 
   const size_t convlen = iconv(cd, (ICONV_CONST char **) &s, &slen, &out, &outlen);
@@ -865,7 +865,7 @@ int mutt_ch_convert_string(char **ps, const char *from, const char *to, uint8_t 
     return -1;
   }
   size_t obl = MB_LEN_MAX * ibl;
-  char *buf = mutt_mem_malloc(obl + 1);
+  char *buf = mutt_mem_mallocarray(obl + 1, sizeof(char));
   char *ob = buf;
 
   mutt_ch_iconv(cd, &ib, &ibl, &ob, &obl, inrepls, outrepl, &rc);
@@ -942,7 +942,7 @@ struct FgetConv *mutt_ch_fgetconv_open(FILE *fp, const char *from, const char *t
   {
     static const char *repls[] = { "\357\277\275", "?", 0 };
 
-    fc = mutt_mem_malloc(sizeof(struct FgetConv));
+    fc = mutt_mem_mallocarray(1, sizeof(struct FgetConv));
     fc->p = fc->bufo;
     fc->ob = fc->bufo;
     fc->ib = fc->bufi;
@@ -951,7 +951,7 @@ struct FgetConv *mutt_ch_fgetconv_open(FILE *fp, const char *from, const char *t
   }
   else
   {
-    fc = mutt_mem_malloc(sizeof(struct FgetConvNot));
+    fc = mutt_mem_mallocarray(1, sizeof(struct FgetConvNot));
   }
   fc->fp = fp;
   fc->cd = cd;

--- a/mutt/charset.h
+++ b/mutt/charset.h
@@ -53,15 +53,6 @@ struct FgetConv
 };
 
 /**
- * struct FgetConvNot - A dummy converter
- */
-struct FgetConvNot
-{
-  FILE *fp;
-  iconv_t cd; ///< iconv conversion descriptor
-};
-
-/**
  * enum LookupType - Types of character set lookups
  */
 enum LookupType

--- a/mutt/envlist.c
+++ b/mutt/envlist.c
@@ -66,7 +66,7 @@ char **envlist_init(char **envp)
   for (src = envp; src && *src; src++)
     count++;
 
-  char **env_copy = mutt_mem_calloc(count + 1, sizeof(char *));
+  char **env_copy = MUTT_MEM_CALLOC(count + 1, char *);
   for (src = envp, dst = env_copy; src && *src; src++, dst++)
     *dst = mutt_str_dup(*src);
 

--- a/mutt/envlist.c
+++ b/mutt/envlist.c
@@ -118,7 +118,7 @@ bool envlist_set(char ***envp, const char *name, const char *value, bool overwri
   else
   {
     // not found, add a new entry
-    mutt_mem_reallocarray(envp, count + 2, sizeof(char *));
+    MUTT_MEM_REALLOC(envp, count + 2, char *);
     (*envp)[count] = mutt_str_dup(work);
     (*envp)[count + 1] = NULL;
   }
@@ -152,7 +152,7 @@ bool envlist_unset(char ***envp, const char *name)
       // Move down the later entries
       memmove(&(*envp)[match], &(*envp)[match + 1], (count - match) * sizeof(char *));
       // Shrink the array
-      mutt_mem_reallocarray(envp, count, sizeof(char *));
+      MUTT_MEM_REALLOC(envp, count, char *);
       return true;
     }
   }

--- a/mutt/envlist.c
+++ b/mutt/envlist.c
@@ -118,7 +118,7 @@ bool envlist_set(char ***envp, const char *name, const char *value, bool overwri
   else
   {
     // not found, add a new entry
-    mutt_mem_realloc(envp, (count + 2) * sizeof(char *));
+    mutt_mem_reallocarray(envp, count + 2, sizeof(char *));
     (*envp)[count] = mutt_str_dup(work);
     (*envp)[count + 1] = NULL;
   }
@@ -152,7 +152,7 @@ bool envlist_unset(char ***envp, const char *name)
       // Move down the later entries
       memmove(&(*envp)[match], &(*envp)[match + 1], (count - match) * sizeof(char *));
       // Shrink the array
-      mutt_mem_realloc(envp, count * sizeof(char *));
+      mutt_mem_reallocarray(envp, count, sizeof(char *));
       return true;
     }
   }

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -861,7 +861,7 @@ char *mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, Rea
         /* There wasn't room for the line -- increase "line" */
         offset = *size - 1; /* overwrite the terminating 0 */
         *size += 256;
-        mutt_mem_reallocarray(&line, *size, sizeof(char));
+        MUTT_MEM_REALLOC(&line, *size, char);
       }
     }
   }

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -816,7 +816,7 @@ char *mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, Rea
   if (!line)
   {
     *size = 256;
-    line = mutt_mem_malloc(*size);
+    line = mutt_mem_mallocarray(*size, sizeof(char));
   }
 
   while (true)

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -861,7 +861,7 @@ char *mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, Rea
         /* There wasn't room for the line -- increase "line" */
         offset = *size - 1; /* overwrite the terminating 0 */
         *size += 256;
-        mutt_mem_realloc(&line, *size);
+        mutt_mem_reallocarray(&line, *size, sizeof(char));
       }
     }
   }

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -816,7 +816,7 @@ char *mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, Rea
   if (!line)
   {
     *size = 256;
-    line = mutt_mem_mallocarray(*size, sizeof(char));
+    line = MUTT_MEM_MALLOC(*size, char);
   }
 
   while (true)

--- a/mutt/hash.c
+++ b/mutt/hash.c
@@ -120,11 +120,11 @@ static int cmp_key_int(union HashKey a, union HashKey b)
  */
 static struct HashTable *hash_new(size_t num_elems)
 {
-  struct HashTable *table = mutt_mem_calloc(1, sizeof(struct HashTable));
+  struct HashTable *table = MUTT_MEM_CALLOC(1, struct HashTable);
   if (num_elems == 0)
     num_elems = 2;
   table->num_elems = num_elems;
-  table->table = mutt_mem_calloc(num_elems, sizeof(struct HashElem *));
+  table->table = MUTT_MEM_CALLOC(num_elems, struct HashElem *);
   return table;
 }
 
@@ -142,7 +142,7 @@ static struct HashElem *union_hash_insert(struct HashTable *table,
   if (!table)
     return NULL; // LCOV_EXCL_LINE
 
-  struct HashElem *he = mutt_mem_calloc(1, sizeof(struct HashElem));
+  struct HashElem *he = MUTT_MEM_CALLOC(1, struct HashElem);
   size_t hash = table->gen_hash(key, table->num_elems);
   he->key = key;
   he->data = data;

--- a/mutt/list.c
+++ b/mutt/list.c
@@ -48,7 +48,7 @@ struct ListNode *mutt_list_insert_head(struct ListHead *h, char *s)
   if (!h)
     return NULL;
 
-  struct ListNode *np = mutt_mem_calloc(1, sizeof(struct ListNode));
+  struct ListNode *np = MUTT_MEM_CALLOC(1, struct ListNode);
   np->data = s;
   STAILQ_INSERT_HEAD(h, np, entries);
   return np;
@@ -67,7 +67,7 @@ struct ListNode *mutt_list_insert_tail(struct ListHead *h, char *s)
   if (!h)
     return NULL;
 
-  struct ListNode *np = mutt_mem_calloc(1, sizeof(struct ListNode));
+  struct ListNode *np = MUTT_MEM_CALLOC(1, struct ListNode);
   np->data = s;
   STAILQ_INSERT_TAIL(h, np, entries);
   return np;
@@ -87,7 +87,7 @@ struct ListNode *mutt_list_insert_after(struct ListHead *h, struct ListNode *n, 
   if (!h || !n)
     return NULL;
 
-  struct ListNode *np = mutt_mem_calloc(1, sizeof(struct ListNode));
+  struct ListNode *np = MUTT_MEM_CALLOC(1, struct ListNode);
   np->data = s;
   STAILQ_INSERT_AFTER(h, n, np, entries);
   return np;

--- a/mutt/logging.c
+++ b/mutt/logging.c
@@ -413,7 +413,7 @@ int log_disp_queue(time_t stamp, const char *file, int line, const char *functio
     level = LL_ERROR;
   }
 
-  struct LogLine *ll = mutt_mem_calloc(1, sizeof(*ll));
+  struct LogLine *ll = MUTT_MEM_CALLOC(1, struct LogLine);
   ll->time = (stamp != 0) ? stamp : mutt_date_now();
   ll->file = file;
   ll->line = line;

--- a/mutt/mbyte.c
+++ b/mutt/mbyte.c
@@ -309,7 +309,7 @@ size_t mutt_mb_mbstowcs(wchar_t **pwbuf, size_t *pwbuflen, size_t i, const char 
       if (i >= wbuflen)
       {
         wbuflen = i + 20;
-        mutt_mem_reallocarray(&wbuf, wbuflen, sizeof(*wbuf));
+        MUTT_MEM_REALLOC(&wbuf, wbuflen, wchar_t);
       }
       wbuf[i++] = wc;
     }
@@ -318,7 +318,7 @@ size_t mutt_mb_mbstowcs(wchar_t **pwbuf, size_t *pwbuflen, size_t i, const char 
       if (i >= wbuflen)
       {
         wbuflen = i + 20;
-        mutt_mem_reallocarray(&wbuf, wbuflen, sizeof(*wbuf));
+        MUTT_MEM_REALLOC(&wbuf, wbuflen, wchar_t);
       }
       wbuf[i++] = ReplacementChar;
       buf++;

--- a/mutt/mbyte.c
+++ b/mutt/mbyte.c
@@ -309,7 +309,7 @@ size_t mutt_mb_mbstowcs(wchar_t **pwbuf, size_t *pwbuflen, size_t i, const char 
       if (i >= wbuflen)
       {
         wbuflen = i + 20;
-        mutt_mem_realloc(&wbuf, wbuflen * sizeof(*wbuf));
+        mutt_mem_reallocarray(&wbuf, wbuflen, sizeof(*wbuf));
       }
       wbuf[i++] = wc;
     }
@@ -318,7 +318,7 @@ size_t mutt_mb_mbstowcs(wchar_t **pwbuf, size_t *pwbuflen, size_t i, const char 
       if (i >= wbuflen)
       {
         wbuflen = i + 20;
-        mutt_mem_realloc(&wbuf, wbuflen * sizeof(*wbuf));
+        mutt_mem_reallocarray(&wbuf, wbuflen, sizeof(*wbuf));
       }
       wbuf[i++] = ReplacementChar;
       buf++;

--- a/mutt/mbyte.c
+++ b/mutt/mbyte.c
@@ -452,7 +452,7 @@ int mutt_mb_filter_unprintable(char **s)
   FREE(s);
 
   if (buf_is_empty(buf))
-    *s = mutt_mem_calloc(1, 1); // Fake empty string
+    *s = MUTT_MEM_CALLOC(1, char); // Fake empty string
   else
     *s = buf_strdup(buf);
 

--- a/mutt/memory.c
+++ b/mutt/memory.c
@@ -90,15 +90,24 @@ void mutt_mem_free(void *ptr)
  */
 void *mutt_mem_malloc(size_t size)
 {
-  if (size == 0)
-    return NULL;
+  return mutt_mem_mallocarray(size, 1);
+}
 
-  void *p = malloc(size);
-  if (!p)
-  {
-    mutt_error("%s", strerror(errno)); // LCOV_EXCL_LINE
-    mutt_exit(1);                      // LCOV_EXCL_LINE
-  }
+/**
+ * mutt_mem_mallocarray - Allocate memory on the heap (array version)
+ * @param nmemb Number of blocks
+ * @param size  Size of blocks
+ * @retval ptr  Memory on the heap
+ *
+ * @note On error, this function will never return NULL.
+ *       It will print an error and exit the program.
+ *
+ * The caller should call mutt_mem_free() to release the memory
+ */
+void *mutt_mem_mallocarray(size_t nmemb, size_t size)
+{
+  void *p = NULL;
+  mutt_mem_reallocarray(&p, nmemb, size);
   return p;
 }
 

--- a/mutt/memory.c
+++ b/mutt/memory.c
@@ -110,7 +110,7 @@ void *mutt_mem_mallocarray(size_t nmemb, size_t size)
 
 /**
  * mutt_mem_realloc - Resize a block of memory on the heap
- * @param ptr Memory block to resize
+ * @param pptr Address of pointer to memory block to resize
  * @param size New size
  *
  * @note On error, this function will never return NULL.
@@ -118,14 +118,14 @@ void *mutt_mem_mallocarray(size_t nmemb, size_t size)
  *
  * If the new size is zero, the block will be freed.
  */
-void mutt_mem_realloc(void *ptr, size_t size)
+void mutt_mem_realloc(void *pptr, size_t size)
 {
-  mutt_mem_reallocarray(ptr, size, 1);
+  mutt_mem_reallocarray(pptr, size, 1);
 }
 
 /**
  * mutt_mem_reallocarray - Resize a block of memory on the heap (array version)
- * @param ptr   Memory block to resize
+ * @param pptr  Address of pointer to memory block to resize
  * @param nmemb Number of blocks
  * @param size  Size of blocks
  *
@@ -134,26 +134,26 @@ void mutt_mem_realloc(void *ptr, size_t size)
  *
  * If the new size is zero, the block will be freed.
  */
-void mutt_mem_reallocarray(void *ptr, size_t nmemb, size_t size)
+void mutt_mem_reallocarray(void *pptr, size_t nmemb, size_t size)
 {
-  if (!ptr)
+  if (!pptr)
     return;
 
-  void **p = (void **) ptr;
+  void **pp = (void **) pptr;
 
   if ((nmemb == 0) || (size == 0))
   {
-    free(*p);
-    *p = NULL;
+    free(*pp);
+    *pp = NULL;
     return;
   }
 
-  void *r = reallocarray(*p, nmemb, size);
+  void *r = reallocarray(*pp, nmemb, size);
   if (!r)
   {
     mutt_error("%s", strerror(errno)); // LCOV_EXCL_LINE
     mutt_exit(1);                      // LCOV_EXCL_LINE
   }
 
-  *p = r;
+  *pp = r;
 }

--- a/mutt/memory.c
+++ b/mutt/memory.c
@@ -114,12 +114,28 @@ void *mutt_mem_malloc(size_t size)
  */
 void mutt_mem_realloc(void *ptr, size_t size)
 {
+  mutt_mem_reallocarray(ptr, size, 1);
+}
+
+/**
+ * mutt_mem_reallocarray - Resize a block of memory on the heap (array version)
+ * @param ptr   Memory block to resize
+ * @param nmemb Number of blocks
+ * @param size  Size of blocks
+ *
+ * @note On error, this function will never return NULL.
+ *       It will print an error and exit the program.
+ *
+ * If the new size is zero, the block will be freed.
+ */
+void mutt_mem_reallocarray(void *ptr, size_t nmemb, size_t size)
+{
   if (!ptr)
     return;
 
   void **p = (void **) ptr;
 
-  if (size == 0)
+  if ((nmemb == 0) || (size == 0))
   {
     if (*p)
     {
@@ -129,7 +145,7 @@ void mutt_mem_realloc(void *ptr, size_t size)
     return;
   }
 
-  void *r = realloc(*p, size);
+  void *r = reallocarray(*p, nmemb, size);
   if (!r)
   {
     mutt_error("%s", strerror(errno)); // LCOV_EXCL_LINE

--- a/mutt/memory.c
+++ b/mutt/memory.c
@@ -71,11 +71,8 @@ void mutt_mem_free(void *ptr)
   if (!ptr)
     return;
   void **p = (void **) ptr;
-  if (*p)
-  {
-    free(*p);
-    *p = NULL;
-  }
+  free(*p);
+  *p = NULL;
 }
 
 /**
@@ -146,11 +143,8 @@ void mutt_mem_reallocarray(void *ptr, size_t nmemb, size_t size)
 
   if ((nmemb == 0) || (size == 0))
   {
-    if (*p)
-    {
-      free(*p);
-      *p = NULL;
-    }
+    free(*p);
+    *p = NULL;
     return;
   }
 

--- a/mutt/memory.h
+++ b/mutt/memory.h
@@ -40,6 +40,7 @@
 void *mutt_mem_calloc(size_t nmemb, size_t size);
 void  mutt_mem_free(void *ptr);
 void *mutt_mem_malloc(size_t size);
+void *mutt_mem_mallocarray(size_t nmemb, size_t size);
 void  mutt_mem_realloc(void *ptr, size_t size);
 void  mutt_mem_reallocarray(void *ptr, size_t nmemb, size_t size);
 

--- a/mutt/memory.h
+++ b/mutt/memory.h
@@ -40,17 +40,17 @@
 #define MUTT_MEM_CALLOC(n, type)  ((type *) mutt_mem_calloc(n, sizeof(type)))
 #define MUTT_MEM_MALLOC(n, type)  ((type *) mutt_mem_mallocarray(n, sizeof(type)))
 
-#define MUTT_MEM_REALLOC(ptr, n, type)                                        \
+#define MUTT_MEM_REALLOC(pptr, n, type)                                       \
 (                                                                             \
-  _Generic(*(ptr), type *: mutt_mem_reallocarray(ptr, n, sizeof(type)))       \
+  _Generic(*(pptr), type *: mutt_mem_reallocarray(pptr, n, sizeof(type)))     \
 )
 
 void *mutt_mem_calloc(size_t nmemb, size_t size);
 void  mutt_mem_free(void *ptr);
 void *mutt_mem_malloc(size_t size);
 void *mutt_mem_mallocarray(size_t nmemb, size_t size);
-void  mutt_mem_realloc(void *ptr, size_t size);
-void  mutt_mem_reallocarray(void *ptr, size_t nmemb, size_t size);
+void  mutt_mem_realloc(void *pptr, size_t size);
+void  mutt_mem_reallocarray(void *pptr, size_t nmemb, size_t size);
 
 #define FREE(x) mutt_mem_free(x)
 

--- a/mutt/memory.h
+++ b/mutt/memory.h
@@ -41,6 +41,7 @@ void *mutt_mem_calloc(size_t nmemb, size_t size);
 void  mutt_mem_free(void *ptr);
 void *mutt_mem_malloc(size_t size);
 void  mutt_mem_realloc(void *ptr, size_t size);
+void  mutt_mem_reallocarray(void *ptr, size_t nmemb, size_t size);
 
 #define FREE(x) mutt_mem_free(x)
 

--- a/mutt/memory.h
+++ b/mutt/memory.h
@@ -37,6 +37,14 @@
 
 #define mutt_array_size(x) (sizeof(x) / sizeof((x)[0]))
 
+#define MUTT_MEM_CALLOC(n, type)  ((type *) mutt_mem_calloc(n, sizeof(type)))
+#define MUTT_MEM_MALLOC(n, type)  ((type *) mutt_mem_mallocarray(n, sizeof(type)))
+
+#define MUTT_MEM_REALLOC(ptr, n, type)                                        \
+(                                                                             \
+  _Generic(*(ptr), type *: mutt_mem_reallocarray(ptr, n, sizeof(type)))       \
+)
+
 void *mutt_mem_calloc(size_t nmemb, size_t size);
 void  mutt_mem_free(void *ptr);
 void *mutt_mem_malloc(size_t size);

--- a/mutt/notify.c
+++ b/mutt/notify.c
@@ -61,7 +61,7 @@ struct Notify
  */
 struct Notify *notify_new(void)
 {
-  struct Notify *notify = mutt_mem_calloc(1, sizeof(*notify));
+  struct Notify *notify = MUTT_MEM_CALLOC(1, struct Notify);
 
   STAILQ_INIT(&notify->observers);
 
@@ -204,12 +204,12 @@ bool notify_observer_add(struct Notify *notify, enum NotifyType type,
       return true;
   }
 
-  struct Observer *o = mutt_mem_calloc(1, sizeof(*o));
+  struct Observer *o = MUTT_MEM_CALLOC(1, struct Observer);
   o->type = type;
   o->callback = callback;
   o->global_data = global_data;
 
-  np = mutt_mem_calloc(1, sizeof(*np));
+  np = MUTT_MEM_CALLOC(1, struct ObserverNode);
   np->observer = o;
   STAILQ_INSERT_HEAD(&notify->observers, np, entries);
 

--- a/mutt/pool.c
+++ b/mutt/pool.c
@@ -52,7 +52,7 @@ static void pool_increase_size(void)
   BufferPoolLen += BufferPoolIncrement;
   mutt_debug(LL_DEBUG1, "%zu\n", BufferPoolLen);
 
-  mutt_mem_reallocarray(&BufferPool, BufferPoolLen, sizeof(struct Buffer *));
+  MUTT_MEM_REALLOC(&BufferPool, BufferPoolLen, struct Buffer *);
   while (BufferPoolCount < BufferPoolIncrement)
   {
     struct Buffer *newbuf = buf_new(NULL);
@@ -111,7 +111,7 @@ void buf_pool_release(struct Buffer **ptr)
       (buf->dsize < BufferPoolInitialBufferSize))
   {
     buf->dsize = BufferPoolInitialBufferSize;
-    mutt_mem_reallocarray(&buf->data, buf->dsize, sizeof(char));
+    MUTT_MEM_REALLOC(&buf->data, buf->dsize, char);
   }
   buf_reset(buf);
   BufferPool[BufferPoolCount++] = buf;

--- a/mutt/pool.c
+++ b/mutt/pool.c
@@ -52,7 +52,7 @@ static void pool_increase_size(void)
   BufferPoolLen += BufferPoolIncrement;
   mutt_debug(LL_DEBUG1, "%zu\n", BufferPoolLen);
 
-  mutt_mem_realloc(&BufferPool, BufferPoolLen * sizeof(struct Buffer *));
+  mutt_mem_reallocarray(&BufferPool, BufferPoolLen, sizeof(struct Buffer *));
   while (BufferPoolCount < BufferPoolIncrement)
   {
     struct Buffer *newbuf = buf_new(NULL);
@@ -111,7 +111,7 @@ void buf_pool_release(struct Buffer **ptr)
       (buf->dsize < BufferPoolInitialBufferSize))
   {
     buf->dsize = BufferPoolInitialBufferSize;
-    mutt_mem_realloc(&buf->data, buf->dsize);
+    mutt_mem_reallocarray(&buf->data, buf->dsize, sizeof(char));
   }
   buf_reset(buf);
   BufferPool[BufferPoolCount++] = buf;

--- a/mutt/prex.c
+++ b/mutt/prex.c
@@ -277,12 +277,12 @@ static struct PrexStorage *prex(enum Prex which)
     uint32_t ccount = 0;
     pcre2_pattern_info(h->re, PCRE2_INFO_CAPTURECOUNT, &ccount);
     ASSERT(((ccount + 1) == h->nmatches) && "Number of matches do not match (...)");
-    h->matches = mutt_mem_calloc(h->nmatches, sizeof(*h->matches));
+    h->matches = MUTT_MEM_CALLOC(h->nmatches, regmatch_t);
 #else
-    h->re = mutt_mem_calloc(1, sizeof(*h->re));
+    h->re = MUTT_MEM_CALLOC(1, regex_t);
     const int rc = regcomp(h->re, h->str, REG_EXTENDED);
     ASSERT(rc == 0 && "Fix your RE");
-    h->matches = mutt_mem_calloc(h->nmatches, sizeof(*h->matches));
+    h->matches = MUTT_MEM_CALLOC(h->nmatches, regmatch_t);
 #endif
   }
   return h;

--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -60,9 +60,9 @@ struct Regex *mutt_regex_compile(const char *str, uint16_t flags)
 {
   if (!str || (*str == '\0'))
     return NULL;
-  struct Regex *rx = mutt_mem_calloc(1, sizeof(struct Regex));
+  struct Regex *rx = MUTT_MEM_CALLOC(1, struct Regex);
   rx->pattern = mutt_str_dup(str);
-  rx->regex = mutt_mem_calloc(1, sizeof(regex_t));
+  rx->regex = MUTT_MEM_CALLOC(1, regex_t);
   if (REG_COMP(rx->regex, str, flags) != 0)
     mutt_regex_free(&rx);
 
@@ -83,9 +83,9 @@ struct Regex *mutt_regex_new(const char *str, uint32_t flags, struct Buffer *err
     return NULL;
 
   uint16_t rflags = 0;
-  struct Regex *reg = mutt_mem_calloc(1, sizeof(struct Regex));
+  struct Regex *reg = MUTT_MEM_CALLOC(1, struct Regex);
 
-  reg->regex = mutt_mem_calloc(1, sizeof(regex_t));
+  reg->regex = MUTT_MEM_CALLOC(1, regex_t);
   reg->pattern = mutt_str_dup(str);
 
   /* Should we use smart case matching? */
@@ -220,7 +220,7 @@ bool mutt_regexlist_match(struct RegexList *rl, const char *str)
  */
 struct RegexNode *mutt_regexlist_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct RegexNode));
+  return MUTT_MEM_CALLOC(1, struct RegexNode);
 }
 
 /**
@@ -554,7 +554,7 @@ bool mutt_replacelist_match(struct ReplaceList *rl, char *buf, size_t buflen, co
  */
 struct Replace *mutt_replacelist_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct Replace));
+  return MUTT_MEM_CALLOC(1, struct Replace);
 }
 
 /**

--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -386,7 +386,7 @@ char *mutt_replacelist_apply(struct ReplaceList *rl, const char *str)
     /* If this pattern needs more matches, expand pmatch. */
     if (np->nmatch > nmatch)
     {
-      mutt_mem_realloc(&pmatch, np->nmatch * sizeof(regmatch_t));
+      mutt_mem_reallocarray(&pmatch, np->nmatch, sizeof(regmatch_t));
       nmatch = np->nmatch;
     }
 
@@ -491,7 +491,7 @@ bool mutt_replacelist_match(struct ReplaceList *rl, char *buf, size_t buflen, co
     /* If this pattern needs more matches, expand pmatch. */
     if (np->nmatch > nmatch)
     {
-      mutt_mem_realloc(&pmatch, np->nmatch * sizeof(regmatch_t));
+      mutt_mem_reallocarray(&pmatch, np->nmatch, sizeof(regmatch_t));
       nmatch = np->nmatch;
     }
 

--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -386,7 +386,7 @@ char *mutt_replacelist_apply(struct ReplaceList *rl, const char *str)
     /* If this pattern needs more matches, expand pmatch. */
     if (np->nmatch > nmatch)
     {
-      mutt_mem_reallocarray(&pmatch, np->nmatch, sizeof(regmatch_t));
+      MUTT_MEM_REALLOC(&pmatch, np->nmatch, regmatch_t);
       nmatch = np->nmatch;
     }
 
@@ -491,7 +491,7 @@ bool mutt_replacelist_match(struct ReplaceList *rl, char *buf, size_t buflen, co
     /* If this pattern needs more matches, expand pmatch. */
     if (np->nmatch > nmatch)
     {
-      mutt_mem_reallocarray(&pmatch, np->nmatch, sizeof(regmatch_t));
+      MUTT_MEM_REALLOC(&pmatch, np->nmatch, regmatch_t);
       nmatch = np->nmatch;
     }
 

--- a/mutt/slist.c
+++ b/mutt/slist.c
@@ -50,7 +50,7 @@
  */
 struct Slist *slist_new(uint32_t flags)
 {
-  struct Slist *list = mutt_mem_calloc(1, sizeof(*list));
+  struct Slist *list = MUTT_MEM_CALLOC(1, struct Slist);
   list->flags = flags;
   STAILQ_INIT(&list->head);
 
@@ -184,7 +184,7 @@ struct Slist *slist_parse(const char *str, uint32_t flags)
   else if ((flags & D_SLIST_SEP_MASK) == D_SLIST_SEP_COLON)
     sep = ':';
 
-  struct Slist *list = mutt_mem_calloc(1, sizeof(struct Slist));
+  struct Slist *list = MUTT_MEM_CALLOC(1, struct Slist);
   list->flags = flags;
   STAILQ_INIT(&list->head);
 

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -300,7 +300,7 @@ void mutt_str_adjust(char **ptr)
 {
   if (!ptr || !*ptr)
     return;
-  mutt_mem_realloc(ptr, strlen(*ptr) + 1);
+  mutt_mem_reallocarray(ptr, strlen(*ptr) + 1, sizeof(char));
 }
 
 /**
@@ -827,12 +827,12 @@ int mutt_str_asprintf(char **strp, const char *fmt, ...)
       if (n == 0) /* convention is to use NULL for zero-length strings. */
         FREE(strp);
       else if (n != rlen - 1)
-        mutt_mem_realloc(strp, n + 1);
+        mutt_mem_reallocarray(strp, n + 1, sizeof(char));
       return n;
     }
     /* increase size and try again */
     rlen = n + 1;
-    mutt_mem_realloc(strp, rlen);
+    mutt_mem_reallocarray(strp, rlen, sizeof(char));
   }
   /* not reached */
 }

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -382,7 +382,7 @@ char *mutt_strn_dup(const char *begin, size_t len)
   if (!begin)
     return NULL;
 
-  char *p = mutt_mem_mallocarray(len + 1, sizeof(char));
+  char *p = MUTT_MEM_MALLOC(len + 1, char);
   memcpy(p, begin, len);
   p[len] = '\0';
   return p;
@@ -807,7 +807,7 @@ int mutt_str_asprintf(char **strp, const char *fmt, ...)
 
   int rlen = 256;
 
-  *strp = mutt_mem_mallocarray(rlen, sizeof(char));
+  *strp = MUTT_MEM_MALLOC(rlen, char);
   while (true)
   {
     va_list ap;

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -382,7 +382,7 @@ char *mutt_strn_dup(const char *begin, size_t len)
   if (!begin)
     return NULL;
 
-  char *p = mutt_mem_malloc(len + 1);
+  char *p = mutt_mem_mallocarray(len + 1, sizeof(char));
   memcpy(p, begin, len);
   p[len] = '\0';
   return p;
@@ -807,7 +807,7 @@ int mutt_str_asprintf(char **strp, const char *fmt, ...)
 
   int rlen = 256;
 
-  *strp = mutt_mem_malloc(rlen);
+  *strp = mutt_mem_mallocarray(rlen, sizeof(char));
   while (true)
   {
     va_list ap;

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -300,7 +300,7 @@ void mutt_str_adjust(char **ptr)
 {
   if (!ptr || !*ptr)
     return;
-  mutt_mem_reallocarray(ptr, strlen(*ptr) + 1, sizeof(char));
+  MUTT_MEM_REALLOC(ptr, strlen(*ptr) + 1, char);
 }
 
 /**
@@ -827,12 +827,12 @@ int mutt_str_asprintf(char **strp, const char *fmt, ...)
       if (n == 0) /* convention is to use NULL for zero-length strings. */
         FREE(strp);
       else if (n != rlen - 1)
-        mutt_mem_reallocarray(strp, n + 1, sizeof(char));
+        MUTT_MEM_REALLOC(strp, n + 1, char);
       return n;
     }
     /* increase size and try again */
     rlen = n + 1;
-    mutt_mem_reallocarray(strp, rlen, sizeof(char));
+    MUTT_MEM_REALLOC(strp, rlen, char);
   }
   /* not reached */
 }

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -356,7 +356,7 @@ static void calculate_visibility(struct MuttThread *tree, int *max_depth)
  */
 struct ThreadsContext *mutt_thread_ctx_init(struct MailboxView *mv)
 {
-  struct ThreadsContext *tctx = mutt_mem_calloc(1, sizeof(struct ThreadsContext));
+  struct ThreadsContext *tctx = MUTT_MEM_CALLOC(1, struct ThreadsContext);
   tctx->mailbox_view = mv;
   return tctx;
 }
@@ -812,7 +812,7 @@ static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
   top = thread;
 
   array_size = 256;
-  array = mutt_mem_calloc(array_size, sizeof(struct MuttThread *));
+  array = MUTT_MEM_CALLOC(array_size, struct MuttThread *);
   while (true)
   {
     if (init || !thread->sort_thread_key || !thread->sort_aux_key)
@@ -1140,7 +1140,7 @@ void mutt_sort_threads(struct ThreadsContext *tctx, bool init)
       {
         tnew = (c_duplicate_threads ? thread : NULL);
 
-        thread = mutt_mem_calloc(1, sizeof(struct MuttThread));
+        thread = MUTT_MEM_CALLOC(1, struct MuttThread);
         thread->message = e;
         thread->check_subject = true;
         e->thread = thread;
@@ -1232,7 +1232,7 @@ void mutt_sort_threads(struct ThreadsContext *tctx, bool init)
       }
       else
       {
-        tnew = mutt_mem_calloc(1, sizeof(struct MuttThread));
+        tnew = MUTT_MEM_CALLOC(1, struct MuttThread);
         mutt_hash_insert(tctx->hash, ref->data, tnew);
       }
 

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -855,7 +855,10 @@ static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
         for (i = 0; thread; i++, thread = thread->prev)
         {
           if (i >= array_size)
-            MUTT_MEM_REALLOC(&array, (array_size *= 2), struct MuttThread *);
+          {
+            array_size *= 2;
+            MUTT_MEM_REALLOC(&array, array_size, struct MuttThread *);
+          }
 
           array[i] = thread;
         }

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -855,7 +855,7 @@ static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
         for (i = 0; thread; i++, thread = thread->prev)
         {
           if (i >= array_size)
-            mutt_mem_reallocarray(&array, (array_size *= 2), sizeof(struct MuttThread *));
+            MUTT_MEM_REALLOC(&array, (array_size *= 2), struct MuttThread *);
 
           array[i] = thread;
         }

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -855,7 +855,7 @@ static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
         for (i = 0; thread; i++, thread = thread->prev)
         {
           if (i >= array_size)
-            mutt_mem_realloc(&array, (array_size *= 2) * sizeof(struct MuttThread *));
+            mutt_mem_reallocarray(&array, (array_size *= 2), sizeof(struct MuttThread *));
 
           array[i] = thread;
         }

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -406,8 +406,8 @@ void mutt_draw_tree(struct ThreadsContext *tctx)
   /* Do the visibility calculations and free the old thread chars.
    * From now on we can simply ignore invisible subtrees */
   calculate_visibility(tree, &max_depth);
-  pfx = mutt_mem_mallocarray((width * max_depth) + 2, sizeof(char));
-  arrow = mutt_mem_mallocarray((width * max_depth) + 2, sizeof(char));
+  pfx = MUTT_MEM_MALLOC((width * max_depth) + 2, char);
+  arrow = MUTT_MEM_MALLOC((width * max_depth) + 2, char);
   const bool c_hide_limited = cs_subset_bool(NeoMutt->sub, "hide_limited");
   const bool c_hide_missing = cs_subset_bool(NeoMutt->sub, "hide_missing");
   while (tree)
@@ -432,7 +432,7 @@ void mutt_draw_tree(struct ThreadsContext *tctx)
       {
         myarrow[width] = MUTT_TREE_RARROW;
         myarrow[width + 1] = 0;
-        new_tree = mutt_mem_mallocarray(((size_t) depth * width) + 2, sizeof(char));
+        new_tree = MUTT_MEM_MALLOC(((size_t) depth * width) + 2, char);
         if (start_depth > 1)
         {
           strncpy(new_tree, pfx, (size_t) width * (start_depth - 1));

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -406,8 +406,8 @@ void mutt_draw_tree(struct ThreadsContext *tctx)
   /* Do the visibility calculations and free the old thread chars.
    * From now on we can simply ignore invisible subtrees */
   calculate_visibility(tree, &max_depth);
-  pfx = mutt_mem_malloc((width * max_depth) + 2);
-  arrow = mutt_mem_malloc((width * max_depth) + 2);
+  pfx = mutt_mem_mallocarray((width * max_depth) + 2, sizeof(char));
+  arrow = mutt_mem_mallocarray((width * max_depth) + 2, sizeof(char));
   const bool c_hide_limited = cs_subset_bool(NeoMutt->sub, "hide_limited");
   const bool c_hide_missing = cs_subset_bool(NeoMutt->sub, "hide_missing");
   while (tree)
@@ -432,7 +432,7 @@ void mutt_draw_tree(struct ThreadsContext *tctx)
       {
         myarrow[width] = MUTT_TREE_RARROW;
         myarrow[width + 1] = 0;
-        new_tree = mutt_mem_malloc(((size_t) depth * width) + 2);
+        new_tree = mutt_mem_mallocarray(((size_t) depth * width) + 2, sizeof(char));
         if (start_depth > 1)
         {
           strncpy(new_tree, pfx, (size_t) width * (start_depth - 1));

--- a/mview.c
+++ b/mview.c
@@ -93,7 +93,7 @@ struct MailboxView *mview_new(struct Mailbox *m, struct Notify *parent)
   if (!m)
     return NULL;
 
-  struct MailboxView *mv = mutt_mem_calloc(1, sizeof(struct MailboxView));
+  struct MailboxView *mv = MUTT_MEM_CALLOC(1, struct MailboxView);
 
   mv->notify = notify_new();
   notify_set_parent(mv->notify, parent);

--- a/mx.c
+++ b/mx.c
@@ -1224,8 +1224,8 @@ void mx_alloc_memory(struct Mailbox *m, int req_size)
 
   if (m->emails)
   {
-    mutt_mem_reallocarray(&m->emails, req_size, sizeof(struct Email *));
-    mutt_mem_reallocarray(&m->v2r, req_size, sizeof(int));
+    MUTT_MEM_REALLOC(&m->emails, req_size, struct Email *);
+    MUTT_MEM_REALLOC(&m->v2r, req_size, int);
   }
   else
   {

--- a/mx.c
+++ b/mx.c
@@ -1229,8 +1229,8 @@ void mx_alloc_memory(struct Mailbox *m, int req_size)
   }
   else
   {
-    m->emails = mutt_mem_calloc(req_size, sizeof(struct Email *));
-    m->v2r = mutt_mem_calloc(req_size, sizeof(int));
+    m->emails = MUTT_MEM_CALLOC(req_size, struct Email *);
+    m->v2r = MUTT_MEM_CALLOC(req_size, int);
   }
 
   for (int i = m->email_max; i < req_size; i++)

--- a/mx.c
+++ b/mx.c
@@ -1224,8 +1224,8 @@ void mx_alloc_memory(struct Mailbox *m, int req_size)
 
   if (m->emails)
   {
-    mutt_mem_realloc(&m->emails, req_size * sizeof(struct Email *));
-    mutt_mem_realloc(&m->v2r, req_size * sizeof(int));
+    mutt_mem_reallocarray(&m->emails, req_size, sizeof(struct Email *));
+    mutt_mem_reallocarray(&m->v2r, req_size, sizeof(int));
   }
   else
   {

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1026,7 +1026,8 @@ int crypt_get_keys(struct Email *e, char **keylist, bool oppenc_mode)
   if (!oppenc_mode && self_encrypt)
   {
     const size_t keylist_size = mutt_str_len(*keylist);
-    mutt_mem_realloc(keylist, keylist_size + mutt_str_len(self_encrypt) + 2);
+    mutt_mem_reallocarray(keylist, keylist_size + mutt_str_len(self_encrypt) + 2,
+                          sizeof(char));
     sprintf(*keylist + keylist_size, " %s", self_encrypt);
   }
 
@@ -1085,7 +1086,7 @@ static void crypt_fetch_signatures(struct Body ***b_sigs, struct Body *b, int *n
     else
     {
       if ((*n % 5) == 0)
-        mutt_mem_realloc(b_sigs, (*n + 6) * sizeof(struct Body *));
+        mutt_mem_reallocarray(b_sigs, *n + 6, sizeof(struct Body *));
 
       (*b_sigs)[(*n)++] = b;
     }

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1026,8 +1026,7 @@ int crypt_get_keys(struct Email *e, char **keylist, bool oppenc_mode)
   if (!oppenc_mode && self_encrypt)
   {
     const size_t keylist_size = mutt_str_len(*keylist);
-    mutt_mem_reallocarray(keylist, keylist_size + mutt_str_len(self_encrypt) + 2,
-                          sizeof(char));
+    MUTT_MEM_REALLOC(keylist, keylist_size + mutt_str_len(self_encrypt) + 2, char);
     sprintf(*keylist + keylist_size, " %s", self_encrypt);
   }
 
@@ -1086,7 +1085,7 @@ static void crypt_fetch_signatures(struct Body ***b_sigs, struct Body *b, int *n
     else
     {
       if ((*n % 5) == 0)
-        mutt_mem_reallocarray(b_sigs, *n + 6, sizeof(struct Body *));
+        MUTT_MEM_REALLOC(b_sigs, *n + 6, struct Body *);
 
       (*b_sigs)[(*n)++] = b;
     }

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -1266,7 +1266,7 @@ static void show_fingerprint(gpgme_key_t key, struct State *state)
     return;
   bool is_pgp = (key->protocol == GPGME_PROTOCOL_OpenPGP);
 
-  char *buf = mutt_mem_mallocarray(strlen(prefix) + strlen(s) * 4 + 2, sizeof(char));
+  char *buf = MUTT_MEM_MALLOC(strlen(prefix) + strlen(s) * 4 + 2, char);
   strcpy(buf, prefix);
   char *p = buf + strlen(buf);
   if (is_pgp && (strlen(s) == 40))
@@ -3500,7 +3500,7 @@ static struct CryptKeyInfo *crypt_ask_for_key(const char *tag, const char *whatf
       }
       else
       {
-        l = mutt_mem_mallocarray(1, sizeof(struct CryptCache));
+        l = MUTT_MEM_MALLOC(1, struct CryptCache);
         l->next = IdDefaults;
         IdDefaults = l;
         l->what = mutt_str_dup(whatfor);

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -1266,7 +1266,7 @@ static void show_fingerprint(gpgme_key_t key, struct State *state)
     return;
   bool is_pgp = (key->protocol == GPGME_PROTOCOL_OpenPGP);
 
-  char *buf = mutt_mem_malloc(strlen(prefix) + strlen(s) * 4 + 2);
+  char *buf = mutt_mem_mallocarray(strlen(prefix) + strlen(s) * 4 + 2, sizeof(char));
   strcpy(buf, prefix);
   char *p = buf + strlen(buf);
   if (is_pgp && (strlen(s) == 40))
@@ -3500,7 +3500,7 @@ static struct CryptKeyInfo *crypt_ask_for_key(const char *tag, const char *whatf
       }
       else
       {
-        l = mutt_mem_malloc(sizeof(struct CryptCache));
+        l = mutt_mem_mallocarray(1, sizeof(struct CryptCache));
         l->next = IdDefaults;
         IdDefaults = l;
         l->what = mutt_str_dup(whatfor);

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3633,7 +3633,7 @@ static char *find_keys(const struct AddressList *addrlist, unsigned int app, boo
 
     bypass_selection:
       keylist_size += mutt_str_len(keyid) + 4 + 1;
-      mutt_mem_realloc(&keylist, keylist_size);
+      mutt_mem_reallocarray(&keylist, keylist_size, sizeof(char));
       sprintf(keylist + keylist_used, "%s0x%s%s", keylist_used ? " " : "",
               keyid, forced_valid ? "!" : "");
       keylist_used = mutt_str_len(keylist);

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3633,7 +3633,7 @@ static char *find_keys(const struct AddressList *addrlist, unsigned int app, boo
 
     bypass_selection:
       keylist_size += mutt_str_len(keyid) + 4 + 1;
-      mutt_mem_reallocarray(&keylist, keylist_size, sizeof(char));
+      MUTT_MEM_REALLOC(&keylist, keylist_size, char);
       sprintf(keylist + keylist_used, "%s0x%s%s", keylist_used ? " " : "",
               keyid, forced_valid ? "!" : "");
       keylist_used = mutt_str_len(keylist);

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -235,7 +235,7 @@ struct CryptKeyInfo *crypt_copy_key(struct CryptKeyInfo *key)
 {
   struct CryptKeyInfo *k = NULL;
 
-  k = mutt_mem_calloc(1, sizeof(*k));
+  k = MUTT_MEM_CALLOC(1, struct CryptKeyInfo);
   k->kobj = key->kobj;
   gpgme_key_ref(key->kobj);
   k->idx = key->idx;
@@ -3020,7 +3020,7 @@ static char *list_to_pattern(struct ListHead *list)
     n++; /* delimiter or end of string */
   }
   n++; /* make sure to allocate at least one byte */
-  p = mutt_mem_calloc(1, n);
+  p = MUTT_MEM_CALLOC(n, char);
   pattern = p;
   STAILQ_FOREACH(np, list, entries)
   {
@@ -3100,7 +3100,7 @@ static struct CryptKeyInfo *get_candidates(struct ListHead *hints, SecurityFlags
     if (n == 0)
       goto no_pgphints;
 
-    char **patarr = mutt_mem_calloc(n + 1, sizeof(*patarr));
+    char **patarr = MUTT_MEM_CALLOC(n + 1, char *);
     n = 0;
     STAILQ_FOREACH(np, hints, entries)
     {
@@ -3138,7 +3138,7 @@ static struct CryptKeyInfo *get_candidates(struct ListHead *hints, SecurityFlags
 
       for (idx = 0, uid = key->uids; uid; idx++, uid = uid->next)
       {
-        k = mutt_mem_calloc(1, sizeof(*k));
+        k = MUTT_MEM_CALLOC(1, struct CryptKeyInfo);
         k->kobj = key;
         gpgme_key_ref(k->kobj);
         k->idx = idx;
@@ -3189,7 +3189,7 @@ static struct CryptKeyInfo *get_candidates(struct ListHead *hints, SecurityFlags
 
       for (idx = 0, uid = key->uids; uid; idx++, uid = uid->next)
       {
-        k = mutt_mem_calloc(1, sizeof(*k));
+        k = MUTT_MEM_CALLOC(1, struct CryptKeyInfo);
         k->kobj = key;
         gpgme_key_ref(k->kobj);
         k->idx = idx;
@@ -3719,7 +3719,7 @@ int mutt_gpgme_select_secret_key(struct Buffer *keyid)
     int idx;
     for (idx = 0, uid = key->uids; uid; idx++, uid = uid->next)
     {
-      k = mutt_mem_calloc(1, sizeof(*k));
+      k = MUTT_MEM_CALLOC(1, struct CryptKeyInfo);
       k->kobj = key;
       gpgme_key_ref(k->kobj);
       k->idx = idx;

--- a/ncrypt/crypt_mod.c
+++ b/ncrypt/crypt_mod.c
@@ -53,7 +53,7 @@ static struct CryptModuleList CryptModules = STAILQ_HEAD_INITIALIZER(CryptModule
  */
 void crypto_module_register(const struct CryptModuleSpecs *specs)
 {
-  struct CryptModule *module = mutt_mem_calloc(1, sizeof(struct CryptModule));
+  struct CryptModule *module = MUTT_MEM_CALLOC(1, struct CryptModule);
   module->specs = specs;
   STAILQ_INSERT_HEAD(&CryptModules, module, entries);
 }

--- a/ncrypt/dlg_gpgme.c
+++ b/ncrypt/dlg_gpgme.c
@@ -651,7 +651,7 @@ struct CryptKeyInfo *dlg_gpgme(struct CryptKeyInfo *keys, struct Address *p,
     if (i == keymax)
     {
       keymax += 20;
-      mutt_mem_reallocarray(&key_table, keymax, sizeof(struct CryptKeyInfo *));
+      MUTT_MEM_REALLOC(&key_table, keymax, struct CryptKeyInfo *);
     }
 
     key_table[i++] = k;

--- a/ncrypt/dlg_gpgme.c
+++ b/ncrypt/dlg_gpgme.c
@@ -651,7 +651,7 @@ struct CryptKeyInfo *dlg_gpgme(struct CryptKeyInfo *keys, struct Address *p,
     if (i == keymax)
     {
       keymax += 20;
-      mutt_mem_realloc(&key_table, sizeof(struct CryptKeyInfo *) * keymax);
+      mutt_mem_reallocarray(&key_table, keymax, sizeof(struct CryptKeyInfo *));
     }
 
     key_table[i++] = k;

--- a/ncrypt/dlg_pgp.c
+++ b/ncrypt/dlg_pgp.c
@@ -648,7 +648,7 @@ struct PgpKeyInfo *dlg_pgp(struct PgpKeyInfo *keys, struct Address *p, const cha
       if (i == keymax)
       {
         keymax += 5;
-        mutt_mem_realloc(&key_table, sizeof(struct PgpUid *) * keymax);
+        mutt_mem_reallocarray(&key_table, keymax, sizeof(struct PgpUid *));
       }
 
       key_table[i++] = a;

--- a/ncrypt/dlg_pgp.c
+++ b/ncrypt/dlg_pgp.c
@@ -648,7 +648,7 @@ struct PgpKeyInfo *dlg_pgp(struct PgpKeyInfo *keys, struct Address *p, const cha
       if (i == keymax)
       {
         keymax += 5;
-        mutt_mem_reallocarray(&key_table, keymax, sizeof(struct PgpUid *));
+        MUTT_MEM_REALLOC(&key_table, keymax, struct PgpUid *);
       }
 
       key_table[i++] = a;

--- a/ncrypt/dlg_smime.c
+++ b/ncrypt/dlg_smime.c
@@ -209,7 +209,7 @@ struct SmimeKey *dlg_smime(struct SmimeKey *keys, const char *query)
     if (table_index == table_size)
     {
       table_size += 5;
-      mutt_mem_realloc(&table, sizeof(struct SmimeKey *) * table_size);
+      mutt_mem_reallocarray(&table, table_size, sizeof(struct SmimeKey *));
     }
 
     table[table_index++] = key;

--- a/ncrypt/dlg_smime.c
+++ b/ncrypt/dlg_smime.c
@@ -209,7 +209,7 @@ struct SmimeKey *dlg_smime(struct SmimeKey *keys, const char *query)
     if (table_index == table_size)
     {
       table_size += 5;
-      mutt_mem_reallocarray(&table, table_size, sizeof(struct SmimeKey *));
+      MUTT_MEM_REALLOC(&table, table_size, struct SmimeKey *);
     }
 
     table[table_index++] = key;

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -336,7 +336,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
 
         mutt_debug(LL_DEBUG2, "user ID: %s\n", NONULL(p));
 
-        uid = mutt_mem_calloc(1, sizeof(struct PgpUid));
+        uid = MUTT_MEM_CALLOC(1, struct PgpUid);
         fix_uid(p);
         uid->addr = mutt_str_dup(p);
         uid->trust = trust;

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -103,7 +103,7 @@ static void fix_uid(char *uid)
   {
     int n = s - uid + 1; /* chars available in original buffer */
 
-    char *buf = mutt_mem_malloc(n + 1);
+    char *buf = mutt_mem_mallocarray(n + 1, sizeof(char));
     const char *ib = uid;
     size_t ibl = d - uid + 1;
     char *ob = buf;
@@ -390,7 +390,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
 
   /* merge temp key back into real key */
   if (!(is_uid || is_fpr || (*is_subkey && c_pgp_ignore_subkeys)))
-    k = mutt_mem_malloc(sizeof(*k));
+    k = mutt_mem_mallocarray(1, sizeof(*k));
   if (!k)
     return NULL;
   memcpy(k, &tmp, sizeof(*k));

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -103,7 +103,7 @@ static void fix_uid(char *uid)
   {
     int n = s - uid + 1; /* chars available in original buffer */
 
-    char *buf = mutt_mem_mallocarray(n + 1, sizeof(char));
+    char *buf = MUTT_MEM_MALLOC(n + 1, char);
     const char *ib = uid;
     size_t ibl = d - uid + 1;
     char *ob = buf;
@@ -390,7 +390,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
 
   /* merge temp key back into real key */
   if (!(is_uid || is_fpr || (*is_subkey && c_pgp_ignore_subkeys)))
-    k = mutt_mem_mallocarray(1, sizeof(*k));
+    k = MUTT_MEM_MALLOC(1, struct PgpKeyInfo);
   if (!k)
     return NULL;
   memcpy(k, &tmp, sizeof(*k));

--- a/ncrypt/gpgme_functions.c
+++ b/ncrypt/gpgme_functions.c
@@ -83,7 +83,7 @@ struct DnArray
  */
 static void print_utf8(FILE *fp, const char *buf, size_t len)
 {
-  char *tstr = mutt_mem_mallocarray(len + 1, sizeof(char));
+  char *tstr = MUTT_MEM_MALLOC(len + 1, char);
   memcpy(tstr, buf, len);
   tstr[len] = 0;
 
@@ -186,7 +186,7 @@ static const char *parse_dn_part(struct DnArray *array, const char *str)
   n = s - str;
   if (n == 0)
     return NULL; /* empty key */
-  array->key = mutt_mem_mallocarray(n + 1, sizeof(char));
+  array->key = MUTT_MEM_MALLOC(n + 1, char);
   p = array->key;
   memcpy(p, str, n); /* fixme: trim trailing spaces */
   p[n] = 0;
@@ -201,7 +201,7 @@ static const char *parse_dn_part(struct DnArray *array, const char *str)
     if ((n == 0) || (n & 1))
       return NULL; /* empty or odd number of digits */
     n /= 2;
-    p = mutt_mem_mallocarray(n + 1, sizeof(char));
+    p = MUTT_MEM_MALLOC(n + 1, char);
     array->value = (char *) p;
     for (s1 = str; n; s1 += 2, n--)
       sscanf(s1, "%2hhx", (unsigned char *) p++);
@@ -244,7 +244,7 @@ static const char *parse_dn_part(struct DnArray *array, const char *str)
       }
     }
 
-    p = mutt_mem_mallocarray(n + 1, sizeof(char));
+    p = MUTT_MEM_MALLOC(n + 1, char);
     array->value = (char *) p;
     for (s = str; n; s++, n--)
     {
@@ -285,7 +285,7 @@ static struct DnArray *parse_dn(const char *str)
   size_t arrayidx, arraysize;
 
   arraysize = 7; /* C,ST,L,O,OU,CN,email */
-  array = mutt_mem_mallocarray(arraysize + 1, sizeof(*array));
+  array = MUTT_MEM_MALLOC(arraysize + 1, struct DnArray);
   arrayidx = 0;
   while (*str)
   {
@@ -297,7 +297,7 @@ static struct DnArray *parse_dn(const char *str)
     {
       /* neomutt lacks a real mutt_mem_realloc - so we need to copy */
       arraysize += 5;
-      struct DnArray *a2 = mutt_mem_mallocarray(arraysize + 1, sizeof(*array));
+      struct DnArray *a2 = MUTT_MEM_MALLOC(arraysize + 1, struct DnArray);
       for (int i = 0; i < arrayidx; i++)
       {
         a2[i].key = array[i].key;

--- a/ncrypt/gpgme_functions.c
+++ b/ncrypt/gpgme_functions.c
@@ -83,7 +83,7 @@ struct DnArray
  */
 static void print_utf8(FILE *fp, const char *buf, size_t len)
 {
-  char *tstr = mutt_mem_malloc(len + 1);
+  char *tstr = mutt_mem_mallocarray(len + 1, sizeof(char));
   memcpy(tstr, buf, len);
   tstr[len] = 0;
 
@@ -186,7 +186,7 @@ static const char *parse_dn_part(struct DnArray *array, const char *str)
   n = s - str;
   if (n == 0)
     return NULL; /* empty key */
-  array->key = mutt_mem_malloc(n + 1);
+  array->key = mutt_mem_mallocarray(n + 1, sizeof(char));
   p = array->key;
   memcpy(p, str, n); /* fixme: trim trailing spaces */
   p[n] = 0;
@@ -201,7 +201,7 @@ static const char *parse_dn_part(struct DnArray *array, const char *str)
     if ((n == 0) || (n & 1))
       return NULL; /* empty or odd number of digits */
     n /= 2;
-    p = mutt_mem_malloc(n + 1);
+    p = mutt_mem_mallocarray(n + 1, sizeof(char));
     array->value = (char *) p;
     for (s1 = str; n; s1 += 2, n--)
       sscanf(s1, "%2hhx", (unsigned char *) p++);
@@ -244,7 +244,7 @@ static const char *parse_dn_part(struct DnArray *array, const char *str)
       }
     }
 
-    p = mutt_mem_malloc(n + 1);
+    p = mutt_mem_mallocarray(n + 1, sizeof(char));
     array->value = (char *) p;
     for (s = str; n; s++, n--)
     {
@@ -285,7 +285,7 @@ static struct DnArray *parse_dn(const char *str)
   size_t arrayidx, arraysize;
 
   arraysize = 7; /* C,ST,L,O,OU,CN,email */
-  array = mutt_mem_malloc((arraysize + 1) * sizeof(*array));
+  array = mutt_mem_mallocarray(arraysize + 1, sizeof(*array));
   arrayidx = 0;
   while (*str)
   {
@@ -297,7 +297,7 @@ static struct DnArray *parse_dn(const char *str)
     {
       /* neomutt lacks a real mutt_mem_realloc - so we need to copy */
       arraysize += 5;
-      struct DnArray *a2 = mutt_mem_malloc((arraysize + 1) * sizeof(*array));
+      struct DnArray *a2 = mutt_mem_mallocarray(arraysize + 1, sizeof(*array));
       for (int i = 0; i < arrayidx; i++)
       {
         a2[i].key = array[i].key;

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1559,7 +1559,7 @@ char *pgp_class_find_keys(const struct AddressList *addrlist, bool oppenc_mode)
 
     bypass_selection:
       keylist_size += mutt_str_len(keyid) + 4;
-      mutt_mem_reallocarray(&keylist, keylist_size, sizeof(char));
+      MUTT_MEM_REALLOC(&keylist, keylist_size, char);
       sprintf(keylist + keylist_used, "%s0x%s", keylist_used ? " " : "", keyid);
       keylist_used = mutt_str_len(keylist);
 

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1559,7 +1559,7 @@ char *pgp_class_find_keys(const struct AddressList *addrlist, bool oppenc_mode)
 
     bypass_selection:
       keylist_size += mutt_str_len(keyid) + 4;
-      mutt_mem_realloc(&keylist, keylist_size);
+      mutt_mem_reallocarray(&keylist, keylist_size, sizeof(char));
       sprintf(keylist + keylist_used, "%s0x%s", keylist_used ? " " : "", keyid);
       keylist_used = mutt_str_len(keylist);
 

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -233,7 +233,7 @@ struct PgpKeyInfo *pgp_ask_for_key(char *tag, const char *whatfor,
       }
       else
       {
-        l = mutt_mem_malloc(sizeof(struct PgpCache));
+        l = mutt_mem_mallocarray(1, sizeof(struct PgpCache));
         l->next = IdDefaults;
         IdDefaults = l;
         l->what = mutt_str_dup(whatfor);

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -233,7 +233,7 @@ struct PgpKeyInfo *pgp_ask_for_key(char *tag, const char *whatfor,
       }
       else
       {
-        l = mutt_mem_mallocarray(1, sizeof(struct PgpCache));
+        l = MUTT_MEM_MALLOC(1, struct PgpCache);
         l->next = IdDefaults;
         IdDefaults = l;
         l->what = mutt_str_dup(whatfor);

--- a/ncrypt/pgplib.c
+++ b/ncrypt/pgplib.c
@@ -131,7 +131,7 @@ struct PgpUid *pgp_copy_uids(struct PgpUid *up, struct PgpKeyInfo *parent)
 
   for (; up; up = up->next)
   {
-    *lp = mutt_mem_calloc(1, sizeof(struct PgpUid));
+    *lp = MUTT_MEM_CALLOC(1, struct PgpUid);
     (*lp)->trust = up->trust;
     (*lp)->flags = up->flags;
     (*lp)->addr = mutt_str_dup(up->addr);

--- a/ncrypt/pgppacket.c
+++ b/ncrypt/pgppacket.c
@@ -54,7 +54,7 @@ static int read_material(size_t material, size_t *used, FILE *fp)
   {
     PacketBufLen = *used + material + CHUNK_SIZE;
 
-    mutt_mem_reallocarray(&PacketBuf, PacketBufLen, sizeof(unsigned char));
+    MUTT_MEM_REALLOC(&PacketBuf, PacketBufLen, unsigned char);
   }
 
   if (fread(PacketBuf + *used, 1, material, fp) < material)

--- a/ncrypt/pgppacket.c
+++ b/ncrypt/pgppacket.c
@@ -54,7 +54,7 @@ static int read_material(size_t material, size_t *used, FILE *fp)
   {
     PacketBufLen = *used + material + CHUNK_SIZE;
 
-    mutt_mem_realloc(&PacketBuf, PacketBufLen);
+    mutt_mem_reallocarray(&PacketBuf, PacketBufLen, sizeof(unsigned char));
   }
 
   if (fread(PacketBuf + *used, 1, material, fp) < material)

--- a/ncrypt/pgppacket.c
+++ b/ncrypt/pgppacket.c
@@ -90,7 +90,7 @@ unsigned char *pgp_read_packet(FILE *fp, size_t *len)
   if (PacketBufLen == 0)
   {
     PacketBufLen = CHUNK_SIZE;
-    PacketBuf = mutt_mem_malloc(PacketBufLen);
+    PacketBuf = mutt_mem_mallocarray(PacketBufLen, sizeof(unsigned char));
   }
 
   if (fread(&ctb, 1, 1, fp) < 1)

--- a/ncrypt/pgppacket.c
+++ b/ncrypt/pgppacket.c
@@ -90,7 +90,7 @@ unsigned char *pgp_read_packet(FILE *fp, size_t *len)
   if (PacketBufLen == 0)
   {
     PacketBufLen = CHUNK_SIZE;
-    PacketBuf = mutt_mem_mallocarray(PacketBufLen, sizeof(unsigned char));
+    PacketBuf = MUTT_MEM_MALLOC(PacketBufLen, unsigned char);
   }
 
   if (fread(&ctb, 1, 1, fp) < 1)

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -824,7 +824,7 @@ char *smime_class_find_keys(const struct AddressList *al, bool oppenc_mode)
 
     keyid = key->hash;
     keylist_size += mutt_str_len(keyid) + 2;
-    mutt_mem_realloc(&keylist, keylist_size);
+    mutt_mem_reallocarray(&keylist, keylist_size, sizeof(char));
     sprintf(keylist + keylist_used, "%s%s", keylist_used ? " " : "", keyid);
     keylist_used = mutt_str_len(keylist);
 

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -824,7 +824,7 @@ char *smime_class_find_keys(const struct AddressList *al, bool oppenc_mode)
 
     keyid = key->hash;
     keylist_size += mutt_str_len(keyid) + 2;
-    mutt_mem_reallocarray(&keylist, keylist_size, sizeof(char));
+    MUTT_MEM_REALLOC(&keylist, keylist_size, char);
     sprintf(keylist + keylist_used, "%s%s", keylist_used ? " " : "", keyid);
     keylist_used = mutt_str_len(keylist);
 

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -135,7 +135,7 @@ static struct SmimeKey *smime_copy_key(struct SmimeKey *key)
 
   struct SmimeKey *copy = NULL;
 
-  copy = mutt_mem_calloc(1, sizeof(struct SmimeKey));
+  copy = MUTT_MEM_CALLOC(1, struct SmimeKey);
   copy->email = mutt_str_dup(key->email);
   copy->hash = mutt_str_dup(key->hash);
   copy->label = mutt_str_dup(key->label);
@@ -404,7 +404,7 @@ static struct SmimeKey *smime_parse_key(char *buf)
   char *pend = NULL, *p = NULL;
   int field = 0;
 
-  struct SmimeKey *key = mutt_mem_calloc(1, sizeof(struct SmimeKey));
+  struct SmimeKey *key = MUTT_MEM_CALLOC(1, struct SmimeKey);
 
   for (p = buf; p; p = pend)
   {
@@ -916,7 +916,7 @@ static int smime_handle_cert_email(const char *certificate, const char *mailbox,
   if (copy && buffer && num)
   {
     (*num) = count;
-    *buffer = mutt_mem_calloc(count, sizeof(char *));
+    *buffer = MUTT_MEM_CALLOC(count, char *);
     count = 0;
 
     rewind(fp_out);
@@ -925,7 +925,7 @@ static int smime_handle_cert_email(const char *certificate, const char *mailbox,
       size_t len = mutt_str_len(email);
       if (len && (email[len - 1] == '\n'))
         email[len - 1] = '\0';
-      (*buffer)[count] = mutt_mem_calloc(mutt_str_len(email) + 1, sizeof(char));
+      (*buffer)[count] = MUTT_MEM_CALLOC(mutt_str_len(email) + 1, char);
       strncpy((*buffer)[count], email, mutt_str_len(email));
       count++;
     }

--- a/nntp/adata.c
+++ b/nntp/adata.c
@@ -64,7 +64,7 @@ void nntp_adata_free(void **ptr)
  */
 struct NntpAccountData *nntp_adata_new(struct Connection *conn)
 {
-  struct NntpAccountData *adata = mutt_mem_calloc(1, sizeof(struct NntpAccountData));
+  struct NntpAccountData *adata = MUTT_MEM_CALLOC(1, struct NntpAccountData);
   adata->conn = conn;
   adata->groups_hash = mutt_hash_new(1009, MUTT_HASH_NO_FLAGS);
   mutt_hash_set_destructor(adata->groups_hash, nntp_hashelem_free, 0);

--- a/nntp/adata.c
+++ b/nntp/adata.c
@@ -69,7 +69,6 @@ struct NntpAccountData *nntp_adata_new(struct Connection *conn)
   adata->groups_hash = mutt_hash_new(1009, MUTT_HASH_NO_FLAGS);
   mutt_hash_set_destructor(adata->groups_hash, nntp_hashelem_free, 0);
   adata->groups_max = 16;
-  adata->groups_list = mutt_mem_mallocarray(adata->groups_max,
-                                            sizeof(struct NntpMboxData *));
+  adata->groups_list = MUTT_MEM_MALLOC(adata->groups_max, struct NntpMboxData *);
   return adata;
 }

--- a/nntp/adata.c
+++ b/nntp/adata.c
@@ -69,6 +69,7 @@ struct NntpAccountData *nntp_adata_new(struct Connection *conn)
   adata->groups_hash = mutt_hash_new(1009, MUTT_HASH_NO_FLAGS);
   mutt_hash_set_destructor(adata->groups_hash, nntp_hashelem_free, 0);
   adata->groups_max = 16;
-  adata->groups_list = mutt_mem_malloc(adata->groups_max * sizeof(struct NntpMboxData *));
+  adata->groups_list = mutt_mem_mallocarray(adata->groups_max,
+                                            sizeof(struct NntpMboxData *));
   return adata;
 }

--- a/nntp/adata.h
+++ b/nntp/adata.h
@@ -57,7 +57,7 @@ struct NntpAccountData
   time_t check_time;
   unsigned int groups_num;
   unsigned int groups_max;
-  void **groups_list;
+  struct NntpMboxData **groups_list;
   struct HashTable *groups_hash; ///< Hash Table: "newsgroup" -> NntpMboxData
   struct Connection *conn;       ///< Connection to NNTP Server
 };

--- a/nntp/edata.c
+++ b/nntp/edata.c
@@ -49,7 +49,7 @@ void nntp_edata_free(void **ptr)
  */
 struct NntpEmailData *nntp_edata_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct NntpEmailData));
+  return MUTT_MEM_CALLOC(1, struct NntpEmailData);
 }
 
 /**

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -92,7 +92,7 @@ static struct NntpMboxData *mdata_find(struct NntpAccountData *adata, const char
   if (adata->groups_num >= adata->groups_max)
   {
     adata->groups_max *= 2;
-    mutt_mem_realloc(&adata->groups_list, adata->groups_max * sizeof(mdata));
+    mutt_mem_reallocarray(&adata->groups_list, adata->groups_max, sizeof(mdata));
   }
   adata->groups_list[adata->groups_num++] = mdata;
 
@@ -288,7 +288,7 @@ int nntp_newsrc_parse(struct NntpAccountData *adata)
     if (mdata->last_message == 0)
       mdata->last_message = mdata->newsrc_ent[j - 1].last;
     mdata->newsrc_len = j;
-    mutt_mem_realloc(&mdata->newsrc_ent, j * sizeof(struct NewsrcEntry));
+    mutt_mem_reallocarray(&mdata->newsrc_ent, j, sizeof(struct NewsrcEntry));
     nntp_group_unread_stat(mdata);
     mutt_debug(LL_DEBUG2, "%s\n", mdata->group);
   }
@@ -345,7 +345,7 @@ void nntp_newsrc_gen_entries(struct Mailbox *m)
         if (mdata->newsrc_len >= entries)
         {
           entries *= 2;
-          mutt_mem_realloc(&mdata->newsrc_ent, entries * sizeof(struct NewsrcEntry));
+          mutt_mem_reallocarray(&mdata->newsrc_ent, entries, sizeof(struct NewsrcEntry));
         }
         mdata->newsrc_ent[mdata->newsrc_len].first = first;
         mdata->newsrc_ent[mdata->newsrc_len].last = last - 1;
@@ -370,13 +370,13 @@ void nntp_newsrc_gen_entries(struct Mailbox *m)
     if (mdata->newsrc_len >= entries)
     {
       entries++;
-      mutt_mem_realloc(&mdata->newsrc_ent, entries * sizeof(struct NewsrcEntry));
+      mutt_mem_reallocarray(&mdata->newsrc_ent, entries, sizeof(struct NewsrcEntry));
     }
     mdata->newsrc_ent[mdata->newsrc_len].first = first;
     mdata->newsrc_ent[mdata->newsrc_len].last = mdata->last_loaded;
     mdata->newsrc_len++;
   }
-  mutt_mem_realloc(&mdata->newsrc_ent, mdata->newsrc_len * sizeof(struct NewsrcEntry));
+  mutt_mem_reallocarray(&mdata->newsrc_ent, mdata->newsrc_len, sizeof(struct NewsrcEntry));
 
   if (c_sort != SORT_ORDER)
   {
@@ -465,7 +465,7 @@ int nntp_newsrc_update(struct NntpAccountData *adata)
     if ((off + strlen(mdata->group) + 3) > buflen)
     {
       buflen *= 2;
-      mutt_mem_realloc(&buf, buflen);
+      mutt_mem_reallocarray(&buf, buflen, sizeof(char));
     }
     snprintf(buf + off, buflen - off, "%s%c ", mdata->group, mdata->subscribed ? ':' : '!');
     off += strlen(buf + off);
@@ -476,7 +476,7 @@ int nntp_newsrc_update(struct NntpAccountData *adata)
       if ((off + 1024) > buflen)
       {
         buflen *= 2;
-        mutt_mem_realloc(&buf, buflen);
+        mutt_mem_reallocarray(&buf, buflen, sizeof(char));
       }
       if (j)
         buf[off++] = ',';
@@ -666,7 +666,7 @@ int nntp_active_save_cache(struct NntpAccountData *adata)
     if ((off + strlen(mdata->group) + (mdata->desc ? strlen(mdata->desc) : 0) + 50) > buflen)
     {
       buflen *= 2;
-      mutt_mem_realloc(&buf, buflen);
+      mutt_mem_reallocarray(&buf, buflen, sizeof(char));
     }
     snprintf(buf + off, buflen - off, "%s " ANUM_FMT " " ANUM_FMT " %c%s%s\n",
              mdata->group, mdata->last_message, mdata->first_message,
@@ -1352,7 +1352,7 @@ struct NntpMboxData *mutt_newsgroup_catchup(struct Mailbox *m,
 
   if (mdata->newsrc_ent)
   {
-    mutt_mem_realloc(&mdata->newsrc_ent, sizeof(struct NewsrcEntry));
+    mutt_mem_reallocarray(&mdata->newsrc_ent, 1, sizeof(struct NewsrcEntry));
     mdata->newsrc_len = 1;
     mdata->newsrc_ent[0].first = 1;
     mdata->newsrc_ent[0].last = mdata->last_message;
@@ -1391,7 +1391,7 @@ struct NntpMboxData *mutt_newsgroup_uncatchup(struct Mailbox *m,
 
   if (mdata->newsrc_ent)
   {
-    mutt_mem_realloc(&mdata->newsrc_ent, sizeof(struct NewsrcEntry));
+    mutt_mem_reallocarray(&mdata->newsrc_ent, 1, sizeof(struct NewsrcEntry));
     mdata->newsrc_len = 1;
     mdata->newsrc_ent[0].first = 1;
     mdata->newsrc_ent[0].last = mdata->first_message - 1;

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -252,7 +252,7 @@ int nntp_newsrc_parse(struct NntpAccountData *adata)
     while (*b)
       if (*b++ == ',')
         j++;
-    mdata->newsrc_ent = mutt_mem_calloc(j, sizeof(struct NewsrcEntry));
+    mdata->newsrc_ent = MUTT_MEM_CALLOC(j, struct NewsrcEntry);
     mdata->subscribed = subs;
 
     /* parse entries */
@@ -321,7 +321,7 @@ void nntp_newsrc_gen_entries(struct Mailbox *m)
   if (!entries)
   {
     entries = 5;
-    mdata->newsrc_ent = mutt_mem_calloc(entries, sizeof(struct NewsrcEntry));
+    mdata->newsrc_ent = MUTT_MEM_CALLOC(entries, struct NewsrcEntry);
   }
 
   /* Set up to fake initial sequence from 1 to the article before the
@@ -450,7 +450,7 @@ int nntp_newsrc_update(struct NntpAccountData *adata)
   int rc = -1;
 
   size_t buflen = 10240;
-  char *buf = mutt_mem_calloc(1, buflen);
+  char *buf = MUTT_MEM_CALLOC(buflen, char);
   size_t off = 0;
 
   /* we will generate full newsrc here */
@@ -652,7 +652,7 @@ int nntp_active_save_cache(struct NntpAccountData *adata)
     return 0;
 
   size_t buflen = 10240;
-  char *buf = mutt_mem_calloc(1, buflen);
+  char *buf = MUTT_MEM_CALLOC(buflen, char);
   snprintf(buf, buflen, "%lu\n", (unsigned long) adata->newgroups_time);
   size_t off = strlen(buf);
 
@@ -1298,7 +1298,7 @@ struct NntpMboxData *mutt_newsgroup_subscribe(struct NntpAccountData *adata, cha
   mdata->subscribed = true;
   if (!mdata->newsrc_ent)
   {
-    mdata->newsrc_ent = mutt_mem_calloc(1, sizeof(struct NewsrcEntry));
+    mdata->newsrc_ent = MUTT_MEM_CALLOC(1, struct NewsrcEntry);
     mdata->newsrc_len = 1;
     mdata->newsrc_ent[0].first = 1;
     mdata->newsrc_ent[0].last = 0;

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -226,7 +226,7 @@ int nntp_newsrc_parse(struct NntpAccountData *adata)
     FREE(&mdata->newsrc_ent);
   }
 
-  line = mutt_mem_mallocarray(st.st_size + 1, sizeof(char));
+  line = MUTT_MEM_MALLOC(st.st_size + 1, char);
   while (st.st_size && fgets(line, st.st_size + 1, adata->fp_newsrc))
   {
     char *b = NULL, *h = NULL;

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -288,7 +288,7 @@ int nntp_newsrc_parse(struct NntpAccountData *adata)
     if (mdata->last_message == 0)
       mdata->last_message = mdata->newsrc_ent[j - 1].last;
     mdata->newsrc_len = j;
-    mutt_mem_reallocarray(&mdata->newsrc_ent, j, sizeof(struct NewsrcEntry));
+    MUTT_MEM_REALLOC(&mdata->newsrc_ent, j, struct NewsrcEntry);
     nntp_group_unread_stat(mdata);
     mutt_debug(LL_DEBUG2, "%s\n", mdata->group);
   }
@@ -345,7 +345,7 @@ void nntp_newsrc_gen_entries(struct Mailbox *m)
         if (mdata->newsrc_len >= entries)
         {
           entries *= 2;
-          mutt_mem_reallocarray(&mdata->newsrc_ent, entries, sizeof(struct NewsrcEntry));
+          MUTT_MEM_REALLOC(&mdata->newsrc_ent, entries, struct NewsrcEntry);
         }
         mdata->newsrc_ent[mdata->newsrc_len].first = first;
         mdata->newsrc_ent[mdata->newsrc_len].last = last - 1;
@@ -370,13 +370,13 @@ void nntp_newsrc_gen_entries(struct Mailbox *m)
     if (mdata->newsrc_len >= entries)
     {
       entries++;
-      mutt_mem_reallocarray(&mdata->newsrc_ent, entries, sizeof(struct NewsrcEntry));
+      MUTT_MEM_REALLOC(&mdata->newsrc_ent, entries, struct NewsrcEntry);
     }
     mdata->newsrc_ent[mdata->newsrc_len].first = first;
     mdata->newsrc_ent[mdata->newsrc_len].last = mdata->last_loaded;
     mdata->newsrc_len++;
   }
-  mutt_mem_reallocarray(&mdata->newsrc_ent, mdata->newsrc_len, sizeof(struct NewsrcEntry));
+  MUTT_MEM_REALLOC(&mdata->newsrc_ent, mdata->newsrc_len, struct NewsrcEntry);
 
   if (c_sort != SORT_ORDER)
   {
@@ -465,7 +465,7 @@ int nntp_newsrc_update(struct NntpAccountData *adata)
     if ((off + strlen(mdata->group) + 3) > buflen)
     {
       buflen *= 2;
-      mutt_mem_reallocarray(&buf, buflen, sizeof(char));
+      MUTT_MEM_REALLOC(&buf, buflen, char);
     }
     snprintf(buf + off, buflen - off, "%s%c ", mdata->group, mdata->subscribed ? ':' : '!');
     off += strlen(buf + off);
@@ -476,7 +476,7 @@ int nntp_newsrc_update(struct NntpAccountData *adata)
       if ((off + 1024) > buflen)
       {
         buflen *= 2;
-        mutt_mem_reallocarray(&buf, buflen, sizeof(char));
+        MUTT_MEM_REALLOC(&buf, buflen, char);
       }
       if (j)
         buf[off++] = ',';
@@ -666,7 +666,7 @@ int nntp_active_save_cache(struct NntpAccountData *adata)
     if ((off + strlen(mdata->group) + (mdata->desc ? strlen(mdata->desc) : 0) + 50) > buflen)
     {
       buflen *= 2;
-      mutt_mem_reallocarray(&buf, buflen, sizeof(char));
+      MUTT_MEM_REALLOC(&buf, buflen, char);
     }
     snprintf(buf + off, buflen - off, "%s " ANUM_FMT " " ANUM_FMT " %c%s%s\n",
              mdata->group, mdata->last_message, mdata->first_message,
@@ -1352,7 +1352,7 @@ struct NntpMboxData *mutt_newsgroup_catchup(struct Mailbox *m,
 
   if (mdata->newsrc_ent)
   {
-    mutt_mem_reallocarray(&mdata->newsrc_ent, 1, sizeof(struct NewsrcEntry));
+    MUTT_MEM_REALLOC(&mdata->newsrc_ent, 1, struct NewsrcEntry);
     mdata->newsrc_len = 1;
     mdata->newsrc_ent[0].first = 1;
     mdata->newsrc_ent[0].last = mdata->last_message;
@@ -1391,7 +1391,7 @@ struct NntpMboxData *mutt_newsgroup_uncatchup(struct Mailbox *m,
 
   if (mdata->newsrc_ent)
   {
-    mutt_mem_reallocarray(&mdata->newsrc_ent, 1, sizeof(struct NewsrcEntry));
+    MUTT_MEM_REALLOC(&mdata->newsrc_ent, 1, struct NewsrcEntry);
     mdata->newsrc_len = 1;
     mdata->newsrc_ent[0].first = 1;
     mdata->newsrc_ent[0].last = mdata->first_message - 1;

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -92,7 +92,7 @@ static struct NntpMboxData *mdata_find(struct NntpAccountData *adata, const char
   if (adata->groups_num >= adata->groups_max)
   {
     adata->groups_max *= 2;
-    mutt_mem_reallocarray(&adata->groups_list, adata->groups_max, sizeof(mdata));
+    MUTT_MEM_REALLOC(&adata->groups_list, adata->groups_max, struct NntpMboxData *);
   }
   adata->groups_list[adata->groups_num++] = mdata;
 

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -226,7 +226,7 @@ int nntp_newsrc_parse(struct NntpAccountData *adata)
     FREE(&mdata->newsrc_ent);
   }
 
-  line = mutt_mem_malloc(st.st_size + 1);
+  line = mutt_mem_mallocarray(st.st_size + 1, sizeof(char));
   while (st.st_size && fgets(line, st.st_size + 1, adata->fp_newsrc))
   {
     char *b = NULL, *h = NULL;

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -348,7 +348,7 @@ static int nntp_attempt_features(struct NntpAccountData *adata)
         if ((buflen - off) < 1024)
         {
           buflen *= 2;
-          mutt_mem_realloc(&adata->overview_fmt, buflen);
+          mutt_mem_reallocarray(&adata->overview_fmt, buflen, sizeof(char));
         }
 
         const int chunk = mutt_socket_readln_d(adata->overview_fmt + off,
@@ -387,7 +387,7 @@ static int nntp_attempt_features(struct NntpAccountData *adata)
         }
       }
       adata->overview_fmt[off++] = '\0';
-      mutt_mem_realloc(&adata->overview_fmt, off);
+      mutt_mem_reallocarray(&adata->overview_fmt, off, sizeof(char));
     }
   }
   rc = 0; // Success
@@ -880,7 +880,7 @@ static int nntp_fetch_lines(struct NntpMboxData *mdata, char *query, size_t qlen
         off = 0;
       }
 
-      mutt_mem_realloc(&line, off + sizeof(buf));
+      mutt_mem_reallocarray(&line, off + sizeof(buf), sizeof(char));
     }
     FREE(&line);
     func(NULL, data);
@@ -1457,7 +1457,7 @@ static int nntp_group_poll(struct NntpMboxData *mdata, bool update_stat)
     mdata->last_cached = 0;
     if (mdata->newsrc_len)
     {
-      mutt_mem_realloc(&mdata->newsrc_ent, sizeof(struct NewsrcEntry));
+      mutt_mem_reallocarray(&mdata->newsrc_ent, 1, sizeof(struct NewsrcEntry));
       mdata->newsrc_len = 1;
       mdata->newsrc_ent[0].first = 1;
       mdata->newsrc_ent[0].last = 0;
@@ -1751,7 +1751,7 @@ static int fetch_children(char *line, void *data)
   if (cc->num >= cc->max)
   {
     cc->max *= 2;
-    mutt_mem_realloc(&cc->child, sizeof(anum_t) * cc->max);
+    mutt_mem_reallocarray(&cc->child, cc->max, sizeof(anum_t));
   }
   cc->child[cc->num++] = anum;
   return 0;

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -348,7 +348,7 @@ static int nntp_attempt_features(struct NntpAccountData *adata)
         if ((buflen - off) < 1024)
         {
           buflen *= 2;
-          mutt_mem_reallocarray(&adata->overview_fmt, buflen, sizeof(char));
+          MUTT_MEM_REALLOC(&adata->overview_fmt, buflen, char);
         }
 
         const int chunk = mutt_socket_readln_d(adata->overview_fmt + off,
@@ -387,7 +387,7 @@ static int nntp_attempt_features(struct NntpAccountData *adata)
         }
       }
       adata->overview_fmt[off++] = '\0';
-      mutt_mem_reallocarray(&adata->overview_fmt, off, sizeof(char));
+      MUTT_MEM_REALLOC(&adata->overview_fmt, off, char);
     }
   }
   rc = 0; // Success
@@ -880,7 +880,7 @@ static int nntp_fetch_lines(struct NntpMboxData *mdata, char *query, size_t qlen
         off = 0;
       }
 
-      mutt_mem_reallocarray(&line, off + sizeof(buf), sizeof(char));
+      MUTT_MEM_REALLOC(&line, off + sizeof(buf), char);
     }
     FREE(&line);
     func(NULL, data);
@@ -1457,7 +1457,7 @@ static int nntp_group_poll(struct NntpMboxData *mdata, bool update_stat)
     mdata->last_cached = 0;
     if (mdata->newsrc_len)
     {
-      mutt_mem_reallocarray(&mdata->newsrc_ent, 1, sizeof(struct NewsrcEntry));
+      MUTT_MEM_REALLOC(&mdata->newsrc_ent, 1, struct NewsrcEntry);
       mdata->newsrc_len = 1;
       mdata->newsrc_ent[0].first = 1;
       mdata->newsrc_ent[0].last = 0;
@@ -1751,7 +1751,7 @@ static int fetch_children(char *line, void *data)
   if (cc->num >= cc->max)
   {
     cc->max *= 2;
-    mutt_mem_reallocarray(&cc->child, cc->max, sizeof(anum_t));
+    MUTT_MEM_REALLOC(&cc->child, cc->max, anum_t);
   }
   cc->child[cc->num++] = anum;
   return 0;

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1223,7 +1223,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
   fc.first = first;
   fc.last = last;
   fc.restore = restore;
-  fc.messages = mutt_mem_calloc(last - first + 1, sizeof(unsigned char));
+  fc.messages = MUTT_MEM_CALLOC(last - first + 1, unsigned char);
   if (!fc.messages)
     return -1;
   fc.hc = hc;
@@ -1545,7 +1545,7 @@ static enum MxStatus check_mailbox(struct Mailbox *m)
     const long c_nntp_context = cs_subset_long(NeoMutt->sub, "nntp_context");
     if (c_nntp_context && ((mdata->last_message - first + 1) > c_nntp_context))
       first = mdata->last_message - c_nntp_context + 1;
-    messages = mutt_mem_calloc(mdata->last_loaded - first + 1, sizeof(unsigned char));
+    messages = MUTT_MEM_CALLOC(mdata->last_loaded - first + 1, unsigned char);
     hc = nntp_hcache_open(mdata);
     nntp_hcache_update(mdata, hc);
 #endif

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -341,7 +341,7 @@ static int nntp_attempt_features(struct NntpAccountData *adata)
       size_t buflen = 2048, off = 0, b = 0;
 
       FREE(&adata->overview_fmt);
-      adata->overview_fmt = mutt_mem_mallocarray(buflen, sizeof(char));
+      adata->overview_fmt = MUTT_MEM_MALLOC(buflen, char);
 
       while (true)
       {
@@ -834,7 +834,7 @@ static int nntp_fetch_lines(struct NntpMboxData *mdata, char *query, size_t qlen
       return 1;
     }
 
-    line = mutt_mem_mallocarray(sizeof(buf), sizeof(char));
+    line = MUTT_MEM_MALLOC(sizeof(buf), char);
     rc = 0;
 
     if (msg)
@@ -2303,7 +2303,7 @@ int nntp_check_children(struct Mailbox *m, const char *msgid)
   cc.mailbox = m;
   cc.num = 0;
   cc.max = 10;
-  cc.child = mutt_mem_mallocarray(cc.max, sizeof(anum_t));
+  cc.child = MUTT_MEM_MALLOC(cc.max, anum_t);
 
   /* fetch numbers of child messages */
   snprintf(buf, sizeof(buf), "XPAT References " ANUM_FMT "-" ANUM_FMT " *%s*\r\n",

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -341,7 +341,7 @@ static int nntp_attempt_features(struct NntpAccountData *adata)
       size_t buflen = 2048, off = 0, b = 0;
 
       FREE(&adata->overview_fmt);
-      adata->overview_fmt = mutt_mem_malloc(buflen);
+      adata->overview_fmt = mutt_mem_mallocarray(buflen, sizeof(char));
 
       while (true)
       {
@@ -834,7 +834,7 @@ static int nntp_fetch_lines(struct NntpMboxData *mdata, char *query, size_t qlen
       return 1;
     }
 
-    line = mutt_mem_malloc(sizeof(buf));
+    line = mutt_mem_mallocarray(sizeof(buf), sizeof(char));
     rc = 0;
 
     if (msg)
@@ -2303,7 +2303,7 @@ int nntp_check_children(struct Mailbox *m, const char *msgid)
   cc.mailbox = m;
   cc.num = 0;
   cc.max = 10;
-  cc.child = mutt_mem_malloc(sizeof(anum_t) * cc.max);
+  cc.child = mutt_mem_mallocarray(cc.max, sizeof(anum_t));
 
   /* fetch numbers of child messages */
   snprintf(buf, sizeof(buf), "XPAT References " ANUM_FMT "-" ANUM_FMT " *%s*\r\n",

--- a/notmuch/adata.c
+++ b/notmuch/adata.c
@@ -57,9 +57,7 @@ void nm_adata_free(void **ptr)
  */
 struct NmAccountData *nm_adata_new(void)
 {
-  struct NmAccountData *adata = mutt_mem_calloc(1, sizeof(struct NmAccountData));
-
-  return adata;
+  return MUTT_MEM_CALLOC(1, struct NmAccountData);
 }
 
 /**

--- a/notmuch/complete.c
+++ b/notmuch/complete.c
@@ -64,7 +64,7 @@ int complete_all_nm_tags(struct CompletionData *cd, const char *pt)
     goto done;
 
   /* Get all the tags. */
-  const char **nm_tags = mutt_mem_calloc(tag_count_1, sizeof(char *));
+  const char **nm_tags = MUTT_MEM_CALLOC(tag_count_1, const char *);
   if ((nm_get_all_tags(m_cur, nm_tags, &tag_count_2) != 0) || (tag_count_1 != tag_count_2))
   {
     completion_data_free_match_strings(cd);

--- a/notmuch/edata.c
+++ b/notmuch/edata.c
@@ -60,7 +60,7 @@ void nm_edata_free(void **ptr)
  */
 struct NmEmailData *nm_edata_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct NmEmailData));
+  return MUTT_MEM_CALLOC(1, struct NmEmailData);
 }
 
 /**

--- a/notmuch/mdata.c
+++ b/notmuch/mdata.c
@@ -70,7 +70,7 @@ struct NmMboxData *nm_mdata_new(const char *url)
   if (!url)
     return NULL;
 
-  struct NmMboxData *mdata = mutt_mem_calloc(1, sizeof(struct NmMboxData));
+  struct NmMboxData *mdata = MUTT_MEM_CALLOC(1, struct NmMboxData);
   mutt_debug(LL_DEBUG1, "nm: initialize mailbox mdata %p\n", (void *) mdata);
 
   const short c_nm_db_limit = cs_subset_number(NeoMutt->sub, "nm_db_limit");

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -145,7 +145,7 @@ static char *nm_get_default_url(void)
 {
   // path to DB + query + url "decoration"
   size_t len = PATH_MAX + 1024 + 32;
-  char *url = mutt_mem_mallocarray(len, sizeof(char));
+  char *url = MUTT_MEM_MALLOC(len, char);
 
   // Try to use `$nm_default_url` or `$folder`.
   // If neither are set, it is impossible to create a Notmuch URL.

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -145,7 +145,7 @@ static char *nm_get_default_url(void)
 {
   // path to DB + query + url "decoration"
   size_t len = PATH_MAX + 1024 + 32;
-  char *url = mutt_mem_malloc(len);
+  char *url = mutt_mem_mallocarray(len, sizeof(char));
 
   // Try to use `$nm_default_url` or `$folder`.
   // If neither are set, it is impossible to create a Notmuch URL.

--- a/pager/display.c
+++ b/pager/display.c
@@ -1070,7 +1070,8 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
 
   if (*lines_used == *lines_max)
   {
-    MUTT_MEM_REALLOC(lines, (*lines_max += LINES), struct Line);
+    *lines_max += LINES;
+    MUTT_MEM_REALLOC(lines, *lines_max, struct Line);
     for (ch = *lines_used; ch < *lines_max; ch++)
     {
       memset(&((*lines)[ch]), 0, sizeof(struct Line));

--- a/pager/display.c
+++ b/pager/display.c
@@ -1076,7 +1076,7 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
       memset(&((*lines)[ch]), 0, sizeof(struct Line));
       (*lines)[ch].cid = -1;
       (*lines)[ch].search_arr_size = -1;
-      (*lines)[ch].syntax = mutt_mem_calloc(1, sizeof(struct TextSyntax));
+      (*lines)[ch].syntax = MUTT_MEM_CALLOC(1, struct TextSyntax);
       ((*lines)[ch].syntax)[0].first = -1;
       ((*lines)[ch].syntax)[0].last = -1;
     }
@@ -1207,7 +1207,7 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
       }
       else
       {
-        cur_line->search = mutt_mem_calloc(1, sizeof(struct TextSyntax));
+        cur_line->search = MUTT_MEM_CALLOC(1, struct TextSyntax);
       }
       pmatch[0].rm_so += offset;
       pmatch[0].rm_eo += offset;

--- a/pager/display.c
+++ b/pager/display.c
@@ -436,8 +436,8 @@ static void match_body_patterns(char *pat, struct Line *lines, int line_num)
         }
         if (++(lines[line_num].syntax_arr_size) > 1)
         {
-          mutt_mem_reallocarray(&(lines[line_num].syntax), lines[line_num].syntax_arr_size,
-                                sizeof(struct TextSyntax));
+          MUTT_MEM_REALLOC(&(lines[line_num].syntax),
+                           lines[line_num].syntax_arr_size, struct TextSyntax);
           // Zero the new entry
           const int index = lines[line_num].syntax_arr_size - 1;
           struct TextSyntax *ts = &lines[line_num].syntax[index];
@@ -587,7 +587,7 @@ static void resolve_types(struct MuttWindow *win, char *buf, char *raw,
       if (lines[i].syntax_arr_size)
       {
         lines[i].syntax_arr_size = 0;
-        mutt_mem_reallocarray(&(lines[line_num].syntax), 1, sizeof(struct TextSyntax));
+        MUTT_MEM_REALLOC(&(lines[line_num].syntax), 1, struct TextSyntax);
       }
       lines[i++].cid = MT_COLOR_SIGNATURE;
     }
@@ -655,8 +655,8 @@ static void resolve_types(struct MuttWindow *win, char *buf, char *raw,
           {
             if (++(lines[line_num].syntax_arr_size) > 1)
             {
-              mutt_mem_reallocarray(&(lines[line_num].syntax), lines[line_num].syntax_arr_size,
-                                    sizeof(struct TextSyntax));
+              MUTT_MEM_REALLOC(&(lines[line_num].syntax),
+                               lines[line_num].syntax_arr_size, struct TextSyntax);
               // Zero the new entry
               const int index = lines[line_num].syntax_arr_size - 1;
               struct TextSyntax *ts = &lines[line_num].syntax[index];
@@ -1070,7 +1070,7 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
 
   if (*lines_used == *lines_max)
   {
-    mutt_mem_reallocarray(lines, (*lines_max += LINES), sizeof(struct Line));
+    MUTT_MEM_REALLOC(lines, (*lines_max += LINES), struct Line);
     for (ch = *lines_used; ch < *lines_max; ch++)
     {
       memset(&((*lines)[ch]), 0, sizeof(struct Line));
@@ -1198,8 +1198,7 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
     {
       if (++(cur_line->search_arr_size) > 1)
       {
-        mutt_mem_reallocarray(&(cur_line->search), cur_line->search_arr_size,
-                              sizeof(struct TextSyntax));
+        MUTT_MEM_REALLOC(&(cur_line->search), cur_line->search_arr_size, struct TextSyntax);
         // Zero the new entry
         const int index = cur_line->search_arr_size - 1;
         struct TextSyntax *ts = &cur_line->search[index];

--- a/pager/display.c
+++ b/pager/display.c
@@ -436,8 +436,8 @@ static void match_body_patterns(char *pat, struct Line *lines, int line_num)
         }
         if (++(lines[line_num].syntax_arr_size) > 1)
         {
-          mutt_mem_realloc(&(lines[line_num].syntax),
-                           (lines[line_num].syntax_arr_size) * sizeof(struct TextSyntax));
+          mutt_mem_reallocarray(&(lines[line_num].syntax), lines[line_num].syntax_arr_size,
+                                sizeof(struct TextSyntax));
           // Zero the new entry
           const int index = lines[line_num].syntax_arr_size - 1;
           struct TextSyntax *ts = &lines[line_num].syntax[index];
@@ -587,7 +587,7 @@ static void resolve_types(struct MuttWindow *win, char *buf, char *raw,
       if (lines[i].syntax_arr_size)
       {
         lines[i].syntax_arr_size = 0;
-        mutt_mem_realloc(&(lines[line_num].syntax), sizeof(struct TextSyntax));
+        mutt_mem_reallocarray(&(lines[line_num].syntax), 1, sizeof(struct TextSyntax));
       }
       lines[i++].cid = MT_COLOR_SIGNATURE;
     }
@@ -655,8 +655,8 @@ static void resolve_types(struct MuttWindow *win, char *buf, char *raw,
           {
             if (++(lines[line_num].syntax_arr_size) > 1)
             {
-              mutt_mem_realloc(&(lines[line_num].syntax),
-                               (lines[line_num].syntax_arr_size) * sizeof(struct TextSyntax));
+              mutt_mem_reallocarray(&(lines[line_num].syntax), lines[line_num].syntax_arr_size,
+                                    sizeof(struct TextSyntax));
               // Zero the new entry
               const int index = lines[line_num].syntax_arr_size - 1;
               struct TextSyntax *ts = &lines[line_num].syntax[index];
@@ -1070,7 +1070,7 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
 
   if (*lines_used == *lines_max)
   {
-    mutt_mem_realloc(lines, sizeof(struct Line) * (*lines_max += LINES));
+    mutt_mem_reallocarray(lines, (*lines_max += LINES), sizeof(struct Line));
     for (ch = *lines_used; ch < *lines_max; ch++)
     {
       memset(&((*lines)[ch]), 0, sizeof(struct Line));
@@ -1198,8 +1198,8 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
     {
       if (++(cur_line->search_arr_size) > 1)
       {
-        mutt_mem_realloc(&(cur_line->search),
-                         (cur_line->search_arr_size) * sizeof(struct TextSyntax));
+        mutt_mem_reallocarray(&(cur_line->search), cur_line->search_arr_size,
+                              sizeof(struct TextSyntax));
         // Zero the new entry
         const int index = cur_line->search_arr_size - 1;
         struct TextSyntax *ts = &cur_line->search[index];

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -318,7 +318,7 @@ int dlg_pager(struct PagerView *pview)
   //---------- initialize redraw pdata  -----------------------------------------
   pview->win_pager->size = MUTT_WIN_SIZE_MAXIMISE;
   priv->lines_max = LINES; // number of lines on screen, from curses
-  priv->lines = mutt_mem_calloc(priv->lines_max, sizeof(struct Line));
+  priv->lines = MUTT_MEM_CALLOC(priv->lines_max, struct Line);
   priv->fp = mutt_file_fopen(pview->pdata->fname, "r");
   priv->has_types = ((pview->mode == PAGER_MODE_EMAIL) || (pview->flags & MUTT_SHOWCOLOR)) ?
                         MUTT_TYPES :
@@ -328,7 +328,7 @@ int dlg_pager(struct PagerView *pview)
   {
     priv->lines[i].cid = -1;
     priv->lines[i].search_arr_size = -1;
-    priv->lines[i].syntax = mutt_mem_calloc(1, sizeof(struct TextSyntax));
+    priv->lines[i].syntax = MUTT_MEM_CALLOC(1, struct TextSyntax);
     (priv->lines[i].syntax)[0].first = -1;
     (priv->lines[i].syntax)[0].last = -1;
   }

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -155,7 +155,7 @@ static int pager_repaint(struct MuttWindow *win)
         priv->lines[i].search_arr_size = -1;
         priv->lines[i].quote = NULL;
 
-        mutt_mem_reallocarray(&(priv->lines[i].syntax), 1, sizeof(struct TextSyntax));
+        MUTT_MEM_REALLOC(&(priv->lines[i].syntax), 1, struct TextSyntax);
         if (priv->search_compiled && priv->lines[i].search)
           FREE(&(priv->lines[i].search));
       }

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -155,7 +155,7 @@ static int pager_repaint(struct MuttWindow *win)
         priv->lines[i].search_arr_size = -1;
         priv->lines[i].quote = NULL;
 
-        mutt_mem_realloc(&(priv->lines[i].syntax), sizeof(struct TextSyntax));
+        mutt_mem_reallocarray(&(priv->lines[i].syntax), 1, sizeof(struct TextSyntax));
         if (priv->search_compiled && priv->lines[i].search)
           FREE(&(priv->lines[i].search));
       }

--- a/pager/pbar.c
+++ b/pager/pbar.c
@@ -314,7 +314,7 @@ static void pbar_data_free(struct MuttWindow *win, void **ptr)
 static struct PBarPrivateData *pbar_data_new(struct IndexSharedData *shared,
                                              struct PagerPrivateData *priv)
 {
-  struct PBarPrivateData *pbar_data = mutt_mem_calloc(1, sizeof(struct PBarPrivateData));
+  struct PBarPrivateData *pbar_data = MUTT_MEM_CALLOC(1, struct PBarPrivateData);
 
   pbar_data->shared = shared;
   pbar_data->priv = priv;

--- a/pager/private_data.c
+++ b/pager/private_data.c
@@ -58,7 +58,7 @@ void pager_private_data_free(struct MuttWindow *win, void **ptr)
  */
 struct PagerPrivateData *pager_private_data_new(void)
 {
-  struct PagerPrivateData *priv = mutt_mem_calloc(1, sizeof(struct PagerPrivateData));
+  struct PagerPrivateData *priv = MUTT_MEM_CALLOC(1, struct PagerPrivateData);
 
   priv->notify = notify_new();
 

--- a/pattern/compile.c
+++ b/pattern/compile.c
@@ -93,7 +93,7 @@ static bool eat_regex(struct Pattern *pat, PatternCompFlags flags,
   }
   else
   {
-    pat->p.regex = mutt_mem_calloc(1, sizeof(regex_t));
+    pat->p.regex = MUTT_MEM_CALLOC(1, regex_t);
 #ifdef USE_DEBUG_GRAPHVIZ
     pat->raw_pattern = mutt_str_dup(buf->data);
 #endif
@@ -822,7 +822,7 @@ void mutt_pattern_free(struct PatternList **pat)
  */
 static struct Pattern *mutt_pattern_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct Pattern));
+  return MUTT_MEM_CALLOC(1, struct Pattern);
 }
 
 /**
@@ -831,7 +831,7 @@ static struct Pattern *mutt_pattern_new(void)
  */
 static struct PatternList *mutt_pattern_list_new(void)
 {
-  struct PatternList *h = mutt_mem_calloc(1, sizeof(struct PatternList));
+  struct PatternList *h = MUTT_MEM_CALLOC(1, struct PatternList);
   SLIST_INIT(h);
   struct Pattern *p = mutt_pattern_new();
   SLIST_INSERT_HEAD(h, p, entries);

--- a/pattern/dlg_pattern.c
+++ b/pattern/dlg_pattern.c
@@ -180,7 +180,7 @@ static struct Menu *create_pattern_menu(struct MuttWindow *dlg)
     num_entries++;
   /* Add three more hard-coded entries */
   num_entries += 3;
-  struct PatternEntry *entries = mutt_mem_calloc(num_entries, sizeof(struct PatternEntry));
+  struct PatternEntry *entries = MUTT_MEM_CALLOC(num_entries, struct PatternEntry);
 
   struct Menu *menu = dlg->wdata;
   menu->make_entry = pattern_make_entry;

--- a/pattern/search_state.c
+++ b/pattern/search_state.c
@@ -38,7 +38,7 @@
  */
 struct SearchState *search_state_new(void)
 {
-  struct SearchState *s = mutt_mem_calloc(1, sizeof(struct SearchState));
+  struct SearchState *s = MUTT_MEM_CALLOC(1, struct SearchState);
   s->string = buf_pool_get();
   s->string_expn = buf_pool_get();
   return s;

--- a/pop/adata.c
+++ b/pop/adata.c
@@ -62,7 +62,7 @@ void pop_adata_free(void **ptr)
  */
 struct PopAccountData *pop_adata_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct PopAccountData));
+  return MUTT_MEM_CALLOC(1, struct PopAccountData);
 }
 
 /**

--- a/pop/auth.c
+++ b/pop/auth.c
@@ -251,7 +251,7 @@ static enum PopAuthRes pop_auth_sasl(struct PopAccountData *adata, const char *m
       if ((olen * 2) > bufsize)
       {
         bufsize = olen * 2;
-        mutt_mem_reallocarray(&buf, bufsize, sizeof(char));
+        MUTT_MEM_REALLOC(&buf, bufsize, char);
       }
       if (sasl_encode64(pc, olen, buf, bufsize, &olen) != SASL_OK)
       {

--- a/pop/auth.c
+++ b/pop/auth.c
@@ -192,7 +192,7 @@ static enum PopAuthRes pop_auth_sasl(struct PopAccountData *adata, const char *m
   mutt_message(_("Authenticating (%s)..."), "SASL");
 
   size_t bufsize = MAX((olen * 2), 1024);
-  char *buf = mutt_mem_mallocarray(bufsize, sizeof(char));
+  char *buf = MUTT_MEM_MALLOC(bufsize, char);
 
   snprintf(buf, bufsize, "AUTH %s", mech);
   olen = strlen(buf);

--- a/pop/auth.c
+++ b/pop/auth.c
@@ -251,7 +251,7 @@ static enum PopAuthRes pop_auth_sasl(struct PopAccountData *adata, const char *m
       if ((olen * 2) > bufsize)
       {
         bufsize = olen * 2;
-        mutt_mem_realloc(&buf, bufsize);
+        mutt_mem_reallocarray(&buf, bufsize, sizeof(char));
       }
       if (sasl_encode64(pc, olen, buf, bufsize, &olen) != SASL_OK)
       {

--- a/pop/auth.c
+++ b/pop/auth.c
@@ -192,7 +192,7 @@ static enum PopAuthRes pop_auth_sasl(struct PopAccountData *adata, const char *m
   mutt_message(_("Authenticating (%s)..."), "SASL");
 
   size_t bufsize = MAX((olen * 2), 1024);
-  char *buf = mutt_mem_malloc(bufsize);
+  char *buf = mutt_mem_mallocarray(bufsize, sizeof(char));
 
   snprintf(buf, bufsize, "AUTH %s", mech);
   olen = strlen(buf);

--- a/pop/edata.c
+++ b/pop/edata.c
@@ -55,7 +55,7 @@ void pop_edata_free(void **ptr)
  */
 struct PopEmailData *pop_edata_new(const char *uid)
 {
-  struct PopEmailData *edata = mutt_mem_calloc(1, sizeof(struct PopEmailData));
+  struct PopEmailData *edata = MUTT_MEM_CALLOC(1, struct PopEmailData);
   edata->uid = mutt_str_dup(uid);
   return edata;
 }

--- a/pop/lib.c
+++ b/pop/lib.c
@@ -520,7 +520,7 @@ int pop_fetch_data(struct PopAccountData *adata, const char *query,
   if (rc < 0)
     return rc;
 
-  char *inbuf = mutt_mem_mallocarray(sizeof(buf), sizeof(char));
+  char *inbuf = MUTT_MEM_MALLOC(sizeof(buf), char);
 
   while (true)
   {

--- a/pop/lib.c
+++ b/pop/lib.c
@@ -556,7 +556,7 @@ int pop_fetch_data(struct PopAccountData *adata, const char *query,
       lenbuf = 0;
     }
 
-    mutt_mem_realloc(&inbuf, lenbuf + sizeof(buf));
+    mutt_mem_reallocarray(&inbuf, lenbuf + sizeof(buf), sizeof(char));
   }
 
   FREE(&inbuf);

--- a/pop/lib.c
+++ b/pop/lib.c
@@ -556,7 +556,7 @@ int pop_fetch_data(struct PopAccountData *adata, const char *query,
       lenbuf = 0;
     }
 
-    mutt_mem_reallocarray(&inbuf, lenbuf + sizeof(buf), sizeof(char));
+    MUTT_MEM_REALLOC(&inbuf, lenbuf + sizeof(buf), char);
   }
 
   FREE(&inbuf);

--- a/pop/lib.c
+++ b/pop/lib.c
@@ -520,7 +520,7 @@ int pop_fetch_data(struct PopAccountData *adata, const char *query,
   if (rc < 0)
     return rc;
 
-  char *inbuf = mutt_mem_malloc(sizeof(buf));
+  char *inbuf = mutt_mem_mallocarray(sizeof(buf), sizeof(char));
 
   while (true)
   {

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -524,7 +524,7 @@ void pop_fetch_mail(void)
   int last = 0, msgs = 0, bytes = 0, rset = 0, rc;
   struct ConnAccount cac = { { 0 } };
 
-  char *p = mutt_mem_calloc(strlen(c_pop_host) + 7, sizeof(char));
+  char *p = MUTT_MEM_CALLOC(strlen(c_pop_host) + 7, char);
   char *url = p;
   if (url_check_scheme(c_pop_host) == U_UNKNOWN)
   {

--- a/progress/wdata.c
+++ b/progress/wdata.c
@@ -36,7 +36,7 @@
  */
 struct ProgressWindowData *progress_wdata_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct ProgressWindowData));
+  return MUTT_MEM_CALLOC(1, struct ProgressWindowData);
 }
 
 /**

--- a/score.c
+++ b/score.c
@@ -131,7 +131,7 @@ enum CommandResult mutt_parse_score(struct Buffer *buf, struct Buffer *s,
       FREE(&pattern);
       return MUTT_CMD_ERROR;
     }
-    ptr = mutt_mem_calloc(1, sizeof(struct Score));
+    ptr = MUTT_MEM_CALLOC(1, struct Score);
     if (last)
       last->next = ptr;
     else

--- a/send/header.c
+++ b/send/header.c
@@ -527,7 +527,7 @@ void mutt_write_references(const struct ListHead *r, FILE *fp, size_t trim)
       break;
   }
 
-  struct ListNode **ref = mutt_mem_calloc(length, sizeof(struct ListNode *));
+  struct ListNode **ref = MUTT_MEM_CALLOC(length, struct ListNode *);
 
   // store in reverse order
   size_t tmp = length;

--- a/send/send.c
+++ b/send/send.c
@@ -578,7 +578,7 @@ static int inline_forward_attachments(struct Mailbox *m, struct Email *e,
   mutt_parse_mime_message(e, msg->fp);
   mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
 
-  actx = mutt_mem_calloc(1, sizeof(*actx));
+  actx = MUTT_MEM_CALLOC(1, struct AttachCtx);
   actx->email = e;
   actx->fp_root = msg->fp;
 

--- a/send/send.c
+++ b/send/send.c
@@ -1695,7 +1695,7 @@ static bool search_attach_keyword(char *filename, struct ConfigSubset *sub)
   if (!fp_att)
     return false;
 
-  char *inputline = mutt_mem_mallocarray(1024, sizeof(char));
+  char *inputline = MUTT_MEM_MALLOC(1024, char);
   bool found = false;
   while (!feof(fp_att) && fgets(inputline, 1024, fp_att))
   {

--- a/send/send.c
+++ b/send/send.c
@@ -1695,7 +1695,7 @@ static bool search_attach_keyword(char *filename, struct ConfigSubset *sub)
   if (!fp_att)
     return false;
 
-  char *inputline = mutt_mem_malloc(1024);
+  char *inputline = mutt_mem_mallocarray(1024, sizeof(char));
   bool found = false;
   while (!feof(fp_att) && fgets(inputline, 1024, fp_att))
   {

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -687,7 +687,7 @@ static void encode_headers(struct ListHead *h, struct ConfigSubset *sub)
       continue;
 
     rfc2047_encode(&tmp, NULL, i + 2, c_send_charset);
-    mutt_mem_reallocarray(&np->data, i + 2 + mutt_str_len(tmp) + 1, sizeof(char));
+    MUTT_MEM_REALLOC(&np->data, i + 2 + mutt_str_len(tmp) + 1, char);
 
     sprintf(np->data + i + 2, "%s", tmp);
 

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -687,7 +687,7 @@ static void encode_headers(struct ListHead *h, struct ConfigSubset *sub)
       continue;
 
     rfc2047_encode(&tmp, NULL, i + 2, c_send_charset);
-    mutt_mem_realloc(&np->data, i + 2 + mutt_str_len(tmp) + 1);
+    mutt_mem_reallocarray(&np->data, i + 2 + mutt_str_len(tmp) + 1, sizeof(char));
 
     sprintf(np->data + i + 2, "%s", tmp);
 

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -101,7 +101,7 @@ void sb_add_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
    * they're valid, our pointers will be updated in prepare_sidebar() */
 
   struct IndexSharedData *shared = wdata->shared;
-  struct SbEntry *entry = mutt_mem_calloc(1, sizeof(struct SbEntry));
+  struct SbEntry *entry = MUTT_MEM_CALLOC(1, struct SbEntry);
   entry->mailbox = m;
 
   if (wdata->top_index < 0)

--- a/sidebar/wdata.c
+++ b/sidebar/wdata.c
@@ -43,7 +43,7 @@ struct IndexSharedData;
  */
 struct SidebarWindowData *sb_wdata_new(struct MuttWindow *win, struct IndexSharedData *shared)
 {
-  struct SidebarWindowData *wdata = mutt_mem_calloc(1, sizeof(struct SidebarWindowData));
+  struct SidebarWindowData *wdata = MUTT_MEM_CALLOC(1, struct SidebarWindowData);
   wdata->win = win;
   wdata->shared = shared;
   ARRAY_INIT(&wdata->entries);

--- a/store/bdb.c
+++ b/store/bdb.c
@@ -72,7 +72,7 @@ static void bdb_sdata_free(struct BdbStoreData **ptr)
  */
 static struct BdbStoreData *bdb_sdata_new(void)
 {
-  struct BdbStoreData *sdata = mutt_mem_calloc(1, sizeof(struct BdbStoreData));
+  struct BdbStoreData *sdata = MUTT_MEM_CALLOC(1, struct BdbStoreData);
 
   buf_alloc(&sdata->lockfile, 128);
 

--- a/store/lmdb.c
+++ b/store/lmdb.c
@@ -86,7 +86,7 @@ static void lmdb_sdata_free(struct LmdbStoreData **ptr)
  */
 static struct LmdbStoreData *lmdb_sdata_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct LmdbStoreData));
+  return MUTT_MEM_CALLOC(1, struct LmdbStoreData);
 }
 
 /**

--- a/store/rocksdb.c
+++ b/store/rocksdb.c
@@ -68,7 +68,7 @@ static void rocksdb_sdata_free(struct RocksDbStoreData **ptr)
  */
 static struct RocksDbStoreData *rocksdb_sdata_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct RocksDbStoreData));
+  return MUTT_MEM_CALLOC(1, struct RocksDbStoreData);
 }
 
 /**

--- a/test/account/account_free.c
+++ b/test/account/account_free.c
@@ -48,14 +48,14 @@ void test_account_free(void)
   }
 
   {
-    struct Account *a = mutt_mem_calloc(1, sizeof(*a));
+    struct Account *a = MUTT_MEM_CALLOC(1, struct Account);
     account_free(&a);
     TEST_CHECK_(1, "account_free(&a)");
   }
 
   {
-    struct Account *a = mutt_mem_calloc(1, sizeof(*a));
-    a->adata = mutt_mem_calloc(1, 32);
+    struct Account *a = MUTT_MEM_CALLOC(1, struct Account);
+    a->adata = mutt_mem_calloc(32, 1);
     a->adata_free = adata_free;
 
     account_free(&a);

--- a/test/buffer/buf_alloc.c
+++ b/test/buffer/buf_alloc.c
@@ -37,7 +37,7 @@ void test_buf_alloc(void)
   }
 
   {
-    struct Buffer *buf = mutt_mem_calloc(1, sizeof(struct Buffer));
+    struct Buffer *buf = MUTT_MEM_CALLOC(1, struct Buffer);
     buf_alloc(buf, 10);
     TEST_CHECK_(1, "buf_alloc(buf, 10)");
     buf_free(&buf);
@@ -54,7 +54,7 @@ void test_buf_alloc(void)
 
     for (size_t i = 0; i < mutt_array_size(sizes); i++)
     {
-      struct Buffer *buf = mutt_mem_calloc(1, sizeof(struct Buffer));
+      struct Buffer *buf = MUTT_MEM_CALLOC(1, struct Buffer);
       buf_alloc(buf, orig_size);
       TEST_CASE_("%d", sizes[i][0]);
       buf_alloc(buf, sizes[i][0]);

--- a/test/compress/common.c
+++ b/test/compress/common.c
@@ -119,7 +119,7 @@ static void one_test(const struct ComprOps *compr_ops, short level, size_t size)
   if (!TEST_CHECK(clen != 0))
     return;
 
-  void *copy = mutt_mem_mallocarray(clen, sizeof(char));
+  void *copy = MUTT_MEM_MALLOC(clen, char);
   memcpy(copy, cdata, clen);
 
   void *ddata = compr_ops->decompress(compr_handle, copy, clen);

--- a/test/compress/common.c
+++ b/test/compress/common.c
@@ -119,7 +119,7 @@ static void one_test(const struct ComprOps *compr_ops, short level, size_t size)
   if (!TEST_CHECK(clen != 0))
     return;
 
-  void *copy = mutt_mem_malloc(clen);
+  void *copy = mutt_mem_mallocarray(clen, sizeof(char));
   memcpy(copy, cdata, clen);
 
   void *ddata = compr_ops->decompress(compr_handle, copy, clen);

--- a/test/email/email_header_find.c
+++ b/test/email/email_header_find.c
@@ -33,7 +33,7 @@ void test_email_header_find(void)
   char *header = "X-TestHeader: 123";
 
   struct ListHead hdrlist = STAILQ_HEAD_INITIALIZER(hdrlist);
-  struct ListNode *n = mutt_mem_calloc(1, sizeof(struct ListNode));
+  struct ListNode *n = MUTT_MEM_CALLOC(1, struct ListNode);
   n->data = mutt_str_dup(header);
   STAILQ_INSERT_TAIL(&hdrlist, n, entries);
 

--- a/test/email/email_header_update.c
+++ b/test/email/email_header_update.c
@@ -34,7 +34,7 @@ void test_email_header_update(void)
   const char *existing_header = "X-Found: foo";
   const char *new_value = "X-Found: 3.14";
 
-  struct ListNode *n = mutt_mem_calloc(1, sizeof(struct ListNode));
+  struct ListNode *n = MUTT_MEM_CALLOC(1, struct ListNode);
   n->data = mutt_str_dup(existing_header);
 
   {

--- a/test/list/common.c
+++ b/test/list/common.c
@@ -34,7 +34,7 @@ struct ListHead test_list_create(const char *items[], bool copy)
 
   for (size_t i = 0; items[i]; i++)
   {
-    struct ListNode *np = mutt_mem_calloc(1, sizeof(struct ListNode));
+    struct ListNode *np = MUTT_MEM_CALLOC(1, struct ListNode);
     if (copy)
       np->data = mutt_str_dup(items[i]);
     else

--- a/test/mailbox/mailbox_free.c
+++ b/test/mailbox/mailbox_free.c
@@ -48,14 +48,14 @@ void test_mailbox_free(void)
   }
 
   {
-    struct Mailbox *m = mutt_mem_calloc(1, sizeof(*m));
+    struct Mailbox *m = MUTT_MEM_CALLOC(1, struct Mailbox);
     mailbox_free(&m);
     TEST_CHECK_(1, "mailbox_free(&m)");
   }
 
   {
-    struct Mailbox *m = mutt_mem_calloc(1, sizeof(*m));
-    m->mdata = mutt_mem_calloc(1, 32);
+    struct Mailbox *m = MUTT_MEM_CALLOC(1, struct Mailbox);
+    m->mdata = mutt_mem_calloc(32, 1);
     m->mdata_free = mdata_free;
 
     mailbox_free(&m);

--- a/test/neo/neomutt_free.c
+++ b/test/neo/neomutt_free.c
@@ -43,7 +43,7 @@ void test_neomutt_free(void)
   }
 
   {
-    struct NeoMutt *n = mutt_mem_calloc(1, sizeof(*n));
+    struct NeoMutt *n = MUTT_MEM_CALLOC(1, struct NeoMutt);
     neomutt_free(&n);
     TEST_CHECK_(1, "neomutt_free(&n)");
   }


### PR DESCRIPTION
These functions add safety to the nmemb * size multiplication.

I used them even in cases where the nmemb is 1, and used a sizeof(char) in that case, because I think that's more consistent, and also prepares the ground for using magic macros similar to the ones used in the shadow project.

Also add the magic macros and use them where appropriate.

<https://github.com/shadow-maint/shadow/blob/9b3889696b42d799dbd1b11db50e87b180c98c31/lib/alloc.h#L29>

Only in allocations of void, I kept the old _realloc() and _malloc(), since there's no underlying type, and thus, no size of an element.

Where the macros wouldn't work for some reason, I kept calls to the functions, but the macros are used wherever we can.

This requires C11 for _Generic(3).

---

Revisions:

<details>
<summary>v2</summary>

-  Fix a few accidents
-  Add some magic macros

```
$ git range-diff neomutt/main neomutt/alx/reallocarray alx/reallocarray 
 1:  bd2e52eb1 =  1:  bd2e52eb1 mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  7ee0da20a !  2:  4f9013c2b Use mutt_mem_reallocarray()
    @@ ncrypt/crypt.c: static void crypt_fetch_signatures(struct Body ***b_sigs, struct
          {
            if ((*n % 5) == 0)
     -        mutt_mem_realloc(b_sigs, (*n + 6) * sizeof(struct Body **));
    -+        mutt_mem_reallocarray(b_sigs, *n + 6, sizeof(struct Body **));
    ++        mutt_mem_reallocarray(b_sigs, *n + 6, sizeof(struct Body *));
      
            (*b_sigs)[(*n)++] = b;
          }
 3:  5d6f2382f =  3:  de12f0ed7 mutt/memory.[ch]: Add mutt_mem_mallocarray()
 4:  be0492cbd !  4:  f1e069e8b Use mutt_mem_mallocarray()
    @@ hcache/serialize.c: void serial_restore_char(char **c, const unsigned char *d, i
        }
      
     -  *c = mutt_mem_malloc(size);
    -+  *c = mutt_mem_mallocarray(size, sizeof(char *));
    ++  *c = mutt_mem_mallocarray(size, sizeof(char));
        memcpy(*c, d + *off, size);
        if (convert && !mutt_str_is_ascii(*c, size))
        {
 5:  e4c40b499 =  5:  b0ffb0037 mutt/memory.h: Add MUTT_MEM_MALLOC()
 6:  c6eeff58b !  6:  770fece81 Use MUTT_MEM_MALLOC()
    @@ hcache/serialize.c: void serial_restore_char(char **c, const unsigned char *d, i
          return;
        }
      
    --  *c = mutt_mem_mallocarray(size, sizeof(char *));
    -+  *c = MUTT_MEM_MALLOC(size, char *);
    +-  *c = mutt_mem_mallocarray(size, sizeof(char));
    ++  *c = MUTT_MEM_MALLOC(size, char);
        memcpy(*c, d + *off, size);
        if (convert && !mutt_str_is_ascii(*c, size))
        {
    @@ ncrypt/pgppacket.c: unsigned char *pgp_read_packet(FILE *fp, size_t *len)
      
        if (fread(&ctb, 1, 1, fp) < 1)
     
    - ## nntp/adata.c ##
    -@@ nntp/adata.c: struct NntpAccountData *nntp_adata_new(struct Connection *conn)
    -   adata->groups_hash = mutt_hash_new(1009, MUTT_HASH_NO_FLAGS);
    -   mutt_hash_set_destructor(adata->groups_hash, nntp_hashelem_free, 0);
    -   adata->groups_max = 16;
    --  adata->groups_list = mutt_mem_mallocarray(adata->groups_max, sizeof(struct NntpMboxData *));
    -+  adata->groups_list = MUTT_MEM_MALLOC(adata->groups_max, struct NntpMboxData *);
    -   return adata;
    - }
    -
      ## nntp/newsrc.c ##
     @@ nntp/newsrc.c: int nntp_newsrc_parse(struct NntpAccountData *adata)
          FREE(&mdata->newsrc_ent);
 7:  bbd2ef750 =  7:  b357a1949 mutt/memory.h: Add MUTT_MEM_CALLOC()
 8:  4f163331a !  8:  a373a7f0c Use MUTT_MEM_CALLOC()
    @@ complete/data.c: void completion_data_free(struct CompletionData **ptr)
      
        cd->match_list_len = 512;
     -  cd->match_list = mutt_mem_calloc(cd->match_list_len, sizeof(char *));
    -+  cd->match_list = MUTT_MEM_CALLOC(cd->match_list_len, char *);
    ++  cd->match_list = MUTT_MEM_CALLOC(cd->match_list_len, const char *);
      
        return cd;
      }
 -:  --------- >  9:  68f3816e9 mutt/memory.h: Add MUTT_MEM_REALLOC()
 -:  --------- > 10:  9939f26de Use MUTT_MEM_REALLOC()
```

</details>

<details>
<summary>v3</summary>

-  Reorder commits
-  Squash commits
-  Add detailed commit messages [@gahr ]

```
$ git range-diff main neomutt/alx/reallocarray alx/reallocarray 
 1:  bd2e52eb1 !  1:  9ca18bf93 mutt/memory.[ch]: Add mutt_mem_reallocarray()
    @@ Metadata
      ## Commit message ##
         mutt/memory.[ch]: Add mutt_mem_reallocarray()
     
    +    These array functions avoid an explicit size multiplication, which can
    +    overflow the calculation.
    +
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## mutt/memory.c ##
 3:  de12f0ed7 !  2:  478ab2029 mutt/memory.[ch]: Add mutt_mem_mallocarray()
    @@ Metadata
      ## Commit message ##
         mutt/memory.[ch]: Add mutt_mem_mallocarray()
     
    +    These array functions avoid an explicit size multiplication, which can
    +    overflow the calculation.
    +
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## mutt/memory.c ##
 2:  4f9013c2b =  3:  8707dde00 Use mutt_mem_reallocarray()
 4:  f1e069e8b =  4:  39bf59119 Use mutt_mem_mallocarray()
 5:  b0ffb0037 <  -:  --------- mutt/memory.h: Add MUTT_MEM_MALLOC()
 9:  68f3816e9 !  5:  8698fc1f2 mutt/memory.h: Add MUTT_MEM_REALLOC()
    @@ Metadata
     Author: Alejandro Colomar (@alejandro-colomar) <alx@kernel.org>
     
      ## Commit message ##
    -    mutt/memory.h: Add MUTT_MEM_REALLOC()
    +    mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
     
    +    These macros have several benefits over the functions:
    +
    +    -  The type of the allocated object (not the pointer) is specified as an
    +       argument, which improves readability:
    +       -  It is directly obvious what is the type of the object just by
    +          reading the macro call.
    +       -  It allows grepping for all allocations of a given type.
    +
    +       This is admittedly similar to using sizeof() to get the size of the
    +       object, but we'll see why this is better.
    +
    +    -  The cast is performed automatically, with a pointer type derived from
    +       the type of the object.  This is the best point of this macro, since
    +       it does an automatic cast, where there's no chance of typos.
    +
    +       Usually, programmers have to decide whether to cast or not the result
    +       of malloc(3).  Casts usually hide warnings, so are to be avoided.
    +       However, these functions already return a void *, so a cast doesn't
    +       really add much danger.  Moreover, a cast can even add warnings in
    +       this exceptional case, if the type of the cast is different than the
    +       type of the assigned pointer.  Performing a manual cast is still not
    +       perfect, since there are chances that a mistake will be done, and
    +       even ignoring accidents, they clutter code, hurting readability.
    +       And now we have a cast that is synced with sizeof.
    +
    +    -  Whenever the type of the object changes, since we perform an explicit
    +       cast to the old type, there will be a warning due to type mismatch in
    +       the assignment, so we'll be able to see all lines that are affected
    +       by such a change.  This is especially important, since changing the
    +       type of a variable and missing to update an allocation call far away
    +       from the declaration is easy, and the consequences can be quite bad.
    +
    +    -  In the case of reallocation macro, an extra check is performed to
    +       make sure that the previous pointer was compatible with the allocated
    +       type, which can avoid some mistakes.
    +
    +    This will produce more readable code, since lines will be shorter (by
    +    not having 'array' in the macro names, as all macros consistently
    +    handle arrays), and the allocated size will be also more explicit.
    +
    +    The syntax will now be of the form:
    +
    +      p = MUTT_MEM_MALLOC(42, foo_t); // allocate 42 elements of type foo_t.
    +      p = MUTT_MEM_MALLOC(1, bar_t);  // allocate 1 element of type foo_t.
    +
    +    The *array() allocation functions should only be called directly for
    +    allocating 'void *', which have no type.  In other cases, these macros
    +    should be used.
    +
    +    The non-array functions (e.g., mutt_mem_malloc()) still have their
    +    place, but are limited to allocating structures with flexible array
    +    members.  For any other uses, the macros should be used.
    +
    +    Link: <https://github.com/shadow-maint/shadow/pull/649/commits>
    +    Link: <https://github.com/shadow-maint/shadow/pull/701/commits>
    +    Link: <https://github.com/shadow-maint/shadow/commit/186ca04e8b2aa4d0e3a8ff3912a3d67db570a7ec>
    +    Link: <https://github.com/shadow-maint/shadow/commit/0d381137d1e1369e2ab9ed92011b0da952324f0b>
    +    Link: <https://software.codidact.com/posts/285898/288023#answer-288023>
    +    Cc: Pietro Cerutti <gahr@gahr.ch>
    +    Cc: Richard Russon <rich@flatcap.org>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## mutt/memory.h ##
     @@
    - #define MUTT_MEM_CALLOC(n, type)   ((type *) mutt_mem_calloc(n, sizeof(type)))
    - #define MUTT_MEM_MALLOC(n, type)   ((type *) mutt_mem_mallocarray(n, sizeof(type)))
      
    + #define mutt_array_size(x) (sizeof(x) / sizeof((x)[0]))
    + 
    ++#define MUTT_MEM_CALLOC(n, type)   ((type *) mutt_mem_calloc(n, sizeof(type)))
    ++#define MUTT_MEM_MALLOC(n, type)   ((type *) mutt_mem_mallocarray(n, sizeof(type)))
    ++
     +#define MUTT_MEM_REALLOC(ptr, n, type)                                        \
     +(                                                                             \
     +  _Generic(*(ptr), type *: mutt_mem_reallocarray(ptr, n, sizeof(type)))       \
 6:  770fece81 =  6:  cbc4cd0f7 Use MUTT_MEM_MALLOC()
 7:  b357a1949 <  -:  --------- mutt/memory.h: Add MUTT_MEM_CALLOC()
 8:  a373a7f0c =  7:  35c629d63 Use MUTT_MEM_CALLOC()
10:  9939f26de =  8:  5a0ac604d Use MUTT_MEM_REALLOC()
```
</details>

<details>
<summary>v3b</summary>

-  Rebase

```
$ git range-diff main..neomutt/alx/reallocarray neomutt/main..alx/reallocarray 
1:  9ca18bf93 = 1:  8e572421c mutt/memory.[ch]: Add mutt_mem_reallocarray()
2:  478ab2029 = 2:  cbf9daf51 mutt/memory.[ch]: Add mutt_mem_mallocarray()
3:  8707dde00 ! 3:  af50f10df Use mutt_mem_reallocarray()
    @@ browser/complete.c: int complete_file_mbox(struct EnterWindowData *wdata, int op
     -    mutt_mem_realloc(&wdata->tempbuf, wdata->templen * sizeof(wchar_t));
     +    mutt_mem_reallocarray(&wdata->tempbuf, wdata->templen, sizeof(wchar_t));
          if (wdata->tempbuf)
    -       memcpy(wdata->tempbuf, wdata->state->wbuf, wdata->templen * sizeof(wchar_t));
    +       wmemcpy(wdata->tempbuf, wdata->state->wbuf, wdata->templen);
        }
     @@ browser/complete.c: int complete_file_simple(struct EnterWindowData *wdata, int op)
        if (mutt_complete(wdata->cd, wdata->buffer) == 0)
    @@ browser/complete.c: int complete_file_simple(struct EnterWindowData *wdata, int
     -    mutt_mem_realloc(&wdata->tempbuf, wdata->templen * sizeof(wchar_t));
     +    mutt_mem_reallocarray(&wdata->tempbuf, wdata->templen, sizeof(wchar_t));
          if (wdata->tempbuf)
    -       memcpy(wdata->tempbuf, wdata->state->wbuf + i, wdata->templen * sizeof(wchar_t));
    +       wmemcpy(wdata->tempbuf, wdata->state->wbuf + i, wdata->templen);
        }
     
      ## complete/helpers.c ##
    @@ editor/state.c: void enter_state_resize(struct EnterState *es, size_t num)
     -  mutt_mem_realloc(&es->wbuf, num * sizeof(wchar_t));
     +  mutt_mem_reallocarray(&es->wbuf, num, sizeof(wchar_t));
      
    -   memset(es->wbuf + es->wbuflen, 0, (num - es->wbuflen) * sizeof(wchar_t));
    +   wmemset(es->wbuf + es->wbuflen, 0, num - es->wbuflen);
      
     
      ## editor/window.c ##
4:  39bf59119 = 4:  faaa31232 Use mutt_mem_mallocarray()
5:  8698fc1f2 = 5:  d2735887a mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
6:  cbc4cd0f7 = 6:  2d78fc27c Use MUTT_MEM_MALLOC()
7:  35c629d63 ! 7:  53fb6aeff Use MUTT_MEM_CALLOC()
    @@ editor/functions.c: void replace_part(struct EnterState *es, size_t from, const
        {
     -    savebuf = mutt_mem_calloc(savelen, sizeof(wchar_t));
     +    savebuf = MUTT_MEM_CALLOC(savelen, wchar_t);
    -     memcpy(savebuf, es->wbuf + es->curpos, savelen * sizeof(wchar_t));
    +     wmemcpy(savebuf, es->wbuf + es->curpos, savelen);
        }
      
     
8:  5a0ac604d ! 8:  9a7d07cff Use MUTT_MEM_REALLOC()
    @@ browser/complete.c: int complete_file_mbox(struct EnterWindowData *wdata, int op
     -    mutt_mem_reallocarray(&wdata->tempbuf, wdata->templen, sizeof(wchar_t));
     +    MUTT_MEM_REALLOC(&wdata->tempbuf, wdata->templen, wchar_t);
          if (wdata->tempbuf)
    -       memcpy(wdata->tempbuf, wdata->state->wbuf, wdata->templen * sizeof(wchar_t));
    +       wmemcpy(wdata->tempbuf, wdata->state->wbuf, wdata->templen);
        }
     @@ browser/complete.c: int complete_file_simple(struct EnterWindowData *wdata, int op)
        if (mutt_complete(wdata->cd, wdata->buffer) == 0)
    @@ browser/complete.c: int complete_file_simple(struct EnterWindowData *wdata, int
     -    mutt_mem_reallocarray(&wdata->tempbuf, wdata->templen, sizeof(wchar_t));
     +    MUTT_MEM_REALLOC(&wdata->tempbuf, wdata->templen, wchar_t);
          if (wdata->tempbuf)
    -       memcpy(wdata->tempbuf, wdata->state->wbuf + i, wdata->templen * sizeof(wchar_t));
    +       wmemcpy(wdata->tempbuf, wdata->state->wbuf + i, wdata->templen);
        }
     
      ## complete/helpers.c ##
    @@ editor/state.c: void enter_state_resize(struct EnterState *es, size_t num)
     -  mutt_mem_reallocarray(&es->wbuf, num, sizeof(wchar_t));
     +  MUTT_MEM_REALLOC(&es->wbuf, num, wchar_t);
      
    -   memset(es->wbuf + es->wbuflen, 0, (num - es->wbuflen) * sizeof(wchar_t));
    +   wmemset(es->wbuf + es->wbuflen, 0, num - es->wbuflen);
      
     
      ## editor/window.c ##
```
</details>

<details>
<summary>v4</summary>

-  Rename variables (pp)

```
$ git range-diff neomutt/main neomutt/alx/reallocarray alx/reallocarray 
 1:  8e572421c =  1:  8e572421c mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  cbf9daf51 =  2:  cbf9daf51 mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  af50f10df =  3:  af50f10df Use mutt_mem_reallocarray()
 4:  faaa31232 =  4:  faaa31232 Use mutt_mem_mallocarray()
 5:  d2735887a =  5:  d2735887a mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 6:  2d78fc27c =  6:  2d78fc27c Use MUTT_MEM_MALLOC()
 7:  53fb6aeff =  7:  53fb6aeff Use MUTT_MEM_CALLOC()
 8:  9a7d07cff =  8:  9a7d07cff Use MUTT_MEM_REALLOC()
 -:  --------- >  9:  c725f7546 mutt/memory.[ch]: Improve name of variables
```
</details>

<details>
<summary>v4b</summary>
-  Whitespace

```
$ git range-diff main neomutt/alx/reallocarray alx/reallocarray 
 1:  8e572421c =  1:  8e572421c mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  cbf9daf51 =  2:  cbf9daf51 mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  af50f10df =  3:  af50f10df Use mutt_mem_reallocarray()
 4:  faaa31232 =  4:  faaa31232 Use mutt_mem_mallocarray()
 5:  d2735887a !  5:  d7d8acd8a mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
    @@ mutt/memory.h
      
      #define mutt_array_size(x) (sizeof(x) / sizeof((x)[0]))
      
    -+#define MUTT_MEM_CALLOC(n, type)   ((type *) mutt_mem_calloc(n, sizeof(type)))
    -+#define MUTT_MEM_MALLOC(n, type)   ((type *) mutt_mem_mallocarray(n, sizeof(type)))
    ++#define MUTT_MEM_CALLOC(n, type)  ((type *) mutt_mem_calloc(n, sizeof(type)))
    ++#define MUTT_MEM_MALLOC(n, type)  ((type *) mutt_mem_mallocarray(n, sizeof(type)))
     +
     +#define MUTT_MEM_REALLOC(ptr, n, type)                                        \
     +(                                                                             \
 6:  2d78fc27c =  6:  2a66922d7 Use MUTT_MEM_MALLOC()
 7:  53fb6aeff =  7:  f3320008d Use MUTT_MEM_CALLOC()
 8:  9a7d07cff =  8:  f00412e9f Use MUTT_MEM_REALLOC()
 9:  c725f7546 !  9:  d5bf2eba2 mutt/memory.[ch]: Improve name of variables
    @@ mutt/memory.c: void mutt_mem_realloc(void *ptr, size_t size)
     
      ## mutt/memory.h ##
     @@
    - #define MUTT_MEM_CALLOC(n, type)   ((type *) mutt_mem_calloc(n, sizeof(type)))
    - #define MUTT_MEM_MALLOC(n, type)   ((type *) mutt_mem_mallocarray(n, sizeof(type)))
    + #define MUTT_MEM_CALLOC(n, type)  ((type *) mutt_mem_calloc(n, sizeof(type)))
    + #define MUTT_MEM_MALLOC(n, type)  ((type *) mutt_mem_mallocarray(n, sizeof(type)))
      
     -#define MUTT_MEM_REALLOC(ptr, n, type)                                        \
     +#define MUTT_MEM_REALLOC(pptr, n, type)                                       \
```
</details>

<details>
<summary>v5</summary>

-  Fix type of struct member

```
$ git range-diff neomutt/main neomutt/alx/reallocarray alx/reallocarray 
 1:  8e572421c =  1:  8e572421c mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  cbf9daf51 =  2:  cbf9daf51 mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  af50f10df =  3:  af50f10df Use mutt_mem_reallocarray()
 4:  faaa31232 =  4:  faaa31232 Use mutt_mem_mallocarray()
 5:  d7d8acd8a =  5:  d7d8acd8a mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 6:  2a66922d7 =  6:  2a66922d7 Use MUTT_MEM_MALLOC()
 7:  f3320008d =  7:  f3320008d Use MUTT_MEM_CALLOC()
 8:  f00412e9f =  8:  f00412e9f Use MUTT_MEM_REALLOC()
 9:  d5bf2eba2 =  9:  d5bf2eba2 mutt/memory.[ch]: Improve name of variables
 -:  --------- > 10:  3f67fb7f5 nntp/adata.[ch]: struct NntpAccountData: Fix type of member
```
</details>

<details>
<summary>v6</summary>

-  Don't use assignment operators in allocation calls

```
$ git range-diff neomutt/main neomutt/alx/reallocarray alx/reallocarray 
 1:  8e572421c =  1:  8e572421c mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  cbf9daf51 =  2:  cbf9daf51 mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  af50f10df =  3:  af50f10df Use mutt_mem_reallocarray()
 4:  faaa31232 =  4:  faaa31232 Use mutt_mem_mallocarray()
 5:  d7d8acd8a =  5:  d7d8acd8a mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 6:  2a66922d7 =  6:  2a66922d7 Use MUTT_MEM_MALLOC()
 7:  f3320008d =  7:  f3320008d Use MUTT_MEM_CALLOC()
 8:  f00412e9f =  8:  f00412e9f Use MUTT_MEM_REALLOC()
 9:  d5bf2eba2 =  9:  d5bf2eba2 mutt/memory.[ch]: Improve name of variables
10:  3f67fb7f5 = 10:  3f67fb7f5 nntp/adata.[ch]: struct NntpAccountData: Fix type of member
 -:  --------- > 11:  93ffc40b2 Don't use assignment operators in arguments to allocation calls
```
</details>

<details>
<summary>v7</summary>

-  Cherry-pick (from `devel/realloc`) the commit about free(NULL)  [Cc: @flatcap ]

```
$ git range-diff main neomutt/alx/reallocarray alx/reallocarray 
 1:  8e572421c =  1:  8e572421c mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  cbf9daf51 =  2:  cbf9daf51 mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  af50f10df =  3:  af50f10df Use mutt_mem_reallocarray()
 4:  faaa31232 =  4:  faaa31232 Use mutt_mem_mallocarray()
 5:  d7d8acd8a =  5:  d7d8acd8a mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 6:  2a66922d7 =  6:  2a66922d7 Use MUTT_MEM_MALLOC()
 7:  f3320008d =  7:  f3320008d Use MUTT_MEM_CALLOC()
 8:  f00412e9f =  8:  f00412e9f Use MUTT_MEM_REALLOC()
 -:  --------- >  9:  f6e8a781f mutt/memory.c: free(NULL) is valid C (it's a no-op)
 9:  d5bf2eba2 ! 10:  e07b0c51d mutt/memory.[ch]: Improve name of variables
    @@ mutt/memory.c: void mutt_mem_realloc(void *ptr, size_t size)
      
        if ((nmemb == 0) || (size == 0))
        {
    --    if (*p)
    -+    if (*pp)
    -     {
    --      free(*p);
    --      *p = NULL;
    -+      free(*pp);
    -+      *pp = NULL;
    -     }
    +-    free(*p);
    +-    *p = NULL;
    ++    free(*pp);
    ++    *pp = NULL;
          return;
        }
      
10:  3f67fb7f5 = 11:  547ee22c5 nntp/adata.[ch]: struct NntpAccountData: Fix type of member
11:  93ffc40b2 = 12:  969d0fba9 Don't use assignment operators in arguments to allocation calls
```
</details>

<details>
<summary>v8</summary>

-  Remove a useless cast

```
$ git range-diff main neomutt/alx/reallocarray alx/reallocarray 
 1:  8e572421c =  1:  8e572421c mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  cbf9daf51 =  2:  cbf9daf51 mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  af50f10df =  3:  af50f10df Use mutt_mem_reallocarray()
 4:  faaa31232 =  4:  faaa31232 Use mutt_mem_mallocarray()
 5:  d7d8acd8a =  5:  d7d8acd8a mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 6:  2a66922d7 =  6:  2a66922d7 Use MUTT_MEM_MALLOC()
 7:  f3320008d =  7:  f3320008d Use MUTT_MEM_CALLOC()
 8:  f00412e9f =  8:  f00412e9f Use MUTT_MEM_REALLOC()
 9:  f6e8a781f =  9:  f6e8a781f mutt/memory.c: free(NULL) is valid C (it's a no-op)
10:  e07b0c51d = 10:  e07b0c51d mutt/memory.[ch]: Improve name of variables
11:  547ee22c5 = 11:  547ee22c5 nntp/adata.[ch]: struct NntpAccountData: Fix type of member
12:  969d0fba9 = 12:  969d0fba9 Don't use assignment operators in arguments to allocation calls
 -:  --------- > 13:  9ca7dc7dc conn/openssl.c: Remove useless cast
```
</details>

<details>
<summary>v8b</summary>

-  Rebase

```
$ git range-diff main..neomutt/alx/reallocarray neomutt/main..alx/reallocarray 
 1:  8e572421c =  1:  5c48939a4 mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  cbf9daf51 =  2:  b314f072f mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  af50f10df !  3:  bb12c8654 Use mutt_mem_reallocarray()
    @@ ncrypt/crypt.c: static void crypt_fetch_signatures(struct Body ***b_sigs, struct
          else
          {
            if ((*n % 5) == 0)
    --        mutt_mem_realloc(b_sigs, (*n + 6) * sizeof(struct Body **));
    +-        mutt_mem_realloc(b_sigs, (*n + 6) * sizeof(struct Body *));
     +        mutt_mem_reallocarray(b_sigs, *n + 6, sizeof(struct Body *));
      
            (*b_sigs)[(*n)++] = b;
 4:  faaa31232 =  4:  7fc92adac Use mutt_mem_mallocarray()
 5:  d7d8acd8a =  5:  1634ed4b4 mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 6:  2a66922d7 =  6:  c9edce66b Use MUTT_MEM_MALLOC()
 7:  f3320008d =  7:  3e686c052 Use MUTT_MEM_CALLOC()
 8:  f00412e9f =  8:  6c6c40450 Use MUTT_MEM_REALLOC()
 9:  f6e8a781f =  9:  499ada335 mutt/memory.c: free(NULL) is valid C (it's a no-op)
10:  e07b0c51d = 10:  311b0112a mutt/memory.[ch]: Improve name of variables
11:  547ee22c5 = 11:  269f3be6c nntp/adata.[ch]: struct NntpAccountData: Fix type of member
12:  969d0fba9 = 12:  a86f6fc5d Don't use assignment operators in arguments to allocation calls
13:  9ca7dc7dc = 13:  379e0a1f6 conn/openssl.c: Remove useless cast
```
</details>

<details>
<summary>v8c</summary>

-  Add Fixes tag for commit ONE :-).  Reminded by @flatcap 

```
$ git range-diff neomutt/main neomutt/alx/reallocarray alx/reallocarray 
 1:  5c48939a4 =  1:  5c48939a4 mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  b314f072f =  2:  b314f072f mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  bb12c8654 =  3:  bb12c8654 Use mutt_mem_reallocarray()
 4:  7fc92adac =  4:  7fc92adac Use mutt_mem_mallocarray()
 5:  1634ed4b4 =  5:  1634ed4b4 mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 6:  c9edce66b =  6:  c9edce66b Use MUTT_MEM_MALLOC()
 7:  3e686c052 =  7:  3e686c052 Use MUTT_MEM_CALLOC()
 8:  6c6c40450 =  8:  6c6c40450 Use MUTT_MEM_REALLOC()
 9:  499ada335 !  9:  5d2a62f4b mutt/memory.c: free(NULL) is valid C (it's a no-op)
    @@ Metadata
      ## Commit message ##
         mutt/memory.c: free(NULL) is valid C (it's a no-op)
     
    +    Fixes: 1a5381e07e97 ("Initial revision")
    +    Cc: Richard Russon <rich@flatcap.org>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## mutt/memory.c ##
10:  311b0112a = 10:  5acaf1044 mutt/memory.[ch]: Improve name of variables
11:  269f3be6c = 11:  68d9546d9 nntp/adata.[ch]: struct NntpAccountData: Fix type of member
12:  a86f6fc5d = 12:  963e52c3c Don't use assignment operators in arguments to allocation calls
13:  379e0a1f6 = 13:  0b34e2e53 conn/openssl.c: Remove useless cast
```
</details>

<details>
<summary>v9</summary>

-  Remove last case of *array() allocation function.  The *ALLOC() macros are _always_ preferred over the *array() functions.

```
$ git range-diff neomutt/main neomutt/alx/reallocarray alx/reallocarray 
 -:  --------- >  1:  772810177 mutt/array.h: Add ARRAY_ELEM_TYPE()
 1:  5c48939a4 =  2:  a7bf21005 mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  b314f072f =  3:  8dbb3d9f8 mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  bb12c8654 =  4:  3f22d8ff0 Use mutt_mem_reallocarray()
 4:  7fc92adac =  5:  5db53fce6 Use mutt_mem_mallocarray()
 5:  1634ed4b4 !  6:  5b5dbcebb mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
    @@ Commit message
           p = MUTT_MEM_MALLOC(42, foo_t); // allocate 42 elements of type foo_t.
           p = MUTT_MEM_MALLOC(1, bar_t);  // allocate 1 element of type foo_t.
     
    -    The *array() allocation functions should only be called directly for
    -    allocating 'void *', which have no type.  In other cases, these macros
    -    should be used.
    +    The *array() allocation functions should _never_ be used.  The *ALLOC()
    +    macros are always preferred.
     
         The non-array functions (e.g., mutt_mem_malloc()) still have their
         place, but are limited to allocating structures with flexible array
    -    members.  For any other uses, the macros should be used.
    +    members, and raw memory (void *).  For any other uses, the macros should
    +    be used.
     
         Link: <https://github.com/shadow-maint/shadow/pull/649/commits>
         Link: <https://github.com/shadow-maint/shadow/pull/701/commits>
 6:  c9edce66b =  7:  dd64b4c5c Use MUTT_MEM_MALLOC()
 7:  3e686c052 =  8:  1bcd937c0 Use MUTT_MEM_CALLOC()
 8:  6c6c40450 !  9:  92b5b129b Use MUTT_MEM_REALLOC()
    @@ monitor.c: static void mutt_poll_fd_add(int fd, short events)
          PollFdsCount++;
          PollFds[i].fd = fd;
     
    + ## mutt/array.h ##
    +@@
    + #define ARRAY_RESERVE(head, num)                                               \
    +   (((head)->capacity > (num)) ?                                                \
    +        (head)->capacity :                                                      \
    +-       ((mutt_mem_reallocarray(                                                \
    +-         &(head)->entries, (num) + ARRAY_HEADROOM, ARRAY_ELEM_SIZE(head))),    \
    ++       ((MUTT_MEM_REALLOCARRAY(                                                \
    ++         &(head)->entries, (num) + ARRAY_HEADROOM, ARRAY_ELEM_TYPE(head))),    \
    +         (memset((head)->entries + (head)->capacity, 0,                         \
    +                 ((num) + ARRAY_HEADROOM - (head)->capacity) *                  \
    +                 ARRAY_ELEM_SIZE(head))),                                       \
    +
      ## mutt/buffer.c ##
     @@ mutt/buffer.c: void buf_alloc(struct Buffer *buf, size_t new_size)
      
 9:  5d2a62f4b = 10:  8b0288db1 mutt/memory.c: free(NULL) is valid C (it's a no-op)
10:  5acaf1044 = 11:  00b825591 mutt/memory.[ch]: Improve name of variables
11:  68d9546d9 = 12:  5d0217d40 nntp/adata.[ch]: struct NntpAccountData: Fix type of member
12:  963e52c3c = 13:  980c1aca9 Don't use assignment operators in arguments to allocation calls
13:  0b34e2e53 = 14:  24b7f7854 conn/openssl.c: Remove useless cast
```
</details>

<details>
<summary>v10</summary>

-  Remove spurious parentheses in ARRAY_ELEM_TYPE() definition: the parens convert it into a cast, which we don't want.
-  Spell correctly MUTT_MEM_REALLOC().

```
$ git range-diff neomutt/main neomutt/alx/reallocarray alx/reallocarray 
 1:  772810177 !  1:  55be66029 mutt/array.h: Add ARRAY_ELEM_TYPE()
    @@ mutt/array.h
     + * @param head Pointer to a struct defined using ARRAY_HEAD()
     + */
     +#define ARRAY_ELEM_TYPE(head)                                                  \
    -+  (typeof(*(head)->entries))
    ++  typeof(*(head)->entries)
     +
      /**
       * ARRAY_ELEM_SIZE - Number of bytes occupied by an element of this array
 2:  a7bf21005 =  2:  40cd73dfb mutt/memory.[ch]: Add mutt_mem_reallocarray()
 3:  8dbb3d9f8 =  3:  ae734af87 mutt/memory.[ch]: Add mutt_mem_mallocarray()
 4:  3f22d8ff0 =  4:  b318e29ec Use mutt_mem_reallocarray()
 5:  5db53fce6 =  5:  2c9291bca Use mutt_mem_mallocarray()
 6:  5b5dbcebb =  6:  09bd83c83 mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 7:  dd64b4c5c =  7:  39c1f7aa8 Use MUTT_MEM_MALLOC()
 8:  1bcd937c0 =  8:  436907250 Use MUTT_MEM_CALLOC()
 9:  92b5b129b !  9:  b665fb502 Use MUTT_MEM_REALLOC()
    @@ mutt/array.h
             (head)->capacity :                                                      \
     -       ((mutt_mem_reallocarray(                                                \
     -         &(head)->entries, (num) + ARRAY_HEADROOM, ARRAY_ELEM_SIZE(head))),    \
    -+       ((MUTT_MEM_REALLOCARRAY(                                                \
    ++       ((MUTT_MEM_REALLOC(                                                     \
     +         &(head)->entries, (num) + ARRAY_HEADROOM, ARRAY_ELEM_TYPE(head))),    \
              (memset((head)->entries + (head)->capacity, 0,                         \
                      ((num) + ARRAY_HEADROOM - (head)->capacity) *                  \
10:  8b0288db1 = 10:  1899809b3 mutt/memory.c: free(NULL) is valid C (it's a no-op)
11:  00b825591 = 11:  53de790ba mutt/memory.[ch]: Improve name of variables
12:  5d0217d40 = 12:  298cba41b nntp/adata.[ch]: struct NntpAccountData: Fix type of member
13:  980c1aca9 = 13:  83f392336 Don't use assignment operators in arguments to allocation calls
14:  24b7f7854 = 14:  06614859a conn/openssl.c: Remove useless cast
```
</details>

<details>
<summary>v10b</summary>

-  Add fixes tag

```
$ git range-diff neomutt/main neomutt/alx/reallocarray alx/reallocarray 
 1:  55be66029 =  1:  55be66029 mutt/array.h: Add ARRAY_ELEM_TYPE()
 2:  40cd73dfb =  2:  40cd73dfb mutt/memory.[ch]: Add mutt_mem_reallocarray()
 3:  ae734af87 =  3:  ae734af87 mutt/memory.[ch]: Add mutt_mem_mallocarray()
 4:  b318e29ec =  4:  b318e29ec Use mutt_mem_reallocarray()
 5:  2c9291bca =  5:  2c9291bca Use mutt_mem_mallocarray()
 6:  09bd83c83 =  6:  09bd83c83 mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 7:  39c1f7aa8 =  7:  39c1f7aa8 Use MUTT_MEM_MALLOC()
 8:  436907250 =  8:  436907250 Use MUTT_MEM_CALLOC()
 9:  b665fb502 =  9:  b665fb502 Use MUTT_MEM_REALLOC()
10:  1899809b3 = 10:  1899809b3 mutt/memory.c: free(NULL) is valid C (it's a no-op)
11:  53de790ba = 11:  53de790ba mutt/memory.[ch]: Improve name of variables
12:  298cba41b ! 12:  d3efcabbd nntp/adata.[ch]: struct NntpAccountData: Fix type of member
    @@ Commit message
     
         This allows using the type-safe allocation macros with it.
     
    +    Fixes: 5d7872ae3721 ("feature: nntp")
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## nntp/adata.c ##
13:  83f392336 = 13:  2e34eb150 Don't use assignment operators in arguments to allocation calls
14:  06614859a = 14:  187c4c4ab conn/openssl.c: Remove useless cast
```
</details>

<details>
<summary>v11 - Review</summary>

- fix typo in commit message
- clang-format

```
$ git range-diff main alx/reallocarray github/alx/reallocarray
 1:  55be66029 =  1:  55be66029 mutt/array.h: Add ARRAY_ELEM_TYPE()
 2:  40cd73dfb =  2:  40cd73dfb mutt/memory.[ch]: Add mutt_mem_reallocarray()
 3:  ae734af87 =  3:  ae734af87 mutt/memory.[ch]: Add mutt_mem_mallocarray()
 4:  b318e29ec =  4:  b318e29ec Use mutt_mem_reallocarray()
 5:  2c9291bca =  5:  2c9291bca Use mutt_mem_mallocarray()
 6:  492ed9275 !  6:  09bd83c83 mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
    @@ Commit message
         The syntax will now be of the form:
     
           p = MUTT_MEM_MALLOC(42, foo_t); // allocate 42 elements of type foo_t.
    -      p = MUTT_MEM_MALLOC(1, bar_t);  // allocate 1 element of type bar_t.
    +      p = MUTT_MEM_MALLOC(1, bar_t);  // allocate 1 element of type foo_t.
     
         The *array() allocation functions should _never_ be used.  The *ALLOC()
         macros are always preferred.
 7:  f25229833 =  7:  39c1f7aa8 Use MUTT_MEM_MALLOC()
 8:  9c1300344 =  8:  436907250 Use MUTT_MEM_CALLOC()
 9:  db768b3b7 !  9:  b665fb502 Use MUTT_MEM_REALLOC()
    @@ pager/display.c: static void match_body_patterns(char *pat, struct Line *lines,
              {
     -          mutt_mem_reallocarray(&(lines[line_num].syntax), lines[line_num].syntax_arr_size,
     -                                sizeof(struct TextSyntax));
    -+          MUTT_MEM_REALLOC(&(lines[line_num].syntax),
    -+                           lines[line_num].syntax_arr_size, struct TextSyntax);
    ++          MUTT_MEM_REALLOC(&(lines[line_num].syntax), lines[line_num].syntax_arr_size,
    ++                           struct TextSyntax);
                // Zero the new entry
                const int index = lines[line_num].syntax_arr_size - 1;
                struct TextSyntax *ts = &lines[line_num].syntax[index];
    @@ pager/display.c: int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **li
            {
     -        mutt_mem_reallocarray(&(cur_line->search), cur_line->search_arr_size,
     -                              sizeof(struct TextSyntax));
    -+        MUTT_MEM_REALLOC(&(cur_line->search), cur_line->search_arr_size, struct TextSyntax);
    ++        MUTT_MEM_REALLOC(&(cur_line->search), cur_line->search_arr_size,
    ++                         struct TextSyntax);
              // Zero the new entry
              const int index = cur_line->search_arr_size - 1;
              struct TextSyntax *ts = &cur_line->search[index];
10:  808a09982 = 10:  1899809b3 mutt/memory.c: free(NULL) is valid C (it's a no-op)
11:  f5d63ff28 = 11:  53de790ba mutt/memory.[ch]: Improve name of variables
12:  8dbc3f1a7 = 12:  d3efcabbd nntp/adata.[ch]: struct NntpAccountData: Fix type of member
13:  161d82da3 = 13:  2e34eb150 Don't use assignment operators in arguments to allocation calls
14:  b096dfa5e = 14:  187c4c4ab conn/openssl.c: Remove useless cast
```

</details>

<details>
<summary>v12</summary>

- Fix `FgetConv` vs `FgetConvNot`
  Kill the ugly hack

```
 1:  55be66029 =  1:  55be66029 mutt/array.h: Add ARRAY_ELEM_TYPE()
 2:  40cd73dfb =  2:  40cd73dfb mutt/memory.[ch]: Add mutt_mem_reallocarray()
 3:  ae734af87 =  3:  ae734af87 mutt/memory.[ch]: Add mutt_mem_mallocarray()
 4:  b318e29ec =  4:  b318e29ec Use mutt_mem_reallocarray()
 5:  2c9291bca =  5:  2c9291bca Use mutt_mem_mallocarray()
 6:  492ed9275 =  6:  492ed9275 mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 7:  f25229833 =  7:  f25229833 Use MUTT_MEM_MALLOC()
 8:  9c1300344 =  8:  9c1300344 Use MUTT_MEM_CALLOC()
 9:  db768b3b7 =  9:  db768b3b7 Use MUTT_MEM_REALLOC()
10:  808a09982 = 10:  808a09982 mutt/memory.c: free(NULL) is valid C (it's a no-op)
11:  f5d63ff28 = 11:  f5d63ff28 mutt/memory.[ch]: Improve name of variables
12:  8dbc3f1a7 = 12:  8dbc3f1a7 nntp/adata.[ch]: struct NntpAccountData: Fix type of member
13:  161d82da3 = 13:  161d82da3 Don't use assignment operators in arguments to allocation calls
14:  b096dfa5e = 14:  b096dfa5e conn/openssl.c: Remove useless cast
 -:  --------- > 15:  3a764ecaa charset: drop FgetConvNot
```

</details>

<details>
<summary>v13</summary>

-  Split the change that requires typeof() into a separate commit.
-  Reorder commit 1 (now, commit 9).

```
$ git range-diff main neomutt/alx/reallocarray alx/reallocarray 
 2:  40cd73dfb =  1:  c4e8c0020 mutt/memory.[ch]: Add mutt_mem_reallocarray()
 3:  ae734af87 =  2:  78918d04a mutt/memory.[ch]: Add mutt_mem_mallocarray()
 4:  b318e29ec =  3:  2a6d9dd9f Use mutt_mem_reallocarray()
 5:  2c9291bca =  4:  a1a373ac0 Use mutt_mem_mallocarray()
 6:  492ed9275 =  5:  ea33b6fef mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 7:  f25229833 =  6:  9d38133fc Use MUTT_MEM_MALLOC()
 8:  9c1300344 =  7:  d2d09baf2 Use MUTT_MEM_CALLOC()
 9:  db768b3b7 !  8:  fe0fb911c Use MUTT_MEM_REALLOC()
    @@ monitor.c: static void mutt_poll_fd_add(int fd, short events)
          PollFdsCount++;
          PollFds[i].fd = fd;
     
    - ## mutt/array.h ##
    -@@
    - #define ARRAY_RESERVE(head, num)                                               \
    -   (((head)->capacity > (num)) ?                                                \
    -        (head)->capacity :                                                      \
    --       ((mutt_mem_reallocarray(                                                \
    --         &(head)->entries, (num) + ARRAY_HEADROOM, ARRAY_ELEM_SIZE(head))),    \
    -+       ((MUTT_MEM_REALLOC(                                                     \
    -+         &(head)->entries, (num) + ARRAY_HEADROOM, ARRAY_ELEM_TYPE(head))),    \
    -         (memset((head)->entries + (head)->capacity, 0,                         \
    -                 ((num) + ARRAY_HEADROOM - (head)->capacity) *                  \
    -                 ARRAY_ELEM_SIZE(head))),                                       \
    -
      ## mutt/buffer.c ##
     @@ mutt/buffer.c: void buf_alloc(struct Buffer *buf, size_t new_size)
      
 1:  55be66029 =  9:  027b079b7 mutt/array.h: Add ARRAY_ELEM_TYPE()
 -:  --------- > 10:  ca1e1bd5b mutt/array.h: Use MUTT_MEM_REALLOC()
10:  808a09982 = 11:  c31142a66 mutt/memory.c: free(NULL) is valid C (it's a no-op)
11:  f5d63ff28 = 12:  5a380c22d mutt/memory.[ch]: Improve name of variables
12:  8dbc3f1a7 = 13:  26929ff54 nntp/adata.[ch]: struct NntpAccountData: Fix type of member
13:  161d82da3 = 14:  1c4ac37cd Don't use assignment operators in arguments to allocation calls
14:  b096dfa5e = 15:  7ebd062ca conn/openssl.c: Remove useless cast
15:  3a764ecaa = 16:  489bd8b21 charset: drop FgetConvNot
```
</details>

<details>
<summary>v13b</summary>

-  Rebase

```
$ git range-diff main..neomutt/alx/reallocarray neomutt/main..alx/reallocarray 
 1:  c4e8c0020 =  1:  7e4294bd7 mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  78918d04a =  2:  fee9c6082 mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  2a6d9dd9f =  3:  fbb3cd568 Use mutt_mem_reallocarray()
 4:  a1a373ac0 =  4:  5728230d7 Use mutt_mem_mallocarray()
 5:  ea33b6fef =  5:  0143aecf8 mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 6:  9d38133fc =  6:  e4495b22c Use MUTT_MEM_MALLOC()
 7:  d2d09baf2 =  7:  5925d41b8 Use MUTT_MEM_CALLOC()
 8:  fe0fb911c =  8:  6cee0df2c Use MUTT_MEM_REALLOC()
 9:  027b079b7 =  9:  f53ba5507 mutt/array.h: Add ARRAY_ELEM_TYPE()
10:  ca1e1bd5b = 10:  b044cce75 mutt/array.h: Use MUTT_MEM_REALLOC()
11:  c31142a66 = 11:  892c6ba87 mutt/memory.c: free(NULL) is valid C (it's a no-op)
12:  5a380c22d = 12:  b5fffd2ac mutt/memory.[ch]: Improve name of variables
13:  26929ff54 = 13:  07335c3c0 nntp/adata.[ch]: struct NntpAccountData: Fix type of member
14:  1c4ac37cd = 14:  4fe3c41ab Don't use assignment operators in arguments to allocation calls
15:  7ebd062ca = 15:  12ec81380 conn/openssl.c: Remove useless cast
16:  489bd8b21 = 16:  a8a590152 charset: drop FgetConvNot
```
</details>

<details>
<summary>v13c</summary>

-  Rebase

```
$ git range-diff 7e4294bd7^..neomutt/alx/reallocarray neomutt/main..alx/reallocarray 
 1:  7e4294bd7 =  1:  baedfcc0e mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  fee9c6082 =  2:  2dd3f1f8b mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  fbb3cd568 !  3:  f3c37e7da Use mutt_mem_reallocarray()
    @@ autocrypt/db.c: int mutt_autocrypt_db_account_get_all(struct AutocryptAccount **
          struct AutocryptAccount *account = mutt_autocrypt_db_account_new();
     
      ## browser/complete.c ##
    -@@ browser/complete.c: int complete_file_mbox(struct EnterWindowData *wdata, int op)
    +@@ browser/complete.c: enum FunctionRetval complete_file_mbox(struct EnterWindowData *wdata, int op)
        if (mutt_complete(wdata->cd, wdata->buffer) == 0)
        {
          wdata->templen = wdata->state->lastchar;
    @@ browser/complete.c: int complete_file_mbox(struct EnterWindowData *wdata, int op
          if (wdata->tempbuf)
            wmemcpy(wdata->tempbuf, wdata->state->wbuf, wdata->templen);
        }
    -@@ browser/complete.c: int complete_file_simple(struct EnterWindowData *wdata, int op)
    +@@ browser/complete.c: enum FunctionRetval complete_file_simple(struct EnterWindowData *wdata, int op)
        if (mutt_complete(wdata->cd, wdata->buffer) == 0)
        {
          wdata->templen = wdata->state->lastchar - i;
 4:  5728230d7 =  4:  1d1ad6a62 Use mutt_mem_mallocarray()
 5:  0143aecf8 =  5:  1f24e702c mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 6:  e4495b22c =  6:  a982481a1 Use MUTT_MEM_MALLOC()
 7:  5925d41b8 !  7:  a91d92d6a Use MUTT_MEM_CALLOC()
    @@ email/email.c: struct Email *email_new(void)
      
     -  struct Email *e = mutt_mem_calloc(1, sizeof(struct Email));
     +  struct Email *e = MUTT_MEM_CALLOC(1, struct Email);
    - #ifdef MIXMASTER
    -   STAILQ_INIT(&e->chain);
    - #endif
    +   STAILQ_INIT(&e->tags);
    +   e->visible = true;
    +   e->sequence = sequence++;
     
      ## email/envelope.c ##
     @@
    @@ mh/mhemail.c
      
      /**
     
    - ## mixmaster/chain_data.c ##
    -@@
    -  */
    - struct ChainData *chain_data_new(void)
    - {
    --  return mutt_mem_calloc(1, sizeof(struct ChainData));
    -+  return MUTT_MEM_CALLOC(1, struct ChainData);
    - }
    - 
    - /**
    -
    - ## mixmaster/remailer.c ##
    -@@ mixmaster/remailer.c: void remailer_free(struct Remailer **ptr)
    -  */
    - struct Remailer *remailer_new(void)
    - {
    --  return mutt_mem_calloc(1, sizeof(struct Remailer));
    -+  return MUTT_MEM_CALLOC(1, struct Remailer);
    - }
    - 
    - /**
    -
      ## monitor.c ##
     @@ monitor.c: static void monitor_check_cleanup(void)
       */
    @@ pop/edata.c: void pop_edata_free(void **ptr)
     
      ## pop/pop.c ##
     @@ pop/pop.c: void pop_fetch_mail(void)
    -   int last = 0, msgs, bytes, rset = 0, rc;
    +   int last = 0, msgs = 0, bytes = 0, rset = 0, rc;
        struct ConnAccount cac = { { 0 } };
      
     -  char *p = mutt_mem_calloc(strlen(c_pop_host) + 7, sizeof(char));
 8:  6cee0df2c !  8:  d4c32c634 Use MUTT_MEM_REALLOC()
    @@ autocrypt/db.c: int mutt_autocrypt_db_account_get_all(struct AutocryptAccount **
          struct AutocryptAccount *account = mutt_autocrypt_db_account_new();
     
      ## browser/complete.c ##
    -@@ browser/complete.c: int complete_file_mbox(struct EnterWindowData *wdata, int op)
    +@@ browser/complete.c: enum FunctionRetval complete_file_mbox(struct EnterWindowData *wdata, int op)
        if (mutt_complete(wdata->cd, wdata->buffer) == 0)
        {
          wdata->templen = wdata->state->lastchar;
    @@ browser/complete.c: int complete_file_mbox(struct EnterWindowData *wdata, int op
          if (wdata->tempbuf)
            wmemcpy(wdata->tempbuf, wdata->state->wbuf, wdata->templen);
        }
    -@@ browser/complete.c: int complete_file_simple(struct EnterWindowData *wdata, int op)
    +@@ browser/complete.c: enum FunctionRetval complete_file_simple(struct EnterWindowData *wdata, int op)
        if (mutt_complete(wdata->cd, wdata->buffer) == 0)
        {
          wdata->templen = wdata->state->lastchar - i;
 9:  f53ba5507 =  9:  859055c9c mutt/array.h: Add ARRAY_ELEM_TYPE()
10:  b044cce75 = 10:  adf0f50d5 mutt/array.h: Use MUTT_MEM_REALLOC()
11:  892c6ba87 = 11:  cd9ed2f5d mutt/memory.c: free(NULL) is valid C (it's a no-op)
12:  b5fffd2ac = 12:  ce55c87c2 mutt/memory.[ch]: Improve name of variables
13:  07335c3c0 = 13:  d273104a8 nntp/adata.[ch]: struct NntpAccountData: Fix type of member
14:  4fe3c41ab = 14:  7f430b5ee Don't use assignment operators in arguments to allocation calls
15:  12ec81380 = 15:  75ed81e83 conn/openssl.c: Remove useless cast
16:  a8a590152 = 16:  97365df4c charset: drop FgetConvNot
```
</details>

<details>
<summary>v14</summary>

-  Add `-fasm` to enable `typeof()`.

```
$ git range-diff neomutt/main neomutt/alx/reallocarray alx/reallocarray 
 1:  baedfcc0e =  1:  baedfcc0e mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  2dd3f1f8b =  2:  2dd3f1f8b mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  f3c37e7da =  3:  f3c37e7da Use mutt_mem_reallocarray()
 4:  1d1ad6a62 =  4:  1d1ad6a62 Use mutt_mem_mallocarray()
 5:  1f24e702c =  5:  1f24e702c mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 6:  a982481a1 =  6:  a982481a1 Use MUTT_MEM_MALLOC()
 7:  a91d92d6a =  7:  a91d92d6a Use MUTT_MEM_CALLOC()
 8:  d4c32c634 =  8:  d4c32c634 Use MUTT_MEM_REALLOC()
 9:  859055c9c =  9:  859055c9c mutt/array.h: Add ARRAY_ELEM_TYPE()
10:  adf0f50d5 = 10:  adf0f50d5 mutt/array.h: Use MUTT_MEM_REALLOC()
11:  cd9ed2f5d = 11:  cd9ed2f5d mutt/memory.c: free(NULL) is valid C (it's a no-op)
12:  ce55c87c2 = 12:  ce55c87c2 mutt/memory.[ch]: Improve name of variables
13:  d273104a8 = 13:  d273104a8 nntp/adata.[ch]: struct NntpAccountData: Fix type of member
14:  7f430b5ee = 14:  7f430b5ee Don't use assignment operators in arguments to allocation calls
15:  75ed81e83 = 15:  75ed81e83 conn/openssl.c: Remove useless cast
16:  97365df4c = 16:  97365df4c charset: drop FgetConvNot
 -:  --------- > 17:  fc7ab5c92 auto.def: Append -fasm to CFLAGS
```
</details>

<details>
<summary>v15</summary>

-  Drop changes that need `typeof`.  @gahr 

```
$ git range-diff neomutt/main neomutt/alx/reallocarray alx/reallocarray 
 1:  baedfcc0e =  1:  baedfcc0e mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  2dd3f1f8b =  2:  2dd3f1f8b mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  f3c37e7da =  3:  f3c37e7da Use mutt_mem_reallocarray()
 4:  1d1ad6a62 =  4:  1d1ad6a62 Use mutt_mem_mallocarray()
 5:  1f24e702c =  5:  1f24e702c mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 6:  a982481a1 =  6:  a982481a1 Use MUTT_MEM_MALLOC()
 7:  a91d92d6a =  7:  a91d92d6a Use MUTT_MEM_CALLOC()
 8:  d4c32c634 =  8:  d4c32c634 Use MUTT_MEM_REALLOC()
 9:  859055c9c <  -:  --------- mutt/array.h: Add ARRAY_ELEM_TYPE()
10:  adf0f50d5 <  -:  --------- mutt/array.h: Use MUTT_MEM_REALLOC()
11:  cd9ed2f5d =  9:  202ca5bbb mutt/memory.c: free(NULL) is valid C (it's a no-op)
12:  ce55c87c2 = 10:  f9ccbdb2c mutt/memory.[ch]: Improve name of variables
13:  d273104a8 = 11:  14f77fa97 nntp/adata.[ch]: struct NntpAccountData: Fix type of member
14:  7f430b5ee = 12:  55023eac4 Don't use assignment operators in arguments to allocation calls
15:  75ed81e83 = 13:  8f36662b0 conn/openssl.c: Remove useless cast
16:  97365df4c = 14:  b9f8c7a41 charset: drop FgetConvNot
17:  fc7ab5c92 <  -:  --------- auto.def: Append -fasm to CFLAGS
```
</details>

<details>
<summary>v16</summary>

-  Use `char *` for the compressed buffers.

```
$ git range-diff neomutt/main neomutt/alx/reallocarray alx/reallocarray 
 1:  baedfcc0e =  1:  baedfcc0e mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  2dd3f1f8b =  2:  2dd3f1f8b mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  f3c37e7da =  3:  f3c37e7da Use mutt_mem_reallocarray()
 4:  1d1ad6a62 =  4:  1d1ad6a62 Use mutt_mem_mallocarray()
 5:  1f24e702c =  5:  1f24e702c mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 6:  a982481a1 =  6:  a982481a1 Use MUTT_MEM_MALLOC()
 7:  a91d92d6a =  7:  a91d92d6a Use MUTT_MEM_CALLOC()
 8:  d4c32c634 =  8:  d4c32c634 Use MUTT_MEM_REALLOC()
 9:  202ca5bbb =  9:  202ca5bbb mutt/memory.c: free(NULL) is valid C (it's a no-op)
10:  f9ccbdb2c = 10:  f9ccbdb2c mutt/memory.[ch]: Improve name of variables
11:  14f77fa97 = 11:  14f77fa97 nntp/adata.[ch]: struct NntpAccountData: Fix type of member
12:  55023eac4 = 12:  55023eac4 Don't use assignment operators in arguments to allocation calls
13:  8f36662b0 = 13:  8f36662b0 conn/openssl.c: Remove useless cast
14:  b9f8c7a41 = 14:  b9f8c7a41 charset: drop FgetConvNot
 -:  --------- > 15:  7a6368195 compress/: Use 'char *' for the compressed buffer
```
</details>

<details>
<summary>v16b</summary>

-  Fix typos introduced in v16.

```
$ git range-diff neomutt/main neomutt/alx/reallocarray alx/reallocarray 
 1:  baedfcc0e =  1:  baedfcc0e mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  2dd3f1f8b =  2:  2dd3f1f8b mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  f3c37e7da =  3:  f3c37e7da Use mutt_mem_reallocarray()
 4:  1d1ad6a62 =  4:  1d1ad6a62 Use mutt_mem_mallocarray()
 5:  1f24e702c =  5:  1f24e702c mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 6:  a982481a1 =  6:  a982481a1 Use MUTT_MEM_MALLOC()
 7:  a91d92d6a =  7:  a91d92d6a Use MUTT_MEM_CALLOC()
 8:  d4c32c634 =  8:  d4c32c634 Use MUTT_MEM_REALLOC()
 9:  202ca5bbb =  9:  202ca5bbb mutt/memory.c: free(NULL) is valid C (it's a no-op)
10:  f9ccbdb2c = 10:  f9ccbdb2c mutt/memory.[ch]: Improve name of variables
11:  14f77fa97 = 11:  14f77fa97 nntp/adata.[ch]: struct NntpAccountData: Fix type of member
12:  55023eac4 = 12:  55023eac4 Don't use assignment operators in arguments to allocation calls
13:  8f36662b0 = 13:  8f36662b0 conn/openssl.c: Remove useless cast
14:  b9f8c7a41 = 14:  b9f8c7a41 charset: drop FgetConvNot
15:  7a6368195 ! 15:  ea8c5f9b0 compress/: Use 'char *' for the compressed buffer
    @@ compress/lz4.c: static void *compr_lz4_decompress(ComprHandle *handle, const cha
      
     -  mutt_mem_realloc(&cdata->buf, ulen);
     -  void *ubuf = cdata->buf;
    -+  MUTT_MEM_REALLOC(&cdata->buf, ulen, char
    ++  MUTT_MEM_REALLOC(&cdata->buf, ulen, char);
     +  char *ubuf = cdata->buf;
        const char *data = cbuf;
        int rc = LZ4_decompress_safe(data + 4, ubuf, clen - 4, ulen);
    @@ compress/zlib.c: static ComprHandle *compr_zlib_open(short level)
        struct ZlibComprData *cdata = zlib_cdata_new();
      
     -  cdata->buf = mutt_mem_calloc(compressBound(1024 * 32), 1);
    -+  cdata->buf = MUTT_MEM_CALLOC(compressBound(1024 * 32), char
    ++  cdata->buf = MUTT_MEM_CALLOC(compressBound(1024 * 32), char);
      
        if ((level < MIN_COMP_LEVEL) || (level > MAX_COMP_LEVEL))
        {
    @@ compress/zlib.c: static void *compr_zlib_compress(ComprHandle *handle, const cha
      
        uLong len = compressBound(dlen);
     -  mutt_mem_realloc(&cdata->buf, len + 4);
    -+  MUTT_MEM_REALLOC(&cdata->buf, len + 4, char
    ++  MUTT_MEM_REALLOC(&cdata->buf, len + 4, char);
        Bytef *cbuf = (unsigned char *) cdata->buf + 4;
     -  const void *ubuf = data;
     +  const char *ubuf = data;
```
</details>

<details>
<summary>v16c</summary>

-  Reviewed-by @gahr 

```
$ git range-diff main neomutt/alx/reallocarray alx/reallocarray 
 1:  baedfcc0e !  1:  3b2e17a26 mutt/memory.[ch]: Add mutt_mem_reallocarray()
    @@ Commit message
         These array functions avoid an explicit size multiplication, which can
         overflow the calculation.
     
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## mutt/memory.c ##
 2:  2dd3f1f8b !  2:  5931bc6e4 mutt/memory.[ch]: Add mutt_mem_mallocarray()
    @@ Commit message
         These array functions avoid an explicit size multiplication, which can
         overflow the calculation.
     
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## mutt/memory.c ##
 3:  f3c37e7da !  3:  e0288b924 Use mutt_mem_reallocarray()
    @@ Metadata
      ## Commit message ##
         Use mutt_mem_reallocarray()
     
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## attach/attach.c ##
 4:  1d1ad6a62 !  4:  abe99bb39 Use mutt_mem_mallocarray()
    @@ Metadata
      ## Commit message ##
         Use mutt_mem_mallocarray()
     
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## attach/attachments.c ##
 5:  1f24e702c !  5:  46fae5405 mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
    @@ Commit message
         Link: <https://github.com/shadow-maint/shadow/commit/186ca04e8b2aa4d0e3a8ff3912a3d67db570a7ec>
         Link: <https://github.com/shadow-maint/shadow/commit/0d381137d1e1369e2ab9ed92011b0da952324f0b>
         Link: <https://software.codidact.com/posts/285898/288023#answer-288023>
    -    Cc: Pietro Cerutti <gahr@gahr.ch>
         Cc: Richard Russon <rich@flatcap.org>
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## mutt/memory.h ##
 6:  a982481a1 !  6:  144780f9c Use MUTT_MEM_MALLOC()
    @@ Metadata
      ## Commit message ##
         Use MUTT_MEM_MALLOC()
     
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## attach/attachments.c ##
 7:  a91d92d6a !  7:  767aeecbb Use MUTT_MEM_CALLOC()
    @@ Metadata
      ## Commit message ##
         Use MUTT_MEM_CALLOC()
     
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## address/address.c ##
 8:  d4c32c634 !  8:  58a7c898a Use MUTT_MEM_REALLOC()
    @@ Metadata
      ## Commit message ##
         Use MUTT_MEM_REALLOC()
     
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## attach/attach.c ##
 9:  202ca5bbb !  9:  cd073c24a mutt/memory.c: free(NULL) is valid C (it's a no-op)
    @@ Commit message
     
         Fixes: 1a5381e07e97 ("Initial revision")
         Cc: Richard Russon <rich@flatcap.org>
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## mutt/memory.c ##
10:  f9ccbdb2c ! 10:  6292f98b2 mutt/memory.[ch]: Improve name of variables
    @@ Commit message
         For pointers to pointers in realloc functions, use a double-p, that is,
         'pp', to indicate the number of references.
     
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## mutt/memory.c ##
11:  14f77fa97 ! 11:  cda7b1dac nntp/adata.[ch]: struct NntpAccountData: Fix type of member
    @@ Commit message
         This allows using the type-safe allocation macros with it.
     
         Fixes: 5d7872ae3721 ("feature: nntp")
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## nntp/adata.c ##
12:  55023eac4 ! 12:  6c875d776 Don't use assignment operators in arguments to allocation calls
    @@ Metadata
      ## Commit message ##
         Don't use assignment operators in arguments to allocation calls
     
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## enriched.c ##
13:  8f36662b0 ! 13:  60d4424d6 conn/openssl.c: Remove useless cast
    @@ Metadata
      ## Commit message ##
         conn/openssl.c: Remove useless cast
     
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## conn/openssl.c ##
14:  b9f8c7a41 ! 14:  d1780f4b5 charset: drop FgetConvNot
    @@ Commit message
         Drop struct FgetConvNot.
         It just makes the code more complicated.
     
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
    +
      ## mutt/charset.c ##
     @@ mutt/charset.c: bool mutt_ch_check_charset(const char *cs, bool strict)
       */
15:  ea8c5f9b0 ! 15:  f9e27018c compress/: Use 'char *' for the compressed buffer
    @@ Commit message
         This allows using the type-safe allocation macros.
     
         Suggested-by: Pietro Cerutti <gahr@gahr.ch>
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## compress/lib.h ##
```
</details>

<details>
<summary>v17 (by @flatcap )</summary>

- Rebased over `main`
- Changed merge branch to `post-release`

```
$ git range-diff 3b2e17a26^..f9e27018c neomutt/main..neomutt/alx/reallocarray 
 1:  3b2e17a26 =  1:  63e0c7173 mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  5931bc6e4 =  2:  e6244f1b5 mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  e0288b924 !  3:  785e05004 Use mutt_mem_reallocarray()
    @@ enriched.c: static void enriched_putwc(wchar_t c, struct EnrichedState *enriched
          {
            if ((enriched->param_used + 1) >= enriched->param_len)
     -        mutt_mem_realloc(&enriched->param, (enriched->param_len += 256) * sizeof(wchar_t));
    -+        mutt_mem_reallocarray(&enriched->param, (enriched->param_len += 256), sizeof(wchar_t));
    ++        mutt_mem_reallocarray(&enriched->param, (enriched->param_len += 256),
    ++                              sizeof(wchar_t));
      
            enriched->param[enriched->param_used++] = c;
          }
    @@ ncrypt/crypt.c: int crypt_get_keys(struct Email *e, char **keylist, bool oppenc_
        {
          const size_t keylist_size = mutt_str_len(*keylist);
     -    mutt_mem_realloc(keylist, keylist_size + mutt_str_len(self_encrypt) + 2);
    -+    mutt_mem_reallocarray(keylist, keylist_size + mutt_str_len(self_encrypt) + 2, sizeof(char));
    ++    mutt_mem_reallocarray(keylist, keylist_size + mutt_str_len(self_encrypt) + 2,
    ++                          sizeof(char));
          sprintf(*keylist + keylist_size, " %s", self_encrypt);
        }
      
    @@ pager/display.c: static void resolve_types(struct MuttWindow *win, char *buf, ch
                  {
     -              mutt_mem_realloc(&(lines[line_num].syntax),
     -                               (lines[line_num].syntax_arr_size) * sizeof(struct TextSyntax));
    -+              mutt_mem_reallocarray(&(lines[line_num].syntax),
    -+                                    lines[line_num].syntax_arr_size,
    ++              mutt_mem_reallocarray(&(lines[line_num].syntax), lines[line_num].syntax_arr_size,
     +                                    sizeof(struct TextSyntax));
                    // Zero the new entry
                    const int index = lines[line_num].syntax_arr_size - 1;
 4:  abe99bb39 !  4:  e5393cfc7 Use mutt_mem_mallocarray()
    @@ imap/util.c: int imap_mxcmp(const char *mx1, const char *mx2)
     +  b1 = mutt_mem_mallocarray(strlen(mx1) + 1, sizeof(char));
     +  b2 = mutt_mem_mallocarray(strlen(mx2) + 1, sizeof(char));
      
    -   imap_fix_path('\0', mx1, b1, strlen(mx1) + 1);
    -   imap_fix_path('\0', mx2, b2, strlen(mx2) + 1);
    +   imap_fix_path(mx1, b1, strlen(mx1) + 1);
    +   imap_fix_path(mx2, b2, strlen(mx2) + 1);
     
      ## index/dlg_index.c ##
     @@ index/dlg_index.c: static void update_index_threaded(struct MailboxView *mv, enum MxStatus check, i
    @@ nntp/adata.c: struct NntpAccountData *nntp_adata_new(struct Connection *conn)
        mutt_hash_set_destructor(adata->groups_hash, nntp_hashelem_free, 0);
        adata->groups_max = 16;
     -  adata->groups_list = mutt_mem_malloc(adata->groups_max * sizeof(struct NntpMboxData *));
    -+  adata->groups_list = mutt_mem_mallocarray(adata->groups_max, sizeof(struct NntpMboxData *));
    ++  adata->groups_list = mutt_mem_mallocarray(adata->groups_max,
    ++                                            sizeof(struct NntpMboxData *));
        return adata;
      }
     
 5:  46fae5405 =  5:  9dae058eb mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 6:  144780f9c !  6:  a9e2f67d7 Use MUTT_MEM_MALLOC()
    @@ imap/util.c: int imap_mxcmp(const char *mx1, const char *mx2)
     +  b1 = MUTT_MEM_MALLOC(strlen(mx1) + 1, char);
     +  b2 = MUTT_MEM_MALLOC(strlen(mx2) + 1, char);
      
    -   imap_fix_path('\0', mx1, b1, strlen(mx1) + 1);
    -   imap_fix_path('\0', mx2, b2, strlen(mx2) + 1);
    +   imap_fix_path(mx1, b1, strlen(mx1) + 1);
    +   imap_fix_path(mx2, b2, strlen(mx2) + 1);
     
      ## index/dlg_index.c ##
     @@ index/dlg_index.c: static void update_index_threaded(struct MailboxView *mv, enum MxStatus check, i
 7:  767aeecbb !  7:  7412f98ac Use MUTT_MEM_CALLOC()
    @@ envelope/wdata.c: void env_wdata_free(struct MuttWindow *win, void **ptr)
        wdata->autocrypt_rec = AUTOCRYPT_REC_OFF;
     
      ## expando/expando.c ##
    -@@
    +@@ expando/expando.c: struct ExpandoDefinition;
       */
      struct Expando *expando_new(const char *format)
      {
     -  struct Expando *exp = mutt_mem_calloc(1, sizeof(struct Expando));
     +  struct Expando *exp = MUTT_MEM_CALLOC(1, struct Expando);
        exp->string = mutt_str_dup(format);
    +   exp->node = node_container_new();
        return exp;
    - }
     
      ## expando/node.c ##
     @@
    @@ expando/node_expando.c
      
        // NOTE(g0mb4): Expando definition should contain this
        priv->color = -1;
    -@@ expando/node_expando.c: struct ExpandoFormat *parse_format(const char *start, const char *end,
    -   if (start == end)
    -     return NULL;
    +@@ expando/node_expando.c: struct ExpandoFormat *parse_format(const char *str, const char **parsed_until,
    + 
    +   const char *start = str;
      
     -  struct ExpandoFormat *fmt = mutt_mem_calloc(1, sizeof(struct ExpandoFormat));
     +  struct ExpandoFormat *fmt = MUTT_MEM_CALLOC(1, struct ExpandoFormat);
      
        fmt->leader = ' ';
    -   fmt->start = start;
    +   fmt->justification = JUSTIFY_RIGHT;
     
      ## expando/node_padding.c ##
     @@
    @@ imap/mdata.c: struct ImapMboxData *imap_mdata_get(struct Mailbox *m)
     -  struct ImapMboxData *mdata = mutt_mem_calloc(1, sizeof(struct ImapMboxData));
     +  struct ImapMboxData *mdata = MUTT_MEM_CALLOC(1, struct ImapMboxData);
      
    -   mdata->real_name = mutt_str_dup(name);
    - 
    +   imap_fix_path_with_delim(adata->delim, name, buf, sizeof(buf));
    +   if (buf[0] == '\0')
     
      ## imap/util.c ##
     @@ imap/util.c: struct SeqsetIterator *mutt_seqset_iterator_new(const char *seqset)
 8:  58a7c898a !  8:  bd5a61c50 Use MUTT_MEM_REALLOC()
    @@ enriched.c: static void enriched_putwc(wchar_t c, struct EnrichedState *enriched
          if (enriched->tag_level[RICH_COLOR])
          {
            if ((enriched->param_used + 1) >= enriched->param_len)
    --        mutt_mem_reallocarray(&enriched->param, (enriched->param_len += 256), sizeof(wchar_t));
    +-        mutt_mem_reallocarray(&enriched->param, (enriched->param_len += 256),
    +-                              sizeof(wchar_t));
     +        MUTT_MEM_REALLOC(&enriched->param, (enriched->param_len += 256), wchar_t);
      
            enriched->param[enriched->param_used++] = c;
    @@ ncrypt/crypt.c: int crypt_get_keys(struct Email *e, char **keylist, bool oppenc_
        if (!oppenc_mode && self_encrypt)
        {
          const size_t keylist_size = mutt_str_len(*keylist);
    --    mutt_mem_reallocarray(keylist, keylist_size + mutt_str_len(self_encrypt) + 2, sizeof(char));
    +-    mutt_mem_reallocarray(keylist, keylist_size + mutt_str_len(self_encrypt) + 2,
    +-                          sizeof(char));
     +    MUTT_MEM_REALLOC(keylist, keylist_size + mutt_str_len(self_encrypt) + 2, char);
          sprintf(*keylist + keylist_size, " %s", self_encrypt);
        }
    @@ pager/display.c: static void resolve_types(struct MuttWindow *win, char *buf, ch
                {
                  if (++(lines[line_num].syntax_arr_size) > 1)
                  {
    --              mutt_mem_reallocarray(&(lines[line_num].syntax),
    --                                    lines[line_num].syntax_arr_size,
    +-              mutt_mem_reallocarray(&(lines[line_num].syntax), lines[line_num].syntax_arr_size,
     -                                    sizeof(struct TextSyntax));
     +              MUTT_MEM_REALLOC(&(lines[line_num].syntax),
     +                               lines[line_num].syntax_arr_size, struct TextSyntax);
 9:  cd073c24a =  9:  b6d9a6289 mutt/memory.c: free(NULL) is valid C (it's a no-op)
10:  6292f98b2 = 10:  78d348173 mutt/memory.[ch]: Improve name of variables
11:  cda7b1dac ! 11:  83f6bab1f nntp/adata.[ch]: struct NntpAccountData: Fix type of member
    @@ nntp/adata.c: struct NntpAccountData *nntp_adata_new(struct Connection *conn)
        adata->groups_hash = mutt_hash_new(1009, MUTT_HASH_NO_FLAGS);
        mutt_hash_set_destructor(adata->groups_hash, nntp_hashelem_free, 0);
        adata->groups_max = 16;
    --  adata->groups_list = mutt_mem_mallocarray(adata->groups_max, sizeof(struct NntpMboxData *));
    +-  adata->groups_list = mutt_mem_mallocarray(adata->groups_max,
    +-                                            sizeof(struct NntpMboxData *));
     +  adata->groups_list = MUTT_MEM_MALLOC(adata->groups_max, struct NntpMboxData *);
        return adata;
      }
12:  6c875d776 = 12:  7d81ae5f2 Don't use assignment operators in arguments to allocation calls
13:  60d4424d6 = 13:  f62033013 conn/openssl.c: Remove useless cast
14:  d1780f4b5 = 14:  104ddde0d charset: drop FgetConvNot
15:  f9e27018c = 15:  eb81ddff0 compress/: Use 'char *' for the compressed buffer
```
</details>

<details>
<summary>v18</summary>

-  Drop last commit.  It caused sign-mismatch diagnostics, and required casts to silence them.  I strongly dislike using casts, and think `void*` is safer than anything requiring casts.

```
$ git range-diff neomutt/main neomutt/alx/reallocarray alx/reallocarray 
 1:  63e0c7173 =  1:  63e0c7173 mutt/memory.[ch]: Add mutt_mem_reallocarray()
 2:  e6244f1b5 =  2:  e6244f1b5 mutt/memory.[ch]: Add mutt_mem_mallocarray()
 3:  785e05004 =  3:  785e05004 Use mutt_mem_reallocarray()
 4:  e5393cfc7 =  4:  e5393cfc7 Use mutt_mem_mallocarray()
 5:  9dae058eb =  5:  9dae058eb mutt/memory.h: Add MUTT_MEM_MALLOC(), MUTT_MEM_CALLOC(), MUTT_MEM_REALLOC()
 6:  a9e2f67d7 =  6:  a9e2f67d7 Use MUTT_MEM_MALLOC()
 7:  7412f98ac =  7:  7412f98ac Use MUTT_MEM_CALLOC()
 8:  bd5a61c50 =  8:  bd5a61c50 Use MUTT_MEM_REALLOC()
 9:  b6d9a6289 =  9:  b6d9a6289 mutt/memory.c: free(NULL) is valid C (it's a no-op)
10:  78d348173 = 10:  78d348173 mutt/memory.[ch]: Improve name of variables
11:  83f6bab1f = 11:  83f6bab1f nntp/adata.[ch]: struct NntpAccountData: Fix type of member
12:  7d81ae5f2 = 12:  7d81ae5f2 Don't use assignment operators in arguments to allocation calls
13:  f62033013 = 13:  f62033013 conn/openssl.c: Remove useless cast
14:  104ddde0d = 14:  104ddde0d charset: drop FgetConvNot
15:  eb81ddff0 <  -:  --------- compress/: Use 'char *' for the compressed buffer
```
</details>