### PR TITLE
Simplify mutt_file_fopen

### DIFF
--- a/alias/alias.c
+++ b/alias/alias.c
@@ -529,10 +529,6 @@ retry_name:
   }
 
   /* terminate existing file with \n if necessary */
-  if (!mutt_file_seek(fp_alias, 0, SEEK_END))
-  {
-    goto done;
-  }
   if (ftell(fp_alias) > 0)
   {
     if (!mutt_file_seek(fp_alias, -1, SEEK_CUR))

--- a/attach/mutt_attach.c
+++ b/attach/mutt_attach.c
@@ -888,11 +888,8 @@ static FILE *save_attachment_open(const char *path, enum SaveAttach opt)
 {
   if (opt == MUTT_SAVE_APPEND)
     return mutt_file_fopen_masked(path, "a");
-
-  FILE *fp = mutt_file_fopen_masked(path, "w");
-  if (fp)
-    ftruncate(fileno(fp), 0);
-  return fp;
+  else
+    return mutt_file_fopen_masked(path, "w");
 }
 
 /**
@@ -1052,8 +1049,6 @@ int mutt_decode_save_attachment(FILE *fp, struct Body *b, const char *path,
 
   if (opt == MUTT_SAVE_APPEND)
     state.fp_out = mutt_file_fopen_masked(path, "a");
-  else if (opt == MUTT_SAVE_OVERWRITE)
-    state.fp_out = mutt_file_fopen_masked(path, "w");
   else
     state.fp_out = mutt_file_fopen_masked(path, "w");
 

--- a/attach/mutt_attach.h
+++ b/attach/mutt_attach.h
@@ -55,9 +55,8 @@ enum ViewAttachMode
  */
 enum SaveAttach
 {
-  MUTT_SAVE_NO_FLAGS = 0, ///< No flags set
-  MUTT_SAVE_APPEND,       ///< Append to existing file
-  MUTT_SAVE_OVERWRITE,    ///< Overwrite existing file
+  MUTT_SAVE_NO_FLAGS  = 0, ///< Overwrite existing file (the default)
+  MUTT_SAVE_APPEND,        ///< Append to existing file
 };
 
 int mutt_attach_display_loop(struct ConfigSubset *sub, struct Menu *menu, int op, struct Email *e, struct AttachCtx *actx, bool recv);

--- a/attach/recvattach.c
+++ b/attach/recvattach.c
@@ -241,7 +241,6 @@ static int save_attachment_flowed_helper(FILE *fp, struct Body *b, const char *p
     struct Buffer *tempfile = buf_pool_get();
     buf_mktemp(tempfile);
 
-    /* Pass MUTT_SAVE_NO_FLAGS to force mutt_file_fopen("w") */
     rc = mutt_save_attachment(fp, b, buf_string(tempfile), MUTT_SAVE_NO_FLAGS, e);
     if (rc != 0)
       goto cleanup;

--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -184,12 +184,7 @@ static int setup_paths(struct Mailbox *m)
   buf_copy(&m->pathbuf, buf);
   buf_pool_release(&buf);
 
-  FILE *fp = mutt_file_fopen(mailbox_path(m), "w");
-  if (!fp)
-    return -1;
-
-  mutt_file_fclose(&fp);
-  return 0;
+  return mutt_file_touch(mailbox_path(m)) ? 0 : -1;
 }
 
 /**

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1479,13 +1479,11 @@ static int op_attachment_new_mime(struct ComposeSharedData *shared, int op)
 
   ap = mutt_aptr_new();
   /* Touch the file */
-  FILE *fp = mutt_file_fopen(buf_string(fname), "w");
-  if (!fp)
+  if (!mutt_file_touch(buf_string(fname)))
   {
     mutt_error(_("Can't create file %s"), buf_string(fname));
     goto done;
   }
-  mutt_file_fclose(&fp);
 
   ap->body = mutt_make_file_attach(buf_string(fname), shared->sub);
   if (!ap->body)

--- a/history/history.c
+++ b/history/history.c
@@ -297,8 +297,6 @@ cleanup:
   {
     if (fflush(fp_tmp) == 0)
     {
-      if (truncate(c_history_file, 0) < 0)
-        mutt_debug(LL_DEBUG1, "truncate: %s\n", strerror(errno));
       fp = mutt_file_fopen(c_history_file, "w");
       if (fp)
       {

--- a/mutt/file.h
+++ b/mutt/file.h
@@ -124,6 +124,7 @@ int         mutt_file_stat_compare(struct stat *st1, enum MuttStatType st1_type,
 int         mutt_file_stat_timespec_compare(struct stat *st, enum MuttStatType type, struct timespec *b);
 int         mutt_file_symlink(const char *oldpath, const char *newpath);
 int         mutt_file_timespec_compare(struct timespec *a, struct timespec *b);
+bool        mutt_file_touch(const char *path);
 void        mutt_file_touch_atime(int fd);
 void        mutt_file_unlink(const char *s);
 void        mutt_file_unlink_empty(const char *path);

--- a/muttlib.c
+++ b/muttlib.c
@@ -609,7 +609,6 @@ int mutt_check_overwrite(const char *attname, const char *path, struct Buffer *f
         *opt = MUTT_SAVE_APPEND;
         break;
       case 1: /* overwrite */
-        *opt = MUTT_SAVE_OVERWRITE;
         break;
     }
   }


### PR DESCRIPTION
Historically, mutt_file_fopen was trying to be smart when files were opening in write or read/write mode:

"When opening files for writing, make sure the file doesn't already exist to avoid race conditions."

We think this is over-zealous and just makes the code difficult. Here, I'm turning mutt_file_fopen into a simple wrapper around fopen + logging.