### PR TITLE
fix parsing prefixed "default" color.

### DIFF
--- a/color/parse_color.c
+++ b/color/parse_color.c
@@ -122,17 +122,17 @@ enum CommandResult parse_color_namedcolor(const char *s, struct ColorElement *el
   if (!s || !elem)
     return MUTT_CMD_ERROR;
 
+  enum ColorPrefix prefix = COLOR_PREFIX_NONE;
+  s += parse_color_prefix(s, &prefix);
+
   // COLOR_DEFAULT (-1) interferes with mutt_map_get_value()
   if (mutt_str_equal(s, "default"))
   {
     elem->color = COLOR_DEFAULT;
     elem->type = CT_SIMPLE;
-    elem->prefix = COLOR_PREFIX_NONE;
+    elem->prefix = prefix;
     return MUTT_CMD_SUCCESS;
   }
-
-  enum ColorPrefix prefix = COLOR_PREFIX_NONE;
-  s += parse_color_prefix(s, &prefix);
 
   int color = mutt_map_get_value(s, ColorNames);
   if (color == -1)


### PR DESCRIPTION
* **What does this PR do?**

Fixes parsing of prefixed "default" color, as in "brightdefault".

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/code)

* **What are the relevant issue numbers?**
