### PR TITLE
Fix function pointer types

### DIFF
--- a/alias/complete.c
+++ b/alias/complete.c
@@ -38,7 +38,7 @@
 /**
  * complete_alias_complete - Complete an Alias - Implements CompleteOps::complete() - @ingroup complete_api
  */
-int complete_alias_complete(struct EnterWindowData *wdata, int op)
+enum FunctionRetval complete_alias_complete(struct EnterWindowData *wdata, int op)
 {
   if (!wdata || (op != OP_EDITOR_COMPLETE))
     return FR_NO_ACTION;
@@ -67,7 +67,7 @@ int complete_alias_complete(struct EnterWindowData *wdata, int op)
 /**
  * complete_alias_query - Complete an Alias Query - Implements CompleteOps::complete() - @ingroup compapi_complete
  */
-int complete_alias_query(struct EnterWindowData *wdata, int op)
+enum FunctionRetval complete_alias_query(struct EnterWindowData *wdata, int op)
 {
   if (!wdata || (op != OP_EDITOR_COMPLETE_QUERY))
     return FR_NO_ACTION;
@@ -92,7 +92,7 @@ int complete_alias_query(struct EnterWindowData *wdata, int op)
 /**
  * complete_alias - Alias completion wrapper - Implements CompleteOps::complete() - @ingroup compapi_complete
  */
-int complete_alias(struct EnterWindowData *wdata, int op)
+enum FunctionRetval complete_alias(struct EnterWindowData *wdata, int op)
 {
   if (op == OP_EDITOR_COMPLETE)
     return complete_alias_complete(wdata, op);

--- a/browser/complete.c
+++ b/browser/complete.c
@@ -43,7 +43,7 @@
 /**
  * complete_file_mbox - Complete a Mailbox - Implements CompleteOps::complete() - @ingroup compapi_complete
  */
-int complete_file_mbox(struct EnterWindowData *wdata, int op)
+enum FunctionRetval complete_file_mbox(struct EnterWindowData *wdata, int op)
 {
   if (!wdata)
     return FR_NO_ACTION;
@@ -110,7 +110,7 @@ int complete_file_mbox(struct EnterWindowData *wdata, int op)
 /**
  * complete_file_simple - Complete a filename - Implements CompleteOps::complete() - @ingroup compapi_complete
  */
-int complete_file_simple(struct EnterWindowData *wdata, int op)
+enum FunctionRetval complete_file_simple(struct EnterWindowData *wdata, int op)
 {
   if (!wdata || ((op != OP_EDITOR_COMPLETE) && (op != OP_EDITOR_COMPLETE_QUERY)))
     return FR_NO_ACTION;

--- a/color/command2.h
+++ b/color/command2.h
@@ -42,7 +42,7 @@ struct Buffer;
  * @retval  0 Success
  * @retval -1 Error
  */
-typedef int (*parser_callback_t)(struct Buffer *buf, struct Buffer *s, struct AttrColor *ac, struct Buffer *err);
+typedef enum CommandResult (*parser_callback_t)(struct Buffer *buf, struct Buffer *s, struct AttrColor *ac, struct Buffer *err);
 
 enum CommandResult mutt_parse_color  (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult mutt_parse_mono   (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);

--- a/complete/helpers.c
+++ b/complete/helpers.c
@@ -423,7 +423,7 @@ int mutt_var_value_complete(struct CompletionData *cd, struct Buffer *buf, int p
 /**
  * complete_command - Complete a NeoMutt Command - Implements CompleteOps::complete() - @ingroup compapi_complete
  */
-int complete_command(struct EnterWindowData *wdata, int op)
+enum FunctionRetval complete_command(struct EnterWindowData *wdata, int op)
 {
   if (!wdata || ((op != OP_EDITOR_COMPLETE) && (op != OP_EDITOR_COMPLETE_QUERY)))
     return FR_NO_ACTION;
@@ -448,7 +448,7 @@ int complete_command(struct EnterWindowData *wdata, int op)
 /**
  * complete_label - Complete a label - Implements CompleteOps::complete() - @ingroup compapi_complete
  */
-int complete_label(struct EnterWindowData *wdata, int op)
+enum FunctionRetval complete_label(struct EnterWindowData *wdata, int op)
 {
   if (!wdata || ((op != OP_EDITOR_COMPLETE) && (op != OP_EDITOR_COMPLETE_QUERY)))
     return FR_NO_ACTION;

--- a/notmuch/complete.c
+++ b/notmuch/complete.c
@@ -210,7 +210,7 @@ bool mutt_nm_tag_complete(struct CompletionData *cd, struct Buffer *buf, int num
 /**
  * complete_nm_query - Complete a Notmuch Query - Implements CompleteOps::complete() - @ingroup compapi_complete
  */
-int complete_nm_query(struct EnterWindowData *wdata, int op)
+enum FunctionRetval complete_nm_query(struct EnterWindowData *wdata, int op)
 {
   if (!wdata || ((op != OP_EDITOR_COMPLETE) && (op != OP_EDITOR_COMPLETE_QUERY)))
     return FR_NO_ACTION;
@@ -227,7 +227,7 @@ int complete_nm_query(struct EnterWindowData *wdata, int op)
 /**
  * complete_nm_tag - Complete a Notmuch Tag - Implements CompleteOps::complete() - @ingroup compapi_complete
  */
-int complete_nm_tag(struct EnterWindowData *wdata, int op)
+enum FunctionRetval complete_nm_tag(struct EnterWindowData *wdata, int op)
 {
   if (!wdata || ((op != OP_EDITOR_COMPLETE) && (op != OP_EDITOR_COMPLETE_QUERY)))
     return FR_NO_ACTION;

--- a/pattern/complete.c
+++ b/pattern/complete.c
@@ -38,7 +38,7 @@
 /**
  * complete_pattern - Complete a NeoMutt Pattern - Implements CompleteOps::complete() - @ingroup compapi_complete
  */
-int complete_pattern(struct EnterWindowData *wdata, int op)
+enum FunctionRetval complete_pattern(struct EnterWindowData *wdata, int op)
 {
   if (!wdata || ((op != OP_EDITOR_COMPLETE) && (op != OP_EDITOR_COMPLETE_QUERY)))
     return FR_NO_ACTION;


### PR DESCRIPTION
This fixes the UB warning: `Call to function ... through pointer to incorrect function type`.