### PR TITLE
check return value of sscanf()

### DIFF
--- a/mutt/date.c
+++ b/mutt/date.c
@@ -43,6 +43,7 @@
 #include <string.h>
 #include <sys/time.h>
 #include <time.h>
+#include "mutt/lib.h"
 #include "date.h"
 #include "buffer.h"
 #include "eqi.h"
@@ -760,15 +761,10 @@ time_t mutt_date_parse_date(const char *s, struct Tz *tz_out)
 
   /* Time */
   int hour, min, sec = 0;
-  if (sscanf(s + mutt_regmatch_start(mhour), "%d", &hour) != 1)
-    return -1;
-  if (sscanf(s + mutt_regmatch_start(mminute), "%d", &min) != 1)
-    return -1;
+  ASSERT(sscanf(s + mutt_regmatch_start(mhour), "%d", &hour) == 1);
+  ASSERT(sscanf(s + mutt_regmatch_start(mminute), "%d", &min) == 1);
   if (mutt_regmatch_start(msecond) != -1)
-  {
-    if (sscanf(s + mutt_regmatch_start(msecond), "%d", &sec) != 1)
-      return -1;
-  }
+    ASSERT(sscanf(s + mutt_regmatch_start(msecond), "%d", &sec) == 1);
   if ((hour > 23) || (min > 59) || (sec > 60))
     return -1;
   tm.tm_hour = hour;
@@ -870,14 +866,12 @@ time_t mutt_date_parse_imap(const char *s)
 
   struct tm tm = { 0 };
 
-  if (sscanf(s + mutt_regmatch_start(mday), " %d", &tm.tm_mday) != 1)
-    return 0;
+  ASSERT(sscanf(s + mutt_regmatch_start(mday), " %d", &tm.tm_mday) == 1);
   tm.tm_mon = mutt_date_check_month(s + mutt_regmatch_start(mmonth));
-  if (sscanf(s + mutt_regmatch_start(myear), "%d", &tm.tm_year) != 1)
-    return 0;
+  ASSERT(sscanf(s + mutt_regmatch_start(myear), "%d", &tm.tm_year) == 1);
   tm.tm_year -= 1900;
-  if (sscanf(s + mutt_regmatch_start(mtime), "%d:%d:%d", &tm.tm_hour, &tm.tm_min, &tm.tm_sec) != 3)
-    return 0;
+  ASSERT(sscanf(s + mutt_regmatch_start(mtime), "%d:%d:%d", &tm.tm_hour,
+                &tm.tm_min, &tm.tm_sec) == 3);
 
   char direction;
   int zhours, zminutes;

--- a/mutt/date.c
+++ b/mutt/date.c
@@ -761,10 +761,17 @@ time_t mutt_date_parse_date(const char *s, struct Tz *tz_out)
 
   /* Time */
   int hour, min, sec = 0;
-  ASSERT(sscanf(s + mutt_regmatch_start(mhour), "%d", &hour) == 1);
-  ASSERT(sscanf(s + mutt_regmatch_start(mminute), "%d", &min) == 1);
+  int assigned = 0;
+  assigned = sscanf(s + mutt_regmatch_start(mhour), "%d", &hour);
+  ASSERT(assigned == 1);
+  assigned = sscanf(s + mutt_regmatch_start(mminute), "%d", &min);
+  ASSERT(assigned == 1);
   if (mutt_regmatch_start(msecond) != -1)
-    ASSERT(sscanf(s + mutt_regmatch_start(msecond), "%d", &sec) == 1);
+  {
+    assigned = sscanf(s + mutt_regmatch_start(msecond), "%d", &sec);
+    ASSERT(assigned == 1);
+  }
+
   if ((hour > 23) || (min > 59) || (sec > 60))
     return -1;
   tm.tm_hour = hour;
@@ -866,12 +873,16 @@ time_t mutt_date_parse_imap(const char *s)
 
   struct tm tm = { 0 };
 
-  ASSERT(sscanf(s + mutt_regmatch_start(mday), " %d", &tm.tm_mday) == 1);
+  int assigned = 0;
+  assigned = sscanf(s + mutt_regmatch_start(mday), " %d", &tm.tm_mday);
+  ASSERT(assigned == 1);
   tm.tm_mon = mutt_date_check_month(s + mutt_regmatch_start(mmonth));
-  ASSERT(sscanf(s + mutt_regmatch_start(myear), "%d", &tm.tm_year) == 1);
+  assigned = sscanf(s + mutt_regmatch_start(myear), "%d", &tm.tm_year);
+  ASSERT(assigned == 1);
   tm.tm_year -= 1900;
-  ASSERT(sscanf(s + mutt_regmatch_start(mtime), "%d:%d:%d", &tm.tm_hour,
-                &tm.tm_min, &tm.tm_sec) == 3);
+  assigned = sscanf(s + mutt_regmatch_start(mtime), "%d:%d:%d", &tm.tm_hour,
+                    &tm.tm_min, &tm.tm_sec);
+  ASSERT(assigned == 3);
 
   char direction;
   int zhours, zminutes;

--- a/mutt/date.c
+++ b/mutt/date.c
@@ -760,10 +760,15 @@ time_t mutt_date_parse_date(const char *s, struct Tz *tz_out)
 
   /* Time */
   int hour, min, sec = 0;
-  sscanf(s + mutt_regmatch_start(mhour), "%d", &hour);
-  sscanf(s + mutt_regmatch_start(mminute), "%d", &min);
+  if (sscanf(s + mutt_regmatch_start(mhour), "%d", &hour) != 1)
+    return -1;
+  if (sscanf(s + mutt_regmatch_start(mminute), "%d", &min) != 1)
+    return -1;
   if (mutt_regmatch_start(msecond) != -1)
-    sscanf(s + mutt_regmatch_start(msecond), "%d", &sec);
+  {
+    if (sscanf(s + mutt_regmatch_start(msecond), "%d", &sec) != 1)
+      return -1;
+  }
   if ((hour > 23) || (min > 59) || (sec > 60))
     return -1;
   tm.tm_hour = hour;
@@ -865,11 +870,14 @@ time_t mutt_date_parse_imap(const char *s)
 
   struct tm tm = { 0 };
 
-  sscanf(s + mutt_regmatch_start(mday), " %d", &tm.tm_mday);
+  if (sscanf(s + mutt_regmatch_start(mday), " %d", &tm.tm_mday) != 1)
+    return 0;
   tm.tm_mon = mutt_date_check_month(s + mutt_regmatch_start(mmonth));
-  sscanf(s + mutt_regmatch_start(myear), "%d", &tm.tm_year);
+  if (sscanf(s + mutt_regmatch_start(myear), "%d", &tm.tm_year) != 1)
+    return 0;
   tm.tm_year -= 1900;
-  sscanf(s + mutt_regmatch_start(mtime), "%d:%d:%d", &tm.tm_hour, &tm.tm_min, &tm.tm_sec);
+  if (sscanf(s + mutt_regmatch_start(mtime), "%d:%d:%d", &tm.tm_hour, &tm.tm_min, &tm.tm_sec) != 3)
+    return 0;
 
   char direction;
   int zhours, zminutes;

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -567,7 +567,8 @@ void pop_fetch_mail(void)
     goto finish;
   }
 
-  sscanf(buf, "+OK %d %d", &msgs, &bytes);
+  if (sscanf(buf, "+OK %d %d", &msgs, &bytes) != 2)
+    goto fail;
 
   /* only get unread messages */
   const bool c_pop_last = cs_subset_bool(NeoMutt->sub, "pop_last");


### PR DESCRIPTION
This fixes the [Missing return-value check for a 'scanf'-like function](https://github.com/neomutt/neomutt/security/code-scanning?query=is%3Aopen+branch%3Amain+rule%3Acpp%2Fmissing-check-scanf) alerts from Github code scanning.

There are a lot more places where we don't check the return value of `sscanf()` but somehow Github doesn't complain about those. Maybe there's a limit of alerts per rule?