### PR TITLE
Fix newlines in subject being shown with `?`

### DIFF
--- a/email/rfc2047.c
+++ b/email/rfc2047.c
@@ -330,7 +330,7 @@ static size_t choose_block(char *d, size_t dlen, int col, const char *fromcode,
 }
 
 /**
- * finalize_chunk - Perform charset conversion and filtering
+ * finalize_chunk - Perform charset conversion
  * @param[out] res        Buffer where the resulting string is appended
  * @param[in]  buf        Buffer with the input string
  * @param[in]  charset    Charset to use for the conversion
@@ -346,7 +346,6 @@ static void finalize_chunk(struct Buffer *res, struct Buffer *buf, char *charset
   charset[charsetlen] = '\0';
   mutt_ch_convert_string(&buf->data, charset, cc_charset(), MUTT_ICONV_HOOK_FROM);
   charset[charsetlen] = end;
-  mutt_mb_filter_unprintable(&buf->data);
   buf_addstr(res, buf->data);
   FREE(&buf->data);
   buf_init(buf);

--- a/expando/format.c
+++ b/expando/format.c
@@ -149,13 +149,8 @@ int format_string(struct Buffer *buf, int min_cols, int max_cols, enum FormatJus
     }
     else
     {
-#ifdef HAVE_ISWBLANK
-      if (iswblank(wc))
-        wc = ' ';
-      else
-#endif
-          if (!IsWPrint(wc))
-        wc = '?';
+      if (!IsWPrint(wc))
+        wc = ReplacementChar;
       w = wcwidth(wc);
     }
 

--- a/subjectrx.h
+++ b/subjectrx.h
@@ -51,7 +51,7 @@ void subjrx_cleanup(void);
 enum CommandResult parse_subjectrx_list  (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult parse_unsubjectrx_list(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 
-bool subjrx_apply_mods(struct Envelope *env);
+void subjrx_apply_mods(struct Envelope *env);
 void subjrx_clear_mods(struct MailboxView *mv);
 
 #endif /* MUTT_SUBJECTRX_H */

--- a/test/common.c
+++ b/test/common.c
@@ -313,9 +313,8 @@ const char *mutt_get_name(const char *s)
   return NULL;
 }
 
-bool subjrx_apply_mods(struct Envelope *env)
+void subjrx_apply_mods(struct Envelope *env)
 {
-  return false;
 }
 
 #ifdef USE_DEBUG_BACKTRACE


### PR DESCRIPTION
* **What does this PR do?**

1. Keeps `env->subject` with the original content, the previous code was replacing `LF` characters with `?`.
    1. Other fields may be affected, but I think that if any additional fixes become needed, it should be done in `format_string()` or similar
2. Sanitize `env->subject` into `env->disp_subj` by replacing whitespace characters (`iswspace()`) with a space ` ` character.

I also tested with and without a `subjectrx` configuration, seems to be working as expected.

There are also some side changes as discussed in #4276 

1. `#ifdef` not needed anymore in `expando/format.c`
> As `iswspace()` is a bigger set than `iswblank()`, we can drop `iswblank()`.
2. Return value of `subjrx_apply_mods` from `bool` to `void`. Return value is not used anywhere

* **Screenshots (if relevant)**

Subject with newlines before the change:

```
???      ? ? ?    ?  ?  ?  ?   ??Google Cloud Platform & APIs...
```

Subject with newlines after the change:

```
                                 Google Cloud Platform & APIs...
```

- **What are the relevant issue numbers?** 
#4276 

---

This is my first PR with C language related changes. Please tell me if there are any security or performance issues in my code.

Thank you @flatcap for giving me so much information in the issue.