### PR TITLE
remove mutt_expand_path() and mutt_expand_path_regex()

### DIFF
--- a/alias/alias.c
+++ b/alias/alias.c
@@ -520,7 +520,7 @@ retry_name:
   {
     goto done;
   }
-  mutt_expand_path(buf->data, buf->dsize);
+  buf_expand_path(buf);
   fp_alias = mutt_file_fopen(buf_string(buf), "a+");
   if (!fp_alias)
   {

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -217,12 +217,13 @@ static int op_browser_subscribe(struct BrowserPrivateData *priv, int op)
       return FR_ERROR;
     }
 
-    char tmp2[256] = { 0 };
+    struct Buffer *buf = buf_pool_get();
     int index = menu_get_index(priv->menu);
     struct FolderFile *ff = ARRAY_GET(&priv->state.entry, index);
-    mutt_str_copy(tmp2, ff->name, sizeof(tmp2));
-    mutt_expand_path(tmp2, sizeof(tmp2));
-    imap_subscribe(tmp2, (op == OP_BROWSER_SUBSCRIBE));
+    buf_strcpy(buf, ff->name);
+    buf_expand_path(buf);
+    imap_subscribe(buf_string(buf), (op == OP_BROWSER_SUBSCRIBE));
+    buf_pool_release(&buf);
   }
   return FR_SUCCESS;
 }

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1220,7 +1220,7 @@ int imap_mailbox_status(struct Mailbox *m, bool queue)
  * @retval  0 Success
  * @retval -1 Failure
  */
-int imap_subscribe(char *path, bool subscribe)
+int imap_subscribe(const char *path, bool subscribe)
 {
   struct ImapAccountData *adata = NULL;
   struct ImapMboxData *mdata = NULL;

--- a/imap/lib.h
+++ b/imap/lib.h
@@ -78,7 +78,7 @@ int imap_delete_mailbox(struct Mailbox *m, char *path);
 enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close);
 int imap_path_status(const char *path, bool queue);
 int imap_mailbox_status(struct Mailbox *m, bool queue);
-int imap_subscribe(char *path, bool subscribe);
+int imap_subscribe(const char *path, bool subscribe);
 int imap_complete(struct Buffer *buf, const char *path);
 int imap_fast_trash(struct Mailbox *m, const char *dest);
 enum MailboxType imap_path_probe(const char *path, const struct stat *st);

--- a/muttlib.c
+++ b/muttlib.c
@@ -113,19 +113,6 @@ void mutt_adv_mktemp(struct Buffer *buf)
 }
 
 /**
- * mutt_expand_path - Create the canonical path
- * @param buf    Buffer with path
- * @param buflen Length of buffer
- * @retval ptr The expanded string
- *
- * @note The path is expanded in-place
- */
-char *mutt_expand_path(char *buf, size_t buflen)
-{
-  return mutt_expand_path_regex(buf, buflen, false);
-}
-
-/**
  * buf_expand_path_regex - Create the canonical path (with regex char escaping)
  * @param buf     Buffer with path
  * @param regex If true, escape any regex characters
@@ -328,28 +315,6 @@ void buf_expand_path_regex(struct Buffer *buf, bool regex)
 void buf_expand_path(struct Buffer *buf)
 {
   buf_expand_path_regex(buf, false);
-}
-
-/**
- * mutt_expand_path_regex - Create the canonical path (with regex char escaping)
- * @param buf     Buffer with path
- * @param buflen  Length of buffer
- * @param regex If true, escape any regex characters
- * @retval ptr The expanded string
- *
- * @note The path is expanded in-place
- */
-char *mutt_expand_path_regex(char *buf, size_t buflen, bool regex)
-{
-  struct Buffer *tmp = buf_pool_get();
-
-  buf_addstr(tmp, NONULL(buf));
-  buf_expand_path_regex(tmp, regex);
-  mutt_str_copy(buf, buf_string(tmp), buflen);
-
-  buf_pool_release(&tmp);
-
-  return buf;
 }
 
 /**

--- a/muttlib.h
+++ b/muttlib.h
@@ -45,8 +45,6 @@ void        buf_sanitize_filename (struct Buffer *buf, const char *path, short s
 void        buf_save_path(struct Buffer *dest, const struct Address *a);
 int         mutt_check_overwrite(const char *attname, const char *path, struct Buffer *fname, enum SaveAttach *opt, char **directory);
 void        mutt_encode_path(struct Buffer *buf, const char *src);
-char *      mutt_expand_path(char *s, size_t slen);
-char *      mutt_expand_path_regex(char *buf, size_t buflen, bool regex);
 char *      mutt_gecos_name(char *dest, size_t destlen, struct passwd *pw);
 void        mutt_get_parent_path(const char *path, char *buf, size_t buflen);
 int         mutt_inbox_cmp(const char *a, const char *b);

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -1146,7 +1146,7 @@ struct NntpAccountData *nntp_select_server(struct Mailbox *m, const char *server
     const struct Expando *c_newsrc = cs_subset_expando(NeoMutt->sub, "newsrc");
     struct Buffer *buf = buf_pool_get();
     expando_filter(c_newsrc, NntpRenderData, adata, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
-    mutt_expand_path(buf->data, buf->dsize);
+    buf_expand_path(buf);
     adata->newsrc_file = buf_strdup(buf);
     buf_pool_release(&buf);
     rc = nntp_newsrc_parse(adata);

--- a/test/pattern/dummy.c
+++ b/test/pattern/dummy.c
@@ -289,11 +289,6 @@ int mutt_complete(char *buf, size_t buflen)
   return 0;
 }
 
-char *mutt_expand_path(char *buf, size_t buflen)
-{
-  return NULL;
-}
-
 void mutt_help(enum MenuType menu)
 {
 }


### PR DESCRIPTION
This replaces the remaining uses of `mutt_expand_path()` with `buf_expand_path()` and removes the unused functions.