### PR TITLE
config dump refactoring

### DIFF
--- a/config/dump.c
+++ b/config/dump.c
@@ -218,8 +218,10 @@ bool dump_config(struct ConfigSet *cs, ConfigDumpFlags flags, FILE *fp)
         if (((type == DT_PATH) || IS_MAILBOX(he->type)) && (value->data[0] == '/'))
           mutt_pretty_mailbox(value->data, value->dsize);
 
+        // These values of these config options don't need quoting / escaping
         if ((type != DT_BOOL) && (type != DT_NUMBER) && (type != DT_LONG) &&
-            (type != DT_QUAD) && !(flags & CS_DUMP_NO_ESCAPING))
+            (type != DT_QUAD) && (type != DT_ENUM) && (type != DT_SORT) &&
+            !(flags & CS_DUMP_NO_ESCAPING))
         {
           buf_reset(tmp);
           pretty_var(value->data, tmp);

--- a/config/dump.c
+++ b/config/dump.c
@@ -139,7 +139,36 @@ void dump_config_neo(struct ConfigSet *cs, struct HashElem *he, struct Buffer *v
   if (show_name && show_value)
     fprintf(fp, "set ");
   if (show_name)
-    fprintf(fp, "%s", name);
+  {
+    if (flags & CS_DUMP_LINK_DOCS)
+    {
+      // Used to generate unique ids for the urls
+      static int seq_num = 1;
+
+      if (DTYPE(he->type) == DT_MYVAR)
+      {
+        static const char *url = "https://neomutt.org/guide/configuration#set-myvar";
+        fprintf(fp, "\033]8;id=%d;%s\a%s\033]8;;\a", seq_num++, url, name);
+      }
+      else
+      {
+        char *fragment = mutt_str_dup(name);
+        for (char *underscore = fragment; (underscore = strchr(underscore, '_')); underscore++)
+        {
+          *underscore = '-';
+        }
+
+        static const char *url = "https://neomutt.org/guide/reference";
+        fprintf(fp, "\033]8;id=%d;%s#%s\a%s\033]8;;\a", seq_num++, url, fragment, name);
+        FREE(&fragment);
+      }
+
+    }
+    else
+    {
+      fprintf(fp, "%s", name);
+    }
+  }
   if (show_name && show_value)
     fprintf(fp, " = ");
   if (show_value)

--- a/config/dump.h
+++ b/config/dump.h
@@ -31,18 +31,19 @@ struct Buffer;
 struct ConfigSet;
 struct HashElem;
 
-typedef uint16_t ConfigDumpFlags;         ///< Flags for dump_config(), e.g. #CS_DUMP_ONLY_CHANGED
-#define CS_DUMP_NO_FLAGS              0   ///< No flags are set
-#define CS_DUMP_ONLY_CHANGED    (1 << 0)  ///< Only show config that the user has changed
-#define CS_DUMP_HIDE_SENSITIVE  (1 << 1)  ///< Obscure sensitive information like passwords
-#define CS_DUMP_NO_ESCAPING     (1 << 2)  ///< Do not escape special chars, or quote the string
-#define CS_DUMP_HIDE_NAME       (1 << 3)  ///< Do not print the name of the config item
-#define CS_DUMP_HIDE_VALUE      (1 << 4)  ///< Do not print the value of the config item
-#define CS_DUMP_SHOW_DEFAULTS   (1 << 5)  ///< Show the default value for the config item
-#define CS_DUMP_SHOW_DISABLED   (1 << 6)  ///< Show disabled config items, too
-#define CS_DUMP_SHOW_SYNONYMS   (1 << 7)  ///< Show synonyms and the config items they're linked to
-#define CS_DUMP_SHOW_DEPRECATED (1 << 8)  ///< Show config items that aren't used any more
-#define CS_DUMP_SHOW_DOCS       (1 << 9)  ///< Show one-liner documentation for the config item
+typedef uint16_t ConfigDumpFlags;          ///< Flags for dump_config(), e.g. #CS_DUMP_ONLY_CHANGED
+#define CS_DUMP_NO_FLAGS               0   ///< No flags are set
+#define CS_DUMP_ONLY_CHANGED    (1 <<  0)  ///< Only show config that the user has changed
+#define CS_DUMP_HIDE_SENSITIVE  (1 <<  1)  ///< Obscure sensitive information like passwords
+#define CS_DUMP_NO_ESCAPING     (1 <<  2)  ///< Do not escape special chars, or quote the string
+#define CS_DUMP_HIDE_NAME       (1 <<  3)  ///< Do not print the name of the config item
+#define CS_DUMP_HIDE_VALUE      (1 <<  4)  ///< Do not print the value of the config item
+#define CS_DUMP_SHOW_DEFAULTS   (1 <<  5)  ///< Show the default value for the config item
+#define CS_DUMP_SHOW_DISABLED   (1 <<  6)  ///< Show disabled config items, too
+#define CS_DUMP_SHOW_SYNONYMS   (1 <<  7)  ///< Show synonyms and the config items they're linked to
+#define CS_DUMP_SHOW_DEPRECATED (1 <<  8)  ///< Show config items that aren't used any more
+#define CS_DUMP_SHOW_DOCS       (1 <<  9)  ///< Show one-liner documentation for the config item
+#define CS_DUMP_LINK_DOCS       (1 << 10)  ///< Link to the online docs
 
 void              dump_config_neo(struct ConfigSet *cs, struct HashElem *he, struct Buffer *value, struct Buffer *initial, ConfigDumpFlags flags, FILE *fp);
 bool              dump_config(struct ConfigSet *cs, ConfigDumpFlags flags, FILE *fp);

--- a/init.c
+++ b/init.c
@@ -657,8 +657,13 @@ int mutt_query_variables(struct ListHead *queries, bool show_docs)
         buf_copy(value, tmp);
       }
 
-      dump_config_neo(NeoMutt->sub->cs, he, value, NULL,
-                      show_docs ? CS_DUMP_SHOW_DOCS : CS_DUMP_NO_FLAGS, stdout);
+      const bool tty = isatty(STDOUT_FILENO);
+
+      ConfigDumpFlags cdflags = tty ? CS_DUMP_LINK_DOCS : CS_DUMP_NO_FLAGS;
+      if (show_docs)
+        cdflags |= CS_DUMP_SHOW_DOCS;
+
+      dump_config_neo(NeoMutt->sub->cs, he, value, NULL, cdflags, stdout);
       continue;
     }
 

--- a/main.c
+++ b/main.c
@@ -898,7 +898,9 @@ main
 
   if (dump_variables)
   {
-    ConfigDumpFlags cdflags = CS_DUMP_NO_FLAGS;
+    const bool tty = isatty(STDOUT_FILENO);
+
+    ConfigDumpFlags cdflags = tty ? CS_DUMP_LINK_DOCS : CS_DUMP_NO_FLAGS;
     if (hide_sensitive)
       cdflags |= CS_DUMP_HIDE_SENSITIVE;
     if (one_liner)


### PR DESCRIPTION
**post-release**

A couple of ideas to improve the config dump command line options.

- Don't "quote" enumerations -- they're keywords, not strings
- Use ANSI Escape sequences to link config to the web guide (terminal dependent)

### Enumerations

You can see the config settings with `neomutt -D`, `neomutt -Q` or `:set` within NeoMutt.
Typically, we don't "quote" numbers or booleans.

This PR extends the non-quoting to enumerations, such as `$sort`.
These values are fixed **keywords** rather than freeform strings.

By leaving them unquoted, we can syntax highlight them as keywords.

This affects the following config:

- `$alias_sort` - alias, email, name, unsorted   
- `$browser_sort` - alpha, count, date, desc, size, new, unsorted 
- `$mbox_type` - mbox, MMDF, MH, Maildir 
- `$pgp_key_sort` - address, date, keyid, trust 
- `$sidebar_sort` - count, desc, flagged, path, unread, unsorted 
- `$sort` - date, date-received, from, label, score, size, spam, subject, threads, to, unsorted 
- `$sort_aux` - date, date-received, from, label, score, size, spam, subject, to, unsorted
- `$use_threads` - unset, flat, threads, reverse

### ANSI Sequences

Use ANSI escape sequences to auto-link the config options to their documentation on the website.

e.g. `neomutt -D`

```
set index_format = "xyz"
```

Where "index_format" is linked to
- https://neomutt.org/guide/reference#index-format

This uses:
- `<Esc>]8;id=NUM;URL\aPLAIN<Esc>]8;;\a`

Where:
- `NUM` is a unique id
- `URL` is the address to be linked
- `PLAIN` config option (plain text)

This only affects the output of:

- `neomutt -D` # Config dump
- `neomutt -Q` # Config query

When the output is piped, the links are disabled.

See also:
- https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda