### PR TITLE
show message preview in compose view

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -230,7 +230,8 @@ $(PWD)/compmbox:
 LIBCOMPOSE=	libcompose.a
 LIBCOMPOSEOBJS=	compose/attach.o compose/attach_data.o compose/cbar.o \
 		compose/cbar_data.o compose/config.o compose/dlg_compose.o \
-		compose/expando.o compose/functions.o compose/shared_data.o
+		compose/expando.o compose/functions.o compose/preview.o \
+		compose/shared_data.o
 
 CLEANFILES+=	$(LIBCOMPOSE) $(LIBCOMPOSEOBJS)
 ALLOBJS+=	$(LIBCOMPOSEOBJS)

--- a/compose/attach.c
+++ b/compose/attach.c
@@ -5,6 +5,7 @@
  * @authors
  * Copyright (C) 2021-2024 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2023-2024 Tóth János <gomba007@gmail.com>
+ * Copyright (C) 2024 Dennis Schön <mail@dennis-schoen.de>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -236,9 +237,32 @@ static int compose_make_entry(struct Menu *menu, int line, int max_cols, struct 
 }
 
 /**
+ * attach_recalc - Recalculate the Window data - Implements MuttWindow::recalc() - @ingroup window_recalc
+ */
+static int attach_recalc(struct MuttWindow *win)
+{
+  struct Menu *menu = win->wdata;
+  struct ComposeAttachData *adata = menu->mdata;
+
+  const int cur_rows = win->state.rows;
+  const int new_rows = adata->actx->idxlen;
+
+  if (new_rows != cur_rows)
+  {
+    win->req_rows = new_rows;
+    mutt_window_reflow(win->parent);
+    menu_adjust(menu);
+  }
+
+  win->actions |= WA_REPAINT;
+  mutt_debug(LL_DEBUG5, "recalc done, request WA_REPAINT\n");
+  return 0;
+}
+
+/**
  * attach_new - Create the Attachments Menu
- * @param parent Parent Window
- * @param shared Shared compose data
+ * @param parent     Parent Window
+ * @param shared     Shared compose data
  */
 struct MuttWindow *attach_new(struct MuttWindow *parent, struct ComposeSharedData *shared)
 {
@@ -264,4 +288,30 @@ struct MuttWindow *attach_new(struct MuttWindow *parent, struct ComposeSharedDat
   adata->menu = menu;
 
   return win_attach;
+}
+
+/**
+ * attachment_size_fixed - Make the Attachment Window fixed-size
+ * @param win Attachment Window
+ */
+void attachment_size_fixed(struct MuttWindow *win)
+{
+  if (!win || (win->size == MUTT_WIN_SIZE_FIXED))
+    return;
+
+  win->size = MUTT_WIN_SIZE_FIXED;
+  win->recalc = attach_recalc;
+}
+
+/**
+ * attachment_size_max - Make the Attachment Window maximised
+ * @param win Attachment Window
+ */
+void attachment_size_max(struct MuttWindow *win)
+{
+  if (!win || (win->size == MUTT_WIN_SIZE_MAXIMISE))
+    return;
+
+  win->size = MUTT_WIN_SIZE_MAXIMISE;
+  win->recalc = NULL;
 }

--- a/compose/config.c
+++ b/compose/config.c
@@ -5,6 +5,7 @@
  * @authors
  * Copyright (C) 2020 Matthew Hughes <matthewhughes934@gmail.com>
  * Copyright (C) 2020-2024 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2024 Dennis Schön <mail@dennis-schoen.de>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -70,8 +71,17 @@ static struct ConfigDef ComposeVars[] = {
   { "compose_format", DT_EXPANDO|D_L10N_STRING, IP N_("-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-"), IP &ComposeFormatDef, NULL,
     "printf-like format string for the Compose panel's status bar"
   },
+  { "compose_show_preview", DT_BOOL, true, 0, NULL,
+    "Display a preview of the message body in the Compose window"
+  },
   { "compose_show_user_headers", DT_BOOL, true, 0, NULL,
     "Controls whether or not custom headers are shown in the compose envelope"
+  },
+  { "compose_preview_min_rows", DT_NUMBER|D_INTEGER_NOT_NEGATIVE, 5, 0, NULL,
+    "Hide the preview if it has fewer than this number of rows"
+  },
+  { "compose_preview_above_attachments", DT_BOOL, false, 0, NULL,
+    "Show the message preview above the attachments list. By default it is shown below it."
   },
   { "copy", DT_QUAD, MUTT_YES, 0, NULL,
     "Save outgoing emails to $record"

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -129,6 +129,8 @@ const struct MenuFuncOp OpCompose[] = { /* map: compose */
   { "pipe-entry",                    OP_PIPE },
   { "pipe-message",                  OP_PIPE },
   { "postpone-message",              OP_COMPOSE_POSTPONE_MESSAGE },
+  { "preview-page-down",             OP_PREVIEW_PAGE_DOWN },
+  { "preview-page-up",               OP_PREVIEW_PAGE_UP },
   { "print-entry",                   OP_ATTACHMENT_PRINT },
   { "rename-attachment",             OP_ATTACHMENT_RENAME_ATTACHMENT },
   { "rename-file",                   OP_COMPOSE_RENAME_FILE },
@@ -202,6 +204,8 @@ const struct MenuOpSeq ComposeDefaultBindings[] = { /* map: compose */
   { OP_ENVELOPE_EDIT_REPLY_TO,             "r" },
   { OP_ENVELOPE_EDIT_SUBJECT,              "s" },
   { OP_ENVELOPE_EDIT_TO,                   "t" },
+  { OP_PREVIEW_PAGE_DOWN,                  "<pagedown>" },
+  { OP_PREVIEW_PAGE_UP,                    "<pageup>" },
   { OP_FORGET_PASSPHRASE,                  "\006" },           // <Ctrl-F>
   { OP_TAG,                                "T" },
   { 0, NULL },

--- a/compose/lib.h
+++ b/compose/lib.h
@@ -35,6 +35,7 @@
  * | compose/dlg_compose.c  | @subpage compose_dlg_compose   |
  * | compose/expando.c      | @subpage compose_expando       |
  * | compose/functions.c    | @subpage compose_functions     |
+ * | compose/preview.c      | @subpage compose_preview       |
  * | compose/shared_data.c  | @subpage compose_shared_data   |
  */
 

--- a/compose/preview.c
+++ b/compose/preview.c
@@ -1,0 +1,384 @@
+/**
+ * @file
+ * Compose message preview
+ *
+ * @authors
+ * Copyright (C) 2024 Dennis Schön <mail@dennis-schoen.de>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page compose_preview Message Preview Window
+ *
+ * The Message Preview Window displays a preview of the email body. The content
+ * can be scrolled with PAGEUP/PAGEDOWN.
+ *
+ * ## Windows
+ *
+ * | Name           | Type      | See Also             |
+ * | :------------- | :-------- | :------------------- |
+ * | Preview Window | WT_CUSTOM | preview_window_new() |
+ *
+ * **Parent**
+ * - @ref compose_dlg_compose
+ *
+ * **Children**
+ *
+ * None.
+ *
+ * ## Data
+ * - #PreviewWindowData
+ *
+ * The Preview Window stores its data (#PreviewWindowData) in MuttWindow::wdata.
+ *
+ * ## Events
+ *
+ * Once constructed, it is controlled by the following events:
+ *
+ * | Event Type               | Handler                    |
+ * | :----------------------- | :------------------------- |
+ * | #NT_COLOR                | preview_color_observer()   |
+ * | #NT_EMAIL (#NT_ENVELOPE) | preview_email_observer()   |
+ * | #NT_WINDOW               | preview_window_observer()  |
+ * | MuttWindow::recalc()     | preview_recalc()           |
+ * | MuttWindow::repaint()    | preview_repaint()          |
+ */
+
+#include "config.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include "private.h"
+#include "mutt/lib.h"
+#include "email/lib.h"
+#include "core/lib.h"
+#include "gui/lib.h"
+#include "color/lib.h"
+
+/**
+ * struct PreviewWindowData - Data to fill the Preview Window
+ */
+struct PreviewWindowData
+{
+  struct Email *email;    ///< Email being composed
+  int scroll_offset;      ///< Scroll offset
+  struct MuttWindow *win; ///< Window holding the message preview
+  struct MuttWindow *bar; ///< Status bar above the preview window
+  bool more_content;      ///< Is there more content to scroll down to?
+};
+
+/**
+ * @defgroup preview_function_api Preview Function API
+ * @ingroup dispatcher_api
+ *
+ * Prototype for a Preview Function
+ *
+ * @param wdata Preview Window data
+ * @param op    Operation to perform, e.g. OP_NEXT_PAGE
+ * @retval enum #FunctionRetval
+ */
+typedef int (*preview_function_t)(struct PreviewWindowData *wdata, int op);
+
+/**
+ * struct PreviewFunction - A message preview function
+ */
+struct PreviewFunction
+{
+  int op;                      ///< Op code, e.g. OP_NEXT_PAGE
+  preview_function_t function; ///< Function to call
+};
+
+/**
+ * preview_wdata_free - Free the Preview Data - Implements MuttWindow::wdata_free() - @ingroup window_wdata_free
+ */
+static void preview_wdata_free(struct MuttWindow *win, void **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  FREE(ptr);
+}
+
+/**
+ * preview_wdata_new - Create new Preview Data
+ * @retval ptr New Preview Data
+ */
+static struct PreviewWindowData *preview_wdata_new(void)
+{
+  struct PreviewWindowData *wdata = mutt_mem_calloc(1, sizeof(struct PreviewWindowData));
+
+  return wdata;
+}
+
+/**
+ * draw_preview - Write the message preview to the compose window
+ * @param win    Window to draw on
+ * @param wdata  Preview Window data
+ */
+static void draw_preview(struct MuttWindow *win, struct PreviewWindowData *wdata)
+{
+  struct Email *e = wdata->email;
+
+  FILE *fp = mutt_file_fopen(e->body->filename, "r");
+  if (!fp)
+  {
+    mutt_perror("%s", e->body->filename);
+    return;
+  }
+
+  mutt_window_clear(win);
+
+  wdata->more_content = false;
+
+  int i = 0;
+  int row = 0;
+  char *buf = NULL;
+  size_t buflen;
+  while ((buf = mutt_file_read_line(buf, &buflen, fp, NULL, MUTT_RL_NO_FLAGS)))
+  {
+    if ((++i < wdata->scroll_offset) || (row >= win->state.rows))
+      continue;
+
+    int rc = mutt_window_move(win, 0, row);
+    if (rc == ERR)
+      mutt_warning(_("Failed to move cursor!"));
+
+    mutt_paddstr(win, win->state.cols, buf);
+
+    row++;
+  }
+
+  mutt_file_fclose(&fp);
+
+  // Show the scroll percentage in the status bar
+  if (i > win->state.rows)
+  {
+    char title[256] = { 0 };
+    double percent = 100.0;
+    if (wdata->scroll_offset + row < i)
+      percent = 100.0 / i * (wdata->scroll_offset + row);
+
+    // TODO: having the percentage right-aligned would be nice
+    snprintf(title, sizeof(title), _("--Preview (%.0f%%)"), percent);
+    sbar_set_title(wdata->bar, title);
+
+    if (i > (wdata->scroll_offset + row))
+      wdata->more_content = true;
+  }
+}
+
+/**
+ * preview_color_observer - Notification that a Color has changed - Implements ::observer_t - @ingroup observer_api
+ */
+static int preview_color_observer(struct NotifyCallback *nc)
+{
+  if (nc->event_type != NT_COLOR)
+    return 0;
+  if (!nc->global_data || !nc->event_data)
+    return -1;
+
+  struct EventColor *ev_c = nc->event_data;
+  struct MuttWindow *win = nc->global_data;
+
+  enum ColorId cid = ev_c->cid;
+
+  switch (cid)
+  {
+    case MT_COLOR_BOLD:
+    case MT_COLOR_NORMAL:
+    case MT_COLOR_STATUS:
+    case MT_COLOR_MAX: // Sent on `uncolor *`
+      mutt_debug(LL_DEBUG5, "color done, request WA_REPAINT\n");
+      win->actions |= WA_REPAINT;
+      break;
+
+    default:
+      break;
+  }
+  return 0;
+}
+
+/**
+ * preview_email_observer - Notification that the Email has changed - Implements ::observer_t - @ingroup observer_api
+ */
+static int preview_email_observer(struct NotifyCallback *nc)
+{
+  if (nc->event_type != NT_EMAIL)
+    return 0;
+  if (!nc->global_data)
+    return -1;
+
+  struct MuttWindow *win = nc->global_data;
+
+  win->actions |= WA_RECALC;
+  mutt_debug(LL_DEBUG5, "email done, request WA_RECALC\n");
+  return 0;
+}
+
+/**
+ * preview_window_observer - Notification that a Window has changed - Implements ::observer_t - @ingroup observer_api
+ */
+static int preview_window_observer(struct NotifyCallback *nc)
+{
+  if (nc->event_type != NT_WINDOW)
+    return 0;
+  if (!nc->global_data || !nc->event_data)
+    return -1;
+
+  struct MuttWindow *win = nc->global_data;
+  struct EventWindow *ev_w = nc->event_data;
+  if (ev_w->win != win)
+    return 0;
+
+  if (nc->event_subtype == NT_WINDOW_STATE)
+  {
+    win->actions |= WA_RECALC;
+    mutt_debug(LL_DEBUG5, "window state done, request WA_RECALC\n");
+  }
+  else if (nc->event_subtype == NT_WINDOW_DELETE)
+  {
+    struct PreviewWindowData *wdata = win->wdata;
+
+    mutt_color_observer_remove(preview_color_observer, win);
+    notify_observer_remove(win->notify, preview_window_observer, win);
+    notify_observer_remove(wdata->email->notify, preview_email_observer, win);
+    mutt_debug(LL_DEBUG5, "window delete done\n");
+  }
+
+  return 0;
+}
+
+/**
+ * preview_repaint - Repaint the Window - Implements MuttWindow::repaint() - @ingroup window_repaint
+ */
+static int preview_repaint(struct MuttWindow *win)
+{
+  struct PreviewWindowData *wdata = win->wdata;
+  draw_preview(win, wdata);
+
+  mutt_debug(LL_DEBUG5, "repaint done\n");
+  return 0;
+}
+
+/**
+ * preview_recalc - Recalculate the Window data - Implements MuttWindow::recalc() - @ingroup window_recalc
+ */
+static int preview_recalc(struct MuttWindow *win)
+{
+  if (!win)
+    return -1;
+
+  win->actions |= WA_REPAINT;
+  mutt_debug(LL_DEBUG5, "recalc done, request WA_REPAINT\n");
+  return 0;
+}
+
+/**
+ * preview_window_new - Create the preview window
+ * @param e   Email
+ * @param bar Preview Bar
+ */
+struct MuttWindow *preview_window_new(struct Email *e, struct MuttWindow *bar)
+{
+  struct MuttWindow *win = mutt_window_new(WT_CUSTOM, MUTT_WIN_ORIENT_VERTICAL,
+                                           MUTT_WIN_SIZE_MAXIMISE, MUTT_WIN_SIZE_UNLIMITED,
+                                           MUTT_WIN_SIZE_UNLIMITED);
+
+  mutt_color_observer_add(preview_color_observer, win);
+  notify_observer_add(win->notify, NT_WINDOW, preview_window_observer, win);
+  notify_observer_add(e->notify, NT_ALL, preview_email_observer, win);
+
+  struct PreviewWindowData *wdata = preview_wdata_new();
+  wdata->email = e;
+  wdata->scroll_offset = 0;
+  wdata->win = win;
+  wdata->bar = bar;
+
+  win->wdata = wdata;
+  win->wdata_free = preview_wdata_free;
+  win->recalc = preview_recalc;
+  win->repaint = preview_repaint;
+
+  return win;
+}
+
+/**
+ * preview_page_up - Show the previous page of the message - Implements ::preview_function_t - @ingroup preview_function_api
+ */
+static int preview_page_up(struct PreviewWindowData *wdata, int op)
+{
+  if (wdata->scroll_offset <= 0)
+    return FR_NO_ACTION;
+
+  wdata->scroll_offset -= MAX(wdata->win->state.rows - 1, 1);
+  draw_preview(wdata->win, wdata);
+
+  return FR_SUCCESS;
+}
+
+/**
+ * preview_page_down - Show the previous page of the message - Implements ::preview_function_t - @ingroup preview_function_api
+ */
+static int preview_page_down(struct PreviewWindowData *wdata, int op)
+{
+  if (!wdata->more_content)
+    return FR_NO_ACTION;
+
+  wdata->scroll_offset += MAX(wdata->win->state.rows - 1, 1);
+  draw_preview(wdata->win, wdata);
+
+  return FR_SUCCESS;
+}
+
+/**
+ * PreviewFunctions - All the functions that the preview window supports
+ */
+static const struct PreviewFunction PreviewFunctions[] = {
+  // clang-format off
+  { OP_PREVIEW_PAGE_DOWN, preview_page_down },
+  { OP_PREVIEW_PAGE_UP,   preview_page_up   },
+  { 0, NULL },
+  // clang-format on
+};
+
+/**
+ * preview_function_dispatcher - Perform a preview function - Implements ::function_dispatcher_t - @ingroup dispatcher_api
+ */
+int preview_function_dispatcher(struct MuttWindow *win, int op)
+{
+  if (!win || !win->wdata)
+    return FR_UNKNOWN;
+
+  int rc = FR_UNKNOWN;
+  for (size_t i = 0; PreviewFunctions[i].op != OP_NULL; i++)
+  {
+    const struct PreviewFunction *fn = &PreviewFunctions[i];
+    if (fn->op == op)
+    {
+      struct PreviewWindowData *wdata = win->wdata;
+      rc = fn->function(wdata, op);
+      break;
+    }
+  }
+
+  if (rc == FR_UNKNOWN) // Not our function
+    return rc;
+
+  const char *result = dispatcher_get_retval_name(rc);
+  mutt_debug(LL_DEBUG1, "Handled %s (%d) -> %s\n", opcodes_get_name(op), op, NONULL(result));
+
+  return rc;
+}

--- a/compose/private.h
+++ b/compose/private.h
@@ -4,6 +4,7 @@
  *
  * @authors
  * Copyright (C) 2021 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2024 Dennis Schön <mail@dennis-schoen.de>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -30,11 +31,17 @@ struct AttachCtx;
 struct ComposeAttachData;
 struct ComposeSharedData;
 struct ConfigSubset;
+struct Email;
 struct Menu;
 struct MuttWindow;
 
 struct MuttWindow *attach_new(struct MuttWindow *parent, struct ComposeSharedData *shared);
 unsigned long cum_attachs_size(struct ConfigSubset *sub, struct ComposeAttachData *adata);
 void update_menu(struct AttachCtx *actx, struct Menu *menu, bool init);
+void attachment_size_fixed(struct MuttWindow *win);
+void attachment_size_max(struct MuttWindow *win);
+
+struct MuttWindow *preview_window_new(struct Email *e, struct MuttWindow *bar);
+int preview_function_dispatcher(struct MuttWindow *win, int op);
 
 #endif /* MUTT_COMPOSE_PRIVATE_H */

--- a/compose/shared_data.h
+++ b/compose/shared_data.h
@@ -4,6 +4,7 @@
  *
  * @authors
  * Copyright (C) 2021-2024 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2024 Dennis Schön <mail@dennis-schoen.de>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -33,15 +34,18 @@ struct MuttWindow;
  */
 struct ComposeSharedData
 {
-  struct ConfigSubset *sub;          ///< Config set to use
-  struct Mailbox *mailbox;           ///< Current Mailbox
-  struct Email *email;               ///< Email being composed
-  struct ComposeAttachData *adata;   ///< Attachments
+  struct ConfigSubset *sub;              ///< Config set to use
+  struct Mailbox *mailbox;               ///< Current Mailbox
+  struct Email *email;                   ///< Email being composed
+  struct ComposeAttachData *adata;       ///< Attachments
+  struct MuttWindow *win_attach_bar;     ///< Status bar divider above attachments
+  struct MuttWindow *win_preview;        ///< Message preview window
+  struct MuttWindow *win_preview_bar;    ///< Status bar divider above preview
 
-  struct Buffer *fcc;                ///< Buffer to save FCC
-  int flags;                         ///< Flags, e.g. #MUTT_COMPOSE_NOFREEHEADER
-  bool fcc_set;                      ///< User has edited the Fcc: field
-  int rc;                            ///< Return code to leave compose
+  struct Buffer *fcc;                    ///< Buffer to save FCC
+  int flags;                             ///< Flags, e.g. #MUTT_COMPOSE_NOFREEHEADER
+  bool fcc_set;                          ///< User has edited the Fcc: field
+  int rc;                                ///< Return code to leave compose
 };
 
 /**

--- a/docs/config.c
+++ b/docs/config.c
@@ -688,6 +688,26 @@
 ** information on how to set $$compose_format.
 */
 
+{ "compose_preview_min_rows", DT_NUMBER, 5 },
+/*
+** .pp
+** This variable specifies the minimum number of rows that have to be
+** available for the message preview window to shown.
+*/
+
+{ "compose_preview_above_attachments", DT_BOOL, false },
+/*
+** .pp
+** Show the message preview above the attachments list.
+** By default it is shown below it.
+*/
+
+{ "compose_show_preview", DT_BOOL, true },
+/*
+** .pp
+** When \fIset\fP, Neomutt will display a preview of message in the compose view.
+*/
+
 { "compose_show_user_headers", DT_BOOL, true },
 /*
 ** .pp

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -13468,6 +13468,125 @@ sendmailcmd = neomutt -C -H - &amp;&amp; true
       </sect2>
     </sect1>
 
+    <sect1 id="compose-message-preview">
+      <title>Compose Message Preview Feature</title>
+      <subtitle>Show a preview of the message in the compose dialog</subtitle>
+
+      <sect2 id="compose-message-preview-support">
+        <title>Support</title>
+        <para><emphasis role="bold">Since:</emphasis> NeoMutt 2024-11-25</para>
+        <para><emphasis role="bold">Dependencies:</emphasis> None</para>
+      </sect2>
+
+      <sect2 id="compose-message-preview-intro">
+        <title>Introduction</title>
+        <para>
+          NeoMutt shows you a preview of the message you are about to send in
+          the compose dialog.
+        </para>
+      </sect2>
+
+      <sect2 id="compose-message-preview-variables">
+        <title>Variables</title>
+
+        <table id="table-compose-message-preview-variables">
+          <title>Message Preview Variables</title>
+          <tgroup cols="4">
+            <thead>
+              <row>
+                <entry>Name</entry>
+                <entry>Type</entry>
+                <entry>Default</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry><literal>compose_show_preview</literal></entry>
+                <entry>boolean</entry>
+                <entry><literal>true</literal></entry>
+                <entry>Enable or disable the message preview feature</entry>
+              </row>
+              <row>
+                <entry><literal>compose_preview_min_rows</literal></entry>
+                <entry>number</entry>
+                <entry><literal>5</literal></entry>
+                <entry>Hide the preview if it has fewer than this number of rows</entry>
+              </row>
+              <row>
+                <entry><literal>compose_preview_above_attachments</literal></entry>
+                <entry>boolean</entry>
+                <entry><literal>false</literal></entry>
+                <entry>Show the message preview above the attachments list.</entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </sect2>
+
+      <sect2 id="compose-message-preview-functions">
+        <title>Functions</title>
+        <para>
+          The message preview is controller by the following functions.
+        </para>
+
+        <table id="compose-message-preview-functions-table">
+          <title>Message Preview Functions</title>
+          <tgroup cols="3">
+            <thead>
+              <row>
+                <entry>Menus</entry>
+                <entry>Function</entry>
+                <entry>Description</entry>
+                <entry>Default</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>compose</entry>
+                <entry><literal>&lt;preview-page-down&gt;</literal></entry>
+                <entry>show the next page of the message</entry>
+                <entry><literal>&lt;pagedown&gt;</literal></entry>
+              </row>
+              <row>
+                <entry>compose</entry>
+                <entry><literal>&lt;preview-page-up&gt;</literal></entry>
+                <entry>show the previous page of the message</entry>
+                <entry><literal>&lt;pageup&gt;</literal></entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+      </sect2>
+
+      <sect2 id="compose-message-preview-limitations">
+        <title>Limitations</title>
+        <para>
+          This is a new feature and it's still under development. If you find
+          any problems, or you'd like to help improve it, please let us know.
+        </para>
+        <itemizedlist>
+          <listitem>
+            <para>
+              Pager displays simple text, no colour or attributes
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Text wrapping is not supported
+            </para>
+          </listitem>
+        </itemizedlist>
+      </sect2>
+
+      <sect2 id="compose-message-preview-credits">
+        <title>Credits</title>
+        <para>
+          Dennis Schön
+        </para>
+      </sect2>
+    </sect1>
+
     <sect1 id="compose-to-sender">
       <title>Compose to Sender Feature</title>
       <subtitle>Send new mail to the sender of the current mail</subtitle>

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -278,7 +278,6 @@ void window_redraw(struct MuttWindow *win);
 void window_invalidate_all(void);
 const char *mutt_window_win_name(const struct MuttWindow *win);
 bool window_status_on_top(struct MuttWindow *panel, struct ConfigSubset *sub);
-bool mutt_window_swap(struct MuttWindow *parent, struct MuttWindow *win1,
-                      struct MuttWindow *win2);
+bool mutt_window_swap(struct MuttWindow *parent, struct MuttWindow *win1, struct MuttWindow *win2);
 
 #endif /* MUTT_GUI_MUTT_WINDOW_H */

--- a/gui/opcodes.h
+++ b/gui/opcodes.h
@@ -147,6 +147,12 @@ const char *opcodes_get_name       (int op);
   /*       Attach Dialog: <op_attachment_view_text> */ \
   /*       Compose Dialog: <op_display_headers> */ \
   _fmt(OP_ATTACHMENT_VIEW_TEXT,               N_("view attachment as text")) \
+  /* L10N: Help screen description for OP_PREVIEW_PAGE_DOWN */ \
+  /*       Compose Dialog: <op_preview_page_down> */ \
+  _fmt(OP_PREVIEW_PAGE_DOWN,                  N_("show the next page of the message")) \
+  /* L10N: Help screen description for OP_PREVIEW_PAGE_UP */ \
+  /*       Compose Dialog: <op_preview_page_up> */ \
+  _fmt(OP_PREVIEW_PAGE_UP,                    N_("show the previous page of the message")) \
 
 #ifdef USE_AUTOCRYPT
 #define OPS_AUTOCRYPT(_fmt) \


### PR DESCRIPTION
This adds a message preview to the compose dialog. The preview is enabled by default but can be disabled with `compose_show_preview=false`. Two additional config variables control the behavior:

*   `compose_preview_min_rows`: The minimum number of rows that must be available for the message preview window to be shown.
*   `compose_preview_above_attachments`: Show the message preview above the attachments list. By default, it is shown below it.

If the message is larger than the number of available rows in the window, the content can be scrolled using:

* `preview-page-down` (default `<pagedown>`)
* `preview-page-up` (default `<pageup>`)

Example screenshot (with `compose_preview_above_attachments=true`):
<img width="921" alt="Screenshot 2024-11-25 at 07 32 43" src="https://github.com/user-attachments/assets/10df9408-de05-4d4f-96f1-55f3b5096f4e">

Initially I wanted to add text wrapping to the window but I decided to skip that for the first iteration because it wasn't non-trivial.

fixes #4415