### PR TITLE
Don't return the result of `realpath` on failure

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -210,7 +210,7 @@ int source_rc(const char *rcfile_path, struct Buffer *err)
   struct Buffer *token = NULL, *linebuf = NULL;
   char *line = NULL;
   char *currentline = NULL;
-  char rcfile[PATH_MAX] = { 0 };
+  char rcfile[PATH_MAX + 1] = { 0 };
   size_t linelen = 0;
   pid_t pid;
 

--- a/test/path/mutt_path_to_absolute.c
+++ b/test/path/mutt_path_to_absolute.c
@@ -83,7 +83,7 @@ void test_mutt_path_to_absolute(void)
   }
 
   {
-    // Unreadable dir
+    // Non-existing dir
     char path[PATH_MAX] = { 0 };
     char reference[PATH_MAX] = { 0 };
     char expected[PATH_MAX] = { 0 };
@@ -92,13 +92,10 @@ void test_mutt_path_to_absolute(void)
     const char *relative = "tmp";
 
     strncpy(path, relative, sizeof(path));
-    snprintf(reference, sizeof(reference), "%s/maildir/damson/cur", test_dir);
-    snprintf(expected, sizeof(expected), "%s/maildir/damson/%s", test_dir, relative);
+    snprintf(reference, sizeof(reference), "%s/maildir/not-there/cur", test_dir);
+    snprintf(expected, sizeof(expected), "%s/maildir/not-there/%s", test_dir, relative);
 
-    // We don't check the return value here.
-    // If the tests are run as root, like under GitHub Actions, then realpath() will succeed.
-    // If they're run as a non-root user, realpath() will fail.
-    mutt_path_to_absolute(path, reference);
-    TEST_CHECK_STR_EQ(path, expected);
+    TEST_CHECK(!mutt_path_to_absolute(path, reference));
+    TEST_CHECK_STR_EQ(path, relative);
   }
 }


### PR DESCRIPTION
According to POSIX, the output argument of `realpath(3)` is undefined on failure. The Linux man page agrees, but apparently if the failure is caused by EACCESS or ENOENT, the resolved path is still provided as output. This is also the behaviour on FreeBSD, which specifically says that on failure the path that caused the issue is left in the output.

Anyway, we should not rely on anything being in the output argument on failure, and we should leave the path argument alone.

Follow up of #4351.