### PR TITLE
Assume 'struct timespec' exists

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -424,10 +424,6 @@ if {1} {
   cc-check-function-in-lib getaddrinfo_a anl
   cc-check-function-in-lib nanosleep rt
 
-  cc-with {-includes time.h} {
-    cc-check-types "struct timespec"
-  }
-
   cc-with {-includes sys/stat.h} {
     cc-check-members "struct stat.st_atim.tv_nsec"
   }

--- a/mutt/file.h
+++ b/mutt/file.h
@@ -41,18 +41,7 @@ typedef uint8_t ReadLineFlags;             ///< Flags for mutt_file_read_line(),
 #define MUTT_RL_CONT      (1 << 0) ///< \-continuation
 #define MUTT_RL_EOL       (1 << 1) ///< don't strip `\n` / `\r\n`
 
-#ifdef HAVE_STRUCT_TIMESPEC
 struct timespec;
-#else
-/**
- * struct timespec - Time value with nanosecond precision
- */
-struct timespec
-{
-  time_t tv_sec; ///< Number of seconds since the epoch
-  long tv_nsec;  ///< Number of nanosecond, on top
-};
-#endif
 
 /**
  * enum MuttStatType - Flags for mutt_file_get_stat_timespec


### PR DESCRIPTION
It is guaranteed by ISO C11, which is the minimum C version we support.