### PR TITLE
scanf: initialise out-vars

### DIFF
--- a/history/history.c
+++ b/history/history.c
@@ -206,7 +206,7 @@ static void shrink_histfile(void)
 {
   FILE *fp_tmp = NULL;
   int n[HC_MAX] = { 0 };
-  int line, hclass, read;
+  int line, hclass = 0, read = 0;
   char *linebuf = NULL, *p = NULL;
   size_t buflen;
   bool regen_file = false;
@@ -607,7 +607,7 @@ void mutt_hist_read_file(void)
   if (!fp)
     return;
 
-  int line = 0, hclass, read;
+  int line = 0, hclass = 0, read = 0;
   char *linebuf = NULL, *p = NULL;
   size_t buflen;
 

--- a/imap/message.c
+++ b/imap/message.c
@@ -168,8 +168,8 @@ static int msg_cache_commit(struct Mailbox *m, struct Email *e)
  */
 static int imap_bcache_delete(const char *id, struct BodyCache *bcache, void *data)
 {
-  uint32_t uv;
-  unsigned int uid;
+  uint32_t uv = 0;
+  unsigned int uid = 0;
   struct ImapMboxData *mdata = data;
 
   if (sscanf(id, "%u-%u", &uv, &uid) != 2)

--- a/mutt/date.c
+++ b/mutt/date.c
@@ -759,7 +759,7 @@ time_t mutt_date_parse_date(const char *s, struct Tz *tz_out)
     tm.tm_year -= 1900;
 
   /* Time */
-  int hour, min, sec = 0;
+  int hour = 0, min = 0, sec = 0;
   sscanf(s + mutt_regmatch_start(mhour), "%d", &hour);
   sscanf(s + mutt_regmatch_start(mminute), "%d", &min);
   if (mutt_regmatch_start(msecond) != -1)
@@ -776,7 +776,7 @@ time_t mutt_date_parse_date(const char *s, struct Tz *tz_out)
   bool zoccident = false;
   if (mutt_regmatch_start(mtz) != -1)
   {
-    char direction;
+    char direction = '\0';
     sscanf(s + mutt_regmatch_start(mtz), "%c%02d%02d", &direction, &zhours, &zminutes);
     zoccident = (direction == '-');
   }
@@ -871,8 +871,8 @@ time_t mutt_date_parse_imap(const char *s)
   tm.tm_year -= 1900;
   sscanf(s + mutt_regmatch_start(mtime), "%d:%d:%d", &tm.tm_hour, &tm.tm_min, &tm.tm_sec);
 
-  char direction;
-  int zhours, zminutes;
+  char direction = '\0';
+  int zhours = 0, zminutes = 0;
   sscanf(s + mutt_regmatch_start(mtz), "%c%02d%02d", &direction, &zhours, &zminutes);
   bool zoccident = (direction == '-');
 

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -577,8 +577,8 @@ int nntp_add_group(char *line, void *data)
   struct NntpMboxData *mdata = NULL;
   char group[1024] = { 0 };
   char desc[8192] = { 0 };
-  char mod;
-  anum_t first, last;
+  char mod = '\0';
+  anum_t first = 0, last = 0;
 
   if (!adata || !line)
     return 0;
@@ -781,8 +781,8 @@ void nntp_hcache_update(struct NntpMboxData *mdata, struct HeaderCache *hc)
 static int nntp_bcache_delete(const char *id, struct BodyCache *bcache, void *data)
 {
   struct NntpMboxData *mdata = data;
-  anum_t anum;
-  char c;
+  anum_t anum = 0;
+  char c = '\0';
 
   if (!mdata || (sscanf(id, ANUM_FMT "%c", &anum, &c) != 1) ||
       (anum < mdata->first_message) || (anum > mdata->last_message))
@@ -1198,7 +1198,7 @@ struct NntpAccountData *nntp_select_server(struct Mailbox *m, const char *server
         char *hdata = hcache_fetch_raw_str(hc, "index", 5);
         if (hdata)
         {
-          anum_t first, last;
+          anum_t first = 0, last = 0;
 
           if (sscanf(hdata, ANUM_FMT " " ANUM_FMT, &first, &last) == 2)
           {

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -973,7 +973,7 @@ static void nntp_parse_xref(struct Mailbox *m, struct Email *e)
   char *p = buf;
   while (p)
   {
-    anum_t anum;
+    anum_t anum = 0;
 
     /* skip to next word */
     p += strspn(p, " \t");
@@ -1026,7 +1026,7 @@ static int fetch_tempfile(char *line, void *data)
 static int fetch_numbers(char *line, void *data)
 {
   struct FetchCtx *fc = data;
-  anum_t anum;
+  anum_t anum = 0;
 
   if (!line)
     return 0;
@@ -1059,7 +1059,7 @@ static int parse_overview_line(char *line, void *data)
   struct Email *e = NULL;
   char *header = NULL, *field = NULL;
   bool save = true;
-  anum_t anum;
+  anum_t anum = 0;
 
   /* parse article number */
   field = strchr(line, '\t');
@@ -1441,7 +1441,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
 static int nntp_group_poll(struct NntpMboxData *mdata, bool update_stat)
 {
   char buf[1024] = { 0 };
-  anum_t count, first, last;
+  anum_t count = 0, first = 0, last = 0;
 
   /* use GROUP command to poll newsgroup */
   if (nntp_query(mdata, buf, sizeof(buf)) < 0)
@@ -1736,7 +1736,7 @@ static int nntp_date(struct NntpAccountData *adata, time_t *now)
 static int fetch_children(char *line, void *data)
 {
   struct ChildCtx *cc = data;
-  anum_t anum;
+  anum_t anum = 0;
 
   if (!line || (sscanf(line, ANUM_FMT, &anum) != 1))
     return 0;
@@ -2390,7 +2390,7 @@ static enum MxOpenReturns nntp_mbox_open(struct Mailbox *m)
   char *group = NULL;
   int rc;
   struct HeaderCache *hc = NULL;
-  anum_t first, last, count = 0;
+  anum_t first = 0, last = 0, count = 0;
 
   struct Url *url = url_parse(mailbox_path(m));
   if (!url || !url->host || !url->path ||

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -521,7 +521,7 @@ void pop_fetch_mail(void)
 
   char buf[1024] = { 0 };
   char msgbuf[128] = { 0 };
-  int last = 0, msgs, bytes, rset = 0, rc;
+  int last = 0, msgs = 0, bytes = 0, rset = 0, rc;
   struct ConnAccount cac = { { 0 } };
 
   char *p = mutt_mem_calloc(strlen(c_pop_host) + 7, sizeof(char));


### PR DESCRIPTION
`scanf()` returns values via pointers.
Ensure that all of them are initialised.

It seems to be the only difference between whether CodeQL warns us, or not.