### PR TITLE
Fix configure script name in INSTALL.md.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,12 +46,12 @@ If they aren't available, Autosetup will use a version bundled with NeoMutt.
 
 ### Configure
 
-Autosetup's  `configure.autosetup` performs two tasks.  It allows the user to
+The Autosetup `configure` script performs two tasks.  It allows the user to
 enable/disable certain features of NeoMutt and it checks that all the build
 dependencies are present.
 
 For a list of the currently supported options and a brief help text, run:
-`./configure.autosetup --help`
+`./configure --help`
 
 | Configure option        | Path | Notes                                        |
 | :---------------------- | :--- | :------------------------------------------- |


### PR DESCRIPTION
configure.autosetup was renamed to configure in 2017 (commit cf3e8ff3).

* **What does this PR do?**

Fixes a mistake in the installation instructions.

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

   - All builds and tests are passing

      Hopefully this won't affect any tests. I haven't checked.

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/code)

* **What are the relevant issue numbers?**

None
