### PR TITLE
 mutt_path_to_absolute: Fail when realpath fails.

### DIFF
--- a/mutt/path.c
+++ b/mutt/path.c
@@ -322,11 +322,12 @@ char *mutt_path_dirname(const char *path)
 /**
  * mutt_path_to_absolute - Convert relative filepath to an absolute path
  * @param path      Relative path
- * @param reference Absolute path that \a path is relative to
+ * @param reference \a path is relative to the dirname of this path
  * @retval true  Success
  * @retval false Failure
  *
- * Use POSIX functions to convert a path to absolute, relatively to another path
+ * Use POSIX functions to convert a path to absolute, relative to the dirname
+ * of another path.
  *
  * @note \a path should be at least of PATH_MAX length
  */
@@ -348,14 +349,13 @@ bool mutt_path_to_absolute(char *path, const char *reference)
   FREE(&dirpath);
 
   path = realpath(buf_string(abs_path), path);
-  if (!path && (errno != ENOENT))
+  buf_pool_release(&abs_path);
+  if (!path)
   {
     mutt_perror(_("Error: converting path to absolute"));
-    buf_pool_release(&abs_path);
     return false;
   }
 
-  buf_pool_release(&abs_path);
   return true;
 }
 

--- a/test/path/mutt_path_to_absolute.c
+++ b/test/path/mutt_path_to_absolute.c
@@ -41,11 +41,13 @@ void test_mutt_path_to_absolute(void)
   }
 
   {
-    TEST_CHECK(!mutt_path_to_absolute("apple", NULL));
+    char path[PATH_MAX] = "apple";
+    TEST_CHECK(!mutt_path_to_absolute(path, NULL));
   }
 
   {
-    TEST_CHECK(mutt_path_to_absolute("/apple", "banana"));
+    char path[PATH_MAX] = "/apple";
+    TEST_CHECK(mutt_path_to_absolute(path, "banana"));
   }
 
   {
@@ -79,26 +81,6 @@ void test_mutt_path_to_absolute(void)
     snprintf(expected, sizeof(expected), "%s/notmuch/%s", test_dir, relative);
 
     TEST_CHECK(mutt_path_to_absolute(path, reference));
-    TEST_CHECK_STR_EQ(path, expected);
-  }
-
-  {
-    // Unreadable dir
-    char path[PATH_MAX] = { 0 };
-    char reference[PATH_MAX] = { 0 };
-    char expected[PATH_MAX] = { 0 };
-
-    const char *test_dir = get_test_dir();
-    const char *relative = "tmp";
-
-    strncpy(path, relative, sizeof(path));
-    snprintf(reference, sizeof(reference), "%s/maildir/damson/cur", test_dir);
-    snprintf(expected, sizeof(expected), "%s/maildir/damson/%s", test_dir, relative);
-
-    // We don't check the return value here.
-    // If the tests are run as root, like under GitHub Actions, then realpath() will succeed.
-    // If they're run as a non-root user, realpath() will fail.
-    mutt_path_to_absolute(path, reference);
     TEST_CHECK_STR_EQ(path, expected);
   }
 }


### PR DESCRIPTION
## What does this PR do?

 mutt_path_to_absolute was assuming realpath leaves something sensible in `*path` when it fails with `ENOENT`. Also, the last test case for `mutt_path_to_absolute` required it to put the right answer in `*path` in a situation where `realpath` fails with `EACCES`.
 
 In fact, the contents of `*path` are undefined when `realpath` fails. In particular, the last test case in `mutt_path_to_absolute` (which involves exactly this situation) was failing on OpenBSD, like this:

```
Test test_mutt_path_to_absolute...              [ FAILED ]
  Case Common setup:
    mutt_path_to_absolute.c:102: test_check_str_eq... failed
      Expected : '/home/falsifian/co/neomutt-test-files/maildir/damson/tmp'
      Actual   : 'tmp'
```

So:
 - Remove that last test case, which can't be expected to pass when `mutt_path_to_absolute` relies on `realpath`; and
 - Make `mutt_path_to_absolute` always fail when `realpath` fails, even with `ENOENT`.

Also:
- Correct the doc comment for `mutt_path_to_absolute`.
- In the test, make sure the path argument is always at least `PATH_MAX` long. (It doesn't matter under the current implementation, but IMO tests should be written to match the documentation, not the implementation.)
- Simplify cleanup by calling `buf_pool_release` earlier.