### PR TITLE
Allow longer maildir filename suffixes.

### DIFF
--- a/maildir/message.c
+++ b/maildir/message.c
@@ -223,7 +223,7 @@ static int maildir_sync_message(struct Mailbox *m, struct Email *e)
   struct Buffer *partpath = NULL;
   struct Buffer *fullpath = NULL;
   struct Buffer *oldpath = NULL;
-  char suffix[16] = { 0 };
+  char suffix[PATH_MAX] = { 0 };
   int rc = 0;
 
   if (e->attach_del || e->env->changed)
@@ -361,7 +361,7 @@ bool maildir_sync_mailbox_message(struct Mailbox *m, struct Email *e, struct Hea
 static int maildir_commit_message(struct Mailbox *m, struct Message *msg, struct Email *e)
 {
   char subdir[4] = { 0 };
-  char suffix[16] = { 0 };
+  char suffix[PATH_MAX] = { 0 };
   int rc = 0;
 
   if (mutt_file_fsync_close(&msg->fp))
@@ -533,7 +533,7 @@ bool maildir_msg_open_new(struct Mailbox *m, struct Message *msg, const struct E
 {
   int fd;
   char path[PATH_MAX] = { 0 };
-  char suffix[16] = { 0 };
+  char suffix[PATH_MAX] = { 0 };
   char subdir[16] = { 0 };
 
   if (e)


### PR DESCRIPTION
Custom flags can make the suffix of a maildir filename longer than 16 characters.

* **What does this PR do?**

This fixes the following bug:

1. Give a message in a maildir a lot of custom flags (making the suffix more than 16 characters long).
2. Change the flags with neomutt (e.g. flag the message).
3. Neomutt drops some of those custom flags.

A more specific example:

- Setup: using dovecot IMAP server with Maildir backend.
- Connect to dovecot and give a message a lot of IMAP keywords. As a result, its maildir filename will end with something like `:2,FSabcdefghijklmn`. NB: these keywords must be listed in the `dovecot-keywords` file; after the first 26 keywords dovecot gives up and stops trying to store them in the filename. [How dovecot stores IMAP keywords in a maildir](https://doc.dovecot.org/admin_manual/mailbox_formats/maildir/#imap-keywords)
- Open the same maildir with neomutt's maildir backend. (E.g. run neomutt on the dovecot server.) Modify the flags of that message and quit neomutt.
- Connect to dovecot again. Observe some of the keywords got lost, because neomutt dropped them from the filename.

I don't know if I found every place custom flags could be truncated, nor am I sure all three places I did find could come up in practice.