### PR TITLE
ncrypt/crypt.c: Read the protected Message-ID

### DIFF
--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1209,6 +1209,12 @@ int mutt_protected_headers_handler(struct Body *b_email, struct State *state)
 
   if (c_devel_security)
   {
+    if (b_email->mime_headers->message_id &&
+        (!weed || !mutt_matches_ignore("message-id")))
+    {
+      mutt_write_one_header(state->fp_out, "Message-ID", b_email->mime_headers->message_id,
+                            state->prefix, wraplen, chflags, NeoMutt->sub);
+    }
     if (!weed || !mutt_matches_ignore("references"))
     {
       buf_reset(buf);


### PR DESCRIPTION
I've seen some messages sent with thunderbird(1) which protected the Message-ID field.  Let's read it if it's there.

Tested with an old mail I had in my mailbox:

```
...

[-- Begin signature information --]
Good signature from: Alejandro Colomar <alx@alejandro-colomar.es>
                aka: Alejandro Colomar <alx@kernel.org>
                aka: Alejandro Colomar Andres <alx.manpages@gmail.com>
            created: Thu Dec 22 15:11:26 2022
[-- End signature information --]

[-- The following data is signed --]
From: Alejandro Colomar <alx.manpages@gmail.com>
To: Deri <deri@chuzzlewit.myzen.co.uk>
Subject: Re: The Linux Manpages Book - Happy Christmas
Message-ID: <e5567e8b-def9-288a-c0bb-32ab3d67e3ea@gmail.com>
References: <1842694.tdWV9SEqCh@pip>
In-Reply-To: <1842694.tdWV9SEqCh@pip>

[-- Attachment #1 --]
[-- Type: text/plain; charset=UTF-8, Encoding: base64, Size: 8.0K --]

...
```

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff neomutt/alx/protect^..neomutt/alx/protect neomutt/main..alx/protect 
1:  09574e869 = 1:  adcfd7730 ncrypt/crypt.c: Read the protected Message-ID
```
</details>

<details>
<summary>v2</summary>

-  Simplify (just like the surrounding code has been recently simplified).
-  Add review tags [@gahr , @roccoblues ].

```
$ git range-diff neomutt/main neomutt/alx/protect alx/protect 
1:  adcfd7730 ! 1:  e7ae71551 ncrypt/crypt.c: Read the protected Message-ID
    @@ Commit message
         I've seen some messages sent with thunderbird(1) which protected the
         Message-ID field.  Let's read it if it's there.
     
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
    +    Reviewed-by: Dennis Schön <mail@dennis-schoen.de>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## ncrypt/crypt.c ##
    @@ ncrypt/crypt.c: int mutt_protected_headers_handler(struct Body *b_email, struct
        if (c_devel_security)
        {
     +    if (b_email->mime_headers->message_id &&
    -+        (!display || !c_weed || !mutt_matches_ignore("message-id")))
    ++        (!weed || !mutt_matches_ignore("message-id")))
     +    {
     +      mutt_write_one_header(state->fp_out, "Message-ID", b_email->mime_headers->message_id,
     +                            state->prefix, wraplen, chflags, NeoMutt->sub);
```
</details>