### PR TITLE
compose: fix redraw on attachment

### DIFF
--- a/compose/cbar.c
+++ b/compose/cbar.c
@@ -245,7 +245,7 @@ static int cbar_email_observer(struct NotifyCallback *nc)
 {
   if (nc->event_type != NT_EMAIL)
     return 0;
-  if (!nc->global_data || !nc->event_data)
+  if (!nc->global_data)
     return -1;
 
   struct MuttWindow *win_cbar = nc->global_data;
@@ -272,7 +272,7 @@ static int cbar_window_observer(struct NotifyCallback *nc)
 
   if (nc->event_subtype == NT_WINDOW_STATE)
   {
-    win_cbar->actions |= WA_RECALC;
+    win_cbar->actions |= WA_RECALC | WA_REPAINT;
     mutt_debug(LL_DEBUG5, "window state done, request WA_RECALC\n");
   }
   else if (nc->event_subtype == NT_WINDOW_DELETE)

--- a/compose/dlg_compose.c
+++ b/compose/dlg_compose.c
@@ -176,7 +176,10 @@ static int compose_window_observer(struct NotifyCallback *nc)
   if (ev_w->win != dlg)
     return 0;
 
+  struct ComposeSharedData *shared = dlg->wdata;
+
   notify_observer_remove(NeoMutt->sub->notify, compose_config_observer, dlg);
+  notify_observer_remove(shared->email->notify, compose_email_observer, shared);
   notify_observer_remove(dlg->notify, compose_window_observer, dlg);
   mutt_debug(LL_DEBUG5, "window delete done\n");
 


### PR DESCRIPTION
Fix the repainting of the Compose Bar after adding/deleting an attachment.
Also fix a leak of an Observer.

**Tests**: Open the Compose Dialog, then

1. Attach a file, then cancel, `<attach-file>`, "main.c" <kbd>Ctrl-G</kbd>
  Compose bar unchanged
1. Attach a file by name, `<attach-file>`, "main.c" <kbd>\<enter\></kbd>
  Compose bar updated
1. Attach a file by dialog, then cancel, `<attach-file>`, <kbd>?</kbd>, <kbd>q</kbd>
  Compose bar updated
1. Attach a file by dialog, `<attach-file>`, <kbd>?</kbd>, select file
  Compose bar updated
1. Delete an attachment, `<detach-file>`
  Compose bar updated
