### PR TITLE
ignore macro events during autocrypt initialization (fixes: #4316)

### DIFF
--- a/autocrypt/autocrypt.c
+++ b/autocrypt/autocrypt.c
@@ -75,7 +75,7 @@ static int autocrypt_dir_init(bool can_create)
      for some reason (e.g. autocrypt, header cache, bcache), but it
      doesn't exist.  The prompt is asking whether to create the directory */
   buf_printf(prompt, _("%s does not exist. Create it?"), c_autocrypt_dir);
-  if (query_yesorno(buf_string(prompt), MUTT_YES) == MUTT_YES)
+  if (query_yesorno_interactive(buf_string(prompt), MUTT_YES) == MUTT_YES)
   {
     if (mutt_file_mkdir(c_autocrypt_dir, S_IRWXU) < 0)
     {
@@ -105,8 +105,6 @@ int mutt_autocrypt_init(bool can_create)
   const char *const c_autocrypt_dir = cs_subset_path(NeoMutt->sub, "autocrypt_dir");
   if (!c_autocrypt || !c_autocrypt_dir)
     return -1;
-
-  mutt_flushinp();
 
   if (autocrypt_dir_init(can_create))
     goto bail;
@@ -155,7 +153,7 @@ int mutt_autocrypt_account_init(bool prompt)
     /* L10N: The first time NeoMutt is started with $autocrypt set, it will
        create $autocrypt_dir and then prompt to create an autocrypt account
        with this message.  */
-    if (query_yesorno(_("Create an initial autocrypt account?"), MUTT_YES) != MUTT_YES)
+    if (query_yesorno_interactive(_("Create an initial autocrypt account?"), MUTT_YES) != MUTT_YES)
       return 0;
   }
 
@@ -218,7 +216,7 @@ int mutt_autocrypt_account_init(bool prompt)
      enabled.
      Otherwise the UI will show encryption is "available" but the user
      will be required to enable encryption manually.  */
-  if (query_yesorno(_("Prefer encryption?"), MUTT_NO) == MUTT_YES)
+  if (query_yesorno_interactive(_("Prefer encryption?"), MUTT_NO) == MUTT_YES)
     prefer_encrypt = true;
 
   if (mutt_autocrypt_db_account_insert(addr, buf_string(keyid), buf_string(keydata), prefer_encrypt))
@@ -927,7 +925,7 @@ void mutt_autocrypt_scan_mailboxes(void)
      through one or more mailboxes for Autocrypt: headers.  Those headers are
      then captured in the database as peer records and used for encryption.
      If this is answered yes, they will be prompted for a mailbox.  */
-  enum QuadOption scan = query_yesorno(_("Scan a mailbox for autocrypt headers?"), MUTT_YES);
+  enum QuadOption scan = query_yesorno_interactive(_("Scan a mailbox for autocrypt headers?"), MUTT_YES);
   while (scan == MUTT_YES)
   {
     struct Mailbox *m_cur = get_current_mailbox();
@@ -953,7 +951,7 @@ void mutt_autocrypt_scan_mailboxes(void)
        I'm purposely being extra verbose; asking first then prompting
        for a mailbox.  This is because this is a one-time operation
        and I don't want them to accidentally ctrl-g and abort it.  */
-    scan = query_yesorno(_("Scan another mailbox for autocrypt headers?"), MUTT_YES);
+    scan = query_yesorno_interactive(_("Scan another mailbox for autocrypt headers?"), MUTT_YES);
   }
 
 #ifdef USE_HCACHE

--- a/autocrypt/autocrypt.c
+++ b/autocrypt/autocrypt.c
@@ -75,7 +75,7 @@ static int autocrypt_dir_init(bool can_create)
      for some reason (e.g. autocrypt, header cache, bcache), but it
      doesn't exist.  The prompt is asking whether to create the directory */
   buf_printf(prompt, _("%s does not exist. Create it?"), c_autocrypt_dir);
-  if (query_yesorno_interactive(buf_string(prompt), MUTT_YES) == MUTT_YES)
+  if (query_yesorno_ignore_macro(buf_string(prompt), MUTT_YES) == MUTT_YES)
   {
     if (mutt_file_mkdir(c_autocrypt_dir, S_IRWXU) < 0)
     {
@@ -153,7 +153,7 @@ int mutt_autocrypt_account_init(bool prompt)
     /* L10N: The first time NeoMutt is started with $autocrypt set, it will
        create $autocrypt_dir and then prompt to create an autocrypt account
        with this message.  */
-    if (query_yesorno_interactive(_("Create an initial autocrypt account?"), MUTT_YES) != MUTT_YES)
+    if (query_yesorno_ignore_macro(_("Create an initial autocrypt account?"), MUTT_YES) != MUTT_YES)
       return 0;
   }
 
@@ -216,7 +216,7 @@ int mutt_autocrypt_account_init(bool prompt)
      enabled.
      Otherwise the UI will show encryption is "available" but the user
      will be required to enable encryption manually.  */
-  if (query_yesorno_interactive(_("Prefer encryption?"), MUTT_NO) == MUTT_YES)
+  if (query_yesorno_ignore_macro(_("Prefer encryption?"), MUTT_NO) == MUTT_YES)
     prefer_encrypt = true;
 
   if (mutt_autocrypt_db_account_insert(addr, buf_string(keyid), buf_string(keydata), prefer_encrypt))
@@ -925,7 +925,7 @@ void mutt_autocrypt_scan_mailboxes(void)
      through one or more mailboxes for Autocrypt: headers.  Those headers are
      then captured in the database as peer records and used for encryption.
      If this is answered yes, they will be prompted for a mailbox.  */
-  enum QuadOption scan = query_yesorno_interactive(_("Scan a mailbox for autocrypt headers?"), MUTT_YES);
+  enum QuadOption scan = query_yesorno_ignore_macro(_("Scan a mailbox for autocrypt headers?"), MUTT_YES);
   while (scan == MUTT_YES)
   {
     struct Mailbox *m_cur = get_current_mailbox();
@@ -951,7 +951,7 @@ void mutt_autocrypt_scan_mailboxes(void)
        I'm purposely being extra verbose; asking first then prompting
        for a mailbox.  This is because this is a one-time operation
        and I don't want them to accidentally ctrl-g and abort it.  */
-    scan = query_yesorno_interactive(_("Scan another mailbox for autocrypt headers?"), MUTT_YES);
+    scan = query_yesorno_ignore_macro(_("Scan another mailbox for autocrypt headers?"), MUTT_YES);
   }
 
 #ifdef USE_HCACHE

--- a/question/lib.h
+++ b/question/lib.h
@@ -36,10 +36,10 @@
 
 #include "config/lib.h"
 
-int             mw_multi_choice           (const char *prompt, const char *letters);
-enum QuadOption query_yesorno             (const char *prompt, enum QuadOption def);
-enum QuadOption query_yesorno_interactive (const char *prompt, enum QuadOption def);
-enum QuadOption query_yesorno_help        (const char *prompt, enum QuadOption def, struct ConfigSubset *sub, const char *name);
-enum QuadOption query_quadoption          (const char *prompt, struct ConfigSubset *sub, const char *name);
+int             mw_multi_choice            (const char *prompt, const char *letters);
+enum QuadOption query_yesorno              (const char *prompt, enum QuadOption def);
+enum QuadOption query_yesorno_ignore_macro (const char *prompt, enum QuadOption def);
+enum QuadOption query_yesorno_help         (const char *prompt, enum QuadOption def, struct ConfigSubset *sub, const char *name);
+enum QuadOption query_quadoption           (const char *prompt, struct ConfigSubset *sub, const char *name);
 
 #endif /* MUTT_QUESTION_LIB_H */

--- a/question/lib.h
+++ b/question/lib.h
@@ -36,9 +36,10 @@
 
 #include "config/lib.h"
 
-int             mw_multi_choice   (const char *prompt, const char *letters);
-enum QuadOption query_yesorno     (const char *prompt, enum QuadOption def);
-enum QuadOption query_yesorno_help(const char *prompt, enum QuadOption def, struct ConfigSubset *sub, const char *name);
-enum QuadOption query_quadoption  (const char *prompt, struct ConfigSubset *sub, const char *name);
+int             mw_multi_choice           (const char *prompt, const char *letters);
+enum QuadOption query_yesorno             (const char *prompt, enum QuadOption def);
+enum QuadOption query_yesorno_interactive (const char *prompt, enum QuadOption def);
+enum QuadOption query_yesorno_help        (const char *prompt, enum QuadOption def, struct ConfigSubset *sub, const char *name);
+enum QuadOption query_quadoption          (const char *prompt, struct ConfigSubset *sub, const char *name);
 
 #endif /* MUTT_QUESTION_LIB_H */

--- a/question/question.c
+++ b/question/question.c
@@ -330,14 +330,14 @@ enum QuadOption query_yesorno(const char *prompt, enum QuadOption def)
 }
 
 /**
- * query_yesorno_interactive - Ask the user a Yes/No question interactively only
+ * query_yesorno_ignore_macro - Ask the user a Yes/No question ignoring the macro buffer
  * @param prompt Prompt
  * @param def Default answer, e.g. #MUTT_YES
  * @retval enum #QuadOption, Selection made
  *
  * Like query_yesorno but don't read from the macro events buffer.
  */
-enum QuadOption query_yesorno_interactive(const char *prompt, enum QuadOption def)
+enum QuadOption query_yesorno_ignore_macro(const char *prompt, enum QuadOption def)
 {
   return mw_yesorno(prompt, def, NULL, GETCH_IGNORE_MACRO);
 }

--- a/question/question.c
+++ b/question/question.c
@@ -153,6 +153,7 @@ int mw_multi_choice(const char *prompt, const char *letters)
  * @param prompt Prompt
  * @param def    Default answer, e.g. #MUTT_YES
  * @param cdef   Config definition for help
+ * @param flags  mutt_getch Flags, e.g. #GETCH_IGNORE_MACRO
  * @retval enum #QuadOption, Selection made
  *
  * This function uses a message window.
@@ -171,7 +172,7 @@ int mw_multi_choice(const char *prompt, const char *letters)
  * Additionally, if `$help` is set, a link to the config's documentation is shown.
  */
 static enum QuadOption mw_yesorno(const char *prompt, enum QuadOption def,
-                                  struct ConfigDef *cdef)
+                                  struct ConfigDef *cdef, GetChFlags flags)
 {
   struct MuttWindow *win = msgwin_new(true);
   if (!win)
@@ -249,7 +250,7 @@ static enum QuadOption mw_yesorno(const char *prompt, enum QuadOption def,
   window_redraw(NULL);
   while (true)
   {
-    event = mutt_getch(GETCH_NO_FLAGS);
+    event = mutt_getch(flags);
     if ((event.op == OP_TIMEOUT) || (event.op == OP_REPAINT))
     {
       window_redraw(NULL);
@@ -325,7 +326,7 @@ static enum QuadOption mw_yesorno(const char *prompt, enum QuadOption def,
  */
 enum QuadOption query_yesorno(const char *prompt, enum QuadOption def)
 {
-  return mw_yesorno(prompt, def, NULL);
+  return mw_yesorno(prompt, def, NULL, GETCH_NO_FLAGS);
 }
 
 /**
@@ -349,7 +350,7 @@ enum QuadOption query_yesorno_help(const char *prompt, enum QuadOption def,
   ASSERT(value != INT_MIN);
 
   struct ConfigDef *cdef = he_base->data;
-  return mw_yesorno(prompt, def, cdef);
+  return mw_yesorno(prompt, def, cdef, GETCH_NO_FLAGS);
 }
 
 /**
@@ -376,5 +377,5 @@ enum QuadOption query_quadoption(const char *prompt, struct ConfigSubset *sub, c
 
   struct ConfigDef *cdef = he_base->data;
   enum QuadOption def = (value == MUTT_ASKYES) ? MUTT_YES : MUTT_NO;
-  return mw_yesorno(prompt, def, cdef);
+  return mw_yesorno(prompt, def, cdef, GETCH_NO_FLAGS);
 }

--- a/question/question.c
+++ b/question/question.c
@@ -330,6 +330,19 @@ enum QuadOption query_yesorno(const char *prompt, enum QuadOption def)
 }
 
 /**
+ * query_yesorno_interactive - Ask the user a Yes/No question interactively only
+ * @param prompt Prompt
+ * @param def Default answer, e.g. #MUTT_YES
+ * @retval enum #QuadOption, Selection made
+ *
+ * Like query_yesorno but don't read from the macro events buffer.
+ */
+enum QuadOption query_yesorno_interactive(const char *prompt, enum QuadOption def)
+{
+  return mw_yesorno(prompt, def, NULL, GETCH_IGNORE_MACRO);
+}
+
+/**
  * query_yesorno_help - Ask the user a Yes/No question offering help
  * @param prompt Prompt
  * @param def    Default answer, e.g. #MUTT_YES


### PR DESCRIPTION
This takes another stab at fixing #4316. The previous attempt (#4326) was to invasive.

We only disable the reading from the macro events buffer during the autocrypt initialization. This restores the original behavior (https://github.com/neomutt/neomutt/commit/3b2790cb5c808e71ed7978f54b4fbb15de77a289) from before it was slightly changed in https://github.com/neomutt/neomutt/pull/3998.

I added an additional wrapper `query_yesorno_ignore_macro()` to not change all callers of `query_yesorno()`.