### PR TITLE
Fix sorting INBOX and its subfolders

### DIFF
--- a/browser/sort.c
+++ b/browser/sort.c
@@ -58,7 +58,7 @@ static int browser_sort_subject(const void *a, const void *b, void *sdata)
   const struct FolderFile *pb = (const struct FolderFile *) b;
 
   /* inbox should be sorted ahead of its siblings */
-  int rc = mutt_inbox_cmp(pa->name, pb->name);
+  int rc = mutt_str_inbox_cmp(pa->name, pb->name);
   if (rc == 0)
     rc = mutt_str_coll(pa->name, pb->name);
 

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -89,6 +89,7 @@ bool        mutt_istr_equal(const char *a, const char *b);
 const char *mutt_istr_find(const char *haystack, const char *needle);
 int         mutt_istr_remall(char *str, const char *target);
 size_t      mutt_istr_startswith(const char *str, const char *prefix);
+int         mutt_str_inbox_cmp(const char *a, const char *b);
 
 /* case-insensitive, length-bound flavours */
 int         mutt_istrn_cmp(const char *a, const char *b, size_t num);

--- a/muttlib.c
+++ b/muttlib.c
@@ -974,68 +974,6 @@ void mutt_get_parent_path(const char *path, char *buf, size_t buflen)
 }
 
 /**
- * mutt_inbox_cmp - Do two folders share the same path and one is an inbox - @ingroup sort_api
- * @param a First path
- * @param b Second path
- * @retval -1 a is INBOX of b
- * @retval  0 None is INBOX
- * @retval  1 b is INBOX for a
- *
- * This function compares two folder paths. It first looks for the position of
- * the last common '/' character. If a valid position is found and it's not the
- * last character in any of the two paths, the remaining parts of the paths are
- * compared (case insensitively) with the string "INBOX". If one of the two
- * paths matches, it's reported as being less than the other and the function
- * returns -1 (a < b) or 1 (a > b). If no paths match the requirements, the two
- * paths are considered equivalent and this function returns 0.
- *
- * Examples:
- * * mutt_inbox_cmp("/foo/bar",      "/foo/baz") --> 0
- * * mutt_inbox_cmp("/foo/bar/",     "/foo/bar/inbox") --> 0
- * * mutt_inbox_cmp("/foo/bar/sent", "/foo/bar/inbox") --> 1
- * * mutt_inbox_cmp("=INBOX",        "=Drafts") --> -1
- */
-int mutt_inbox_cmp(const char *a, const char *b)
-{
-  /* fast-track in case the paths have been mutt_pretty_mailbox'ified */
-  if ((a[0] == '+') && (b[0] == '+'))
-  {
-    return mutt_istr_equal(a + 1, "inbox") ? -1 :
-           mutt_istr_equal(b + 1, "inbox") ? 1 :
-                                             0;
-  }
-
-  const char *a_end = strrchr(a, '/');
-  const char *b_end = strrchr(b, '/');
-
-  /* If one path contains a '/', but not the other */
-  if ((!a_end) ^ (!b_end))
-    return 0;
-
-  /* If neither path contains a '/' */
-  if (!a_end)
-    return 0;
-
-  /* Compare the subpaths */
-  size_t a_len = a_end - a;
-  size_t b_len = b_end - b;
-  size_t min = MIN(a_len, b_len);
-  int same = (a[min] == '/') && (b[min] == '/') && (a[min + 1] != '\0') &&
-             (b[min + 1] != '\0') && mutt_istrn_equal(a, b, min);
-
-  if (!same)
-    return 0;
-
-  if (mutt_istr_equal(&a[min + 1], "inbox"))
-    return -1;
-
-  if (mutt_istr_equal(&b[min + 1], "inbox"))
-    return 1;
-
-  return 0;
-}
-
-/**
  * buf_sanitize_filename - Replace unsafe characters in a filename
  * @param buf   Buffer for the result
  * @param path  Filename to make safe

--- a/muttlib.h
+++ b/muttlib.h
@@ -47,7 +47,6 @@ int         mutt_check_overwrite(const char *attname, const char *path, struct B
 void        mutt_encode_path(struct Buffer *buf, const char *src);
 char *      mutt_gecos_name(char *dest, size_t destlen, struct passwd *pw);
 void        mutt_get_parent_path(const char *path, char *buf, size_t buflen);
-int         mutt_inbox_cmp(const char *a, const char *b);
 bool        mutt_is_text_part(const struct Body *b);
 const char *mutt_make_version(void);
 bool        mutt_needs_mailcap(struct Body *b);

--- a/sidebar/sort.c
+++ b/sidebar/sort.c
@@ -104,7 +104,7 @@ static int sb_sort_path(const void *a, const void *b, void *sdata)
   const bool sort_reverse = *(bool *) sdata;
 
   int rc = 0;
-  rc = mutt_inbox_cmp(mailbox_path(m1), mailbox_path(m2));
+  rc = mutt_str_inbox_cmp(mailbox_path(m1), mailbox_path(m2));
   if (rc == 0)
     rc = mutt_str_coll(mailbox_path(m1), mailbox_path(m2));
 

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -621,6 +621,7 @@ STRING_OBJS	= test/string/mutt_istrn_cmp.o \
 		  test/string/mutt_str_find_word.o \
 		  test/string/mutt_str_getenv.o \
 		  test/string/mutt_str_hyphenate.o \
+		  test/string/mutt_str_inbox_cmp.o \
 		  test/string/mutt_str_is_ascii.o \
 		  test/string/mutt_str_is_email_wsp.o \
 		  test/string/mutt_str_len.o \

--- a/test/main.c
+++ b/test/main.c
@@ -648,6 +648,7 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_mutt_str_find_word)                                   \
   NEOMUTT_TEST_ITEM(test_mutt_str_getenv)                                      \
   NEOMUTT_TEST_ITEM(test_mutt_str_hyphenate)                                   \
+  NEOMUTT_TEST_ITEM(test_mutt_str_inbox_cmp)                                   \
   NEOMUTT_TEST_ITEM(test_mutt_str_is_ascii)                                    \
   NEOMUTT_TEST_ITEM(test_mutt_str_is_email_wsp)                                \
   NEOMUTT_TEST_ITEM(test_mutt_str_len)                                         \

--- a/test/string/mutt_str_inbox_cmp.c
+++ b/test/string/mutt_str_inbox_cmp.c
@@ -43,12 +43,13 @@ static int sort(const void *a, const void *b, void *state)
 
 void test_mutt_str_inbox_cmp(void)
 {
-  char *folders[] = { "+Inbox", "+Foo", "+Inbox.Archive", "+Bar", "+FooBar", "+FooBar.Baz" };
+  char *folders[] = { "+Inbox", "+Foo", "+Inbox.Archive", "+", "+Bar", "+FooBar", "+FooBar.Baz" };
   mutt_qsort_r(&folders, mutt_array_size(folders), sizeof(*folders), sort, NULL);
   TEST_CHECK_STR_EQ(folders[0], "+Inbox");
   TEST_CHECK_STR_EQ(folders[1], "+Inbox.Archive");
-  TEST_CHECK_STR_EQ(folders[2], "+Bar");
-  TEST_CHECK_STR_EQ(folders[3], "+Foo");
-  TEST_CHECK_STR_EQ(folders[4], "+FooBar");
-  TEST_CHECK_STR_EQ(folders[5], "+FooBar.Baz");
+  TEST_CHECK_STR_EQ(folders[2], "+");
+  TEST_CHECK_STR_EQ(folders[3], "+Bar");
+  TEST_CHECK_STR_EQ(folders[4], "+Foo");
+  TEST_CHECK_STR_EQ(folders[5], "+FooBar");
+  TEST_CHECK_STR_EQ(folders[6], "+FooBar.Baz");
 }

--- a/test/string/mutt_str_inbox_cmp.c
+++ b/test/string/mutt_str_inbox_cmp.c
@@ -1,0 +1,52 @@
+/**
+ * @file
+ * Test code for mutt_str_inbox_cmp()
+ *
+ * @authors
+ * Copyright (C) 2022 Pietro Cerutti <gahr@gahr.ch>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include "mutt/lib.h"
+#include "test_common.h"
+
+/* This is basically browser_sort_subject and sb_sort_path */
+static int sort(const void *a, const void *b, void *state)
+{
+  const char *fa = *(char **) a;
+  const char *fb = *(char **) b;
+
+  const int rc = mutt_str_inbox_cmp(fa, fb);
+  if (rc != 0)
+  {
+    return rc;
+  }
+  return mutt_str_coll(fa, fb);
+}
+
+void test_mutt_str_inbox_cmp(void)
+{
+  char *folders[] = { "+Inbox", "+Inbox.Archive", "+FooBar", "+FooBar.Baz" };
+  mutt_qsort_r(&folders, mutt_array_size(folders), sizeof(*folders), sort, NULL);
+  TEST_CHECK_STR_EQ(folders[0], "+Inbox");
+  TEST_CHECK_STR_EQ(folders[1], "+Inbox.Archive");
+  TEST_CHECK_STR_EQ(folders[2], "+FooBar");
+  TEST_CHECK_STR_EQ(folders[3], "+FooBar.Baz");
+}

--- a/test/string/mutt_str_inbox_cmp.c
+++ b/test/string/mutt_str_inbox_cmp.c
@@ -43,10 +43,12 @@ static int sort(const void *a, const void *b, void *state)
 
 void test_mutt_str_inbox_cmp(void)
 {
-  char *folders[] = { "+Inbox", "+Inbox.Archive", "+FooBar", "+FooBar.Baz" };
+  char *folders[] = { "+Inbox", "+Foo", "+Inbox.Archive", "+Bar", "+FooBar", "+FooBar.Baz" };
   mutt_qsort_r(&folders, mutt_array_size(folders), sizeof(*folders), sort, NULL);
   TEST_CHECK_STR_EQ(folders[0], "+Inbox");
   TEST_CHECK_STR_EQ(folders[1], "+Inbox.Archive");
-  TEST_CHECK_STR_EQ(folders[2], "+FooBar");
-  TEST_CHECK_STR_EQ(folders[3], "+FooBar.Baz");
+  TEST_CHECK_STR_EQ(folders[2], "+Bar");
+  TEST_CHECK_STR_EQ(folders[3], "+Foo");
+  TEST_CHECK_STR_EQ(folders[4], "+FooBar");
+  TEST_CHECK_STR_EQ(folders[5], "+FooBar.Baz");
 }


### PR DESCRIPTION
Fixes #4364

The bottom line is:

```c
    return mutt_istr_equal(a + 1, "inbox") ? -1 :
           mutt_istr_equal(b + 1, "inbox") ? 1 :
                                             0;
```

vs.

```c
#define IS_INBOX(s) (mutt_istrn_equal(s, "inbox", 5) && !isalnum((s)[5]))
#define CMP_INBOX(a, b) (IS_INBOX(b) - IS_INBOX(a))

...

return CMP_INBOX(a + 1, b + 1);
```

so,

1. check both `a` and `b` in all cases: before, we weren't contemplating the possibility that both folders might be Inbox-ish
2. treat `Inbox.<Anything>` as `Inbox`