### PR TITLE
Spaces can be wide

### DIFF
--- a/expando/format.c
+++ b/expando/format.c
@@ -143,10 +143,6 @@ int format_string(struct Buffer *buf, int min_cols, int max_cols, enum FormatJus
     {
       w = 1; /* hack */
     }
-    else if (iswspace(wc))
-    {
-      w = 1;
-    }
     else
     {
 #ifdef HAVE_ISWBLANK

--- a/expando/format.c
+++ b/expando/format.c
@@ -143,6 +143,10 @@ int format_string(struct Buffer *buf, int min_cols, int max_cols, enum FormatJus
     {
       w = 1; /* hack */
     }
+    else if (iswspace(wc))
+    {
+      w = MAX(1, wcwidth(wc));
+    }
     else
     {
 #ifdef HAVE_ISWBLANK


### PR DESCRIPTION
"The glyph is a wide version of the glyph Space. Accordingly, its width in East Asian Text is fullwidth."
https://codepoints.net/U+3000?lang=en

Fixes #4460