### PR TITLE
send/: Generate the Message-ID earlier

### DIFF
--- a/send/send.c
+++ b/send/send.c
@@ -2301,6 +2301,9 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
     }
   }
 
+  if (!e_templ->env->message_id)
+    e_templ->env->message_id = mutt_gen_msgid();
+
   const bool c_resume_draft_files = cs_subset_bool(sub, "resume_draft_files");
   if (!(flags & (SEND_POSTPONED | SEND_RESEND)) &&
       !((flags & SEND_DRAFT_FILE) && c_resume_draft_files))

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -728,7 +728,7 @@ const char *mutt_fqdn(bool may_hide_host, const struct ConfigSubset *sub)
 }
 
 /**
- * gen_msgid - Generate a random Message ID
+ * mutt_gen_msgid - Generate a random Message ID
  * @retval ptr Message ID
  *
  * The length of the message id is chosen such that it is maximal and fits in
@@ -750,7 +750,7 @@ const char *mutt_fqdn(bool may_hide_host, const struct ConfigSubset *sub)
  *
  * @note The caller should free the string
  */
-static char *gen_msgid(void)
+char *mutt_gen_msgid(void)
 {
   const int ID_LEFT_LEN = 50;
   const int ID_RIGHT_LEN = 12;
@@ -801,7 +801,7 @@ void mutt_prepare_envelope(struct Envelope *env, bool final, struct ConfigSubset
     mutt_set_followup_to(env, sub);
 
     if (!env->message_id)
-      env->message_id = gen_msgid();
+      env->message_id = mutt_gen_msgid();
   }
 
   /* Take care of 8-bit => 7-bit conversion. */
@@ -874,7 +874,7 @@ static int bounce_message(FILE *fp, struct Mailbox *m, struct Email *e,
     fprintf(fp_tmp, "Resent-Date: %s\n", buf_string(date));
     buf_pool_release(&date);
 
-    char *msgid_str = gen_msgid();
+    char *msgid_str = mutt_gen_msgid();
     fprintf(fp_tmp, "Resent-Message-ID: %s\n", msgid_str);
     FREE(&msgid_str);
     mutt_addrlist_write_file(to, fp_tmp, "Resent-To");

--- a/send/sendlib.h
+++ b/send/sendlib.h
@@ -36,6 +36,7 @@ struct Mailbox;
 
 int              mutt_bounce_message     (FILE *fp, struct Mailbox *m, struct Email *e, struct AddressList *to, struct ConfigSubset *sub);
 const char *     mutt_fqdn               (bool may_hide_host, const struct ConfigSubset *sub);
+char *           mutt_gen_msgid          (void);
 enum ContentType mutt_lookup_mime_type   (struct Body *b, const char *path);
 struct Body *    mutt_make_file_attach   (const char *path, struct ConfigSubset *sub);
 struct Body *    mutt_make_message_attach(struct Mailbox *m, struct Email *e, bool attach_msg, struct ConfigSubset *sub);


### PR DESCRIPTION
This will allow protecting the field cryptographically.  thunderbird(1) protects the Message-ID.  And neomutt(1) already protects the In-Reply-To and References headers, so this would be more consistent.

neomutt(1) was already capable of using a Message-ID generated earlier, if a user enabled `edit_headers` and manually generated the field, or if a template for the message contained the field.

Closes: <https://github.com/neomutt/neomutt/issues/4382>
Cc: @gahr 
Cc: @ossilator 

---

Revisions:

<details>
<summary>v2</summary>

-  Obvious typo fixes

```
$ git range-diff neomutt/main neomutt/alx/msgid alx/msgid 
1:  3000cd16d ! 1:  508f7a464 send/: Generate the Message-ID earlier
    @@ send/send.c: static int edit_envelope(struct Envelope *en, SendFlags flags, stru
        mutt_env_set_subject(en, buf_string(buf));
     +
     +  if (!en->message_id)
    -+    env->message_id = gen_msgid();
    ++    en->message_id = mutt_gen_msgid();
     +
        rc = 0;
      
```
</details>

<details>
<summary>v2b</summary>

-  Cc: @nabijaczleweli 
-  Commit message: note that postponed messages respect the Message-ID.

```
$ git range-diff neomutt/main neomutt/alx/msgid alx/msgid 
1:  508f7a464 ! 1:  c4896f50e send/: Generate the Message-ID earlier
    @@ Commit message
         if a user enabled `edit_headers` and manually generated the field, or if
         a template for the message contained the field.
     
    +    Postponed messages respect the Message-ID header generated this way.
    +
         Closes: <https://github.com/neomutt/neomutt/issues/4382>
         Cc: Pietro Cerutti <gahr@gahr.ch>
         Cc: Oswald Buddenhagen <oswald.buddenhagen@gmx.de>
    +    Cc: наб <nabijaczleweli@nabijaczleweli.xyz>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## send/send.c ##
```
</details>

<details>
<summary>v3</summary>

-  Don't do this within an interactive function.  [@gahr ]

```
$ git range-diff neomutt/main neomutt/alx/msgid alx/msgid 
1:  c4896f50e ! 1:  f30ad8d68 send/: Generate the Message-ID earlier
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## send/send.c ##
    -@@ send/send.c: static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
    -     goto done;
    -   }
    -   mutt_env_set_subject(en, buf_string(buf));
    -+
    -+  if (!en->message_id)
    -+    en->message_id = mutt_gen_msgid();
    -+
    -   rc = 0;
    +@@ send/send.c: int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
    +         goto cleanup;
    +     }
      
    - done:
    ++    if (!e_templ->env->message_id)
    ++      e_templ->env->message_id = mutt_gen_msgid();
    ++
    +     /* the from address must be set here regardless of whether or not
    +      * $use_from is set so that the '~P' (from you) operator in send-hook
    +      * patterns will work.  if $use_from is unset, the from address is killed
     
      ## send/sendlib.c ##
     @@ send/sendlib.c: const char *mutt_fqdn(bool may_hide_host, const struct ConfigSubset *sub)
```
</details>

<details>
<summary>v4</summary>

-  Generate Message-ID in postponed messages if it wasn't present already.  [@ossilator ]

```
$ git range-diff neomutt/main neomutt/alx/msgid alx/msgid 
1:  f30ad8d68 ! 1:  5102e1435 send/: Generate the Message-ID earlier
    @@ Commit message
         if a user enabled `edit_headers` and manually generated the field, or if
         a template for the message contained the field.
     
    -    Postponed messages respect the Message-ID header generated this way.
    +    Postponed messages respect the Message-ID header generated this way.  If
    +    a postponed message didn't have the header, the header is generated when
    +    resuming it.
     
         Closes: <https://github.com/neomutt/neomutt/issues/4382>
         Cc: Pietro Cerutti <gahr@gahr.ch>
    @@ Commit message
     
      ## send/send.c ##
     @@ send/send.c: int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
    -         goto cleanup;
          }
    +   }
      
    -+    if (!e_templ->env->message_id)
    -+      e_templ->env->message_id = mutt_gen_msgid();
    ++  if (!e_templ->env->message_id)
    ++    e_templ->env->message_id = mutt_gen_msgid();
     +
    -     /* the from address must be set here regardless of whether or not
    -      * $use_from is set so that the '~P' (from you) operator in send-hook
    -      * patterns will work.  if $use_from is unset, the from address is killed
    +   const bool c_resume_draft_files = cs_subset_bool(sub, "resume_draft_files");
    +   if (!(flags & (SEND_POSTPONED | SEND_RESEND)) &&
    +       !((flags & SEND_DRAFT_FILE) && c_resume_draft_files))
     
      ## send/sendlib.c ##
     @@ send/sendlib.c: const char *mutt_fqdn(bool may_hide_host, const struct ConfigSubset *sub)
```
</details>

<details>
<summary>v4b</summary>

-  Document in the commit message that the Message-ID is still generated when actually sending if it was removed while editing the message.

```
$ git range-diff neomutt/main neomutt/alx/msgid alx/msgid 
1:  5102e1435 ! 1:  3ef04d17a send/: Generate the Message-ID earlier
    @@ Commit message
         a postponed message didn't have the header, the header is generated when
         resuming it.
     
    +    There's still code for generating a Message-ID when actually sending, so
    +    that if the header is removed in the editor (with edit_headers) we still
    +    send a Message-ID header with the email.
    +
         Closes: <https://github.com/neomutt/neomutt/issues/4382>
         Cc: Pietro Cerutti <gahr@gahr.ch>
         Cc: Oswald Buddenhagen <oswald.buddenhagen@gmx.de>
```
</details>

<details>
<summary>v4c</summary>

-  Reword commit message.  [@ossilator ]

```
$ git range-diff neomutt/main neomutt/alx/msgid alx/msgid 
1:  3ef04d17a ! 1:  efa0ac475 send/: Generate the Message-ID earlier
    @@ Commit message
         if a user enabled `edit_headers` and manually generated the field, or if
         a template for the message contained the field.
     
    +    After this change, the Message-ID header is generated if it was not
    +    already present before opening the message in the editor, so that if
    +    `edit_headers` is set, the user will already see the header.
    +
         Postponed messages respect the Message-ID header generated this way.  If
         a postponed message didn't have the header, the header is generated when
    -    resuming it.
    +    resuming it, again before opening it in the editor.
     
         There's still code for generating a Message-ID when actually sending, so
    -    that if the header is removed in the editor (with edit_headers) we still
    -    send a Message-ID header with the email.
    +    that if the header is removed in the editor we still send a Message-ID
    +    header with the email.
     
         Closes: <https://github.com/neomutt/neomutt/issues/4382>
         Cc: Pietro Cerutti <gahr@gahr.ch>
```
</details>

<details>
<summary>v4d</summary>

-  wfix commit message
-  Reviewed-by @gahr 

```
$ git range-diff neomutt/main neomutt/alx/msgid alx/msgid 
1:  efa0ac475 ! 1:  d40306647 send/: Generate the Message-ID earlier
    @@ Commit message
         if a user enabled `edit_headers` and manually generated the field, or if
         a template for the message contained the field.
     
    -    After this change, the Message-ID header is generated if it was not
    -    already present before opening the message in the editor, so that if
    +    After this change, the Message-ID header is generated (if it was not
    +    already present) before opening the message in the editor, so that if
         `edit_headers` is set, the user will already see the header.
     
         Postponed messages respect the Message-ID header generated this way.  If
    @@ Commit message
         header with the email.
     
         Closes: <https://github.com/neomutt/neomutt/issues/4382>
    -    Cc: Pietro Cerutti <gahr@gahr.ch>
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Cc: Oswald Buddenhagen <oswald.buddenhagen@gmx.de>
         Cc: наб <nabijaczleweli@nabijaczleweli.xyz>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
```
</details>