### PR TITLE
buffer: Refactor the string comparison functions

### DIFF
--- a/address/address.c
+++ b/address/address.c
@@ -849,8 +849,7 @@ bool mutt_addrlist_equal(const struct AddressList *ala, const struct AddressList
 
   while (ana && anb)
   {
-    if (!buf_str_equal(ana->mailbox, anb->mailbox) ||
-        !buf_str_equal(ana->personal, anb->personal))
+    if (!buf_equal(ana->mailbox, anb->mailbox) || !buf_equal(ana->personal, anb->personal))
     {
       break;
     }

--- a/address/address.c
+++ b/address/address.c
@@ -1085,7 +1085,7 @@ size_t mutt_addr_write(struct Buffer *buf, struct Address *addr, bool display)
 
   if (addr->mailbox)
   {
-    if (!mutt_str_equal(buf_string(addr->mailbox), "@"))
+    if (!buf_str_equal(addr->mailbox, "@"))
     {
       const char *a = display ? mutt_addr_for_display(addr) : buf_string(addr->mailbox);
       buf_addstr(buf, a);

--- a/address/address.c
+++ b/address/address.c
@@ -444,7 +444,7 @@ int mutt_addrlist_remove(struct AddressList *al, const char *mailbox)
   struct Address *a = NULL, *tmp = NULL;
   TAILQ_FOREACH_SAFE(a, al, entries, tmp)
   {
-    if (mutt_istr_equal(mailbox, buf_string(a->mailbox)))
+    if (buf_istr_equal(a->mailbox, mailbox))
     {
       TAILQ_REMOVE(al, a, entries);
       mutt_addr_free(&a);

--- a/address/address.c
+++ b/address/address.c
@@ -894,7 +894,7 @@ bool mutt_addr_cmp(const struct Address *a, const struct Address *b)
     return false;
   if (!a->mailbox || !b->mailbox)
     return false;
-  if (!buf_istr_equal(a->mailbox, b->mailbox))
+  if (!buf_iequal(a->mailbox, b->mailbox))
     return false;
   return true;
 }
@@ -1410,7 +1410,7 @@ void mutt_addrlist_dedupe(struct AddressList *al)
       {
         TAILQ_FOREACH_FROM_SAFE(a2, al, entries, tmp)
         {
-          if (a2->mailbox && buf_istr_equal(a->mailbox, a2->mailbox))
+          if (a2->mailbox && buf_iequal(a->mailbox, a2->mailbox))
           {
             mutt_debug(LL_DEBUG2, "Removing %s\n", buf_string(a2->mailbox));
             TAILQ_REMOVE(al, a2, entries);

--- a/address/group.c
+++ b/address/group.c
@@ -377,7 +377,7 @@ bool mutt_group_match(struct Group *g, const char *s)
   struct Address *a = NULL;
   TAILQ_FOREACH(a, &g->al, entries)
   {
-    if (a->mailbox && mutt_istr_equal(s, buf_string(a->mailbox)))
+    if (a->mailbox && buf_istr_equal(a->mailbox, s))
       return true;
   }
 

--- a/alias/alias.c
+++ b/alias/alias.c
@@ -637,7 +637,7 @@ bool mutt_addr_is_user(const struct Address *addr)
   }
 
   const struct Address *c_from = cs_subset_address(NeoMutt->sub, "from");
-  if (c_from && mutt_istr_equal(buf_string(c_from->mailbox), buf_string(addr->mailbox)))
+  if (c_from && buf_iequal(c_from->mailbox, addr->mailbox))
   {
     mutt_debug(LL_DEBUG5, "#5 yes, %s = %s\n", buf_string(addr->mailbox),
                buf_string(c_from->mailbox));

--- a/alias/alias.c
+++ b/alias/alias.c
@@ -117,7 +117,7 @@ static void expand_aliases_r(struct AddressList *al, struct ListHead *expn)
         struct ListNode *np = NULL;
         STAILQ_FOREACH(np, expn, entries)
         {
-          if (mutt_str_equal(buf_string(a->mailbox), np->data)) /* alias already found */
+          if (buf_str_equal(a->mailbox, np->data)) /* alias already found */
           {
             mutt_debug(LL_DEBUG1, "loop in alias found for '%s'\n", buf_string(a->mailbox));
             duplicate = true;

--- a/alias/alias.c
+++ b/alias/alias.c
@@ -610,7 +610,7 @@ bool mutt_addr_is_user(const struct Address *addr)
     return false;
   }
 
-  if (mutt_istr_equal(buf_string(addr->mailbox), Username))
+  if (buf_istr_equal(addr->mailbox, Username))
   {
     mutt_debug(LL_DEBUG5, "#1 yes, %s = %s\n", buf_string(addr->mailbox), Username);
     return true;

--- a/alias/dlg_alias.c
+++ b/alias/dlg_alias.c
@@ -487,7 +487,7 @@ int alias_complete(struct Buffer *buf, struct ConfigSubset *sub)
       FREE(&mdata.limit);
       mdata.limit = mtitle;
 
-      if (!mutt_str_equal(bestname, buf_string(buf)))
+      if (!buf_str_equal(buf, bestname))
       {
         /* we are adding something to the completion */
         buf_strcpy_n(buf, bestname, mutt_str_len(bestname) + 1);

--- a/autocrypt/autocrypt.c
+++ b/autocrypt/autocrypt.c
@@ -456,7 +456,7 @@ int mutt_autocrypt_process_gossip_header(struct Email *e, struct Envelope *prot_
     /* Check to make sure the address is in the recipient list. */
     TAILQ_FOREACH(peer_addr, &recips, entries)
     {
-      if (buf_str_equal(peer_addr->mailbox, ac_hdr_addr.mailbox))
+      if (buf_equal(peer_addr->mailbox, ac_hdr_addr.mailbox))
         break;
     }
 

--- a/autocrypt/autocrypt.c
+++ b/autocrypt/autocrypt.c
@@ -296,7 +296,7 @@ int mutt_autocrypt_process_autocrypt_header(struct Email *e, struct Envelope *en
     /* NOTE: this assumes the processing is occurring right after
      * mutt_parse_rfc822_line() and the from ADDR is still in the same
      * form (intl) as the autocrypt header addr field */
-    if (!mutt_istr_equal(buf_string(from->mailbox), ac_hdr->addr))
+    if (!buf_istr_equal(from->mailbox, ac_hdr->addr))
       continue;
 
     /* 1.1 spec says ignore all, if more than one valid header is found. */

--- a/browser/dlg_browser.c
+++ b/browser/dlg_browser.c
@@ -801,7 +801,7 @@ int examine_directory(struct Mailbox *m, struct Menu *menu, struct BrowserState 
       struct MailboxNode *np = NULL;
       STAILQ_FOREACH(np, &ml, entries)
       {
-        if (mutt_str_equal(buf_string(buf), mailbox_path(np->mailbox)))
+        if (buf_str_equal(buf, mailbox_path(np->mailbox)))
           break;
       }
 
@@ -1436,7 +1436,7 @@ void dlg_browser(struct Buffer *file, SelectFileFlags flags, struct Mailbox *m,
               break;
           }
         }
-        else if (!mutt_str_equal(CurrentFolder, buf_string(&LastDirBackup)))
+        else if (!buf_str_equal(&LastDirBackup, CurrentFolder))
         {
           mutt_browser_select_dir(CurrentFolder);
         }

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -1049,7 +1049,7 @@ static int op_toggle_mailboxes(struct BrowserPrivateData *priv, int op)
                  buf_string(&LastDir));
       if (priv->goto_swapper[0] == '\0')
       {
-        if (!mutt_str_equal(buf_string(&LastDir), c_folder))
+        if (!buf_str_equal(&LastDir, c_folder))
         {
           /* Stores into goto_swapper LastDir, and swaps to `$folder` */
           mutt_str_copy(priv->goto_swapper, buf_string(&LastDir), sizeof(priv->goto_swapper));

--- a/commands.c
+++ b/commands.c
@@ -756,7 +756,7 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
       // Start by handling the options
       parse_extract_token(buf, s, TOKEN_NO_FLAGS);
 
-      if (mutt_str_equal(buf_string(buf), "-label"))
+      if (buf_str_equal(buf, "-label"))
       {
         if (!MoreArgs(s))
         {
@@ -767,24 +767,24 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
         parse_extract_token(label, s, TOKEN_NO_FLAGS);
         label_set = true;
       }
-      else if (mutt_str_equal(buf_string(buf), "-nolabel"))
+      else if (buf_str_equal(buf, "-nolabel"))
       {
         buf_reset(label);
         label_set = true;
       }
-      else if (mutt_str_equal(buf_string(buf), "-notify"))
+      else if (buf_str_equal(buf, "-notify"))
       {
         notify = TB_TRUE;
       }
-      else if (mutt_str_equal(buf_string(buf), "-nonotify"))
+      else if (buf_str_equal(buf, "-nonotify"))
       {
         notify = TB_FALSE;
       }
-      else if (mutt_str_equal(buf_string(buf), "-poll"))
+      else if (buf_str_equal(buf, "-poll"))
       {
         poll = TB_TRUE;
       }
-      else if (mutt_str_equal(buf_string(buf), "-nopoll"))
+      else if (buf_str_equal(buf, "-nopoll"))
       {
         poll = TB_FALSE;
       }
@@ -1120,7 +1120,7 @@ static enum CommandResult parse_nospam(struct Buffer *buf, struct Buffer *s,
   }
 
   // "*" is special - clear both spam and nospam lists
-  if (mutt_str_equal(buf_string(buf), "*"))
+  if (buf_str_equal(buf, "*"))
   {
     mutt_replacelist_free(&SpamList);
     mutt_regexlist_free(&NoSpamList);

--- a/complete/complete.c
+++ b/complete/complete.c
@@ -230,8 +230,8 @@ int mutt_complete(struct CompletionData *cd, struct Buffer *buf)
   else
   {
     buf_copy(buf, dirpart);
-    if (!mutt_str_equal("/", buf_string(dirpart)) &&
-        (buf_string(dirpart)[0] != '=') && (buf_string(dirpart)[0] != '+'))
+    if (!buf_str_equal(dirpart, "/") && (buf_string(dirpart)[0] != '=') &&
+        (buf_string(dirpart)[0] != '+'))
     {
       buf_addstr(buf, "/");
     }

--- a/compose/cbar.c
+++ b/compose/cbar.c
@@ -160,7 +160,7 @@ static int cbar_recalc(struct MuttWindow *win)
                  MUTT_FORMAT_NO_FLAGS, win->state.cols, buf);
 
   struct ComposeBarData *cbar_data = win->wdata;
-  if (!mutt_str_equal(buf_string(buf), cbar_data->compose_format))
+  if (!buf_str_equal(buf, cbar_data->compose_format))
   {
     mutt_str_replace(&cbar_data->compose_format, buf_string(buf));
     win->actions |= WA_REPAINT;

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1029,7 +1029,7 @@ static int op_attachment_edit_content_id(struct ComposeSharedData *shared, int o
 
   if (mw_get_field("Content-ID: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) == 0)
   {
-    if (!mutt_str_equal(id, buf_string(buf)))
+    if (!buf_str_equal(buf, id))
     {
       if (check_cid(buf_string(buf)))
       {
@@ -1073,7 +1073,7 @@ static int op_attachment_edit_description(struct ComposeSharedData *shared, int 
   /* header names should not be translated */
   if (mw_get_field("Description: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) == 0)
   {
-    if (!mutt_str_equal(cur_att->body->description, buf_string(buf)))
+    if (!buf_str_equal(buf, cur_att->body->description))
     {
       mutt_str_replace(&cur_att->body->description, buf_string(buf));
       menu_queue_redraw(shared->adata->menu, MENU_REDRAW_CURRENT);
@@ -1145,7 +1145,7 @@ static int op_attachment_edit_language(struct ComposeSharedData *shared, int op)
   buf_strcpy(buf, cur_att->body->language);
   if (mw_get_field("Content-Language: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) == 0)
   {
-    if (!mutt_str_equal(cur_att->body->language, buf_string(buf)))
+    if (!buf_str_equal(buf, cur_att->body->language))
     {
       mutt_str_replace(&cur_att->body->language, buf_string(buf));
       menu_queue_redraw(shared->adata->menu, MENU_REDRAW_CURRENT);

--- a/conn/gnutls.c
+++ b/conn/gnutls.c
@@ -209,7 +209,7 @@ static bool tls_check_stored_hostname(const gnutls_datum_t *cert, const char *ho
       linestr[mutt_regmatch_end(mhost)] = '\0';
       linestr[mutt_regmatch_end(mhash)] = '\0';
       if ((mutt_str_equal(linestr + mutt_regmatch_start(mhost), hostname)) &&
-          (mutt_str_equal(linestr + mutt_regmatch_start(mhash), buf_string(buf))))
+          (buf_str_equal(buf, linestr + mutt_regmatch_start(mhash))))
       {
         FREE(&linestr);
         mutt_file_fclose(&fp);

--- a/envelope/functions.c
+++ b/envelope/functions.c
@@ -132,7 +132,7 @@ static bool edit_address_list(enum HeaderField field, struct AddressList *al)
     FREE(&err);
   }
 
-  const bool rc = !mutt_str_equal(buf_string(new_list), buf_string(old_list));
+  const bool rc = !buf_equal(new_list, old_list);
   buf_pool_release(&old_list);
   buf_pool_release(&new_list);
   return rc;

--- a/envelope/functions.c
+++ b/envelope/functions.c
@@ -282,7 +282,7 @@ static int op_envelope_edit_subject(struct EnvelopeWindowData *wdata, int op)
     goto done; // aborted
   }
 
-  if (mutt_str_equal(wdata->email->env->subject, buf_string(buf)))
+  if (buf_str_equal(buf, wdata->email->env->subject))
     goto done; // no change
 
   mutt_env_set_subject(wdata->email->env, buf_string(buf));

--- a/external.c
+++ b/external.c
@@ -1107,7 +1107,7 @@ bool mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp)
   mutt_parse_content_type(buf_string(buf), b);
 
   buf_printf(tmp, "%s/%s", TYPE(b), NONULL(b->subtype));
-  type_changed = !mutt_istr_equal(buf_string(tmp), buf_string(obuf));
+  type_changed = !buf_iequal(tmp, obuf);
   charset_changed = !mutt_istr_equal(buf_string(charset),
                                      mutt_param_get(&b->parameter, "charset"));
 

--- a/external.c
+++ b/external.c
@@ -1108,8 +1108,7 @@ bool mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp)
 
   buf_printf(tmp, "%s/%s", TYPE(b), NONULL(b->subtype));
   type_changed = !buf_iequal(tmp, obuf);
-  charset_changed = !mutt_istr_equal(buf_string(charset),
-                                     mutt_param_get(&b->parameter, "charset"));
+  charset_changed = !buf_istr_equal(charset, mutt_param_get(&b->parameter, "charset"));
 
   /* if in send mode, check for conversion - current setting is default. */
 

--- a/external.c
+++ b/external.c
@@ -857,7 +857,7 @@ int mutt_save_message(struct Mailbox *m, struct EmailArray *ea,
    * Leitner <leitner@prz.fu-berlin.de> */
   if (buf_is_empty(&LastSaveFolder))
     buf_alloc(&LastSaveFolder, PATH_MAX);
-  if (mutt_str_equal(buf_string(buf), "."))
+  if (buf_str_equal(buf, "."))
     buf_copy(buf, &LastSaveFolder);
   else
     buf_strcpy(&LastSaveFolder, buf_string(buf));

--- a/gui/msgwin.c
+++ b/gui/msgwin.c
@@ -490,7 +490,7 @@ void msgwin_set_text(struct MuttWindow *win, const char *text, enum ColorId colo
 
   struct MsgWinWindowData *wdata = win->wdata;
 
-  if (mutt_str_equal(buf_string(wdata->text), text))
+  if (buf_str_equal(wdata->text, text))
     return;
 
   buf_strcpy(wdata->text, text);

--- a/hdrline.c
+++ b/hdrline.c
@@ -912,7 +912,7 @@ void index_J(const struct ExpandoNode *node, void *data, MuttFormatFlags flags,
       {
         driver_tags_get_transformed(&e->thread->parent->message->tags, parent_tags);
       }
-      if (parent_tags && buf_istr_equal(tags, parent_tags))
+      if (parent_tags && buf_iequal(tags, parent_tags))
         have_tags = false;
       buf_pool_release(&parent_tags);
     }

--- a/hook.c
+++ b/hook.c
@@ -188,7 +188,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
     }
 
     parse_extract_token(pattern, s, TOKEN_NO_FLAGS);
-    if (folder_or_mbox && mutt_str_equal(buf_string(pattern), "-noregex"))
+    if (folder_or_mbox && buf_str_equal(pattern, "-noregex"))
     {
       use_regex = false;
       if (!MoreArgs(s))
@@ -290,14 +290,14 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
     if (data & MUTT_GLOBAL_HOOK)
     {
       /* Ignore duplicate global hooks */
-      if (mutt_str_equal(hook->command, buf_string(cmd)))
+      if (buf_str_equal(cmd, hook->command))
       {
         rc = MUTT_CMD_SUCCESS;
         goto cleanup;
       }
     }
     else if ((hook->type == data) && (hook->regex.pat_not == pat_not) &&
-             mutt_str_equal(buf_string(pattern), hook->regex.pattern))
+             buf_str_equal(pattern, hook->regex.pattern))
     {
       if (data & (MUTT_FOLDER_HOOK | MUTT_SEND_HOOK | MUTT_SEND2_HOOK | MUTT_MESSAGE_HOOK |
                   MUTT_ACCOUNT_HOOK | MUTT_REPLY_HOOK | MUTT_CRYPT_HOOK |
@@ -306,7 +306,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
         /* these hooks allow multiple commands with the same
          * pattern, so if we've already seen this pattern/command pair, just
          * ignore it instead of creating a duplicate */
-        if (mutt_str_equal(hook->command, buf_string(cmd)))
+        if (buf_str_equal(cmd, hook->command))
         {
           rc = MUTT_CMD_SUCCESS;
           goto cleanup;
@@ -500,8 +500,7 @@ static enum CommandResult mutt_parse_idxfmt_hook(struct Buffer *buf, struct Buff
   {
     TAILQ_FOREACH(hook, hl, entries)
     {
-      if ((hook->regex.pat_not == pat_not) &&
-          mutt_str_equal(buf_string(pattern), hook->regex.pattern))
+      if ((hook->regex.pat_not == pat_not) && buf_str_equal(pattern, hook->regex.pattern))
       {
         expando_free(&hook->expando);
         hook->expando = exp;

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2258,7 +2258,7 @@ static int imap_tags_edit(struct Mailbox *m, const char *tags, struct Buffer *bu
   new_tag = buf->data; /* rewind */
   mutt_str_remove_trailing_ws(new_tag);
 
-  return !mutt_str_equal(tags, buf_string(buf));
+  return !buf_str_equal(buf, tags);
 }
 
 /**

--- a/imap/util.c
+++ b/imap/util.c
@@ -314,7 +314,7 @@ void imap_hcache_open(struct ImapAccountData *adata, struct ImapMboxData *mdata,
 
   imap_cachepath(adata->delim, mdata->name, mbox);
 
-  if (strstr(buf_string(mbox), "/../") || mutt_str_equal(buf_string(mbox), "..") ||
+  if (strstr(buf_string(mbox), "/../") || buf_str_equal(mbox, "..") ||
       mutt_strn_equal(buf_string(mbox), "../", 3))
   {
     goto cleanup;

--- a/index/ibar.c
+++ b/index/ibar.c
@@ -111,7 +111,7 @@ static int ibar_recalc(struct MuttWindow *win)
     buf_reset(buf);
     const struct Expando *c_ts_status_format = cs_subset_expando(shared->sub, "ts_status_format");
     menu_status_line(buf, shared, priv->menu, -1, c_ts_status_format);
-    if (!mutt_str_equal(buf_string(buf), ibar_data->ts_status_format))
+    if (!buf_str_equal(buf, ibar_data->ts_status_format))
     {
       mutt_str_replace(&ibar_data->ts_status_format, buf_string(buf));
       win->actions |= WA_REPAINT;
@@ -121,7 +121,7 @@ static int ibar_recalc(struct MuttWindow *win)
     buf_reset(buf);
     const struct Expando *c_ts_icon_format = cs_subset_expando(shared->sub, "ts_icon_format");
     menu_status_line(buf, shared, priv->menu, -1, c_ts_icon_format);
-    if (!mutt_str_equal(buf_string(buf), ibar_data->ts_icon_format))
+    if (!buf_str_equal(buf, ibar_data->ts_icon_format))
     {
       mutt_str_replace(&ibar_data->ts_icon_format, buf_string(buf));
       win->actions |= WA_REPAINT;

--- a/key/dump.c
+++ b/key/dump.c
@@ -188,7 +188,7 @@ enum CommandResult dump_bind_macro(struct Buffer *buf, struct Buffer *s,
   }
 
   struct Buffer *filebuf = buf_pool_get();
-  if (dump_all || mutt_istr_equal(buf_string(buf), "all"))
+  if (dump_all || buf_istr_equal(buf, "all"))
   {
     if (bind)
       dump_all_binds(filebuf);

--- a/mailcap.c
+++ b/mailcap.c
@@ -105,7 +105,7 @@ int mailcap_expand_command(struct Body *b, const char *filename,
         /* In send mode, use the current charset, since the message hasn't
          * been converted yet.   If noconv is set, then we assume the
          * charset parameter has the correct value instead. */
-        if (mutt_istr_equal(buf_string(param), "charset") && b->charset && !b->noconv)
+        if (buf_istr_equal(param, "charset") && b->charset && !b->noconv)
           pvalue2 = b->charset;
         else
           pvalue2 = mutt_param_get(&b->parameter, buf_string(param));

--- a/maildir/message.c
+++ b/maildir/message.c
@@ -136,7 +136,7 @@ static FILE *maildir_open_find_message_dir(const char *folder, const char *uniqu
   {
     maildir_canon_filename(tunique, de->d_name);
 
-    if (mutt_str_equal(buf_string(tunique), unique))
+    if (buf_str_equal(tunique, unique))
     {
       buf_printf(fname, "%s/%s/%s", folder, subfolder, de->d_name);
       fp = mutt_file_fopen(buf_string(fname), "r");

--- a/maildir/message.c
+++ b/maildir/message.c
@@ -267,7 +267,7 @@ static int maildir_sync_message(struct Mailbox *m, struct Email *e)
     buf_printf(fullpath, "%s/%s", mailbox_path(m), buf_string(partpath));
     buf_printf(oldpath, "%s/%s", mailbox_path(m), e->path);
 
-    if (mutt_str_equal(buf_string(fullpath), buf_string(oldpath)))
+    if (buf_equal(fullpath, oldpath))
     {
       /* message hasn't really changed */
       goto cleanup;

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -700,13 +700,13 @@ bool buf_str_equal(const struct Buffer *a, const char *b)
 }
 
 /**
- * buf_istr_equal - Return if two buffers are equal, case insensitive
+ * buf_iequal - Check if two buffers are equal, case insensitive
  * @param a - First buffer to compare
  * @param b - Second buffer to compare
  * @retval true  Strings are equal
  * @retval false String are not equal
  */
-bool buf_istr_equal(const struct Buffer *a, const struct Buffer *b)
+bool buf_iequal(const struct Buffer *a, const struct Buffer *b)
 {
   return mutt_istr_equal(buf_string(a), buf_string(b));
 }

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -712,6 +712,18 @@ bool buf_iequal(const struct Buffer *a, const struct Buffer *b)
 }
 
 /**
+ * buf_istr_equal - Check if a buffer and a string are equal, case insensitive
+ * @param a - Buffer to compare
+ * @param b - String to compare
+ * @retval true  Strings are equal
+ * @retval false String are not equal
+ */
+bool buf_istr_equal(const struct Buffer *a, const char *b)
+{
+  return mutt_istr_equal(buf_string(a), b);
+}
+
+/**
  * buf_startswith - Check whether a buffer starts with a prefix
  * @param buf Buffer to check
  * @param prefix Prefix to match

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -688,6 +688,18 @@ bool buf_equal(const struct Buffer *a, const struct Buffer *b)
 }
 
 /**
+ * buf_str_equal - Check if a buffer and a string are equal
+ * @param a - Buffer to compare
+ * @param b - String to compare
+ * @retval true  Strings are equal
+ * @retval false String are not equal
+ */
+bool buf_str_equal(const struct Buffer *a, const char *b)
+{
+  return mutt_str_equal(buf_string(a), b);
+}
+
+/**
  * buf_istr_equal - Return if two buffers are equal, case insensitive
  * @param a - First buffer to compare
  * @param b - Second buffer to compare

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -676,13 +676,13 @@ char buf_at(const struct Buffer *buf, size_t offset)
 }
 
 /**
- * buf_str_equal - Return if two buffers are equal
+ * buf_equal - Check if two buffers are equal
  * @param a - Buffer to compare
  * @param b - Buffer to compare
  * @retval true  Strings are equal
  * @retval false String are not equal
  */
-bool buf_str_equal(const struct Buffer *a, const struct Buffer *b)
+bool buf_equal(const struct Buffer *a, const struct Buffer *b)
 {
   return mutt_str_equal(buf_string(a), buf_string(b));
 }

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -56,7 +56,7 @@ const char*    buf_find_char       (const struct Buffer *buf, const char c);
 char           buf_at              (const struct Buffer *buf, size_t offset);
 bool           buf_equal           (const struct Buffer *a, const struct Buffer *b);
 bool           buf_str_equal       (const struct Buffer *a, const char *b);
-bool           buf_istr_equal      (const struct Buffer *a, const struct Buffer *b);
+bool           buf_iequal          (const struct Buffer *a, const struct Buffer *b);
 int            buf_coll            (const struct Buffer *a, const struct Buffer *b);
 size_t         buf_startswith      (const struct Buffer *buf, const char *prefix);
 const char    *buf_rfind           (const struct Buffer *buf, const char *str);

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -54,7 +54,7 @@ void           buf_seek            (struct Buffer *buf, size_t offset);
 const char*    buf_find_string     (const struct Buffer *buf, const char *s);
 const char*    buf_find_char       (const struct Buffer *buf, const char c);
 char           buf_at              (const struct Buffer *buf, size_t offset);
-bool           buf_str_equal       (const struct Buffer *a, const struct Buffer *b);
+bool           buf_equal           (const struct Buffer *a, const struct Buffer *b);
 bool           buf_istr_equal      (const struct Buffer *a, const struct Buffer *b);
 int            buf_coll            (const struct Buffer *a, const struct Buffer *b);
 size_t         buf_startswith      (const struct Buffer *buf, const char *prefix);

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -55,6 +55,7 @@ const char*    buf_find_string     (const struct Buffer *buf, const char *s);
 const char*    buf_find_char       (const struct Buffer *buf, const char c);
 char           buf_at              (const struct Buffer *buf, size_t offset);
 bool           buf_equal           (const struct Buffer *a, const struct Buffer *b);
+bool           buf_str_equal       (const struct Buffer *a, const char *b);
 bool           buf_istr_equal      (const struct Buffer *a, const struct Buffer *b);
 int            buf_coll            (const struct Buffer *a, const struct Buffer *b);
 size_t         buf_startswith      (const struct Buffer *buf, const char *prefix);

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -57,6 +57,7 @@ char           buf_at              (const struct Buffer *buf, size_t offset);
 bool           buf_equal           (const struct Buffer *a, const struct Buffer *b);
 bool           buf_str_equal       (const struct Buffer *a, const char *b);
 bool           buf_iequal          (const struct Buffer *a, const struct Buffer *b);
+bool           buf_istr_equal      (const struct Buffer *a, const char *b);
 int            buf_coll            (const struct Buffer *a, const struct Buffer *b);
 size_t         buf_startswith      (const struct Buffer *buf, const char *prefix);
 const char    *buf_rfind           (const struct Buffer *buf, const char *str);

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -340,7 +340,7 @@ static struct Mailbox *find_next_mailbox(struct Buffer *s, bool find_new)
         neomutt_mailboxlist_clear(&ml);
         return m_result;
       }
-      if (mutt_str_equal(buf_string(s), mailbox_path(np->mailbox)))
+      if (buf_str_equal(s, mailbox_path(np->mailbox)))
         found = true;
     }
     neomutt_mailboxlist_clear(&ml);

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -338,13 +338,12 @@ static int crypt_id_matches_addr(struct Address *addr, struct Address *u_addr,
 
   if (addr && u_addr)
   {
-    if (addr->mailbox && u_addr->mailbox && buf_istr_equal(addr->mailbox, u_addr->mailbox))
+    if (addr->mailbox && u_addr->mailbox && buf_iequal(addr->mailbox, u_addr->mailbox))
     {
       rc |= CRYPT_KV_ADDR;
     }
 
-    if (addr->personal && u_addr->personal &&
-        buf_istr_equal(addr->personal, u_addr->personal))
+    if (addr->personal && u_addr->personal && buf_iequal(addr->personal, u_addr->personal))
     {
       rc |= CRYPT_KV_STRING;
     }

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -174,13 +174,12 @@ static PgpKeyValidFlags pgp_id_matches_addr(struct Address *addr,
   if (pgp_id_is_strong(uid))
     flags |= PGP_KV_STRONGID;
 
-  if (addr->mailbox && u_addr->mailbox && buf_istr_equal(addr->mailbox, u_addr->mailbox))
+  if (addr->mailbox && u_addr->mailbox && buf_iequal(addr->mailbox, u_addr->mailbox))
   {
     flags |= PGP_KV_ADDR;
   }
 
-  if (addr->personal && u_addr->personal &&
-      buf_istr_equal(addr->personal, u_addr->personal))
+  if (addr->personal && u_addr->personal && buf_iequal(addr->personal, u_addr->personal))
   {
     flags |= PGP_KV_STRING;
   }

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -179,15 +179,15 @@ static int nntp_capabilities(struct NntpAccountData *adata)
       buf_pool_release(&buf);
       return nntp_connect_error(adata);
     }
-    if (mutt_str_equal("STARTTLS", buf_string(buf)))
+    if (buf_str_equal(buf, "STARTTLS"))
     {
       adata->hasSTARTTLS = true;
     }
-    else if (mutt_str_equal("MODE-READER", buf_string(buf)))
+    else if (buf_str_equal(buf, "MODE-READER"))
     {
       mode_reader = true;
     }
-    else if (mutt_str_equal("READER", buf_string(buf)))
+    else if (buf_str_equal(buf, "READER"))
     {
       adata->hasDATE = true;
       adata->hasLISTGROUP = true;
@@ -207,7 +207,7 @@ static int nntp_capabilities(struct NntpAccountData *adata)
       adata->authenticators = mutt_str_dup(p);
     }
 #endif
-    else if (mutt_str_equal("OVER", buf_string(buf)))
+    else if (buf_str_equal(buf, "OVER"))
     {
       adata->hasOVER = true;
     }
@@ -221,7 +221,7 @@ static int nntp_capabilities(struct NntpAccountData *adata)
           adata->hasLIST_NEWSGROUPS = true;
       }
     }
-  } while (!mutt_str_equal(".", buf_string(buf)));
+  } while (!buf_str_equal(buf, "."));
   buf_reset(buf);
 
 #ifdef USE_SASL_CYRUS

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -498,8 +498,7 @@ static int update_email_tags(struct Email *e, notmuch_message_t *msg)
 
   driver_tags_get(&e->tags, old_tags);
 
-  if (!buf_is_empty(new_tags) && !buf_is_empty(old_tags) &&
-      (buf_str_equal(old_tags, new_tags)))
+  if (!buf_is_empty(new_tags) && !buf_is_empty(old_tags) && (buf_equal(old_tags, new_tags)))
   {
     buf_pool_release(&new_tags);
     buf_pool_release(&old_tags);

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -590,7 +590,7 @@ static int op_pager_search(struct IndexSharedData *shared,
     goto done;
   }
 
-  if (mutt_str_equal(buf_string(buf), priv->search_str))
+  if (buf_str_equal(buf, priv->search_str))
   {
     if (priv->search_compiled)
     {

--- a/pager/pbar.c
+++ b/pager/pbar.c
@@ -137,7 +137,7 @@ static int pbar_recalc(struct MuttWindow *win)
     buf_printf(buf, "%s (%s)", priv->pview->banner, pager_progress_str);
   }
 
-  if (!mutt_str_equal(buf_string(buf), pbar_data->pager_format))
+  if (!buf_str_equal(buf, pbar_data->pager_format))
   {
     mutt_str_replace(&pbar_data->pager_format, buf_string(buf));
     win->actions |= WA_REPAINT;

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -132,8 +132,8 @@ void mutt_check_simple(struct Buffer *buf, const char *simple)
   if (do_simple) /* yup, so spoof a real request */
   {
     /* convert old tokens into the new format */
-    if (mutt_istr_equal("all", buf_string(buf)) || mutt_str_equal("^", buf_string(buf)) ||
-        mutt_str_equal(".", buf_string(buf))) /* ~A is more efficient */
+    if (mutt_istr_equal("all", buf_string(buf)) || buf_str_equal(buf, "^") ||
+        buf_str_equal(buf, ".")) /* ~A is more efficient */
     {
       buf_strcpy(buf, "~A");
     }

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -132,40 +132,40 @@ void mutt_check_simple(struct Buffer *buf, const char *simple)
   if (do_simple) /* yup, so spoof a real request */
   {
     /* convert old tokens into the new format */
-    if (mutt_istr_equal("all", buf_string(buf)) || buf_str_equal(buf, "^") ||
+    if (buf_istr_equal(buf, "all") || buf_str_equal(buf, "^") ||
         buf_str_equal(buf, ".")) /* ~A is more efficient */
     {
       buf_strcpy(buf, "~A");
     }
-    else if (mutt_istr_equal("del", buf_string(buf)))
+    else if (buf_istr_equal(buf, "del"))
     {
       buf_strcpy(buf, "~D");
     }
-    else if (mutt_istr_equal("flag", buf_string(buf)))
+    else if (buf_istr_equal(buf, "flag"))
     {
       buf_strcpy(buf, "~F");
     }
-    else if (mutt_istr_equal("new", buf_string(buf)))
+    else if (buf_istr_equal(buf, "new"))
     {
       buf_strcpy(buf, "~N");
     }
-    else if (mutt_istr_equal("old", buf_string(buf)))
+    else if (buf_istr_equal(buf, "old"))
     {
       buf_strcpy(buf, "~O");
     }
-    else if (mutt_istr_equal("repl", buf_string(buf)))
+    else if (buf_istr_equal(buf, "repl"))
     {
       buf_strcpy(buf, "~Q");
     }
-    else if (mutt_istr_equal("read", buf_string(buf)))
+    else if (buf_istr_equal(buf, "read"))
     {
       buf_strcpy(buf, "~R");
     }
-    else if (mutt_istr_equal("tag", buf_string(buf)))
+    else if (buf_istr_equal(buf, "tag"))
     {
       buf_strcpy(buf, "~T");
     }
-    else if (mutt_istr_equal("unread", buf_string(buf)))
+    else if (buf_istr_equal(buf, "unread"))
     {
       buf_strcpy(buf, "~U");
     }

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -501,7 +501,7 @@ int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
     buf_copy(tmp, state->string);
     const char *const c_simple_search = cs_subset_string(NeoMutt->sub, "simple_search");
     mutt_check_simple(tmp, NONULL(c_simple_search));
-    if (!buf_str_equal(tmp, state->string_expn))
+    if (!buf_equal(tmp, state->string_expn))
     {
       mutt_pattern_free(&state->pattern);
       buf_copy(state->string_expn, tmp);
@@ -657,7 +657,7 @@ int mutt_search_alias_command(struct Menu *menu, int cur,
     struct Buffer *tmp = buf_pool_get();
     buf_copy(tmp, state->string);
     mutt_check_simple(tmp, MUTT_ALIAS_SIMPLESEARCH);
-    if (!buf_str_equal(tmp, state->string_expn))
+    if (!buf_equal(tmp, state->string_expn))
     {
       mutt_pattern_free(&state->pattern);
       buf_copy(state->string_expn, tmp);

--- a/send/send.c
+++ b/send/send.c
@@ -115,7 +115,7 @@ static void append_signature(FILE *fp, struct ConfigSubset *sub)
   struct Buffer *def_sig = buf_pool_get();
   cs_str_initial_get(sub->cs, "signature", def_sig);
   mutt_path_canon(def_sig, HomeDir, false);
-  bool notify_missing = !mutt_str_equal(c_signature, buf_string(def_sig));
+  bool notify_missing = !buf_str_equal(def_sig, c_signature);
   buf_pool_release(&def_sig);
 
   pid_t pid = 0;
@@ -1755,7 +1755,7 @@ static int save_fcc(struct Mailbox *m, struct Email *e, struct Buffer *fcc,
     return rc;
   }
 
-  if (buf_is_empty(fcc) || mutt_str_equal("/dev/null", buf_string(fcc)))
+  if (buf_is_empty(fcc) || buf_str_equal(fcc, "/dev/null"))
     return rc;
 
   struct Body *tmpbody = e->body;

--- a/sidebar/commands.c
+++ b/sidebar/commands.c
@@ -66,7 +66,7 @@ enum CommandResult sb_parse_sidebar_unpin(struct Buffer *buf, struct Buffer *s,
   {
     parse_extract_token(path, s, TOKEN_BACKTICK_VARS);
     /* Check for deletion of entire list */
-    if (mutt_str_equal(buf_string(path), "*"))
+    if (buf_str_equal(path, "*"))
     {
       mutt_list_free(&SidebarPinned);
       break;

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -78,10 +78,10 @@ BUFFER_OBJS	= test/buffer/buf_add_printf.o \
 		  test/buffer/buf_find_string.o \
 		  test/buffer/buf_fix_dptr.o \
 		  test/buffer/buf_free.o \
+		  test/buffer/buf_iequal.o \
 		  test/buffer/buf_init.o \
 		  test/buffer/buf_inline_replace.o \
 		  test/buffer/buf_insert.o \
-		  test/buffer/buf_istr_equal.o \
 		  test/buffer/buf_is_empty.o \
 		  test/buffer/buf_join_str.o \
 		  test/buffer/buf_len.o \

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -73,6 +73,7 @@ BUFFER_OBJS	= test/buffer/buf_add_printf.o \
 		  test/buffer/buf_dealloc.o \
 		  test/buffer/buf_dequote_comment.o \
 		  test/buffer/buf_dup.o \
+		  test/buffer/buf_equal.o \
 		  test/buffer/buf_find_char.o \
 		  test/buffer/buf_find_string.o \
 		  test/buffer/buf_fix_dptr.o \
@@ -94,7 +95,6 @@ BUFFER_OBJS	= test/buffer/buf_add_printf.o \
 		  test/buffer/buf_strcpy.o \
 		  test/buffer/buf_strcpy_n.o \
 		  test/buffer/buf_strdup.o \
-		  test/buffer/buf_str_equal.o \
 		  test/buffer/buf_substrcpy.o
 
 CHARSET_OBJS	= test/charset/mutt_ch_canonical_charset.o \

--- a/test/buffer/buf_equal.c
+++ b/test/buffer/buf_equal.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * Test code for buf_str_equal()
+ * Test code for buf_equal()
  *
  * @authors
  * Copyright (C) 2023 Anna Figueiredo Gomes <navi@vlhl.dev>
@@ -28,19 +28,19 @@
 #include "mutt/lib.h"
 #include "test_common.h" // IWYU pragma: keep
 
-void test_buf_str_equal(void)
+void test_buf_equal(void)
 {
-  // bool buf_str_equal(struct Buffer *a, struct Buffer *b);
+  // bool buf_equal(struct Buffer *a, struct Buffer *b);
 
   {
     // Degenerate tests
-    TEST_CHECK(buf_str_equal(NULL, NULL) == true);
+    TEST_CHECK(buf_equal(NULL, NULL) == true);
 
     struct Buffer *a = buf_new("foo");
     struct Buffer *b = buf_new("foo");
 
-    TEST_CHECK(buf_str_equal(a, NULL) == false);
-    TEST_CHECK(buf_str_equal(NULL, b) == false);
+    TEST_CHECK(buf_equal(a, NULL) == false);
+    TEST_CHECK(buf_equal(NULL, b) == false);
 
     buf_free(&a);
     buf_free(&b);
@@ -50,7 +50,7 @@ void test_buf_str_equal(void)
     struct Buffer *a = buf_new("foo");
     struct Buffer *b = buf_new("foo");
 
-    TEST_CHECK(buf_str_equal(a, b) == true);
+    TEST_CHECK(buf_equal(a, b) == true);
 
     buf_free(&a);
     buf_free(&b);
@@ -60,7 +60,7 @@ void test_buf_str_equal(void)
     struct Buffer *a = buf_new("foobar");
     struct Buffer *b = buf_new("foo");
 
-    TEST_CHECK(buf_str_equal(a, b) == false);
+    TEST_CHECK(buf_equal(a, b) == false);
 
     buf_free(&a);
     buf_free(&b);
@@ -70,7 +70,7 @@ void test_buf_str_equal(void)
     struct Buffer *a = buf_new("foo");
     struct Buffer *b = buf_new("foobar");
 
-    TEST_CHECK(buf_str_equal(a, b) == false);
+    TEST_CHECK(buf_equal(a, b) == false);
 
     buf_free(&a);
     buf_free(&b);
@@ -80,7 +80,7 @@ void test_buf_str_equal(void)
     struct Buffer *a = buf_new("foo");
     struct Buffer *b = buf_new("bar");
 
-    TEST_CHECK(buf_str_equal(a, b) == false);
+    TEST_CHECK(buf_equal(a, b) == false);
 
     buf_free(&a);
     buf_free(&b);
@@ -90,7 +90,7 @@ void test_buf_str_equal(void)
     struct Buffer *a = buf_new("foo");
     struct Buffer *b = buf_new("Foo");
 
-    TEST_CHECK(buf_str_equal(a, b) == false);
+    TEST_CHECK(buf_equal(a, b) == false);
 
     buf_free(&a);
     buf_free(&b);

--- a/test/buffer/buf_iequal.c
+++ b/test/buffer/buf_iequal.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * Test code for buf_istr_equal()
+ * Test code for buf_iequal()
  *
  * @authors
  * Copyright (C) 2023 Anna Figueiredo Gomes <navi@vlhl.dev>
@@ -28,19 +28,19 @@
 #include "mutt/lib.h"
 #include "test_common.h" // IWYU pragma: keep
 
-void test_buf_istr_equal(void)
+void test_buf_iequal(void)
 {
-  // bool buf_istr_equal(struct Buffer *a, struct Buffer *b);
+  // bool buf_iequal(struct Buffer *a, struct Buffer *b);
 
   {
     // Degenerate tests
-    TEST_CHECK(buf_istr_equal(NULL, NULL) == true);
+    TEST_CHECK(buf_iequal(NULL, NULL) == true);
 
     struct Buffer *a = buf_new("apple");
     struct Buffer *b = buf_new("banana");
 
-    TEST_CHECK(buf_istr_equal(a, NULL) == false);
-    TEST_CHECK(buf_istr_equal(NULL, b) == false);
+    TEST_CHECK(buf_iequal(a, NULL) == false);
+    TEST_CHECK(buf_iequal(NULL, b) == false);
 
     buf_free(&a);
     buf_free(&b);
@@ -50,7 +50,7 @@ void test_buf_istr_equal(void)
     struct Buffer *a = buf_new("foo");
     struct Buffer *b = buf_new("foo");
 
-    TEST_CHECK(buf_istr_equal(a, b) == true);
+    TEST_CHECK(buf_iequal(a, b) == true);
 
     buf_free(&a);
     buf_free(&b);
@@ -60,7 +60,7 @@ void test_buf_istr_equal(void)
     struct Buffer *a = buf_new("foo");
     struct Buffer *b = buf_new("bar");
 
-    TEST_CHECK(buf_istr_equal(a, b) == false);
+    TEST_CHECK(buf_iequal(a, b) == false);
 
     buf_free(&a);
     buf_free(&b);
@@ -70,7 +70,7 @@ void test_buf_istr_equal(void)
     struct Buffer *a = buf_new("foo");
     struct Buffer *b = buf_new("Foo");
 
-    TEST_CHECK(buf_istr_equal(a, b) == true);
+    TEST_CHECK(buf_iequal(a, b) == true);
 
     buf_free(&a);
     buf_free(&b);

--- a/test/config/slist.c
+++ b/test/config/slist.c
@@ -491,7 +491,7 @@ static bool test_string_get(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!mutt_str_equal(buf_string(initial), buf_string(err)))
+  if (!buf_equal(initial, err))
   {
     TEST_MSG("Differ: %s '%s' '%s'", name, buf_string(initial), buf_string(err));
     return false;
@@ -516,7 +516,7 @@ static bool test_string_get(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!mutt_str_equal(buf_string(initial), buf_string(err)))
+  if (!buf_equal(initial, err))
   {
     TEST_MSG("Differ: %s '%s' '%s'", name, buf_string(initial), buf_string(err));
     return false;
@@ -541,7 +541,7 @@ static bool test_string_get(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!mutt_str_equal(buf_string(initial), buf_string(err)))
+  if (!buf_equal(initial, err))
   {
     TEST_MSG("Differ: %s '%s' '%s'", name, buf_string(initial), buf_string(err));
     return false;

--- a/test/date/mutt_date_make_imap.c
+++ b/test/date/mutt_date_make_imap.c
@@ -42,8 +42,8 @@ void test_mutt_date_make_imap(void)
     time_t t = 961930800;
     TEST_CHECK(mutt_date_make_imap(buf, t) > 0);
     TEST_MSG(buf_string(buf));
-    bool result = (mutt_str_equal(buf_string(buf), "25-Jun-2000 12:00:00 +0100")) || // Expected result...
-                  (mutt_str_equal(buf_string(buf), "25-Jun-2000 11:00:00 +0000")); // but Travis seems to have locale problems
+    bool result = (buf_str_equal(buf, "25-Jun-2000 12:00:00 +0100")) || // Expected result...
+                  (buf_str_equal(buf, "25-Jun-2000 11:00:00 +0000")); // but Travis seems to have locale problems
     TEST_CHECK(result == true);
     buf_pool_release(&buf);
   }

--- a/test/main.c
+++ b/test/main.c
@@ -137,7 +137,7 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_buf_strcpy)                                           \
   NEOMUTT_TEST_ITEM(test_buf_strcpy_n)                                         \
   NEOMUTT_TEST_ITEM(test_buf_strdup)                                           \
-  NEOMUTT_TEST_ITEM(test_buf_str_equal)                                        \
+  NEOMUTT_TEST_ITEM(test_buf_equal)                                            \
   NEOMUTT_TEST_ITEM(test_buf_substrcpy)                                        \
                                                                                \
   /* charset */                                                                \

--- a/test/main.c
+++ b/test/main.c
@@ -120,7 +120,7 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_buf_init)                                             \
   NEOMUTT_TEST_ITEM(test_buf_inline_replace)                                   \
   NEOMUTT_TEST_ITEM(test_buf_insert)                                           \
-  NEOMUTT_TEST_ITEM(test_buf_istr_equal)                                       \
+  NEOMUTT_TEST_ITEM(test_buf_iequal)                                           \
   NEOMUTT_TEST_ITEM(test_buf_is_empty)                                         \
   NEOMUTT_TEST_ITEM(test_buf_join_str)                                         \
   NEOMUTT_TEST_ITEM(test_buf_len)                                              \


### PR DESCRIPTION
**NOTE**: Post-Release -- This is quite simple, but I'll queue it up and merge it after the next release.

It's a lot of diff, but it's quite simple.
It eliminates quite a lot of `buf_string()`s from string comparisons.

Simplify the name of the **Buffer**-only comparision: `buf_str_equal()` to `buf_equal()`
Then use the old name, `buf_str_equal()`, for a `Buffer` vs string (`char *`) comparison.

Then repeat the same for the case-insensitive versions.

---

1. cb0e61b39 buffer: rename `buf_str_equal()` to `buf_equal()`
1. 7e286b902 buffer: create `buf_str_equal()`
1. 59c9298db buffer: rename `buf_istr_equal()` to `buf_iequal()`
1. 00c280b2c buffer: create `buf_istr_equal()`