### PR TITLE
lua: fix lua_mutt_call()

### DIFF
--- a/mutt_lua.c
+++ b/mutt_lua.c
@@ -124,6 +124,7 @@ static int lua_mutt_call(lua_State *l)
     buf_addstr(buf, lua_tostring(l, i));
     buf_addch(buf, ' ');
   }
+  buf_seek(buf, 0);
 
   if (cmd->parse(token, buf, cmd->data, err))
   {


### PR DESCRIPTION
Fix a faulty `Buffer `refactor.

When we pass a `Buffer` to the command parsing routines,
we need to `seek(0)` so that they start at the beginning of the string.

**Test NeoMutt config file**: `test.rc`
```
echo "hello"
```

**Test steps:**
- Build with Lua `--lua`
- Run command  `:lua mutt.call("source", "/tmp/foo.muttrc")`

**Expected Result**:
- Message window shows "hello"
