### PR TITLE
fix postponed sorting assertion failure

### DIFF
--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -796,7 +796,6 @@ static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
   if ((c_sort & SORT_MASK) == EMAIL_SORT_THREADS)
   {
     ASSERT(!(c_sort & SORT_REVERSE) != reverse);
-    ASSERT(cs_subset_enum(NeoMutt->sub, "use_threads") == UT_UNSET);
     c_sort = c_sort_aux;
   }
   c_sort ^= SORT_REVERSE;


### PR DESCRIPTION
Reported by @ukleinek on IRC: `neomutt -p` crashes (assertion failure).
Tested on `main` (311dd98e9)

<details>
<summary>Backtrace</summary>

```
#0  0x000056353a15e8f2 in mutt_sort_subthreads (tctx=0x56353f4cb7a0, init=true) at ./mutt_thread.c:799
#1  mutt_sort_threads (tctx=<optimized out>, init=<optimized out>, init@entry=true) at ./mutt_thread.c:1270
#2  0x000056353a2550bc in mutt_sort_headers (mv=mv@entry=0x56353f4177e0, init=<optimized out>, init@entry=true) at email/sort.c:405
#3  0x000056353a15feeb in mview_update (mv=mv@entry=0x56353f4177e0) at ./mview.c:227
#4  0x000056353a16003a in mview_new (m=m@entry=0x56353f4b4620, parent=0x56353f3bd030) at ./mview.c:109
#5  0x000056353a198e90 in dlg_postponed (m=0x56353f4b4620) at postpone/dlg_postpone.c:215
#6  0x000056353a198858 in mutt_get_postponed (m_cur=m_cur@entry=0x0, hdr=0x56353f4b4550, cur=cur@entry=0x7fff76ad4c58, fcc=0x56353f3ba6a0) at postpone/postpone.c:703
#7  0x000056353a1a6dbc in mutt_send_message (flags=<optimized out>, flags@entry=16, e_templ=<optimized out>, e_templ@entry=0x0, tempfile=tempfile@entry=0x0, m=m@entry=0x0, ea=ea@entry=0x0, sub=0x56353f3df420) at send/send.c:2101
#8  0x000056353a1416b2 in main (argc=<optimized out>, argv=0x7fff76ad5478, envp=<optimized out>) at ./main.c:997
```

</details>

The Postponed Dialog doesn't support sorting.
We use a `MailboxView` to hold the `Mailbox` and number the `Email`s.
The `MailboxView` tries to sort the `Email`s and an assertion fails.

The assertion check isn't necessary.

Historically, the Postpone Dialog would temporarily reset the sort config variables, `set sort = unsorted`, display the Emails, then restore the config on exit.
Now, we don't touch the config and allow a sort that won't do anything.

---

**Steps to reproduce**:
- Create a mailbox `p.mbox` with some emails in it.

**`test.rc`**
```
set postponed   = p.mbox
set sort        = threads
set use_threads = threads
```

**Run**:
 `./neomutt -n -F test.rc -p`