### PR TITLE
Fix '&&' within '||' warning

### DIFF
--- a/timegm.c
+++ b/timegm.c
@@ -38,7 +38,7 @@
  */
 static bool is_leap_year(int year)
 {
-  return ((year % 400) == 0) || ((year % 4) == 0) && ((year % 100) != 0);
+  return ((year % 400) == 0) || (((year % 4) == 0) && ((year % 100) != 0));
 }
 
 /**


### PR DESCRIPTION
This is just to mute clang being a bit overzealous:
`'&&' within '||' [-Werror,-Wlogical-op-parentheses]`