### PR TITLE
Fix DT_NUMBER entries on 32-bit endian platforms

### DIFF
--- a/config/number.c
+++ b/config/number.c
@@ -49,7 +49,9 @@
  */
 static intptr_t native_get(void *var)
 {
-  return (*(intptr_t *) var & TOGGLE_BIT) ? 0 : *(short *) var;
+  // take care of endianess and always read intptr_t value
+  intptr_t v = *(intptr_t *) var;
+  return (v & TOGGLE_BIT) ? 0 : (short) v;
 }
 
 /**
@@ -57,8 +59,9 @@ static intptr_t native_get(void *var)
  */
 static void native_set(void *var, intptr_t val)
 {
-  *(intptr_t *) var = 0; // clear any pending toggle status
-  *(short *) var = val;
+  // cast to unsigned short to clear any pending toggle status bits
+  val = (unsigned short) val;
+  *(intptr_t *) var = val;
 }
 
 /**


### PR DESCRIPTION
The config_number testcase of Neomutt fails on the parisc (32-bit) platform as can be seen in [1] like this:

```
Test test_config_number...                      [ FAILED ]
  Case Common setup:
    number.c:75: test_check_num_eq... failed
      Expected : 99
      Actual   : 0
    number.c:178: VarDamson == numbers[i]... failed
      Value of Damson wasn't changed
    number.c:1060: test_string_set(sub, err)... failed
```

The problem is, that the `Vars[]` array of `struct ConfigDef` entries stores the numbers in the 3rd column (-42,99) as type `uintptr_t`, which is big-endian 32-bits on parisc:
```c
  { "Apple",      DT_NUMBER,   -42, 0, NULL,    }, /* test_initial_values */
  { "Banana",	  DT_NUMBER,    99, 0, NULL,    },
```

So, when reading or writing that number in `native_get()` and `native_set()` make sure to take care of the endianess too by accessing the pointer address by reading or writing an `uintptr_t` value, and do the casting to short type outside of the memory access.

[1] https://buildd.debian.org/status/fetch.php?pkg=neomutt&arch=hppa&ver=20241212%2Bdfsg-1&stamp=1734064250&raw=0