### PR TITLE
Use the correct delimiter when completing an IMAP path

### DIFF
--- a/imap/lib.h
+++ b/imap/lib.h
@@ -79,7 +79,7 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close);
 int imap_path_status(const char *path, bool queue);
 int imap_mailbox_status(struct Mailbox *m, bool queue);
 int imap_subscribe(const char *path, bool subscribe);
-int imap_complete(struct Buffer *buf, const char *path);
+int imap_complete(struct Buffer *buf, const char *path1, const char *path2);
 int imap_fast_trash(struct Mailbox *m, const char *dest);
 enum MailboxType imap_path_probe(const char *path, const struct stat *st);
 int imap_path_canon(struct Buffer *buf);


### PR DESCRIPTION
**Fixes #2422, partially, but I still want to make this IMAP delimiter business more solid. Please do not merge yet.**

This turned out to be uglier than I expected.

When we expand `=` or `+` to the value of `folder` in the completion code, we insert a `/` between `folder` and what comes next, via `buf_concat_path`. There's also a comment saying that it's safe to do so, because `imap_complete` will rewrite it: https://github.com/neomutt/neomutt/blob/19653add8a9b372fd078aa98662b4d2c989445a7/complete/complete.c#L80-L90 Except it does now. And how could it? I suspect it might be possible for an IMAP using `.` as a delimiter to accept `/` as a regular mailbox character.

So, the solution is to call `imap_complete` with the two parts of the paths (e.g., `+` and `Archiv`), still separated. In `imap_complete`, we check whether we can resolve an IMAP account with the first part of the path, and if we do, we then have a delimiter to use to build the full path.

As I said, it's not nice, but it seems to be working.

Comments and feedback, especially suggestions how to improve it, are welcome.
