### PR TITLE
mutt/memory.c: Add my_reallocarray()

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -407,6 +407,7 @@ if {1} {
     iswblank \
     mkdtemp \
     qsort_s \
+    reallocarray \
     strsep \
     strcasestr \
     tcgetwinsize \

--- a/mutt/memory.c
+++ b/mutt/memory.c
@@ -31,11 +31,37 @@
 
 #include "config.h"
 #include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include "memory.h"
 #include "exit.h"
 #include "logging2.h"
+
+/**
+ * reallocarray - reallocarray(3) implementation
+ * @param p     Address of memory block to resize
+ * @param n     Number of elements
+ * @param size  Size of element
+ *
+ * See reallocarray(3) for the documentation of this function.
+ * We need to implement it because MacOS is cruft from another century
+ * and doesn't have this fundamental API.  We'll remove it once all the
+ * systems we support have it.
+ */
+#if !defined(HAVE_REALLOCARRAY)
+static void *reallocarray(void *p, size_t n, size_t size)
+{
+  if ((n != 0) && (size > (SIZE_MAX / n)))
+  {
+    errno = ENOMEM;
+    return NULL;
+  }
+
+  return realloc(p, n * size);
+}
+#endif
 
 /**
  * mutt_mem_calloc - Allocate zeroed memory on the heap


### PR DESCRIPTION
MacOS doesn't provide reallocarray(3).

Link: <https://github.com/neomutt/neomutt/pull/4294#issuecomment-2477224262>
Reported-by: @flatcap 

---

Revisions:

<details>
<summary>v1b</summary>

-  Add doxygen comments.
-  Fix position of brace.

```
$ git range-diff neomutt/main gh/alx/reallocarray alx/reallocarray 
1:  4dfc74175 ! 1:  cb5fd19b6 mutt/memory.c: Add my_reallocarray()
    @@ mutt/memory.c
      #include "exit.h"
      #include "logging2.h"
      
    ++/**
    ++ * my_reallocarray - My reallocarray(3) implementation
    ++ * @param p     Address of memory block to resize
    ++ * @param n     Number of elements
    ++ * @param size  Size of element
    ++ *
    ++ * See reallocarray(3) for the documentation of this function.
    ++ * We need to implement it because MacOS is cruft from another century
    ++ * and doesn't have this fundamental API.  We'll remove it once all the
    ++ * systems we support have it.
    ++ */
     +static void *my_reallocarray(void *p, size_t n, size_t size)
     +{
    -+  if (n != 0 && size > SIZE_MAX / n) {
    ++  if (n != 0 && size > SIZE_MAX / n)
    ++  {
     +    errno = ENOMEM;
     +    return NULL;
     +  }
```
</details>

<details>
<summary>v2</summary>

-  Use libc's reallocarray(3) if available.

```
$ git range-diff neomutt/main gh/alx/reallocarray alx/reallocarray 
1:  cb5fd19b6 ! 1:  5187058f7 mutt/memory.c: Add my_reallocarray()
    @@ Metadata
     Author: Alejandro Colomar (@alejandro-colomar) <alx@kernel.org>
     
      ## Commit message ##
    -    mutt/memory.c: Add my_reallocarray()
    +    mutt/memory.c: Add reallocarray() implementation if missing
     
    -    MacOS doesn't provide reallocarray(3).
    +    MacOS doesn't provide reallocarray(3).  Shame on them.
     
         Link: <https://github.com/neomutt/neomutt/pull/4294#issuecomment-2477224262>
         Reported-by: Richard Russon <rich@flatcap.org>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    + ## auto.def ##
    +@@ auto.def: if {1} {
    +     iswblank \
    +     mkdtemp \
    +     qsort_s \
    ++    reallocarray \
    +     strsep \
    +     strcasestr \
    +     tcgetwinsize \
    +
      ## mutt/memory.c ##
     @@
      
    @@ mutt/memory.c
      #include "logging2.h"
      
     +/**
    -+ * my_reallocarray - My reallocarray(3) implementation
    ++ * reallocarray - reallocarray(3) implementation
     + * @param p     Address of memory block to resize
     + * @param n     Number of elements
     + * @param size  Size of element
    @@ mutt/memory.c
     + * and doesn't have this fundamental API.  We'll remove it once all the
     + * systems we support have it.
     + */
    -+static void *my_reallocarray(void *p, size_t n, size_t size)
    ++#if !defined(HAVE_REALLOCARRAY)
    ++static void *reallocarray(void *p, size_t n, size_t size)
     +{
     +  if (n != 0 && size > SIZE_MAX / n)
     +  {
    @@ mutt/memory.c
     +
     +  return realloc(p, n * size);
     +}
    ++#endif
     +
      /**
       * mutt_mem_calloc - Allocate zeroed memory on the heap
       * @param nmemb Number of blocks
    -@@ mutt/memory.c: void mutt_mem_reallocarray(void *pptr, size_t nmemb, size_t size)
    -     return;
    -   }
    - 
    --  void *r = reallocarray(*pp, nmemb, size);
    -+  void *r = my_reallocarray(*pp, nmemb, size);
    -   if (!r)
    -   {
    -     mutt_error("%s", strerror(errno)); // LCOV_EXCL_LINE
```
</details>

<details>
<summary>v3</summary>

Add some `()`s because flatcap likes `()` :-)

</details>