### PR TITLE
ignore macro events in mw_yesorno()

### DIFF
--- a/autocrypt/autocrypt.c
+++ b/autocrypt/autocrypt.c
@@ -106,8 +106,6 @@ int mutt_autocrypt_init(bool can_create)
   if (!c_autocrypt || !c_autocrypt_dir)
     return -1;
 
-  mutt_flushinp();
-
   if (autocrypt_dir_init(can_create))
     goto bail;
 

--- a/question/question.c
+++ b/question/question.c
@@ -249,7 +249,7 @@ static enum QuadOption mw_yesorno(const char *prompt, enum QuadOption def,
   window_redraw(NULL);
   while (true)
   {
-    event = mutt_getch(GETCH_NO_FLAGS);
+    event = mutt_getch(GETCH_IGNORE_MACRO);
     if ((event.op == OP_TIMEOUT) || (event.op == OP_REPAINT))
     {
       window_redraw(NULL);


### PR DESCRIPTION
`mw_yesorno()` is used for asking the user a yes/no question and hopefully doesn't need to read macro events.

If we ignore them we can remove the flushing of the buffer from `mutt_autocrypt_init()` and with that fix #4316.