### PR TITLE
autocrypt: fix copy_normalize_addr()

### DIFF
--- a/autocrypt/db.c
+++ b/autocrypt/db.c
@@ -210,8 +210,7 @@ static struct Address *copy_normalize_addr(struct Address *addr)
    * The normalize_addrlist above is extended to work on a list
    * because of requirements in autocrypt.c */
 
-  struct Address *norm_addr = mutt_addr_new();
-  buf_copy(norm_addr->mailbox, addr->mailbox);
+  struct Address *norm_addr = mutt_addr_create(NULL, buf_string(addr->mailbox));
   norm_addr->is_intl = addr->is_intl;
   norm_addr->intl_checked = addr->intl_checked;
 


### PR DESCRIPTION
`copy_normalize_addr()` creates a new `Address` for the result.
`mutt_addr_new()` doesn't create any `Buffer`s in the `Address` so create one manually.

Only `Address.mailbox` is needed.