### PR TITLE
Check mutt_date_parse_date's return value

### DIFF
--- a/email/parse.c
+++ b/email/parse.c
@@ -791,6 +791,7 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e,
       if (e)
       {
         struct Tz tz = { 0 };
+        // the caller will check e->date_sent for -1
         e->date_sent = mutt_date_parse_date(body, &tz);
         if (e->date_sent > 0)
         {
@@ -803,10 +804,13 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e,
       break;
 
     case 'e':
-      if ((name_len == 7) && eqi6(name + 1, "xpires") && e &&
-          (mutt_date_parse_date(body, NULL) < mutt_date_now()))
+      if ((name_len == 7) && eqi6(name + 1, "xpires") && e)
       {
-        e->expired = true;
+        const time_t expired = mutt_date_parse_date(body, NULL);
+        if ((expired != -1) && (expired < mutt_date_now()))
+        {
+          e->expired = true;
+        }
       }
       break;
 
@@ -970,6 +974,7 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e,
           if (d)
           {
             d = mutt_str_skip_email_wsp(d + 1);
+            // the caller will check e->received for -1
             e->received = mutt_date_parse_date(d, NULL);
           }
         }

--- a/mutt/date.c
+++ b/mutt/date.c
@@ -706,7 +706,7 @@ static time_t mutt_date_parse_rfc5322_strict(const char *s, struct Tz *tz_out)
  * mutt_date_parse_date - Parse a date string in RFC822 format
  * @param[in]  s      String to parse
  * @param[out] tz_out Pointer to timezone (optional)
- * @retval num Unix time in seconds
+ * @retval num Unix time in seconds, or -1 on failure
  *
  * Parse a date of the form:
  * `[ weekday , ] day-of-month month year hour:minute:second [ timezone ]`

--- a/mutt/prex.c
+++ b/mutt/prex.c
@@ -81,6 +81,8 @@ struct PrexStorage
 };
 
 #define PREX_MONTH "(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"
+#define PREX_MONTH_LAX                                                         \
+  "(Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|September|Oct|October|Nov|November|Dec|December)"
 #define PREX_DOW "(Mon|Tue|Wed|Thu|Fri|Sat|Sun)"
 #define PREX_DOW_NOCASE                                                        \
   "([Mm][Oo][Nn]|[Tt][Uu][Ee]|[Ww][Ee][Dd]|[Tt][Hh][Uu]|[Ff][Rr][Ii]|[Ss][Aa][Tt]|[Ss][Uu][Nn])"
@@ -171,7 +173,7 @@ static struct PrexStorage *prex(enum Prex which)
         CFWS
         "(([[:alpha:]]+)" CFWS ", *)?"   // Day of week (or whatever)
         CFWS "([[:digit:]]{1,2}) "       // Day
-        CFWS PREX_MONTH                  // Month
+        CFWS PREX_MONTH_LAX              // Month
         CFWS "([[:digit:]]{2,4}) "       // Year
         CFWS "([[:digit:]]{1,2})"        // Hour
         ":" CFWS "([[:digit:]]{1,2})"    // Minute

--- a/test/date/mutt_date_parse_date.c
+++ b/test/date/mutt_date_parse_date.c
@@ -62,6 +62,9 @@ void test_mutt_date_parse_date(void)
      { "Sunday, 21 Apr 2002 21:51:04 +0000",         1019425864 },
      { "Tuesday, 12 Feb 2002 13:08:10 -0500",        1013537290 },
 
+     /* Accept full month names */
+     { "Thursday, 02 January 2025 16:15:00 +0000",   1735834500 },
+
      /* A partial TZ, assume UTC */
      { "Sun, 21 Apr 2002 21:51:04 +000",             1019425864 },
 


### PR DESCRIPTION
While at it, extend PREX_RFC5322_DATE_LAX to accept full month names.

Fixes #4344