### PR TITLE
fix compose preview title

### DIFF
--- a/compose/preview.c
+++ b/compose/preview.c
@@ -172,7 +172,7 @@ static void draw_preview(struct MuttWindow *win, struct PreviewWindowData *wdata
       percent = 100.0 / i * (wdata->scroll_offset + row);
 
     // TODO: having the percentage right-aligned would be nice
-    snprintf(title, sizeof(title), _("--Preview (%.0f%%)"), percent);
+    snprintf(title, sizeof(title), _("-- Preview (%.0f%%)"), percent);
     sbar_set_title(wdata->bar, title);
 
     if (i > (wdata->scroll_offset + row))


### PR DESCRIPTION
As pointed out by Ismael on -devel: The attachments bar uses a different format than the preview bar. This adjusts the preview bar to match the attachments bar.