### PR TITLE
Smartos fixes

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -430,6 +430,10 @@ if {1} {
   cc-with {-includes sys/stat.h} {
     cc-check-members "struct stat.st_atim.tv_nsec"
   }
+
+  cc-with {-includes time.h} {
+    cc-check-members "struct tm.tm_gmtoff"
+  }
 }
 ###############################################################################
 

--- a/docs/config.c
+++ b/docs/config.c
@@ -2258,6 +2258,8 @@
 **                is a bang ("!"), the date is formatted ignoring any locale
 **                settings.  Note that the sender's time zone might only be
 **                available as a numerical offset, so "%Z" behaves like "%z".
+**                %{fmt} behaves like %[fmt] on systems where struct tm
+**                doesn't have a tm_gmtoff member.
 ** .dt %[fmt] .dd the date and time of the message is converted to the local
 **                time zone, and "fmt" is expanded by the library function
 **                \fCstrftime(3)\fP; if the first character inside the brackets

--- a/index/expando_index.c
+++ b/index/expando_index.c
@@ -323,11 +323,15 @@ static void index_email_date(const struct ExpandoNode *node, const struct Email 
   {
     case SENT_SENDER:
     {
+#ifdef HAVE_STRUCT_TM_TM_GMTOFF
       int offset = (e->zhours * 3600 + e->zminutes * 60) * (e->zoccident ? -1 : 1);
       const time_t now = e->date_sent + offset;
       tm = mutt_date_gmtime(now);
       tm.tm_gmtoff = offset;
       break;
+#else
+      FALLTHROUGH;
+#endif
     }
     case SENT_LOCAL:
     {


### PR DESCRIPTION
* **What does this PR do?**

Fix two small compilation issues on SmartOS, use of tm_gmtoff (not available) and index_t already defined in sys/types.h.
