### PR TITLE
build: require C11

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,7 +35,7 @@ See [Signing Releases](https://neomutt.org/dev/signing#source-example) for detai
 
 To build NeoMutt, you will need, at the very minimum:
 
-- A C99 compiler such as gcc or clang
+- A C11 compiler such as gcc or clang
 - SysV-compatible curses library: ncurses
 - Some common libraries, such as iconv and regex
 - DocBook XSL stylesheets and DTDs (for building the docs)

--- a/auto.def
+++ b/auto.def
@@ -313,12 +313,12 @@ if {1} {
 # C compiler definitions and related tools
 if {1} {
 
-  # First off, require c99
-  if {[cc-check-standards c99] eq {}} {
-    user-error "C99 is required"
+  # First off, require c11
+  if {[cc-check-standards c11] eq {}} {
+    user-error "C11 is required"
   }
-  define-append CFLAGS_FOR_BUILD -std=c99
-  define-append CFLAGS -std=c99
+  define-append CFLAGS_FOR_BUILD -std=c11
+  define-append CFLAGS -std=c11
   define LDFLAGS_FOR_BUILD {}
 
   # Check for tools and programs


### PR DESCRIPTION
Update NeoMutt's build requirements to C11.

- https://en.wikipedia.org/wiki/C11_(C_standard_revision)

This will allow us to use `_Generic(3)` in macros.
See also: #4294 
