### PR TITLE
Remove unused declaration

### DIFF
--- a/alias/lib.h
+++ b/alias/lib.h
@@ -84,8 +84,6 @@ void alias_dialog  (struct Mailbox *m, struct ConfigSubset *sub);
 int  query_complete(struct Buffer *buf, struct ConfigSubset *sub);
 void query_index   (struct Mailbox *m, struct ConfigSubset *sub);
 
-int complete_alias(struct EnterWindowData *wdata, int op);
-
 struct Address *alias_reverse_lookup(const struct Address *addr);
 
 #endif /* MUTT_ALIAS_LIB_H */


### PR DESCRIPTION
This declaration is useless: the function is only ever used within the same translation unit where it's defined.

See https://github.com/neomutt/neomutt/commit/f10c0f0dd82d97f88fe54efc1e9aad2c1066d407#commitcomment-143849983
