### PR TITLE
mutt_oauth2.py: Fix reference to client_secret

### DIFF
--- a/contrib/oauth2/mutt_oauth2.py
+++ b/contrib/oauth2/mutt_oauth2.py
@@ -297,7 +297,7 @@ if args.authorize:
         print(response['message'])
         del p['scope']
         p.update({'grant_type': 'urn:ietf:params:oauth:grant-type:device_code',
-                  'client_secret': registration['client_secret'],
+                  'client_secret': token['client_secret'],
                   'device_code': response['device_code']})
         interval = int(response['interval'])
         print('Polling...', end='', flush=True)


### PR DESCRIPTION
* **What does this PR do?**
Commit d8fd4643b1a4221163a96974543fcbd4c4a78892 moved the client_secret to be pulled from the token file, but missed updating all references to when it was stored in the hard-coded registrations configuration. This cleans up the rest of the references, avoiding a KeyError in the devicecode auth flow.

* **Screenshots (if relevant)**
Console log of previous error
```
$ /usr/share/neomutt/oauth2/mutt_oauth2.py --authorize --provider microsoft --client-secret '<redacted>' /path/to/token

Preferred OAuth2 flow ("authcode" or "localhostauthcode" or "devicecode"): devicecode
Account e-mail address: <redacted>
Client ID: <redacted>
To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code D3V1C3C0DE to authenticate.
Traceback (most recent call last):
  File "/usr/share/neomutt/oauth2/mutt_oauth2.py", line 300, in <module>
    'client_secret': registration['client_secret'],
                     ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 'client_secret'
```

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)
      - > probably n/a

   - All builds and tests are passing
      - > not sure, didn't check for this contrib script

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)
      - > probably n/a

   - Code follows the [style guide](https://neomutt.org/dev/code)
      - > yep, didn't change any python style from rest of file

* **What are the relevant issue numbers?**
I didn't find any mentioning KeyError, so probably none.
