### PR TITLE
colour refactoring

### DIFF
--- a/color/color.h
+++ b/color/color.h
@@ -56,7 +56,16 @@ enum ColorId
   MT_COLOR_OPTIONS,                  ///< Options in prompt
   MT_COLOR_PROGRESS,                 ///< Progress bar
   MT_COLOR_PROMPT,                   ///< Question/user input
-  MT_COLOR_QUOTED,                   ///< Pager: quoted text
+  MT_COLOR_QUOTED0,                  ///< Pager: quoted text, level 0
+  MT_COLOR_QUOTED1,                  ///< Pager: quoted text, level 1
+  MT_COLOR_QUOTED2,                  ///< Pager: quoted text, level 2
+  MT_COLOR_QUOTED3,                  ///< Pager: quoted text, level 3
+  MT_COLOR_QUOTED4,                  ///< Pager: quoted text, level 4
+  MT_COLOR_QUOTED5,                  ///< Pager: quoted text, level 5
+  MT_COLOR_QUOTED6,                  ///< Pager: quoted text, level 6
+  MT_COLOR_QUOTED7,                  ///< Pager: quoted text, level 7
+  MT_COLOR_QUOTED8,                  ///< Pager: quoted text, level 8
+  MT_COLOR_QUOTED9,                  ///< Pager: quoted text, level 9
   MT_COLOR_SEARCH,                   ///< Pager: search matches
   MT_COLOR_SIDEBAR_BACKGROUND,       ///< Background colour for the Sidebar
   MT_COLOR_SIDEBAR_DIVIDER,          ///< Line dividing sidebar from the index/pager

--- a/color/color.h
+++ b/color/color.h
@@ -100,7 +100,6 @@ enum ColorId
 };
 
 extern const struct Mapping ColorFields[];
-extern const struct Mapping ComposeColorFields[];
 
 #define COLOR_DEFAULT -1
 

--- a/color/command.c
+++ b/color/command.c
@@ -54,78 +54,69 @@
  */
 const struct Mapping ColorFields[] = {
   // clang-format off
-  { "attachment",        MT_COLOR_ATTACHMENT },
-  { "attach_headers",    MT_COLOR_ATTACH_HEADERS },
-  { "body",              MT_COLOR_BODY },
-  { "bold",              MT_COLOR_BOLD },
-  { "error",             MT_COLOR_ERROR },
-  { "hdrdefault",        MT_COLOR_HDRDEFAULT },
-  { "header",            MT_COLOR_HEADER },
-  { "index",             MT_COLOR_INDEX },
-  { "index_author",      MT_COLOR_INDEX_AUTHOR },
-  { "index_collapsed",   MT_COLOR_INDEX_COLLAPSED },
-  { "index_date",        MT_COLOR_INDEX_DATE },
-  { "index_flags",       MT_COLOR_INDEX_FLAGS },
-  { "index_label",       MT_COLOR_INDEX_LABEL },
-  { "index_number",      MT_COLOR_INDEX_NUMBER },
-  { "index_size",        MT_COLOR_INDEX_SIZE },
-  { "index_subject",     MT_COLOR_INDEX_SUBJECT },
-  { "index_tag",         MT_COLOR_INDEX_TAG },
-  { "index_tags",        MT_COLOR_INDEX_TAGS },
-  { "indicator",         MT_COLOR_INDICATOR },
-  { "italic",            MT_COLOR_ITALIC },
-  { "markers",           MT_COLOR_MARKERS },
-  { "message",           MT_COLOR_MESSAGE },
-  { "normal",            MT_COLOR_NORMAL },
-  { "options",           MT_COLOR_OPTIONS },
-  { "progress",          MT_COLOR_PROGRESS },
-  { "prompt",            MT_COLOR_PROMPT },
-  { "quoted0",           MT_COLOR_QUOTED0 },
-  { "quoted1",           MT_COLOR_QUOTED1 },
-  { "quoted2",           MT_COLOR_QUOTED2 },
-  { "quoted3",           MT_COLOR_QUOTED3 },
-  { "quoted4",           MT_COLOR_QUOTED4 },
-  { "quoted5",           MT_COLOR_QUOTED5 },
-  { "quoted6",           MT_COLOR_QUOTED6 },
-  { "quoted7",           MT_COLOR_QUOTED7 },
-  { "quoted8",           MT_COLOR_QUOTED8 },
-  { "quoted9",           MT_COLOR_QUOTED9 },
-  { "search",            MT_COLOR_SEARCH },
-  { "sidebar_background", MT_COLOR_SIDEBAR_BACKGROUND },
-  { "sidebar_divider",   MT_COLOR_SIDEBAR_DIVIDER },
-  { "sidebar_flagged",   MT_COLOR_SIDEBAR_FLAGGED },
-  { "sidebar_highlight", MT_COLOR_SIDEBAR_HIGHLIGHT },
-  { "sidebar_indicator", MT_COLOR_SIDEBAR_INDICATOR },
-  { "sidebar_new",       MT_COLOR_SIDEBAR_NEW },
-  { "sidebar_ordinary",  MT_COLOR_SIDEBAR_ORDINARY },
-  { "sidebar_spool_file", MT_COLOR_SIDEBAR_SPOOLFILE },
-  { "sidebar_unread",    MT_COLOR_SIDEBAR_UNREAD },
-  { "signature",         MT_COLOR_SIGNATURE },
-  { "status",            MT_COLOR_STATUS },
-  { "stripe_even",       MT_COLOR_STRIPE_EVEN},
-  { "stripe_odd",        MT_COLOR_STRIPE_ODD},
-  { "tilde",             MT_COLOR_TILDE },
-  { "tree",              MT_COLOR_TREE },
-  { "underline",         MT_COLOR_UNDERLINE },
-  { "warning",           MT_COLOR_WARNING },
+  { "attachment",                MT_COLOR_ATTACHMENT },
+  { "attach_headers",            MT_COLOR_ATTACH_HEADERS },
+  { "body",                      MT_COLOR_BODY },
+  { "bold",                      MT_COLOR_BOLD },
+  { "compose_header",            MT_COLOR_COMPOSE_HEADER },
+  { "compose_security_both",     MT_COLOR_COMPOSE_SECURITY_BOTH },
+  { "compose_security_encrypt",  MT_COLOR_COMPOSE_SECURITY_ENCRYPT },
+  { "compose_security_none",     MT_COLOR_COMPOSE_SECURITY_NONE },
+  { "compose_security_sign",     MT_COLOR_COMPOSE_SECURITY_SIGN },
+  { "error",                     MT_COLOR_ERROR },
+  { "hdrdefault",                MT_COLOR_HDRDEFAULT },
+  { "header",                    MT_COLOR_HEADER },
+  { "index",                     MT_COLOR_INDEX },
+  { "index_author",              MT_COLOR_INDEX_AUTHOR },
+  { "index_collapsed",           MT_COLOR_INDEX_COLLAPSED },
+  { "index_date",                MT_COLOR_INDEX_DATE },
+  { "index_flags",               MT_COLOR_INDEX_FLAGS },
+  { "index_label",               MT_COLOR_INDEX_LABEL },
+  { "index_number",              MT_COLOR_INDEX_NUMBER },
+  { "index_size",                MT_COLOR_INDEX_SIZE },
+  { "index_subject",             MT_COLOR_INDEX_SUBJECT },
+  { "index_tag",                 MT_COLOR_INDEX_TAG },
+  { "index_tags",                MT_COLOR_INDEX_TAGS },
+  { "indicator",                 MT_COLOR_INDICATOR },
+  { "italic",                    MT_COLOR_ITALIC },
+  { "markers",                   MT_COLOR_MARKERS },
+  { "message",                   MT_COLOR_MESSAGE },
+  { "normal",                    MT_COLOR_NORMAL },
+  { "options",                   MT_COLOR_OPTIONS },
+  { "progress",                  MT_COLOR_PROGRESS },
+  { "prompt",                    MT_COLOR_PROMPT },
+  { "quoted0",                   MT_COLOR_QUOTED0 },
+  { "quoted1",                   MT_COLOR_QUOTED1 },
+  { "quoted2",                   MT_COLOR_QUOTED2 },
+  { "quoted3",                   MT_COLOR_QUOTED3 },
+  { "quoted4",                   MT_COLOR_QUOTED4 },
+  { "quoted5",                   MT_COLOR_QUOTED5 },
+  { "quoted6",                   MT_COLOR_QUOTED6 },
+  { "quoted7",                   MT_COLOR_QUOTED7 },
+  { "quoted8",                   MT_COLOR_QUOTED8 },
+  { "quoted9",                   MT_COLOR_QUOTED9 },
+  { "search",                    MT_COLOR_SEARCH },
+  { "sidebar_background",        MT_COLOR_SIDEBAR_BACKGROUND },
+  { "sidebar_divider",           MT_COLOR_SIDEBAR_DIVIDER },
+  { "sidebar_flagged",           MT_COLOR_SIDEBAR_FLAGGED },
+  { "sidebar_highlight",         MT_COLOR_SIDEBAR_HIGHLIGHT },
+  { "sidebar_indicator",         MT_COLOR_SIDEBAR_INDICATOR },
+  { "sidebar_new",               MT_COLOR_SIDEBAR_NEW },
+  { "sidebar_ordinary",          MT_COLOR_SIDEBAR_ORDINARY },
+  { "sidebar_spool_file",        MT_COLOR_SIDEBAR_SPOOLFILE },
+  { "sidebar_unread",            MT_COLOR_SIDEBAR_UNREAD },
+  { "signature",                 MT_COLOR_SIGNATURE },
+  { "status",                    MT_COLOR_STATUS },
+  { "stripe_even",               MT_COLOR_STRIPE_EVEN},
+  { "stripe_odd",                MT_COLOR_STRIPE_ODD},
+  { "tilde",                     MT_COLOR_TILDE },
+  { "tree",                      MT_COLOR_TREE },
+  { "underline",                 MT_COLOR_UNDERLINE },
+  { "warning",                   MT_COLOR_WARNING },
   // Deprecated
-  { "quoted",            MT_COLOR_QUOTED0 },
-  { "sidebar_spoolfile", MT_COLOR_SIDEBAR_SPOOLFILE },
+  { "quoted",                    MT_COLOR_QUOTED0 },
+  { "sidebar_spoolfile",         MT_COLOR_SIDEBAR_SPOOLFILE },
   { NULL, 0 },
-  // clang-format on
-};
-
-/**
- * ComposeColorFields - Mapping of compose colour names to their IDs
- */
-const struct Mapping ComposeColorFields[] = {
-  // clang-format off
-  { "header",            MT_COLOR_COMPOSE_HEADER },
-  { "security_encrypt",  MT_COLOR_COMPOSE_SECURITY_ENCRYPT },
-  { "security_sign",     MT_COLOR_COMPOSE_SECURITY_SIGN },
-  { "security_both",     MT_COLOR_COMPOSE_SECURITY_BOTH },
-  { "security_none",     MT_COLOR_COMPOSE_SECURITY_NONE },
-  { NULL, 0 }
   // clang-format on
 };
 
@@ -136,19 +127,7 @@ const struct Mapping ComposeColorFields[] = {
  */
 void get_colorid_name(unsigned int cid, struct Buffer *buf)
 {
-  const char *name = NULL;
-
-  if ((cid >= MT_COLOR_COMPOSE_HEADER) && (cid <= MT_COLOR_COMPOSE_SECURITY_SIGN))
-  {
-    name = mutt_map_get_name(cid, ComposeColorFields);
-    if (name)
-    {
-      buf_printf(buf, "compose %s", name);
-      return;
-    }
-  }
-
-  name = mutt_map_get_name(cid, ColorFields);
+  const char *name = mutt_map_get_name(cid, ColorFields);
   if (name)
     buf_addstr(buf, name);
   else
@@ -168,8 +147,6 @@ void get_colorid_name(unsigned int cid, struct Buffer *buf)
 static enum CommandResult parse_object(struct Buffer *buf, struct Buffer *s,
                                        enum ColorId *cid, struct Buffer *err)
 {
-  int rc;
-
   if (mutt_istr_equal(buf->data, "compose"))
   {
     if (!MoreArgs(s))
@@ -178,20 +155,14 @@ static enum CommandResult parse_object(struct Buffer *buf, struct Buffer *s,
       return MUTT_CMD_WARNING;
     }
 
-    parse_extract_token(buf, s, TOKEN_NO_FLAGS);
-
-    rc = mutt_map_get_value(buf->data, ComposeColorFields);
-    if (rc == -1)
-    {
-      buf_printf(err, _("%s: no such object"), buf->data);
-      return MUTT_CMD_WARNING;
-    }
-
-    *cid = rc;
-    return MUTT_CMD_SUCCESS;
+    struct Buffer *tmp = buf_pool_get();
+    parse_extract_token(tmp, s, TOKEN_NO_FLAGS);
+    buf_fix_dptr(buf);
+    buf_add_printf(buf, "_%s", buf_string(tmp));
+    buf_pool_release(&tmp);
   }
 
-  rc = mutt_map_get_value(buf->data, ColorFields);
+  int rc = mutt_map_get_value(buf->data, ColorFields);
   if (rc == -1)
   {
     buf_printf(err, _("%s: no such object"), buf->data);

--- a/color/command.c
+++ b/color/command.c
@@ -46,7 +46,6 @@
 #include "globals.h"
 #include "notify2.h"
 #include "parse_color.h"
-#include "quoted.h"
 #include "regex4.h"
 #include "simple2.h"
 
@@ -81,7 +80,16 @@ const struct Mapping ColorFields[] = {
   { "options",           MT_COLOR_OPTIONS },
   { "progress",          MT_COLOR_PROGRESS },
   { "prompt",            MT_COLOR_PROMPT },
-  { "quoted",            MT_COLOR_QUOTED },
+  { "quoted0",           MT_COLOR_QUOTED0 },
+  { "quoted1",           MT_COLOR_QUOTED1 },
+  { "quoted2",           MT_COLOR_QUOTED2 },
+  { "quoted3",           MT_COLOR_QUOTED3 },
+  { "quoted4",           MT_COLOR_QUOTED4 },
+  { "quoted5",           MT_COLOR_QUOTED5 },
+  { "quoted6",           MT_COLOR_QUOTED6 },
+  { "quoted7",           MT_COLOR_QUOTED7 },
+  { "quoted8",           MT_COLOR_QUOTED8 },
+  { "quoted9",           MT_COLOR_QUOTED9 },
   { "search",            MT_COLOR_SEARCH },
   { "sidebar_background", MT_COLOR_SIDEBAR_BACKGROUND },
   { "sidebar_divider",   MT_COLOR_SIDEBAR_DIVIDER },
@@ -101,6 +109,7 @@ const struct Mapping ColorFields[] = {
   { "underline",         MT_COLOR_UNDERLINE },
   { "warning",           MT_COLOR_WARNING },
   // Deprecated
+  { "quoted",            MT_COLOR_QUOTED0 },
   { "sidebar_spoolfile", MT_COLOR_SIDEBAR_SPOOLFILE },
   { NULL, 0 },
   // clang-format on
@@ -151,33 +160,15 @@ void get_colorid_name(unsigned int cid, struct Buffer *buf)
  * @param[in]  buf   Temporary Buffer space
  * @param[in]  s     Buffer containing string to be parsed
  * @param[out] cid   Object type, e.g. #MT_COLOR_TILDE
- * @param[out] ql    Quote level, if type #MT_COLOR_QUOTED
  * @param[out] err   Buffer for error messages
  * @retval #CommandResult Result e.g. #MUTT_CMD_SUCCESS
  *
- * Identify a colour object, e.g. "quoted", "compose header"
+ * Identify a colour object, e.g. "message", "compose header"
  */
 static enum CommandResult parse_object(struct Buffer *buf, struct Buffer *s,
-                                       enum ColorId *cid, int *ql, struct Buffer *err)
+                                       enum ColorId *cid, struct Buffer *err)
 {
   int rc;
-
-  if (mutt_str_startswith(buf->data, "quoted") != 0)
-  {
-    int val = 0;
-    if (buf->data[6] != '\0')
-    {
-      if (!mutt_str_atoi_full(buf->data + 6, &val) || (val > COLOR_QUOTES_MAX))
-      {
-        buf_printf(err, _("%s: no such object"), buf->data);
-        return MUTT_CMD_WARNING;
-      }
-    }
-
-    *ql = val;
-    *cid = MT_COLOR_QUOTED;
-    return MUTT_CMD_SUCCESS;
-  }
 
   if (mutt_istr_equal(buf->data, "compose"))
   {
@@ -248,9 +239,8 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
   }
 
   unsigned int cid = MT_COLOR_NONE;
-  int ql = 0;
   color_debug(LL_DEBUG5, "uncolor: %s\n", buf_string(buf));
-  enum CommandResult rc = parse_object(buf, s, &cid, &ql, err);
+  enum CommandResult rc = parse_object(buf, s, &cid, err);
   if (rc != MUTT_CMD_SUCCESS)
     return rc;
 
@@ -258,12 +248,6 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
   {
     buf_printf(err, _("%s: no such object"), buf->data);
     return MUTT_CMD_ERROR;
-  }
-
-  if (COLOR_QUOTED(cid))
-  {
-    color_debug(LL_DEBUG5, "quoted\n");
-    return quoted_colors_parse_uncolor(cid, ql, err);
   }
 
   if ((cid == MT_COLOR_STATUS) && !MoreArgs(s))
@@ -323,7 +307,6 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
                                       struct Buffer *err,
                                       parser_callback_t callback, bool color)
 {
-  int q_level = 0;
   unsigned int match = 0;
   enum ColorId cid = MT_COLOR_NONE;
   enum CommandResult rc = MUTT_CMD_ERROR;
@@ -348,7 +331,7 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
   parse_extract_token(buf, s, TOKEN_NO_FLAGS);
   color_debug(LL_DEBUG5, "color: %s\n", buf_string(buf));
 
-  rc = parse_object(buf, s, &cid, &q_level, err);
+  rc = parse_object(buf, s, &cid, err);
   if (rc != MUTT_CMD_SUCCESS)
     goto done;
 
@@ -408,12 +391,6 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
   if (regex_colors_parse_color_list(cid, buf->data, ac, &rc, err))
   {
     color_debug(LL_DEBUG5, "regex_colors_parse_color_list done\n");
-    goto done;
-    // do nothing
-  }
-  else if (quoted_colors_parse_color(cid, ac, q_level, &rc, err))
-  {
-    color_debug(LL_DEBUG5, "quoted_colors_parse_color done\n");
     goto done;
     // do nothing
   }

--- a/color/dump.c
+++ b/color/dump.c
@@ -323,7 +323,7 @@ void simple_colors_dump(struct Buffer *buf)
     buf_addstr(buf, _("# Simple Colors\n"));
     for (enum ColorId cid = MT_COLOR_NONE + 1; cid < MT_COLOR_MAX; cid++)
     {
-      if (COLOR_QUOTED(cid) || (cid == MT_COLOR_STATUS))
+      if (COLOR_QUOTED(cid) || COLOR_COMPOSE(cid) || (cid == MT_COLOR_STATUS))
         continue;
 
       struct AttrColor *ac = simple_color_get(cid);
@@ -345,11 +345,9 @@ void simple_colors_dump(struct Buffer *buf)
   }
 
   count = 0;
-  for (int i = 0; ComposeColorFields[i].name; i++)
+  for (int i = MT_COLOR_COMPOSE_HEADER; i <= MT_COLOR_COMPOSE_SECURITY_SIGN; i++)
   {
-    enum ColorId cid = ComposeColorFields[i].value;
-
-    struct AttrColor *ac = simple_color_get(cid);
+    struct AttrColor *ac = simple_color_get(i);
     if (attr_color_is_set(ac))
       count++;
   }
@@ -357,18 +355,20 @@ void simple_colors_dump(struct Buffer *buf)
   if (count > 0)
   {
     buf_addstr(buf, _("# Compose Colors\n"));
-    for (int i = 0; ComposeColorFields[i].name; i++)
+    for (int i = 0; ColorFields[i].name; i++)
     {
-      const char *name = ComposeColorFields[i].name;
-      enum ColorId cid = ComposeColorFields[i].value;
+      enum ColorId cid = ColorFields[i].value;
+
+      if (!COLOR_COMPOSE(cid))
+        continue;
 
       struct AttrColor *ac = simple_color_get(cid);
       if (!attr_color_is_set(ac))
         continue;
 
       color_log_color_attrs(ac, swatch);
-      buf_add_printf(buf, "color compose %-18s %-20s %-16s %-16s # %s\n", name,
-                     color_log_attrs_list(ac->attrs),
+      buf_add_printf(buf, "color %-24s %-20s %-16s %-16s # %s\n",
+                     ColorFields[i].name, color_log_attrs_list(ac->attrs),
                      color_log_name(color_fg, sizeof(color_fg), &ac->fg),
                      color_log_name(color_bg, sizeof(color_bg), &ac->bg),
                      buf_string(swatch));

--- a/color/dump.c
+++ b/color/dump.c
@@ -224,20 +224,16 @@ const char *color_log_name(char *buf, int buflen, struct ColorElement *elem)
  */
 void quoted_colors_dump(struct Buffer *buf)
 {
-  int num = quoted_colors_num_used();
-  if (num == 0)
-    return;
-
   struct Buffer *swatch = buf_pool_get();
   char color_fg[64] = { 0 };
   char color_bg[64] = { 0 };
 
   buf_addstr(buf, _("# Quoted Colors\n"));
-  for (int i = 0; i < num; i++)
+  for (int i = 0; i < 10; i++)
   {
-    struct AttrColor *ac = quoted_colors_get(i);
-    if (!ac)
-      continue; // LCOV_EXCL_LINE
+    struct AttrColor *ac = simple_color_get(MT_COLOR_QUOTED0 + i);
+    if (!attr_color_is_set(ac))
+      continue;
 
     color_log_color_attrs(ac, swatch);
     buf_add_printf(buf, "color quoted%d %-20s %-16s %-16s # %s\n", i,

--- a/color/quoted.h
+++ b/color/quoted.h
@@ -31,12 +31,7 @@
 
 struct Buffer;
 
-/// Ten colours, quoted0..quoted9 (quoted and quoted0 are equivalent)
-#define COLOR_QUOTES_MAX 10
-
-extern struct AttrColor QuotedColors[];
-
-#define COLOR_QUOTED(cid) ((cid) == MT_COLOR_QUOTED)
+#define COLOR_QUOTED(cid) (((cid) >= MT_COLOR_QUOTED0) && ((cid) <= MT_COLOR_QUOTED9))
 
 void quoted_colors_init   (void);
 void quoted_colors_reset  (void);
@@ -44,8 +39,5 @@ void quoted_colors_cleanup(void);
 
 struct AttrColor * quoted_colors_get(int q);
 int                quoted_colors_num_used(void);
-
-bool               quoted_colors_parse_color  (enum ColorId cid, struct AttrColor *ac_val, int q_level, int *rc, struct Buffer *err);
-enum CommandResult quoted_colors_parse_uncolor(enum ColorId cid, int q_level, struct Buffer *err);
 
 #endif /* MUTT_COLOR_QUOTED_H */

--- a/color/simple2.h
+++ b/color/simple2.h
@@ -29,6 +29,8 @@
 
 struct AttrColor;
 
+#define COLOR_COMPOSE(cid) (((cid) >= MT_COLOR_COMPOSE_HEADER) && ((cid) <= MT_COLOR_COMPOSE_SECURITY_SIGN))
+
 void simple_colors_init   (void);
 void simple_colors_reset  (void);
 void simple_colors_cleanup(void);

--- a/debug/notify.c
+++ b/debug/notify.c
@@ -38,7 +38,6 @@
 #include "mview.h"
 
 extern const struct Mapping ColorFields[];
-extern const struct Mapping ComposeColorFields[];
 
 static void notify_dump_account(struct NotifyCallback *nc)
 {
@@ -56,7 +55,6 @@ static void notify_dump_color(struct NotifyCallback *nc)
   struct EventColor *ev_c = nc->event_data;
 
   const char *color = NULL;
-  const char *scope = "";
 
   if (ev_c->cid == MT_COLOR_MAX)
     color = "ALL";
@@ -65,17 +63,10 @@ static void notify_dump_color(struct NotifyCallback *nc)
     color = mutt_map_get_name(ev_c->cid, ColorFields);
 
   if (!color)
-  {
-    color = mutt_map_get_name(ev_c->cid, ComposeColorFields);
-    scope = "compose ";
-  }
-
-  if (!color)
     color = "UNKNOWN";
 
-  mutt_debug(LL_DEBUG1, "    Color: %s %s%s (%d)\n",
-             (nc->event_subtype == NT_COLOR_SET) ? "set" : "reset", scope,
-             color, ev_c->cid);
+  mutt_debug(LL_DEBUG1, "    Color: %s %s (%d)\n",
+             (nc->event_subtype == NT_COLOR_SET) ? "set" : "reset", color, ev_c->cid);
 }
 
 static void notify_dump_command(struct NotifyCallback *nc)

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -5195,9 +5195,6 @@ folder-hook work "set sort=threads"
       </para>
       <cmdsynopsis>
         <command>color</command>
-        <arg choice="opt">
-          <option>compose</option>
-        </arg>
         <arg choice="plain">
           <replaceable class="parameter">object</replaceable>
         </arg>
@@ -5266,9 +5263,6 @@ folder-hook work "set sort=threads"
           </group>
         </group>
         <command>uncolor</command>
-        <arg choice="opt">
-          <option>compose</option>
-        </arg>
         <arg choice="plain">
           <replaceable class="parameter">object</replaceable>
         </arg>
@@ -5662,12 +5656,6 @@ uncolor sidebar_divider
         <para>
           These are compose objects.
         </para>
-        <note>
-          <para>
-            The compose objects use a slightly different format of command.
-            They prefix the style with the word <literal>compose</literal>.
-          </para>
-        </note>
         <table id="color-simple-compose">
           <title>Simple Compose Colours</title>
           <tgroup cols="2">
@@ -5679,33 +5667,33 @@ uncolor sidebar_divider
             </thead>
             <tbody>
               <row>
-                <entry>header</entry>
+                <entry>compose_header</entry>
                 <entry>Header labels, e.g. From:</entry>
               </row>
               <row>
-                <entry>security_encrypt</entry>
+                <entry>compose_security_encrypt</entry>
                 <entry>Mail will be encrypted</entry>
               </row>
               <row>
-                <entry>security_sign</entry>
+                <entry>compose_security_sign</entry>
                 <entry>Mail will be signed</entry>
               </row>
               <row>
-                <entry>security_both</entry>
+                <entry>compose_security_both</entry>
                 <entry>Mail will be encrypted and signed</entry>
               </row>
               <row>
-                <entry>security_none</entry>
+                <entry>compose_security_none</entry>
                 <entry>Mail will not be encrypted or signed</entry>
               </row>
             </tbody>
           </tgroup>
         </table>
 <screen>
-color compose header bold white default
+color compose_header bold white default
 </screen>
 <screen>
-uncolor compose header
+uncolor compose_header
 </screen>
         <para>
           The quoted objects refer to quoted lines in an email reply.
@@ -6002,8 +5990,8 @@ uncolor status *
           </group>
         </cmdsynopsis>
         <para>
-          For <emphasis>object</emphasis>, <emphasis>composeobject</emphasis>, and
-          <emphasis>attribute</emphasis>, see the <command>color</command> command.
+          For <emphasis>object</emphasis> and <emphasis>attribute</emphasis>,
+          see the <command>color</command> command.
         </para>
       </sect2>
     </sect1>

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -257,8 +257,8 @@ configuration file.
 \fBcolor\fP { header | body } [ \fIattribute\fP ... ] \fIforeground\fP \fIbackground\fP \fIregex\fP
 \fBcolor\fP status \fIforeground\fP \fIbackground\fP [\fIregex\fP [ \fInum\fP ]]
 \fBcolor\fP index-object [ \fIattribute\fP ... ] \fIforeground\fP \fIbackground\fP \fIpattern\fP
-\fBcolor\fP compose \fIcomposeobject\fP \fIforeground\fP \fIbackground\fP
-\fBcolor\fP compose \fIcomposeobject\fP [ \fIattribute\fP ... ] \fIforeground\fP \fIbackground\fP
+\fBcolor\fP \fIcompose-object\fP \fIforeground\fP \fIbackground\fP
+\fBcolor\fP \fIcompose-object\fP [ \fIattribute\fP ... ] \fIforeground\fP \fIbackground\fP
 \fBuncolor\fP { index-object | header | body } { \fB*\fP | \fIpattern\fP ... }
 .fi
 .IP
@@ -323,9 +323,9 @@ The \fBstatus\fP object optionally takes an regex and a match number.  If the
 regex is given, only the matching parts are colored.  If additionally the match
 number is given, only that sub-match of the regex is colored.
 .IP
-Valid composeobjects include
-.BR header ", " security_encrypt ", " security_sign ", "
-.BR security_both ", " security_none .
+Valid compose-objects include
+.BR compose_header ", " compose_security_encrypt ", " compose_security_sign ", "
+.BR compose_security_both ", " compose_security_none .
 .IP
 Valid colors include:
 .BR default ", "

--- a/pager/display.c
+++ b/pager/display.c
@@ -614,7 +614,7 @@ static void resolve_types(struct MuttWindow *win, char *buf, char *raw,
                                               pmatch[0].rm_eo - pmatch[0].rm_so,
                                               force_redraw, q_level);
     }
-    lines[line_num].cid = MT_COLOR_QUOTED;
+    lines[line_num].cid = MT_COLOR_QUOTED0;
   }
   else
   {

--- a/test/color/color_dump.c
+++ b/test/color/color_dump.c
@@ -91,9 +91,6 @@ void test_color_dump(void)
   simple_color_set(MT_COLOR_PROMPT, &ac);
 
   int rc = 0;
-  quoted_colors_parse_color(MT_COLOR_QUOTED, &ac, 0, &rc, NULL);
-  quoted_colors_parse_color(MT_COLOR_QUOTED, &ac, 2, &rc, NULL);
-
   regex_colors_parse_color_list(MT_COLOR_BODY, "apple", &ac, &rc, NULL);
   regex_colors_parse_color_list(MT_COLOR_BODY, "banana", &ac, &rc, NULL);
 


### PR DESCRIPTION
**post-release**

- Unify the behaviour of quoted colours
- Unify the symbols for the compose colours
- Unify the behaviour of smart-case

Broadly, there are two types of colours: **Simple**, **Regex**.

**Simple Colours** are exactly _that_, simple.
They're a set of { attributes, foreground, background }.

Simple Colours are applied to a fixed object, e.g. Error Message.
If you set a Simple Colour a second time, it overwrites the old value.

**Regex Colours** are a set of Simple Colours, each paired with a Regex.
They're stored as a List and they're accumulative.

If you set a Regex Colour with a different Regex, it will be added to the list.
If you set a Regex Colour with an existing Regex, it will overwrite the original.

---

### Quoted Colours

The Quoted Colours are an exception.
They have a Simple Colour and a custom array of `QuotedColors`.

This means that parsing a Quoted Colour need special code.
Using the colours requires special code.

This PR eliminates much of the custom code.
It creates specific new colours `quoted1`, `quoted2`, etc.
These **Simple** colours can be applied to Emails and the Pager doesn't need custom code to interpret them.

### Compose Colours

The Compose Colours are an exception.

These colours are relatively new.
When they were added to Mutt, they were given a new syntax and separate storage.

Rather than `color OBJECT FG BG`, we have `color compose OBJECT FG BG`

This requires more custom code to parse, store and use these colours.

This PR creates new colour objects for Compose.
This merges them into the Simple Colours.
The old names are backwards compatible.

The Compose Dialog colours have been renamed to:

- `compose_header`
- `compose_security_encrypt`
- `compose_security_sign`
- `compose_security_both`
- `compose_security_none`

e.g. `color compose_header fg bg`

The old syntax still works,

e.g. `color compose header fg bg`

### Smart-Case Searching

Extend the use of Smart-Case searching.

Smart-Case searching uses the case of the search text to determine if the user wants a **case-sensitive** search or not.

- `lower-case` - Case insensitive search
- `Mixed-case` - Case sensitive search

This feature _used_ to be limited to the Index colour matching.
This PR extends this to other colour matching.