### PR TITLE
fix: `save_attachment_open()` when overwriting

### DIFF
--- a/attach/mutt_attach.c
+++ b/attach/mutt_attach.c
@@ -888,10 +888,11 @@ static FILE *save_attachment_open(const char *path, enum SaveAttach opt)
 {
   if (opt == MUTT_SAVE_APPEND)
     return mutt_file_fopen_masked(path, "a");
-  if (opt == MUTT_SAVE_OVERWRITE)
-    return mutt_file_fopen_masked(path, "w");
 
-  return mutt_file_fopen_masked(path, "w");
+  FILE *fp = mutt_file_fopen_masked(path, "w");
+  if (fp)
+    ftruncate(fileno(fp), 0);
+  return fp;
 }
 
 /**


### PR DESCRIPTION
The `truncate()` here is a temporary measure.

Since all the `fopen()` calls were "upgraded" to `mutt_file_fopen()`, the write mode "w" hasn't truncated existing files correctly.

Fixes: #4469 

---

I need to analyse the 169 calls to the `mutt_file_fopen()` family of functions.

![image](https://github.com/user-attachments/assets/004f567f-e672-4a37-a623-2488671218cf)

There are 72 **read-only** calls, which we can ignore, leaving 97 **read-write** calls to examine.

<details>
<summary>Mode: `a`</summary>

- Open for appending (writing at end of file).
- The file is created if it does not exist.
- The stream is positioned at the end of the file.

```
attach/mutt_attach.c:890:22:     `a`
attach/mutt_attach.c:1053:30:    `a`
attach/recvattach.c:507:62:      `a`
compmbox/compress.c:117:29:      `a`
conn/gnutls.c:576:26:            `a`
conn/openssl.c:962:28:           `a`
history/history.c:330:24:        `a`
main.c:1260:28:                  `a`
nntp/newsrc.c:180:34:            `a`
rfc3676.c:462:61:                `a`
```

</details>
<details>
<summary>Mode: `a+`</summary>

- Open for reading and appending (writing at end of file).
- The file is created if it does not exist.
- Output is always appended to the end of the file.
- POSIX is silent on what the initial read position is when using this mode.

```
alias/alias.c:524:24:            `a+`
gui/global.c:105:24:             `a+`
mbox/mbox.c:898:27:              `a+`
mutt/logging.c:131:25:           `a+`
pager/functions.c:1027:23:       `a+`
send/send.c:1525:24:             `a+`
send/send.c:2127:26:             `a+`
send/send.c:2169:28:             `a+`
send/send.c:2188:26:             `a+`
```

</details>
<details>
<summary>Mode: `r+`</summary>

- Open for reading and writing.
- The stream is positioned at the beginning of the file.

```
mbox/mbox.c:804:24:              `r+`
```

</details>
<details>
<summary>Mode: `w`</summary>

- Truncate file to zero length or create text file for writing.
- The stream is positioned at the beginning of the file.

```
attach/mutt_attach.c:89:27:      `w`
attach/mutt_attach.c:209:38:     `w`
attach/mutt_attach.c:630:34:     `w`
attach/mutt_attach.c:787:30:     `w`
attach/mutt_attach.c:892:22:     `w`
attach/mutt_attach.c:894:20:     `w`
attach/mutt_attach.c:1055:30:    `w`
attach/mutt_attach.c:1057:30:    `w`
attach/recvattach.c:615:30:      `w`
color/dump.c:455:24:             `w`
commands.c:879:28:               `w`
commands.c:938:30:               `w`
commands.c:1624:28:              `w`
compmbox/compress.c:187:24:      `w`
compose/functions.c:1482:24:     `w`
handler.c:1375:33:               `w`
help.c:489:20:                   `w`
history/history.c:302:22:        `w`
imap/imap.c:2171:23:             `w`
key/dump.c:227:22:               `w`
main.c:1112:28:                  `w`
mutt/file.c:1383:28:             `w`
mutt_header.c:186:28:            `w`
mutt_header.c:246:22:            `w`
ncrypt/crypt.c:764:24:           `w`
ncrypt/crypt.c:865:28:           `w`
ncrypt/gpgme_functions.c:642:24: `w`
ncrypt/pgp.c:907:28:             `w`
ncrypt/pgp.c:977:28:             `w`
ncrypt/pgp.c:1047:26:            `w`
ncrypt/pgp.c:1346:28:            `w`
ncrypt/pgp.c:1353:25:            `w`
ncrypt/pgp.c:1617:22:            `w`
ncrypt/pgp.c:1747:31:            `w`
ncrypt/pgp_functions.c:123:29:   `w`
ncrypt/pgp_functions.c:132:28:   `w`
ncrypt/pgpkey.c:280:28:          `w`
ncrypt/pgpkey.c:287:29:          `w`
ncrypt/smime.c:1072:28:          `w`
ncrypt/smime.c:1581:29:          `w`
nntp/newsrc.c:402:20:            `w`
pager/message.c:218:28:          `w`
postpone/postpone.c:410:32:      `w`
recvcmd.c:510:28:                `w`
recvcmd.c:701:24:                `w`
recvcmd.c:1012:22:               `w`
send/send.c:1433:28:             `w`
send/sendlib.c:222:32:           `w`
send/sendlib.c:856:28:           `w`
```

</details>
<details>
<summary>Mode: `w+`</summary>

- Open for reading and writing.
- The file is created if it does not exist, otherwise it is truncated.
- The stream is positioned at the beginning of the file.

```
attach/cid.c:197:22:             `w+`
bcache/bcache.c:240:24:          `w+`
handler.c:568:23:                `w+`
imap/message.c:1151:18:          `w+`
imap/message.c:2016:25:          `w+`
mbox/mbox.c:898:27:              `w+`
ncrypt/crypt_gpgme.c:426:28:     `w+`
ncrypt/crypt_gpgme.c:571:24:     `w+`
ncrypt/pgp.c:544:26:             `w+`
ncrypt/pgp.c:1600:28:            `w+`
ncrypt/pgp.c:1792:32:            `w+`
ncrypt/smime.c:826:22:           `w+`
ncrypt/smime.c:860:23:           `w+`
ncrypt/smime.c:937:28:           `w+`
ncrypt/smime.c:1206:22:          `w+`
ncrypt/smime.c:1221:22:          `w+`
ncrypt/smime.c:1383:23:          `w+`
ncrypt/smime.c:1391:28:          `w+`
ncrypt/smime.c:1707:22:          `w+`
nntp/nntp.c:2692:27:             `w+`
pattern/exec.c:733:20:           `w+`
pop/pop.c:1034:27:               `w+`
rfc3676.c:432:22:                `w+`
send/send.c:2178:28:             `w+`
send/send.c:2919:26:             `w+`
send/sendlib.c:289:22:           `w+`
send/sendlib.c:475:18:           `w+`
send/sendlib.c:1089:24:          `w+`
</details>
```

