### PR TITLE
browser: fix enter-quit-enter

### DIFF
--- a/editor/window.c
+++ b/editor/window.c
@@ -383,6 +383,7 @@ int mw_get_field(const char *prompt, struct Buffer *buf, CompletionFlags complet
           goto bye;
 
         case FR_SUCCESS:
+          rc = 0;
           break;
 
         case FR_UNKNOWN:


### PR DESCRIPTION
Fixes: #4385 

Ensure that a successful return code is propagated.
    
If the Message Window was refreshed (Ctrl-L), it could cause `mw_get_field()` to NOT return 0 on success.