### PR TITLE
tags: fix conditionals

### DIFF
--- a/mutt_config.c
+++ b/mutt_config.c
@@ -248,6 +248,12 @@ struct ExpandoNode *parse_tags_transformed(const char *str, const char **parsed_
   node->end++;
   (*parsed_until)++;
 
+  if (flags & EP_CONDITIONAL)
+  {
+    node->type = ENT_CONDBOOL;
+    node->render = node_condbool_render;
+  }
+
   return node;
 }
 


### PR DESCRIPTION
Fixes: #4402 

The notmuch expandos `%Gx` have their own custom parser -- `parse_tags_transformed()`
This function lets `node_expando_parse()` do most of the work.
This is fine for plain expandos, e.g. `%GI`

However, conditional expandos work slightly differently.
They should be type `ENT_CONDBOOL` and use the render function `node_condbool_render()`.

This custom render function knows how to  bool-ify numbers and strings. 

---

## Expandos Tests

I checked the following conditions to make sure there weren't any side-effects.

### Basic Expandos (`%n`)

1. (numeric)             * (0)
1. (numeric)             * (n)
1. (conditional numeric) * (0)
1. (conditional numeric) * (n)
1. (string)              * (empty)
1. (string)              * (non-empty)
1. (conditional string)  * (empty)
1. (conditional string)  * (non-empty)
1. (conditional date)    * (match)
1. (conditional date)    * (no match)

### Fixed Expandos (`%Gx`)

1. (format not defined) * (tag set)
1. (format not defined) * (tag not set)
1. (format defined)     * (tag set)
1. (format defined)     * (tag not set)
1. (format defined)     * (transform defined)     * (tag set)
1. (format defined)     * (transform defined)     * (tag not set)
1. (format defined)     * (transform not defined) * (tag set)
1. (format defined)     * (transform not defined) * (tag not set)

### Conditional Expandos (`%<Gx?`)

1. (format defined)     * (transform defined)     * (tag set)
1. (format defined)     * (transform defined)     * (tag not set)
1. (format defined)     * (transform not defined) * (tag set)
1. (format defined)     * (transform not defined) * (tag not set)
1. (format not defined) * (transform defined)     * (tag set)
1. (format not defined) * (transform defined)     * (tag not set)
1. (format not defined) * (transform not defined) * (tag set)
1. (format not defined) * (transform not defined) * (tag not set)
