### PR TITLE
Use wmem*() functions with wide-character strings

### DIFF
--- a/browser/complete.c
+++ b/browser/complete.c
@@ -30,6 +30,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
+#include <wchar.h>
 #include "mutt/lib.h"
 #include "core/lib.h"
 #include "gui/lib.h"
@@ -70,8 +71,7 @@ int complete_file_mbox(struct EnterWindowData *wdata, int op)
   /* see if the path has changed from the last time */
   if ((!wdata->tempbuf && !wdata->state->lastchar) ||
       (wdata->tempbuf && (wdata->templen == wdata->state->lastchar) &&
-       (memcmp(wdata->tempbuf, wdata->state->wbuf,
-               wdata->state->lastchar * sizeof(wchar_t)) == 0)))
+       (wmemcmp(wdata->tempbuf, wdata->state->wbuf, wdata->state->lastchar) == 0)))
   {
     SelectFileFlags flags = MUTT_SEL_NO_FLAGS;
     if (wdata->hclass == HC_MAILBOX)
@@ -98,7 +98,7 @@ int complete_file_mbox(struct EnterWindowData *wdata, int op)
     wdata->templen = wdata->state->lastchar;
     mutt_mem_realloc(&wdata->tempbuf, wdata->templen * sizeof(wchar_t));
     if (wdata->tempbuf)
-      memcpy(wdata->tempbuf, wdata->state->wbuf, wdata->templen * sizeof(wchar_t));
+      wmemcpy(wdata->tempbuf, wdata->state->wbuf, wdata->templen);
   }
   else
   {
@@ -124,8 +124,7 @@ int complete_file_simple(struct EnterWindowData *wdata, int op)
   }
   buf_mb_wcstombs(wdata->buffer, wdata->state->wbuf + i, wdata->state->curpos - i);
   if (wdata->tempbuf && (wdata->templen == (wdata->state->lastchar - i)) &&
-      (memcmp(wdata->tempbuf, wdata->state->wbuf + i,
-              (wdata->state->lastchar - i) * sizeof(wchar_t)) == 0))
+      (wmemcmp(wdata->tempbuf, wdata->state->wbuf + i, wdata->state->lastchar - i) == 0))
   {
     dlg_browser(wdata->buffer, MUTT_SEL_NO_FLAGS, NULL, NULL, NULL);
     if (!buf_is_empty(wdata->buffer))
@@ -138,7 +137,7 @@ int complete_file_simple(struct EnterWindowData *wdata, int op)
     wdata->templen = wdata->state->lastchar - i;
     mutt_mem_realloc(&wdata->tempbuf, wdata->templen * sizeof(wchar_t));
     if (wdata->tempbuf)
-      memcpy(wdata->tempbuf, wdata->state->wbuf + i, wdata->templen * sizeof(wchar_t));
+      wmemcpy(wdata->tempbuf, wdata->state->wbuf + i, wdata->templen);
   }
   else
   {

--- a/editor/enter.c
+++ b/editor/enter.c
@@ -55,8 +55,7 @@ int editor_backspace(struct EnterState *es)
     i--;
   if (i > 0)
     i--;
-  memmove(es->wbuf + i, es->wbuf + es->curpos,
-          (es->lastchar - es->curpos) * sizeof(wchar_t));
+  wmemmove(es->wbuf + i, es->wbuf + es->curpos, es->lastchar - es->curpos);
   es->lastchar -= es->curpos - i;
   es->curpos = i;
 
@@ -165,7 +164,7 @@ int editor_delete_char(struct EnterState *es)
     i++;
   while ((i < es->lastchar) && COMB_CHAR(es->wbuf[i]))
     i++;
-  memmove(es->wbuf + es->curpos, es->wbuf + i, (es->lastchar - i) * sizeof(wchar_t));
+  wmemmove(es->wbuf + es->curpos, es->wbuf + i, es->lastchar - i);
   es->lastchar -= i - es->curpos;
 
   return FR_SUCCESS;
@@ -278,7 +277,7 @@ int editor_kill_eow(struct EnterState *es)
     }
   }
 
-  memmove(es->wbuf + es->curpos, es->wbuf + i, (es->lastchar - i) * sizeof(wchar_t));
+  wmemmove(es->wbuf + es->curpos, es->wbuf + i, es->lastchar - i);
   es->lastchar += es->curpos - i;
   return FR_SUCCESS;
 }
@@ -296,7 +295,7 @@ int editor_kill_line(struct EnterState *es)
 
   size_t len = es->lastchar - es->curpos;
 
-  memmove(es->wbuf, es->wbuf + es->curpos, len * sizeof(wchar_t));
+  wmemmove(es->wbuf, es->wbuf + es->curpos, len);
 
   es->lastchar = len;
   es->curpos = 0;
@@ -347,8 +346,7 @@ int editor_kill_word(struct EnterState *es)
       i--;
     }
   }
-  memmove(es->wbuf + i, es->wbuf + es->curpos,
-          (es->lastchar - es->curpos) * sizeof(wchar_t));
+  wmemmove(es->wbuf + i, es->wbuf + es->curpos, es->lastchar - es->curpos);
   es->lastchar += i - es->curpos;
   es->curpos = i;
 

--- a/editor/functions.c
+++ b/editor/functions.c
@@ -31,6 +31,7 @@
 #include "docs/makedoc_defs.h"
 #else
 #include <string.h>
+#include <wchar.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"
@@ -138,7 +139,7 @@ void replace_part(struct EnterState *es, size_t from, const char *buf)
   if (savelen)
   {
     savebuf = mutt_mem_calloc(savelen, sizeof(wchar_t));
-    memcpy(savebuf, es->wbuf + es->curpos, savelen * sizeof(wchar_t));
+    wmemcpy(savebuf, es->wbuf + es->curpos, savelen);
   }
 
   /* Convert to wide characters */
@@ -154,7 +155,7 @@ void replace_part(struct EnterState *es, size_t from, const char *buf)
     }
 
     /* Restore suffix */
-    memcpy(es->wbuf + es->curpos, savebuf, savelen * sizeof(wchar_t));
+    wmemcpy(es->wbuf + es->curpos, savebuf, savelen);
     FREE(&savebuf);
   }
 

--- a/editor/state.c
+++ b/editor/state.c
@@ -28,6 +28,7 @@
 
 #include "config.h"
 #include <string.h>
+#include <wchar.h>
 #include "mutt/lib.h"
 #include "state.h"
 
@@ -62,7 +63,7 @@ void enter_state_resize(struct EnterState *es, size_t num)
   num = ROUND_UP(num + 4, 128);
   mutt_mem_realloc(&es->wbuf, num * sizeof(wchar_t));
 
-  memset(es->wbuf + es->wbuflen, 0, (num - es->wbuflen) * sizeof(wchar_t));
+  wmemset(es->wbuf + es->wbuflen, 0, num - es->wbuflen);
 
   es->wbuflen = num;
 }


### PR DESCRIPTION
This avoids an explicit size multiplication, which can overflow the calculation.