### PR TITLE
Allow opening the header cache in non-O_CREAT mode

### DIFF
--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -468,7 +468,7 @@ static unsigned int generate_hcachever(void)
 /**
  * hcache_open - Multiplexor for StoreOps::open
  */
-struct HeaderCache *hcache_open(const char *path, const char *folder, hcache_namer_t namer)
+struct HeaderCache *hcache_open(const char *path, const char *folder, hcache_namer_t namer, bool create)
 {
   if (!path || (path[0] == '\0'))
     return NULL;
@@ -512,13 +512,13 @@ struct HeaderCache *hcache_open(const char *path, const char *folder, hcache_nam
   struct Buffer *hcpath = buf_pool_get();
   hcache_per_folder(hc, hcpath, path, namer);
 
-  hc->store_handle = hc->store_ops->open(buf_string(hcpath));
+  hc->store_handle = hc->store_ops->open(buf_string(hcpath), create);
   if (!hc->store_handle)
   {
     /* remove a possibly incompatible version */
     if (unlink(buf_string(hcpath)) == 0)
     {
-      hc->store_handle = hc->store_ops->open(buf_string(hcpath));
+      hc->store_handle = hc->store_ops->open(buf_string(hcpath), create);
       if (!hc->store_handle)
       {
         if (hc->compr_ops)

--- a/hcache/lib.h
+++ b/hcache/lib.h
@@ -118,10 +118,11 @@ typedef void (*hcache_namer_t)(const char *path, struct Buffer *dest);
  * @param folder Name of the folder containing the messages
  * @param namer  Optional (might be NULL) client-specific function to form the
  *               final name of the hcache database file.
+ * @param create Create the file if it's not there?
  * @retval ptr  Success, struct HeaderCache struct
  * @retval NULL Otherwise
  */
-struct HeaderCache *hcache_open(const char *path, const char *folder, hcache_namer_t namer);
+struct HeaderCache *hcache_open(const char *path, const char *folder, hcache_namer_t namer, bool create);
 
 /**
  * hcache_close - Close the connection to the header cache

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -676,7 +676,7 @@ void imap_expunge_mailbox(struct Mailbox *m, bool resort)
   struct Email *e = NULL;
 
 #ifdef USE_HCACHE
-  imap_hcache_open(adata, mdata);
+  imap_hcache_open(adata, mdata, false);
 #endif
 
   for (int i = 0; i < m->msg_count; i++)
@@ -1529,7 +1529,7 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
   }
 
 #ifdef USE_HCACHE
-  imap_hcache_open(adata, mdata);
+  imap_hcache_open(adata, mdata, true);
 #endif
 
   /* save messages with real (non-flag) changes */

--- a/imap/mdata.c
+++ b/imap/mdata.c
@@ -90,7 +90,7 @@ struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char *n
   STAILQ_INIT(&mdata->flags);
 
 #ifdef USE_HCACHE
-  imap_hcache_open(adata, mdata);
+  imap_hcache_open(adata, mdata, false);
   if (mdata->hcache)
   {
     if (hcache_fetch_raw_obj(mdata->hcache, "UIDVALIDITY", 11, &mdata->uidvalidity))

--- a/imap/message.c
+++ b/imap/message.c
@@ -982,7 +982,7 @@ static int read_headers_condstore_qresync_updates(struct ImapAccountData *adata,
     imap_hcache_close(mdata);
     imap_expunge_mailbox(m, false);
 
-    imap_hcache_open(adata, mdata);
+    imap_hcache_open(adata, mdata, false);
     mdata->reopen &= ~IMAP_EXPUNGE_PENDING;
   }
 
@@ -1374,7 +1374,7 @@ retry:
   mdata->new_mail_count = 0;
 
 #ifdef USE_HCACHE
-  imap_hcache_open(adata, mdata);
+  imap_hcache_open(adata, mdata, true);
 
   if (mdata->hcache && initial_download)
   {
@@ -2201,7 +2201,7 @@ int imap_msg_save_hcache(struct Mailbox *m, struct Email *e)
   if (mdata->hcache)
     close_hc = false;
   else
-    imap_hcache_open(adata, mdata);
+    imap_hcache_open(adata, mdata, true);
   rc = imap_hcache_put(mdata, e);
   if (close_hc)
     imap_hcache_close(mdata);

--- a/imap/private.h
+++ b/imap/private.h
@@ -216,7 +216,7 @@ int imap_msg_save_hcache(struct Mailbox *m, struct Email *e);
 
 /* util.c */
 #ifdef USE_HCACHE
-void imap_hcache_open(struct ImapAccountData *adata, struct ImapMboxData *mdata);
+void imap_hcache_open(struct ImapAccountData *adata, struct ImapMboxData *mdata, bool create);
 void imap_hcache_close(struct ImapMboxData *mdata);
 struct Email *imap_hcache_get(struct ImapMboxData *mdata, unsigned int uid);
 int imap_hcache_put(struct ImapMboxData *mdata, struct Email *e);

--- a/imap/util.c
+++ b/imap/util.c
@@ -296,7 +296,7 @@ static void imap_hcache_namer(const char *path, struct Buffer *dest)
  * @param adata Imap Account data
  * @param mdata Imap Mailbox data
  */
-void imap_hcache_open(struct ImapAccountData *adata, struct ImapMboxData *mdata)
+void imap_hcache_open(struct ImapAccountData *adata, struct ImapMboxData *mdata, bool create)
 {
   if (!adata || !mdata)
     return;
@@ -325,7 +325,7 @@ void imap_hcache_open(struct ImapAccountData *adata, struct ImapMboxData *mdata)
   url_tobuffer(&url, cachepath, U_PATH);
 
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
-  hc = hcache_open(c_header_cache, buf_string(cachepath), imap_hcache_namer);
+  hc = hcache_open(c_header_cache, buf_string(cachepath), imap_hcache_namer, create);
 
 cleanup:
   buf_pool_release(&mbox);

--- a/maildir/hcache.c
+++ b/maildir/hcache.c
@@ -100,7 +100,7 @@ struct HeaderCache *maildir_hcache_open(struct Mailbox *m)
 
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
 
-  return hcache_open(c_header_cache, mailbox_path(m), NULL);
+  return hcache_open(c_header_cache, mailbox_path(m), NULL, true);
 }
 
 /**

--- a/mh/mh.c
+++ b/mh/mh.c
@@ -553,7 +553,7 @@ static void mh_delayed_parsing(struct Mailbox *m, struct MhEmailArray *mha,
 
 #ifdef USE_HCACHE
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
-  struct HeaderCache *hc = hcache_open(c_header_cache, mailbox_path(m), NULL);
+  struct HeaderCache *hc = hcache_open(c_header_cache, mailbox_path(m), NULL, true);
 #endif
 
   struct MhEmail *md = NULL;
@@ -788,7 +788,7 @@ static int mh_msg_save_hcache(struct Mailbox *m, struct Email *e)
   int rc = 0;
 #ifdef USE_HCACHE
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
-  struct HeaderCache *hc = hcache_open(c_header_cache, mailbox_path(m), NULL);
+  struct HeaderCache *hc = hcache_open(c_header_cache, mailbox_path(m), NULL, true);
   rc = hcache_store_email(hc, e->path, strlen(e->path), e, 0);
   hcache_close(&hc);
 #endif
@@ -1071,7 +1071,7 @@ static enum MxStatus mh_mbox_sync(struct Mailbox *m)
   struct HeaderCache *hc = NULL;
 #ifdef USE_HCACHE
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
-  hc = hcache_open(c_header_cache, mailbox_path(m), NULL);
+  hc = hcache_open(c_header_cache, mailbox_path(m), NULL, true);
 #endif
 
   struct Progress *progress = NULL;

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -722,7 +722,7 @@ struct HeaderCache *nntp_hcache_open(struct NntpMboxData *mdata)
   url.path = mdata->group;
   url_tostring(&url, file, sizeof(file), U_PATH);
   const char *const c_news_cache_dir = cs_subset_path(NeoMutt->sub, "news_cache_dir");
-  return hcache_open(c_news_cache_dir, file, nntp_hcache_namer);
+  return hcache_open(c_news_cache_dir, file, nntp_hcache_namer, true);
 }
 
 /**

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -119,7 +119,7 @@ static struct HeaderCache *nm_hcache_open(struct Mailbox *m)
 {
 #ifdef USE_HCACHE
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
-  return hcache_open(c_header_cache, mailbox_path(m), NULL);
+  return hcache_open(c_header_cache, mailbox_path(m), NULL, true);
 #else
   return NULL;
 #endif

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -301,7 +301,7 @@ static struct HeaderCache *pop_hcache_open(struct PopAccountData *adata, const c
 {
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
   if (!adata || !adata->conn)
-    return hcache_open(c_header_cache, path, NULL);
+    return hcache_open(c_header_cache, path, NULL, true);
 
   struct Url url = { 0 };
   char p[1024] = { 0 };
@@ -309,7 +309,7 @@ static struct HeaderCache *pop_hcache_open(struct PopAccountData *adata, const c
   mutt_account_tourl(&adata->conn->account, &url);
   url.path = HC_FNAME;
   url_tostring(&url, p, sizeof(p), U_PATH);
-  return hcache_open(c_header_cache, p, pop_hcache_namer);
+  return hcache_open(c_header_cache, p, pop_hcache_namer, true);
 }
 #endif
 

--- a/store/bdb.c
+++ b/store/bdb.c
@@ -112,7 +112,7 @@ static void dbt_empty_init(DBT *dbt)
 /**
  * store_bdb_open - Open a connection to a Store - Implements StoreOps::open() - @ingroup store_open
  */
-static StoreHandle *store_bdb_open(const char *path)
+static StoreHandle *store_bdb_open(const char *path, bool create)
 {
   if (!path)
     return NULL;
@@ -123,7 +123,7 @@ static StoreHandle *store_bdb_open(const char *path)
 
   buf_printf(&sdata->lockfile, "%s-lock-hack", path);
 
-  sdata->fd = open(buf_string(&sdata->lockfile), O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
+  sdata->fd = open(buf_string(&sdata->lockfile), O_WRONLY | (create ? O_CREAT : 0), S_IRUSR | S_IWUSR);
   if (sdata->fd < 0)
   {
     bdb_sdata_free(&sdata);

--- a/store/gdbm.c
+++ b/store/gdbm.c
@@ -38,14 +38,14 @@
 /**
  * store_gdbm_open - Open a connection to a Store - Implements StoreOps::open() - @ingroup store_open
  */
-static StoreHandle *store_gdbm_open(const char *path)
+static StoreHandle *store_gdbm_open(const char *path, bool create)
 {
   if (!path)
     return NULL;
 
   const int pagesize = 4096;
 
-  GDBM_FILE db = gdbm_open((char *) path, pagesize, GDBM_WRCREAT, 00600, NULL);
+  GDBM_FILE db = gdbm_open((char *) path, pagesize, create ? GDBM_WRCREAT : GDBM_WRITER, 00600, NULL);
   if (!db)
   {
     /* if rw failed try ro */

--- a/store/kc.c
+++ b/store/kc.c
@@ -37,7 +37,7 @@
 /**
  * store_kyotocabinet_open - Open a connection to a Store - Implements StoreOps::open() - @ingroup store_open
  */
-static StoreHandle *store_kyotocabinet_open(const char *path)
+static StoreHandle *store_kyotocabinet_open(const char *path, bool create)
 {
   if (!path)
     return NULL;
@@ -50,7 +50,7 @@ static StoreHandle *store_kyotocabinet_open(const char *path)
 
   buf_printf(kcdbpath, "%s#type=kct#opts=l#rcomp=lex", path);
 
-  if (!kcdbopen(db, buf_string(kcdbpath), KCOWRITER | KCOCREATE))
+  if (!kcdbopen(db, buf_string(kcdbpath), KCOWRITER | (create ? KCOCREATE : 0)))
   {
     int ecode = kcdbecode(db);
     mutt_debug(LL_DEBUG2, "kcdbopen failed for %s: %s (ecode %d)\n",

--- a/store/lib.h
+++ b/store/lib.h
@@ -75,6 +75,7 @@ struct StoreOps
    *
    * open - Open a connection to a Store
    * @param[in] path Path to the database file
+   * @param[in] create Create the file if it's not there?
    * @retval ptr  Success, Store pointer
    * @retval NULL Failure
    *
@@ -82,7 +83,7 @@ struct StoreOps
    * connection to the database file specified by the path parameter. Backends
    * MUST return non-NULL specific handle information on success.
    */
-  StoreHandle *(*open)(const char *path);
+  StoreHandle *(*open)(const char *path, bool create);
 
   /**
    * @defgroup store_fetch fetch()

--- a/store/lmdb.c
+++ b/store/lmdb.c
@@ -33,6 +33,7 @@
 #include <lmdb.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <unistd.h>
 #include "mutt/lib.h"
 #include "lib.h"
 
@@ -145,10 +146,15 @@ static int lmdb_get_write_txn(struct LmdbStoreData *sdata)
 /**
  * store_lmdb_open - Open a connection to a Store - Implements StoreOps::open() - @ingroup store_open
  */
-static StoreHandle *store_lmdb_open(const char *path)
+static StoreHandle *store_lmdb_open(const char *path, bool create)
 {
   if (!path)
     return NULL;
+
+  if (!create && access(path, F_OK) != 0)
+  {
+    return NULL;
+  }
 
   struct LmdbStoreData *sdata = lmdb_sdata_new();
 

--- a/store/qdbm.c
+++ b/store/qdbm.c
@@ -39,12 +39,12 @@
 /**
  * store_qdbm_open - Open a connection to a Store - Implements StoreOps::open() - @ingroup store_open
  */
-static StoreHandle *store_qdbm_open(const char *path)
+static StoreHandle *store_qdbm_open(const char *path, bool create)
 {
   if (!path)
     return NULL;
 
-  VILLA *db = vlopen(path, VL_OWRITER | VL_OCREAT, VL_CMPLEX);
+  VILLA *db = vlopen(path, VL_OWRITER | (create ? VL_OCREAT : 0), VL_CMPLEX);
 
   // Return an opaque pointer
   return (StoreHandle *) db;

--- a/store/rocksdb.c
+++ b/store/rocksdb.c
@@ -73,7 +73,7 @@ static struct RocksDbStoreData *rocksdb_sdata_new(void)
 /**
  * store_rocksdb_open - Open a connection to a Store - Implements StoreOps::open() - @ingroup store_open
  */
-static StoreHandle *store_rocksdb_open(const char *path)
+static StoreHandle *store_rocksdb_open(const char *path, bool create)
 {
   if (!path)
     return NULL;
@@ -85,7 +85,10 @@ static StoreHandle *store_rocksdb_open(const char *path)
 
   /* setup generic options, create new db and limit log to one file */
   sdata->options = rocksdb_options_create();
-  rocksdb_options_set_create_if_missing(sdata->options, 1);
+  if (create)
+  {
+    rocksdb_options_set_create_if_missing(sdata->options, 1);
+  }
   rocksdb_options_set_keep_log_file_num(sdata->options, 1);
 
   /* setup read options, we verify with checksums */

--- a/store/tc.c
+++ b/store/tc.c
@@ -38,7 +38,7 @@
 /**
  * store_tokyocabinet_open - Open a connection to a Store - Implements StoreOps::open() - @ingroup store_open
  */
-static StoreHandle *store_tokyocabinet_open(const char *path)
+static StoreHandle *store_tokyocabinet_open(const char *path, bool create)
 {
   if (!path)
     return NULL;
@@ -46,7 +46,7 @@ static StoreHandle *store_tokyocabinet_open(const char *path)
   TCBDB *db = tcbdbnew();
   if (!db)
     return NULL;
-  if (!tcbdbopen(db, path, BDBOWRITER | BDBOCREAT))
+  if (!tcbdbopen(db, path, BDBOWRITER | (create ? BDBOCREAT : 0)))
   {
     int ecode = tcbdbecode(db);
     mutt_debug(LL_DEBUG2, "tcbdbopen failed for %s: %s (ecode %d)\n", path,

--- a/store/tdb.c
+++ b/store/tdb.c
@@ -38,7 +38,7 @@
 /**
  * store_tdb_open - Open a connection to a Store - Implements StoreOps::open() - @ingroup store_open
  */
-static StoreHandle *store_tdb_open(const char *path)
+static StoreHandle *store_tdb_open(const char *path, bool create)
 {
   if (!path)
     return NULL;
@@ -50,7 +50,7 @@ static StoreHandle *store_tdb_open(const char *path)
   const int flags = TDB_NOLOCK | TDB_INCOMPATIBLE_HASH | TDB_NOSYNC;
   const int hash_size = 33533; // Based on test timings for 100K emails
 
-  struct tdb_context *db = tdb_open(path, hash_size, flags, O_CREAT | O_RDWR, 00600);
+  struct tdb_context *db = tdb_open(path, hash_size, flags, (create ? O_CREAT : 0) | O_RDWR, 00600);
 
   // Return an opaque pointer
   return (StoreHandle *) db;

--- a/test/store/bdb.c
+++ b/test/store/bdb.c
@@ -48,7 +48,7 @@ void test_store_bdb(void)
   buf_addch(path, '/');
   buf_addstr(path, DB_NAME);
 
-  StoreHandle *store_handle = store_ops->open(buf_string(path));
+  StoreHandle *store_handle = store_ops->open(buf_string(path), true);
   TEST_CHECK(store_handle != NULL);
 
   TEST_CHECK(test_store_db(store_ops, store_handle) == true);

--- a/test/store/common.c
+++ b/test/store/common.c
@@ -52,7 +52,7 @@ bool test_store_degenerate(const struct StoreOps *store_ops, const char *name)
   if (!TEST_CHECK_STR_EQ(store_ops->name, name))
     return false;
 
-  if (!TEST_CHECK(store_ops->open(NULL) == NULL))
+  if (!TEST_CHECK(store_ops->open(NULL, false) == NULL))
     return false;
 
   if (!TEST_CHECK(store_ops->fetch(NULL, NULL, 0, NULL) == NULL))

--- a/test/store/gdbm.c
+++ b/test/store/gdbm.c
@@ -46,7 +46,7 @@ void test_store_gdbm(void)
   buf_addch(path, '/');
   buf_addstr(path, DB_NAME);
 
-  StoreHandle *store_handle = store_ops->open(buf_string(path));
+  StoreHandle *store_handle = store_ops->open(buf_string(path), true);
   TEST_CHECK(store_handle != NULL);
 
   TEST_CHECK(test_store_db(store_ops, store_handle) == true);

--- a/test/store/kc.c
+++ b/test/store/kc.c
@@ -46,7 +46,7 @@ void test_store_kc(void)
   buf_addch(path, '/');
   buf_addstr(path, DB_NAME);
 
-  StoreHandle *store_handle = store_ops->open(buf_string(path));
+  StoreHandle *store_handle = store_ops->open(buf_string(path), true);
   TEST_CHECK(store_handle != NULL);
 
   TEST_CHECK(test_store_db(store_ops, store_handle) == true);

--- a/test/store/lmdb.c
+++ b/test/store/lmdb.c
@@ -46,7 +46,7 @@ void test_store_lmdb(void)
   buf_addch(path, '/');
   buf_addstr(path, DB_NAME);
 
-  StoreHandle *store_handle = store_ops->open(buf_string(path));
+  StoreHandle *store_handle = store_ops->open(buf_string(path), true);
   TEST_CHECK(store_handle != NULL);
 
   TEST_CHECK(test_store_db(store_ops, store_handle) == true);

--- a/test/store/qdbm.c
+++ b/test/store/qdbm.c
@@ -46,7 +46,7 @@ void test_store_qdbm(void)
   buf_addch(path, '/');
   buf_addstr(path, DB_NAME);
 
-  StoreHandle *store_handle = store_ops->open(buf_string(path));
+  StoreHandle *store_handle = store_ops->open(buf_string(path), true);
   TEST_CHECK(store_handle != NULL);
 
   TEST_CHECK(test_store_db(store_ops, store_handle) == true);

--- a/test/store/rocksdb.c
+++ b/test/store/rocksdb.c
@@ -46,7 +46,7 @@ void test_store_rocksdb(void)
   buf_addch(path, '/');
   buf_addstr(path, DB_NAME);
 
-  StoreHandle *store_handle = store_ops->open(buf_string(path));
+  StoreHandle *store_handle = store_ops->open(buf_string(path), true);
   TEST_CHECK(store_handle != NULL);
 
   TEST_CHECK(test_store_db(store_ops, store_handle) == true);

--- a/test/store/tc.c
+++ b/test/store/tc.c
@@ -46,7 +46,7 @@ void test_store_tc(void)
   buf_addch(path, '/');
   buf_addstr(path, DB_NAME);
 
-  StoreHandle *store_handle = store_ops->open(buf_string(path));
+  StoreHandle *store_handle = store_ops->open(buf_string(path), true);
   TEST_CHECK(store_handle != NULL);
 
   TEST_CHECK(test_store_db(store_ops, store_handle) == true);

--- a/test/store/tdb.c
+++ b/test/store/tdb.c
@@ -46,7 +46,7 @@ void test_store_tdb(void)
   buf_addch(path, '/');
   buf_addstr(path, DB_NAME);
 
-  StoreHandle *store_handle = store_ops->open(buf_string(path));
+  StoreHandle *store_handle = store_ops->open(buf_string(path), true);
   TEST_CHECK(store_handle != NULL);
 
   TEST_CHECK(test_store_db(store_ops, store_handle) == true);


### PR DESCRIPTION
This enhances the header cache API so we can specify whether we want to create the cache file if it doesn't exist at `hcache_open` time. So far, I have only tried to come up with meaningful variations for IMAP. All other uses of the header cache always specify to create the file if it doesn't exist (current behaviour).

Fixes #4287