### PR TITLE
Remove BOM from UTF-8 text

### DIFF
--- a/mutt/mbyte.c
+++ b/mutt/mbyte.c
@@ -441,6 +441,10 @@ int mutt_mb_filter_unprintable(char **s)
       memset(&mbstate1, 0, sizeof(mbstate1));
       wc = ReplacementChar;
     }
+    if (CharsetIsUtf8 && IsBOM(wc))
+    {
+      continue;
+    }
     if (!IsWPrint(wc))
       wc = '?';
     else if (CharsetIsUtf8 && mutt_mb_is_display_corrupting_utf8(wc))

--- a/mutt/mbyte.h
+++ b/mutt/mbyte.h
@@ -40,6 +40,7 @@ extern bool OptLocales;
 #define IsPrint(ch) (isprint((unsigned char) (ch)) || (OptLocales ? 0 : ((unsigned char) (ch) >= 0xa0)))
 #define IsWPrint(wc) (iswprint(wc) || (OptLocales ? 0 : (wc >= 0xa0)))
 #endif
+#define IsBOM(wc) (wc == L'\xfeff')
 
 int    mutt_mb_charlen(const char *s, int *width);
 int    mutt_mb_filter_unprintable(char **s);


### PR DESCRIPTION
It is [possible](https://en.wikipedia.org/wiki/Byte_order_mark#cite_ref-5) for UTF-8 to have a BOM. We currently display it as a question mark.