### PR TITLE
remove unused mailbox param from mutt_count_body_parts

### DIFF
--- a/attach/attachments.c
+++ b/attach/attachments.c
@@ -249,9 +249,9 @@ static int count_body_parts(struct Body *b)
  * @param fp File to parse
  * @retval num Number of MIME Body parts
  */
-int mutt_count_body_parts(const struct Mailbox *m, struct Email *e, FILE *fp)
+int mutt_count_body_parts(struct Email *e, FILE *fp)
 {
-  if (!m || !e)
+  if (!e)
     return 0;
 
   bool keep_parts = false;

--- a/attach/attachments.h
+++ b/attach/attachments.h
@@ -47,7 +47,7 @@ void attach_init(void);
 void attach_cleanup(void);
 
 void mutt_attachments_reset (struct MailboxView *mv);
-int  mutt_count_body_parts  (const struct Mailbox *m, struct Email *e, FILE *fp);
+int  mutt_count_body_parts  (struct Email *e, FILE *fp);
 void mutt_parse_mime_message(struct Email *e, FILE *fp);
 
 #endif /* MUTT_ATTACH_ATTACHMENTS_H */

--- a/hdrline.c
+++ b/hdrline.c
@@ -1420,7 +1420,7 @@ long index_X_num(const struct ExpandoNode *node, void *data, MuttFormatFlags fla
   if (!msg)
     return 0;
 
-  const int num = mutt_count_body_parts(m, e, msg->fp);
+  const int num = mutt_count_body_parts(e, msg->fp);
   mx_msg_close(m, &msg);
   return num;
 }

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -1108,13 +1108,11 @@ static bool pattern_exec(struct Pattern *pat, PatternExecFlags flags,
     case MUTT_PAT_DUPLICATED:
       return pat->pat_not ^ (e->thread && e->thread->duplicate_thread);
     case MUTT_PAT_MIMEATTACH:
-      if (!m)
-        return false;
-      {
-        int count = mutt_count_body_parts(m, e, msg->fp);
-        return pat->pat_not ^ (count >= pat->min &&
-                               (pat->max == MUTT_MAXRANGE || count <= pat->max));
-      }
+    {
+      int count = mutt_count_body_parts(e, msg->fp);
+      return pat->pat_not ^
+             (count >= pat->min && (pat->max == MUTT_MAXRANGE || count <= pat->max));
+    }
     case MUTT_PAT_MIMETYPE:
       if (!m)
         return false;


### PR DESCRIPTION
I'd like to use the `mutt_count_body_parts()` in the compose window where I don't have a `Mailbox`. 