### PR TITLE
pager: fix repaint

### DIFF
--- a/pager/ppanel.c
+++ b/pager/ppanel.c
@@ -97,10 +97,22 @@ static int ppanel_window_observer(struct NotifyCallback *nc)
     return 0;
   if (!nc->global_data || !nc->event_data)
     return -1;
+
+  struct MuttWindow *panel_pager = nc->global_data;
+  if (nc->event_subtype == NT_WINDOW_STATE)
+  {
+    panel_pager->actions |= WA_RECALC | WA_REPAINT;
+
+    struct PagerPrivateData *priv = panel_pager->wdata;
+    if (priv->pview)
+      pager_queue_redraw(priv, PAGER_REDRAW_PAGER);
+
+    mutt_debug(LL_NOTIFY, "window state done, request WA_RECALC\n");
+  }
+
   if (nc->event_subtype != NT_WINDOW_DELETE)
     return 0;
 
-  struct MuttWindow *panel_pager = nc->global_data;
   struct EventWindow *ev_w = nc->event_data;
   if (ev_w->win != panel_pager)
     return 0;


### PR DESCRIPTION
When the Pager receives a state change notification, force a repaint.

Fixes: #4361 

**Test steps**:
- `set pager_index_lines = 5`
- <kbd>\<enter\></kbd>, open an email
- <kbd>f</kbd>, forward the email
- Type an address
- <kbd>\<tab\></kbd><kbd>\<tab\></kbd>, Auto-completion to bring up the Alias Dialog
- <kbd>\<enter\></kbd>, select an address

**Expected result**:
- Screen is redrawn correctly:
  1. Mini-index
  2. Pager
  3. Message window (with address)
 