### PR TITLE
only show text inline attachments in the compose preview

### DIFF
--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1395,6 +1395,7 @@ static int op_attachment_move_down(struct ComposeSharedData *shared, int op)
   compose_attach_swap(shared->email, shared->adata->actx, index, nextidx);
   mutt_update_tree(shared->adata->actx);
   menu_queue_redraw(shared->adata->menu, MENU_REDRAW_INDEX);
+  notify_send(shared->email->notify, NT_EMAIL, NT_EMAIL_CHANGE_ATTACH, NULL);
   menu_set_index(shared->adata->menu, finalidx);
   return FR_SUCCESS;
 }
@@ -1429,6 +1430,7 @@ static int op_attachment_move_up(struct ComposeSharedData *shared, int op)
   compose_attach_swap(shared->email, actx, previdx, index);
   mutt_update_tree(actx);
   menu_queue_redraw(shared->adata->menu, MENU_REDRAW_INDEX);
+  notify_send(shared->email->notify, NT_EMAIL, NT_EMAIL_CHANGE_ATTACH, NULL);
   menu_set_index(shared->adata->menu, previdx);
   return FR_SUCCESS;
 }
@@ -1602,6 +1604,7 @@ static int op_attachment_toggle_disposition(struct ComposeSharedData *shared, in
                                    DISP_ATTACH :
                                    DISP_INLINE;
   menu_queue_redraw(shared->adata->menu, MENU_REDRAW_CURRENT);
+  notify_send(shared->email->notify, NT_EMAIL, NT_EMAIL_CHANGE_ATTACH, NULL);
   return FR_SUCCESS;
 }
 

--- a/compose/preview.c
+++ b/compose/preview.c
@@ -132,14 +132,22 @@ static void draw_preview(struct MuttWindow *win, struct PreviewWindowData *wdata
 {
   struct Email *e = wdata->email;
 
+  mutt_window_clear(win);
+
+  if ((e->body->disposition != DISP_INLINE) || (e->body->type != TYPE_TEXT))
+  {
+    mutt_error(_("Only inline attachments with content-type text/* can be previewed"));
+    // The preview status bar might still be showing the percentage. Reset it.
+    sbar_set_title(wdata->bar, _("-- Preview"));
+    return;
+  }
+
   FILE *fp = mutt_file_fopen(e->body->filename, "r");
   if (!fp)
   {
     mutt_perror("%s", e->body->filename);
     return;
   }
-
-  mutt_window_clear(win);
 
   wdata->more_content = false;
 


### PR DESCRIPTION
The preview renders the first "attachment" of the email which should be the actual message.

However when people mess with the order of attachments it could be that we end up with content that we can't render (binary files for example). To prevent that we limit the preview to attachments with `Content-Disposition: inline` and `Content-type: text/*`.