### PR TITLE
Handle a NULL mailbox while pattern matching

### DIFF
--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -796,6 +796,11 @@ static int msg_search_sendmode(struct Email *e, struct Pattern *pat)
  */
 static bool pattern_needs_msg(const struct Mailbox *m, const struct Pattern *pat)
 {
+  if (!m)
+  {
+    return false;
+  }
+
   if ((pat->op == MUTT_PAT_MIMETYPE) || (pat->op == MUTT_PAT_MIMEATTACH))
   {
     return true;


### PR DESCRIPTION
A reply-hook when replying to a message/rfc822 attachment gets evaluated without a Mailbox context.
This might limit the things we can match against (e.g., the message content), but should work fine for basis cases.

Fixes #4387