### PR TITLE
fix crash in folder-hook

### DIFF
--- a/main.c
+++ b/main.c
@@ -1402,7 +1402,7 @@ main
 
     struct Mailbox *m_cur = mailbox_find(buf_string(folder));
     // Take a copy of the name just in case the hook alters m_cur
-    const char *name = mutt_str_dup(m_cur ? m_cur->name : NULL);
+    const char *name = m_cur ? mutt_str_dup(m_cur->name) : NULL;
     mutt_folder_hook(buf_string(folder), name);
     FREE(&name);
     mutt_startup_shutdown_hook(MUTT_STARTUP_HOOK);

--- a/main.c
+++ b/main.c
@@ -1401,7 +1401,10 @@ main
     }
 
     struct Mailbox *m_cur = mailbox_find(buf_string(folder));
-    mutt_folder_hook(buf_string(folder), m_cur ? m_cur->name : NULL);
+    // Take a copy of the name just in case the hook alters m_cur
+    const char *name = mutt_str_dup(m_cur ? m_cur->name : NULL);
+    mutt_folder_hook(buf_string(folder), name);
+    FREE(&name);
     mutt_startup_shutdown_hook(MUTT_STARTUP_HOOK);
     mutt_debug(LL_NOTIFY, "NT_GLOBAL_STARTUP\n");
     notify_send(NeoMutt->notify, NT_GLOBAL, NT_GLOBAL_STARTUP, NULL);


### PR DESCRIPTION
Bug reported on IRC by @RaitoBezarius

> I am seeing on 20241002 a heap-after-free reported by ASAN:

<details>
<summary>ASAN Report</summary>

```
READ of size 3 at 0x60200000fb10 thread T0
    #0 0x7f61aa89223a in __interceptor_regexec.part.0
    #1 0x8d8ab6 in mutt_regex_capture mutt/regex.c:603
    #2 0x8da823 in mutt_regex_match mutt/regex.c:616
    #3 0x45effd in mutt_folder_hook hook.c:644
    #4 0x473b59 in main main.c:1406
    #5 0x7f61a943127d in __libc_start_call_main
    #6 0x7f61a9431338 in __libc_start_main_alias_1
    #7 0x40e424 in _start

0x60200000fb10 is located 0 bytes inside of 10-byte region [0x60200000fb10,0x60200000fb1a)
freed by thread T0 here:
    #0 0x7f61aa8dad18 in __interceptor_free.part.0
    #1 0x8cecb5 in mutt_mem_free mutt/memory.c:76
    #2 0x8dec9d in mutt_str_replace mutt/string.c:286
    #3 0x4138a1 in mailbox_add commands.c:668
    #4 0x414b84 in parse_mailboxes commands.c:815
    #5 0x838180 in parse_rc_buffer parse/rc.c:79
    #6 0x4189ef in source_rc commands.c:282
    #7 0x419163 in parse_source commands.c:1087
    #8 0x838180 in parse_rc_buffer parse/rc.c:79
    #9 0x8385d1 in parse_rc_line parse/rc.c:114
    #10 0x417b8a in parse_rc_line_cwd commands.c:169
    #11 0x45f356 in mutt_folder_hook hook.c:651
    #12 0x473b59 in main main.c:1406
    #13 0x7f61a943127d in __libc_start_call_main

previously allocated by thread T0 here:
    #0 0x7f61aa884208 in strdup
    #1 0x8dea76 in mutt_str_dup mutt/string.c:258
    #2 0x8dec5d in mutt_str_replace mutt/string.c:285
    #3 0x4138a1 in mailbox_add commands.c:668
    #4 0x414b84 in parse_mailboxes commands.c:815
    #5 0x838180 in parse_rc_buffer parse/rc.c:79
    #6 0x4189ef in source_rc commands.c:282
    #7 0x419163 in parse_source commands.c:1087
    #8 0x838180 in parse_rc_buffer parse/rc.c:79
    #9 0x4189ef in source_rc commands.c:282
    #10 0x464b5b in mutt_init init.c:537
    #11 0x46e34d in main main.c:855
    #12 0x7f61a943127d in __libc_start_call_main
```

</details>

<details>
<summary>vim quicklist</summary>

```
Memory allocated
main.c:855:        main
init.c:537:        mutt_init
commands.c:282:    source_rc
parse/rc.c:79:     parse_rc_buffer
commands.c:1087:   parse_source
commands.c:282:    source_rc
parse/rc.c:79:     parse_rc_buffer
commands.c:815:    parse_mailboxes
commands.c:668:    mailbox_add
mutt/string.c:285: mutt_str_replace
mutt/string.c:258: mutt_str_dup

Memory freed
main.c:1406:       main
hook.c:651:        mutt_folder_hook
commands.c:169:    parse_rc_line_cwd
parse/rc.c:114:    parse_rc_line
parse/rc.c:79:     parse_rc_buffer
commands.c:1087:   parse_source
commands.c:282:    source_rc
parse/rc.c:79:     parse_rc_buffer
commands.c:815:    parse_mailboxes
commands.c:668:    mailbox_add
mutt/string.c:286: mutt_str_replace

Memory used
main.c:1406:       main
hook.c:644:        mutt_folder_hook
mutt/regex.c:616:  mutt_regex_match
mutt/regex.c:603:  mutt_regex_capture
```

</details>

On startup, `folder-hook` is called for the `$folder` Mailbox.

If the hook commands alter this Mailbox, then `m_cur->name` might get freed before we need it.

Take a copy of the name just in case the hook alters `m_cur`