### PR TITLE
Don't force mbox stats calculations on startup

### DIFF
--- a/core/mxapi.h
+++ b/core/mxapi.h
@@ -49,11 +49,11 @@ typedef uint8_t OpenMailboxFlags;   ///< Flags for mutt_open_mailbox(), e.g. #MU
 #define MUTT_APPENDNEW     (1 << 6) ///< Set in mx_open_mailbox_append if the mailbox doesn't exist.
                                     ///< Used by maildir/mh to create the mailbox.
 
-typedef uint8_t CheckStatsFlags;                ///< Flags for mutt_mailbox_check
-#define MUTT_MAILBOX_CHECK_NO_FLAGS          0  ///< No flags are set
-#define MUTT_MAILBOX_CHECK_FORCE       (1 << 0) ///< Ignore MailboxTime and check for new mail
-#define MUTT_MAILBOX_CHECK_FORCE_STATS (1 << 1) ///< Ignore MailboxType and calculate statistics
-#define MUTT_MAILBOX_CHECK_IMMEDIATE   (1 << 2) ///< Don't postpone the actual checking
+typedef uint8_t CheckStatsFlags;     ///< Flags for mutt_mailbox_check
+#define MUTT_MAILBOX_CHECK_NO_FLAGS  0  ///< No flags are set
+#define MUTT_MAILBOX_CHECK_POSTPONED (1 << 0) ///< Make sure the number of postponed messages is updated
+#define MUTT_MAILBOX_CHECK_STATS     (1 << 1) ///< Ignore mail_check_stats and calculate statistics (used by <check-stats>)
+#define MUTT_MAILBOX_CHECK_IMMEDIATE (1 << 2) ///< Don't postpone the actual checking
 
 /**
  * enum MxStatus - Return values from mbox_check(), mbox_check_stats(),

--- a/gui/global.c
+++ b/gui/global.c
@@ -50,8 +50,7 @@
  */
 static int op_check_stats(int op)
 {
-  mutt_mailbox_check(get_current_mailbox(),
-                     MUTT_MAILBOX_CHECK_FORCE | MUTT_MAILBOX_CHECK_FORCE_STATS);
+  mutt_mailbox_check(get_current_mailbox(), MUTT_MAILBOX_CHECK_POSTPONED | MUTT_MAILBOX_CHECK_STATS);
   return FR_SUCCESS;
 }
 
@@ -88,7 +87,7 @@ static int op_shell_escape(int op)
     if (m_cur)
     {
       m_cur->last_checked = 0; // force a check on the next mx_mbox_check() call
-      mutt_mailbox_check(m_cur, MUTT_MAILBOX_CHECK_FORCE);
+      mutt_mailbox_check(m_cur, MUTT_MAILBOX_CHECK_POSTPONED);
     }
   }
   return FR_SUCCESS;

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -714,7 +714,7 @@ void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *oldcount,
   mutt_clear_error();
   /* force the mailbox check after we have changed the folder */
   struct EventMailbox ev_m = { shared->mailbox };
-  mutt_mailbox_check(ev_m.mailbox, MUTT_MAILBOX_CHECK_FORCE);
+  mutt_mailbox_check(ev_m.mailbox, MUTT_MAILBOX_CHECK_POSTPONED);
   menu_queue_redraw(menu, MENU_REDRAW_FULL);
   mutt_pattern_free(&shared->search_state->pattern);
 }
@@ -1100,7 +1100,7 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
   if (!shared->attach_msg)
   {
     /* force the mailbox check after we enter the folder */
-    mutt_mailbox_check(shared->mailbox, MUTT_MAILBOX_CHECK_FORCE);
+    mutt_mailbox_check(shared->mailbox, MUTT_MAILBOX_CHECK_POSTPONED);
   }
 #ifdef USE_INOTIFY
   mutt_monitor_add(NULL);

--- a/maildir/mailbox.c
+++ b/maildir/mailbox.c
@@ -547,7 +547,6 @@ static enum MxStatus maildir_check(struct Mailbox *m)
   struct HashTable *hash_names = NULL; // Hash Table: "base-filename" -> MdEmail
   struct MaildirMboxData *mdata = maildir_mdata_get(m);
 
-  /* XXX seems like this check belongs in mx_mbox_check() rather than here.  */
   const bool c_check_new = cs_subset_bool(NeoMutt->sub, "check_new");
   if (!c_check_new)
     return MX_STATUS_OK;
@@ -809,7 +808,7 @@ enum MxStatus maildir_mbox_check(struct Mailbox *m)
  */
 enum MxStatus maildir_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
-  bool check_stats = flags & MUTT_MAILBOX_CHECK_FORCE_STATS;
+  bool check_stats = flags & MUTT_MAILBOX_CHECK_STATS;
   bool check_new = true;
 
   if (check_stats)

--- a/main.c
+++ b/main.c
@@ -1322,7 +1322,7 @@ main
     {
       const bool c_imap_passive = cs_subset_bool(NeoMutt->sub, "imap_passive");
       cs_subset_str_native_set(NeoMutt->sub, "imap_passive", false, NULL);
-      const CheckStatsFlags csflags = MUTT_MAILBOX_CHECK_FORCE | MUTT_MAILBOX_CHECK_IMMEDIATE;
+      const CheckStatsFlags csflags = MUTT_MAILBOX_CHECK_IMMEDIATE;
       if (mutt_mailbox_check(NULL, csflags) == 0)
       {
         mutt_message(_("No mailbox with new mail"));

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1688,7 +1688,7 @@ static enum MxStatus mbox_mbox_check_stats(struct Mailbox *m, uint8_t flags)
   if (m->newly_created && ((st.st_ctime != st.st_mtime) || (st.st_ctime != st.st_atime)))
     m->newly_created = false;
 
-  if (flags & (MUTT_MAILBOX_CHECK_FORCE | MUTT_MAILBOX_CHECK_FORCE_STATS))
+  if (flags & MUTT_MAILBOX_CHECK_STATS)
   {
     struct MboxAccountData *adata = mbox_adata_get(m);
     if (adata && mutt_file_stat_timespec_compare(&st, MUTT_STAT_MTIME,

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -368,7 +368,7 @@ struct Mailbox *mutt_mailbox_next(struct Mailbox *m_cur, struct Buffer *s)
     if (m_res)
       return m_res;
 
-    mutt_mailbox_check(m_cur, MUTT_MAILBOX_CHECK_POSTPONED); /* mailbox was wrong - resync things */
+    mutt_mailbox_check(m_cur, MUTT_MAILBOX_CHECK_POSTPONED);
   }
 
   buf_reset(s); // no folders with new mail


### PR DESCRIPTION
This supersedes #4346.

Here's my current best understanding of the issue:

On startup, `main()` used the flags `MUTT_MAILBOX_CHECK_FORCE | MUTT_MAILBOX_CHECK_IMMEDIATE` in its call to `mutt_mailbox_check`. The flag `MUTT_MAILBOX_CHECK_FORCE` was checked only in two places, inconsistently:

1. in `mutt_mailbox_check`, to call `mutt_update_num_postponed()` https://github.com/neomutt/neomutt/blob/19653add8a9b372fd078aa98662b4d2c989445a7/mutt_mailbox.c#L174-L175

2. by the mbox backend, same as it used `MUTT_MAILBOX_CHECK_FORCE_STATS` https://github.com/neomutt/neomutt/blob/19653add8a9b372fd078aa98662b4d2c989445a7/mbox/mbox.c#L1691

The result is that main is forcing a stats check on mbox mailboxes, even though that was never the intention.

As correctly pointed out in #4346, in
6bad3733ee2d59d04db522d396e4b999b28a2811 we inadvertently started propagating `MUTT_MAILBOX_CHECK_FORCE` from `mutt_mailbox_check` to `mailbox_check`, which initially took a boolean flag, aptly named `check_stats`.

So, because the mbox backend had a `MUTT_MAILBOX_CHECK_FORCE | MUTT_MAILBOX_CHECK_FORCE_STATS` logic, we ended up checking stats unnecessarily.

This PR clarifies the flags a bit.

* `MUTT_MAILBOX_CHECK_FORCE` becomes `MUTT_MAILBOX_CHECK_POSTPONED`, since this is what it does.
* it clarifies that `MUTT_MAILBOX_CHECK_STATS` is only used in the context of the `<check-stats>` function