### PR TITLE
compose: fix search with arrow_cursor

### DIFF
--- a/compose/attach.c
+++ b/compose/attach.c
@@ -225,7 +225,8 @@ static int compose_make_entry(struct Menu *menu, int line, int max_cols, struct 
   if (c_arrow_cursor)
   {
     const char *const c_arrow_string = cs_subset_string(menu->sub, "arrow_string");
-    max_cols -= (mutt_strwidth(c_arrow_string) + 1);
+    if (max_cols > 0)
+      max_cols -= (mutt_strwidth(c_arrow_string) + 1);
   }
 
   const struct Expando *c_attach_format = cs_subset_expando(sub, "attach_format");


### PR DESCRIPTION
Fixes: #4435

Don't alter `max_cols` for the arrow string if it's `-1`.
`-1` tells `expando_render()` to use as much space as necessary.