### PR TITLE
Do not force mailbox stats calculations on startup.

### DIFF
--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -213,12 +213,12 @@ int mutt_mailbox_check(struct Mailbox *m_cur, CheckStatsFlags flags)
     if (!m->visible || !m->poll_new_mail)
       continue;
 
-    CheckStatsFlags mb_flags = MUTT_MAILBOX_CHECK_NO_FLAGS;
+    CheckStatsFlags m_flags = MUTT_MAILBOX_CHECK_NO_FLAGS;
     if (force_stats || (!m->first_check_stats_done && c_mail_check_stats))
     {
-      mb_flags |= MUTT_MAILBOX_CHECK_FORCE_STATS;
+      m_flags |= MUTT_MAILBOX_CHECK_FORCE_STATS;
     }
-    mailbox_check(m_cur, m, &st_cur, mb_flags);
+    mailbox_check(m_cur, m, &st_cur, m_flags);
     if (m->has_new)
       MailboxCount++;
     m->first_check_stats_done = true;

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -182,10 +182,11 @@ int mutt_mailbox_check(struct Mailbox *m_cur, CheckStatsFlags flags)
   if ((flags == MUTT_MAILBOX_CHECK_NO_FLAGS) && ((t - MailboxTime) < c_mail_check))
     return MailboxCount;
 
+  bool force_stats = false;
   if ((flags & MUTT_MAILBOX_CHECK_FORCE_STATS) ||
       (c_mail_check_stats && ((t - MailboxStatsTime) >= c_mail_check_stats_interval)))
   {
-    flags |= MUTT_MAILBOX_CHECK_FORCE_STATS;
+    force_stats = true;
     MailboxStatsTime = t;
   }
 
@@ -212,12 +213,12 @@ int mutt_mailbox_check(struct Mailbox *m_cur, CheckStatsFlags flags)
     if (!m->visible || !m->poll_new_mail)
       continue;
 
-    CheckStatsFlags m_flags = flags;
-    if (!m->first_check_stats_done && c_mail_check_stats)
+    CheckStatsFlags mb_flags = MUTT_MAILBOX_CHECK_NO_FLAGS;
+    if (force_stats || (!m->first_check_stats_done && c_mail_check_stats))
     {
-      m_flags |= MUTT_MAILBOX_CHECK_FORCE_STATS;
+      mb_flags |= MUTT_MAILBOX_CHECK_FORCE_STATS;
     }
-    mailbox_check(m_cur, m, &st_cur, m_flags);
+    mailbox_check(m_cur, m, &st_cur, mb_flags);
     if (m->has_new)
       MailboxCount++;
     m->first_check_stats_done = true;


### PR DESCRIPTION
* **What does this PR do?**
A few years ago after update I've noticed that new version of `neomutt` becomes very slow at startup. It takes tens of seconds on my configuration to start, showing `Sorting mailbox...` during this time. I have a few `mbox`es of 100-200Mb size each.
 In [6bad373](https://github.com/neomutt/neomutt/commit/6bad3733ee2d59d04db522d396e4b999b28a2811?diff=unified&w=0) behavior of mutt_mailbox_check() was changed. Looks like incidentally. Original mutt_mailbox_check()'s code calls mailbox_check() with force flag only if needed. For instance, passing force flag to mutt_mailbox_check() doesn't mean that it will be passed directly to mailbox_check(). Commit 6bad373 changed that behavior by passing flags directly to mailbox_check().

 Probably the same bug as https://github.com/neomutt/neomutt/issues/3410

* **Screenshots (if relevant)**
\---

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)
     \---

   - All builds and tests are passing
     `SUCCESS: No unit tests have failed.`

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)
     \---

   - Code follows the [style guide](https://neomutt.org/dev/code)
     Yes

* **What are the relevant issue numbers?**
https://github.com/neomutt/neomutt/issues/3410