### PR TITLE
ncrypt/crypt.c: Fix allocation size calculation

### DIFF
--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1085,7 +1085,7 @@ static void crypt_fetch_signatures(struct Body ***b_sigs, struct Body *b, int *n
     else
     {
       if ((*n % 5) == 0)
-        mutt_mem_realloc(b_sigs, (*n + 6) * sizeof(struct Body **));
+        mutt_mem_realloc(b_sigs, (*n + 6) * sizeof(struct Body *));
 
       (*b_sigs)[(*n)++] = b;
     }


### PR DESCRIPTION
Fixes: b423ebbfa9d2 ("Make the experimental branch the main trunk.")
Cc: @ossilator 
Cc: @gahr 
Cc: @flatcap 
Link: <https://github.com/neomutt/neomutt/pull/4294>

This was found thanks to the MUTT_MEM_REALLOC() macro, which caused a compiler error.