### PR TITLE
fix: Bug with wrong fingerprints in certificate_file

### DIFF
--- a/conn/gnutls.c
+++ b/conn/gnutls.c
@@ -578,7 +578,7 @@ static int tls_check_one_certificate(const gnutls_datum_t *certdata,
     {
       if (certerr & CERTERR_HOSTNAME) // Save hostname if necessary
       {
-        buf_strcpy(fpbuf, "");
+        buf_reset(fpbuf);
         tls_fingerprint(GNUTLS_DIG_MD5, fpbuf, certdata);
         fprintf(fp, "#H %s %s\n", hostname, buf_string(fpbuf));
         saved = true;

--- a/conn/gnutls.c
+++ b/conn/gnutls.c
@@ -578,6 +578,7 @@ static int tls_check_one_certificate(const gnutls_datum_t *certdata,
     {
       if (certerr & CERTERR_HOSTNAME) // Save hostname if necessary
       {
+        buf_strcpy(fpbuf, "");
         tls_fingerprint(GNUTLS_DIG_MD5, fpbuf, certdata);
         fprintf(fp, "#H %s %s\n", hostname, buf_string(fpbuf));
         saved = true;


### PR DESCRIPTION
Fixes bug with wrong fingerprints been written to
certificate_file when using "Accept always" option.

The issue is that `fpbuf` has to be cleared before calling `tls_fingerprint` because `tls_fingerprint` uses `buf_add_printf` and only adds data to the buffer on every call.

* **What does this PR do?**
Fixes the issue https://github.com/neomutt/neomutt/issues/4466

* **What are the relevant issue numbers?**
https://github.com/neomutt/neomutt/issues/4466