### PR TITLE
Alias/Query: Upgrade tagging

### DIFF
--- a/alias/dlg_alias.c
+++ b/alias/dlg_alias.c
@@ -273,7 +273,7 @@ static int alias_alias_observer(struct NotifyCallback *nc)
 
     if (alias_array_count_visible(&mdata->ava) != ARRAY_SIZE(&mdata->ava))
     {
-      mutt_pattern_alias_func(NULL, mdata, menu);
+      mutt_pattern_alias_func(NULL, mdata, PAA_VISIBLE, menu);
     }
   }
   else if (nc->event_subtype == NT_ALIAS_DELETE)
@@ -518,7 +518,7 @@ int alias_complete(struct Buffer *buf, struct ConfigSubset *sub)
       alias_array_alias_add(&mdata.ava, np);
     }
 
-    mutt_pattern_alias_func(NULL, &mdata, NULL);
+    mutt_pattern_alias_func(NULL, &mdata, PAA_VISIBLE, NULL);
   }
 
   if (!dlg_alias(NULL, &mdata))

--- a/alias/functions.c
+++ b/alias/functions.c
@@ -109,6 +109,7 @@ const struct MenuOpSeq QueryDefaultBindings[] = { /* map: query */
   { OP_QUERY_APPEND,                       "A" },
   { OP_SORT,                               "o" },
   { OP_SORT_REVERSE,                       "O" },
+  { OP_TAG,                                "<space>" },
   { 0, NULL },
 };
 // clang-format on

--- a/alias/gui.c
+++ b/alias/gui.c
@@ -49,8 +49,7 @@ int alias_config_observer(struct NotifyCallback *nc)
 
   struct EventConfig *ev_c = nc->event_data;
 
-  if (!mutt_str_equal(ev_c->name, "sort_alias") &&
-      !mutt_str_equal(ev_c->name, "alias_format") &&
+  if (!mutt_str_equal(ev_c->name, "sort_alias") && !mutt_str_equal(ev_c->name, "alias_format") &&
       !mutt_str_equal(ev_c->name, "query_format"))
   {
     return 0;

--- a/pattern/lib.h
+++ b/pattern/lib.h
@@ -179,6 +179,16 @@ enum PatternType
   MUTT_PAT_MAX,
 };
 
+/**
+ * enum PatternAliasAction - What to do with the matching Aliases
+ */
+enum PatternAlias
+{
+  PAA_TAG,        ///< Set   AliasView.is_tagged, but don't touch the others
+  PAA_UNTAG,      ///< Unset AliasView.is_tagged, but don't touch the others
+  PAA_VISIBLE,    ///< Set   AliasView.is_visible and hide the rest
+};
+
 bool mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags, struct Mailbox *m,
                        struct Email *e, struct PatternCache *cache);
 bool mutt_pattern_alias_exec(struct Pattern *pat, PatternExecFlags flags,
@@ -192,7 +202,7 @@ bool dlg_pattern(char *buf, size_t buflen);
 bool mutt_is_list_recipient(bool all_addr, struct Envelope *env);
 bool mutt_is_subscribed_list_recipient(bool all_addr, struct Envelope *env);
 int mutt_pattern_func(struct MailboxView *mv, int op, char *prompt);
-int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata, struct Menu *menu);
+int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata, enum PatternAlias action, struct Menu *menu);
 int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
                         struct SearchState *state, SearchFlags flags);
 int mutt_search_alias_command(struct Menu *menu, int cur,


### PR DESCRIPTION
Two minor upgrades:

**Query Dialog**:
Allow tagging aliases using <kbd>\<space\></kbd> as well as <kbd>t</kbd>
This brings it in line with the Alias dialog

**Alias/Query Dialogs**:
Add two functions: `<tag-pattern>` and `<untag-pattern>`.
This copies the behaviour of the Index dialog.