### PR TITLE
Remove unused global CurrentMenu.

### DIFF
--- a/globals.c
+++ b/globals.c
@@ -54,8 +54,6 @@ struct ListHead TempAttachmentsList  = STAILQ_HEAD_INITIALIZER(TempAttachmentsLi
 struct ListHead UserHeader           = STAILQ_HEAD_INITIALIZER(UserHeader);           ///< List of custom headers to add to outgoing emails
 // clang-format on
 
-enum MenuType CurrentMenu; ///< Current Menu, e.g. #MENU_PAGER
-
 /* pseudo options */
 // clang-format off
 #ifdef USE_AUTOCRYPT

--- a/globals.h
+++ b/globals.h
@@ -50,8 +50,6 @@ extern struct ListHead Muttrc;               ///< List of config files to read
 extern struct ListHead TempAttachmentsList;  ///< List of temporary files for displaying attachments
 extern struct ListHead UserHeader;           ///< List of custom headers to add to outgoing emails
 
-extern enum MenuType CurrentMenu; ///< Current Menu, e.g. #MENU_PAGER
-
 /* pseudo options */
 #ifdef USE_AUTOCRYPT
 extern bool OptAutocryptGpgme;      ///< (pseudo) use Autocrypt context inside ncrypt/crypt_gpgme.c


### PR DESCRIPTION
From git-bisect it looks like the last uses of it went away in commit a82d8d0f.

(Discovered while exploring the code.)