### PR TITLE
Fix serialization of Body.content_id, bump hcache base version

### DIFF
--- a/hcache/hcachever.sh
+++ b/hcache/hcachever.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-BASEVERSION=8
+BASEVERSION=9
 STRUCTURES="Address Body Buffer Email Envelope ListNode Parameter"
 
 cleanstruct () {

--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -533,6 +533,7 @@ unsigned char *serial_dump_body(const struct Body *b, unsigned char *d, int *off
   d = serial_dump_parameter(&b->parameter, d, off, convert);
 
   d = serial_dump_char(b->description, d, off, convert);
+  d = serial_dump_char(b->content_id, d, off, convert);
   d = serial_dump_char(b->form_name, d, off, convert);
   d = serial_dump_char(b->filename, d, off, convert);
   d = serial_dump_char(b->d_filename, d, off, convert);
@@ -568,6 +569,7 @@ void serial_restore_body(struct Body *b, const unsigned char *d, int *off, bool 
   serial_restore_parameter(&b->parameter, d, off, convert);
 
   serial_restore_char(&b->description, d, off, convert);
+  serial_restore_char(&b->content_id, d, off, convert);
   serial_restore_char(&b->form_name, d, off, convert);
   serial_restore_char(&b->filename, d, off, convert);
   serial_restore_char(&b->d_filename, d, off, convert);


### PR DESCRIPTION
In #4327, I added a new member to Body and I forgot to add it to the hcache serialization.

The change in the Body structure should be enough to invalidate the current caches, but apparently it does not. I might try to figure out why later, but for now, let's bump the hcache version to force invalidation.

Fixes #4374