### PR TITLE
notmuch: Fix nm_query_window_available boolean return value

### DIFF
--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -1640,7 +1640,7 @@ bool nm_query_window_available(void)
   const short c_nm_query_window_duration = cs_subset_number(NeoMutt->sub, "nm_query_window_duration");
   const bool c_nm_query_window_enable = cs_subset_bool(NeoMutt->sub, "nm_query_window_enable");
 
-  return c_nm_query_window_enable || (c_nm_query_window_duration > 0);
+  return c_nm_query_window_enable && (c_nm_query_window_duration > 0);
 }
 
 /**


### PR DESCRIPTION
Currently, if the user simply set nm_query_window_duration=1 or higher in his configuration will be enough to enable windowed queries. But he might want to use folder hooks that disable conditionally for some patterns and for that he should be able to only set nm_query_window_enable=no.
