### PR TITLE
fix -Wdouble-promotion warnings

### DIFF
--- a/conn/zstrm.c
+++ b/conn/zstrm.c
@@ -105,9 +105,9 @@ static int zstrm_close(struct Connection *conn)
 
   mutt_debug(LL_DEBUG5, "read %lu->%lu (%.1fx) wrote %lu<-%lu (%.1fx)\n",
              zctx->read.z.total_in, zctx->read.z.total_out,
-             (float) zctx->read.z.total_out / (float) zctx->read.z.total_in,
+             (double) zctx->read.z.total_out / (double) zctx->read.z.total_in,
              zctx->write.z.total_in, zctx->write.z.total_out,
-             (float) zctx->write.z.total_in / (float) zctx->write.z.total_out);
+             (double) zctx->write.z.total_in / (double) zctx->write.z.total_out);
 
   // Restore the Connection's original functions
   conn->sockdata = zctx->next_conn.sockdata;

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -391,8 +391,8 @@ static void set_encoding(struct Body *b, struct Content *info, struct ConfigSubs
   else
   {
     /* Determine which encoding is smaller  */
-    if (1.33 * (float) (info->lobin + info->hibin + info->ascii) <
-        3.0 * (float) (info->lobin + info->hibin) + (float) info->ascii)
+    if (1.33f * (float) (info->lobin + info->hibin + info->ascii) <
+        3.0f * (float) (info->lobin + info->hibin) + (float) info->ascii)
     {
       b->encoding = ENC_BASE64;
     }


### PR DESCRIPTION
With this two fixes NeoMutt compiles for me with -Werror -Wdouble-promotion (`Apple clang version 15.0.0 (clang-1500.3.9.4)`).