### PR TITLE
query: fix comma-separated names

### DIFF
--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -235,7 +235,7 @@ int query_run(const char *s, bool verbose, struct AliasList *al, const struct Co
       if (next_tok)
         *next_tok++ = '\0';
 
-      buf_printf(addr, "%s <%s>", tok, buf);
+      buf_printf(addr, "\"%s\" <%s>", tok, buf);
       mutt_addrlist_parse(&alias->addr, buf_string(addr));
 
       parse_alias_comments(alias, next_tok);


### PR DESCRIPTION
Quote the names when reading the query, to prevent the parser splitting the address in the wrong place.

e.g. "Smith, James" \<jim@example.com\>

Fixes: #4482

---

To test, create some `query.txt` containing an address of the form "Surname, FirstName"
```
# Header line
jim@example.com	Smith, James
```

and config:
```
set query_command="cat query.txt"
```