### PR TITLE
Close the hcache handle on failure to open the store

### DIFF
--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -528,6 +528,10 @@ struct HeaderCache *hcache_open(const char *path, const char *folder, hcache_nam
         hcache_free(&hc);
       }
     }
+    else
+    {
+      hcache_free(&hc);
+    }
   }
 
   buf_pool_release(&hcpath);


### PR DESCRIPTION
This prevents us from trying to use the hcache later on, only to get a failure from the store.

Missed in #4312