### PR TITLE
Dont' mix Content-ID with parameters

### DIFF
--- a/attach/cid.c
+++ b/attach/cid.c
@@ -105,7 +105,7 @@ static void cid_save_attachment(struct Body *b, struct CidMapList *cid_map_list)
   if (!b || !cid_map_list)
     return;
 
-  char *id = mutt_param_get(&b->parameter, "content-id");
+  char *id = b->content_id;
   if (!id)
     return;
 

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1024,7 +1024,7 @@ static int op_attachment_edit_content_id(struct ComposeSharedData *shared, int o
   struct AttachPtr *cur_att = current_attachment(shared->adata->actx,
                                                  shared->adata->menu);
 
-  char *id = mutt_param_get(&cur_att->body->parameter, "content-id");
+  char *id = cur_att->body->content_id;
   if (id)
   {
     buf_strcpy(buf, id);
@@ -1042,7 +1042,7 @@ static int op_attachment_edit_content_id(struct ComposeSharedData *shared, int o
     {
       if (check_cid(buf_string(buf)))
       {
-        mutt_param_set(&cur_att->body->parameter, "content-id", buf_string(buf));
+        mutt_str_replace(&cur_att->body->content_id, buf_string(buf));
         menu_queue_redraw(shared->adata->menu, MENU_REDRAW_CURRENT);
         notify_send(shared->email->notify, NT_EMAIL, NT_EMAIL_CHANGE_ATTACH, NULL);
         mutt_message_hook(NULL, shared->email, MUTT_SEND2_HOOK);
@@ -1340,15 +1340,14 @@ static int op_attachment_group_related(struct ComposeSharedData *shared, int op)
     if (!b->tagged || (b->type == TYPE_MULTIPART))
       continue;
 
-    char *id = mutt_param_get(&b->parameter, "content-id");
+    char *id = b->content_id;
     if (id)
       continue;
 
     id = gen_cid();
     if (id)
     {
-      mutt_param_set(&b->parameter, "content-id", id);
-      FREE(&id);
+      mutt_str_replace(&b->content_id, id);
     }
   }
 

--- a/email/body.c
+++ b/email/body.c
@@ -75,6 +75,7 @@ void mutt_body_free(struct Body **ptr)
       mutt_debug(LL_DEBUG1, "%sunlinking %s\n", b->unlink ? "" : "not ", b->filename);
     }
 
+    FREE(&b->content_id);
     FREE(&b->filename);
     FREE(&b->d_filename);
     FREE(&b->charset);

--- a/email/body.h
+++ b/email/body.h
@@ -55,6 +55,7 @@ struct Body
   char *description;              ///< content-description
   char *d_filename;               ///< filename to be used for the content-disposition header
                                   ///< If NULL, filename is used instead.
+  char *content_id;               ///< Content-Id (RFC2392)
   char *filename;                 ///< When sending a message, this is the file to which this structure refers
   char *form_name;                ///< Content-Disposition form-data name param
   char *subtype;                  ///< content-type subtype

--- a/email/parse.c
+++ b/email/parse.c
@@ -1431,7 +1431,7 @@ struct Body *mutt_read_mime_header(FILE *fp, bool digest)
           if (id[cid_len - 1] == '>')
             id[cid_len - 1] = '\0';
         }
-        mutt_param_set(&b->parameter, "content-id", id);
+        mutt_str_replace(&b->content_id, id);
       }
     }
     else if ((plen = mutt_istr_startswith(line, "x-sun-")))

--- a/send/header.c
+++ b/send/header.c
@@ -762,8 +762,6 @@ int mutt_write_mime_header(struct Body *b, FILE *fp, struct ConfigSubset *sub)
   int tmplen;
   char buf[256] = { 0 };
 
-  char *id = NULL;
-
   fprintf(fp, "Content-Type: %s/%s", TYPE(b), b->subtype);
 
   if (!TAILQ_EMPTY(&b->parameter))
@@ -781,13 +779,6 @@ int mutt_write_mime_header(struct Body *b, FILE *fp, struct ConfigSubset *sub)
       struct Parameter *cont = NULL;
       TAILQ_FOREACH(cont, &pl_conts, entries)
       {
-        if (mutt_istr_equal(cont->attribute, "content-id"))
-        {
-          // Content-ID: gets its own header
-          mutt_str_replace(&id, cont->value);
-          break;
-        }
-
         fputc(';', fp);
 
         buf[0] = 0;
@@ -820,11 +811,8 @@ int mutt_write_mime_header(struct Body *b, FILE *fp, struct ConfigSubset *sub)
 
   fputc('\n', fp);
 
-  if (id)
-  {
-    fprintf(fp, "Content-ID: <%s>\n", id);
-    mutt_mem_free(&id);
-  }
+  if (b->content_id)
+    fprintf(fp, "Content-ID: <%s>\n", b->content_id);
 
   if (b->language)
     fprintf(fp, "Content-Language: %s\n", b->language);


### PR DESCRIPTION
Fixes #4327

This moves `Content-ID` into its own dedicated place instead of reusing the container for `Content-Type` parameters, so we stop applying to it (`Content-ID`) what we should apply to them (`Content-Type` parameters), e.g., RF2231 splitting. See https://github.com/neomutt/neomutt/issues/4327#issuecomment-2165520188.