### PR TITLE
Make sure `mutt_body_copy` deep-copies `content_id`

### DIFF
--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1331,14 +1331,9 @@ static int op_attachment_group_related(struct ComposeSharedData *shared, int op)
     if (!b->tagged || (b->type == TYPE_MULTIPART))
       continue;
 
-    char *id = b->content_id;
-    if (id)
-      continue;
-
-    id = gen_cid();
-    if (id)
+    if (!b->content_id)
     {
-      mutt_str_replace(&b->content_id, id);
+      b->content_id = gen_cid();
     }
   }
 

--- a/mutt_body.c
+++ b/mutt_body.c
@@ -80,6 +80,7 @@ int mutt_body_copy(FILE *fp, struct Body **b_dst, struct Body *b_src)
   b->parts = NULL;
   b->next = NULL;
 
+  b->content_id = mutt_str_dup(b->content_id);
   b->filename = buf_strdup(tmp);
   b->use_disp = use_disp;
   b->unlink = true;


### PR DESCRIPTION
Fixes #4374 