### PR TITLE
fix coverity warning about missing return value check

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2367,8 +2367,7 @@ int imap_path_canon(struct Buffer *path)
   if (url->path)
   {
     struct ImapAccountData *adata = NULL;
-    imap_adata_find(buf_string(path), &adata, NULL);
-    if (adata)
+    if (imap_adata_find(buf_string(path), &adata, NULL) == 0)
     {
       imap_fix_path_with_delim(adata->delim, url->path, tmp, sizeof(tmp));
     }


### PR DESCRIPTION
Whatever makes Coverity happy. 😄 ([CID 416200](https://scan9.scan.coverity.com/#/project-view/55671/12145?selectedIssue=416200))