### PR TITLE
Add trailing commas when editing addresses

### DIFF
--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -523,19 +523,12 @@ int query_complete(struct Buffer *buf, struct ConfigSubset *sub)
 
   buf_reset(buf);
   buf_alloc(buf, 8192);
-  bool first = true;
   struct AliasView *avp = NULL;
   ARRAY_FOREACH(avp, &mdata.ava)
   {
     if (!avp->is_tagged)
       continue;
 
-    if (!first)
-    {
-      buf_addstr(buf, ", ");
-    }
-
-    first = false;
     struct AddressList al_copy = TAILQ_HEAD_INITIALIZER(al_copy);
     if (alias_to_addrlist(&al_copy, avp->alias))
     {
@@ -543,6 +536,7 @@ int query_complete(struct Buffer *buf, struct ConfigSubset *sub)
       mutt_addrlist_write(&al_copy, buf, false);
       mutt_addrlist_clear(&al_copy);
     }
+    buf_addstr(buf, ", ");
   }
 
 done:

--- a/envelope/functions.c
+++ b/envelope/functions.c
@@ -115,6 +115,9 @@ static bool edit_address_list(enum HeaderField field, struct AddressList *al)
   mutt_addrlist_to_local(al);
   mutt_addrlist_write(al, new_list, false);
   buf_fix_dptr(new_list);
+  if (!buf_is_empty(new_list))
+    buf_addstr(new_list, ", ");
+
   buf_copy(old_list, new_list);
   if (mw_get_field(_(Prompts[field]), new_list, MUTT_COMP_NO_FLAGS, HC_ALIAS,
                    &CompleteAliasOps, NULL) == 0)

--- a/send/send.c
+++ b/send/send.c
@@ -201,6 +201,9 @@ int mutt_edit_address(struct AddressList *al, const char *field, bool expand_ali
     mutt_addrlist_to_local(al);
     buf_reset(buf);
     mutt_addrlist_write(al, buf, false);
+    if (!buf_is_empty(buf))
+      buf_addstr(buf, ", ");
+
     if (mw_get_field(field, buf, MUTT_COMP_NO_FLAGS, HC_ALIAS, &CompleteAliasOps, NULL) != 0)
     {
       rc = -1;


### PR DESCRIPTION
When editing a list of email addresses, the cursor starts at the end of the line.
Ensure that the line ends with ", " (comma, space) so that auto-completion is available immediately.

e.g. (`|` denotes the cursor)
```
Dave Smith <dave@orange.com>, |
```

When editing an Address List, the user is more likely to **add** Addresses than remove them.
With a trailing comma-space, they can immediately type a new Address, or hit `<complete>` to select from a dialog.

This already happens when using `<mail>` and auto-completion, but not elsewhere.
The PR adds this behaviour to query-completion and field editing in Compose.

---

**Tested**:

- `<mail>` + `<complete>` + cancel
- `<mail>` + `<complete>` + single
- `<mail>` + `<complete>` + multiple
- `<mail>` + "addr, " + `<complete>` + cancel
- `<mail>` + "addr, " + `<complete>` + single
- `<mail>` + "addr, " + `<complete>` + multiple
- `<mail>` + `<complete-query>` + cancel
- `<mail>` + `<complete-query>` + single
- `<mail>` + `<complete-query>` + multiple
- `<mail>` + "addr, " + `<complete-query>` + cancel
- `<mail>` + "addr, " + `<complete-query>` + single
- `<mail>` + "addr, " + `<complete-query>` + multiple
- `<alias-dialog>` + cancel
- `<alias-dialog>` + single
- `<alias-dialog>` + multiple
- `<query>` + 'a' + cancel
- `<query>` + 'a' + single
- `<query>` + 'a' + multiple
- Compose + `<edit-bcc>`
- Compose + `<edit-cc>`
- Compose + `<edit-reply-to>`
- Compose + `<edit-to>`