### PR TITLE
expand tabs to spaces in compose preview (fixes #4534)

### DIFF
--- a/compose/preview.c
+++ b/compose/preview.c
@@ -181,6 +181,8 @@ static void draw_preview(struct MuttWindow *win, struct PreviewWindowData *wdata
 
       content_lines++;
 
+      line = mutt_str_expand_tabs(line, &line_len, 8);
+
       // Check how much of the string fits into the window width.
       size_t width = 0;
       size_t bytes = mutt_wstr_trunc(&line[pos], line_len - pos, win->state.cols, &width);

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -7,6 +7,7 @@
  * Copyright (C) 2018-2020 Pietro Cerutti <gahr@gahr.ch>
  * Copyright (C) 2021 Austin Ray <austin@austinray.io>
  * Copyright (C) 2022 Claes Nästén <pekdon@gmail.com>
+ * Copyright (C) 2025 Dennis Schön <mail@dennis-schoen.de>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -38,6 +39,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include "gui/lib.h"
 #include "exit.h"
 #include "logging2.h"
 #include "memory.h"
@@ -920,4 +922,50 @@ int mutt_str_inbox_cmp(const char *a, const char *b)
 
 #undef CMP_INBOX
 #undef IS_INBOX
+}
+
+/**
+ * mutt_str_expand_tabs - Convert tabs to spaces in a string
+ * @param str       Input string
+ * @param len       Length of the string
+ * @param tabwidth  The number of spaces per indentation-level
+ *
+ * Replace tab characters (`\t`) with spaces in the string. The string will be
+ * resized to fit the expanded version if necessary.
+ */
+char *mutt_str_expand_tabs(char *str, size_t *len, int tabwidth)
+{
+  if (!str || !len || (tabwidth < 1))
+    return NULL;
+
+  // calculate how much space we need
+  size_t required_len = 0;
+  for (int i = 0; (i < *len) && (str[i] != '\0'); i++)
+  {
+    if (str[i] == '\t')
+      required_len += tabwidth; // cheat, just assume full tab width
+    else
+      required_len++;
+  }
+
+  // resize the string if there isn't enough space
+  while (required_len > *len)
+  {
+    *len += 256;
+    MUTT_MEM_REALLOC(&str, *len, char);
+  }
+
+  // expand tabs
+  for (int i = 0; i < *len; i++)
+  {
+    if (str[i] == '\t')
+    {
+      int num_cells = mutt_strnwidth(str, i);
+      int indent = abs((num_cells % tabwidth) - tabwidth);
+      memmove(str + i + indent, str + i + 1, *len - (i + indent) - indent);
+      memset(str + i, ' ', indent);
+    }
+  }
+
+  return str;
 }

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -70,6 +70,7 @@ char *      mutt_str_skip_email_wsp(const char *s);
 char *      mutt_str_skip_whitespace(const char *p);
 const char *mutt_str_sysexit(int e);
 char *      mutt_str_upper(char *str);
+char *      mutt_str_expand_tabs(char *str, size_t *len, int tabwidth);
 
 /* case-sensitive flavours */
 int         mutt_str_cmp(const char *a, const char *b);

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -622,6 +622,7 @@ STRING_OBJS	= test/string/mutt_istrn_cmp.o \
 		  test/string/mutt_str_copy.o \
 		  test/string/mutt_str_dup.o \
 		  test/string/mutt_str_equal.o \
+		  test/string/mutt_str_expand_tabs.o \
 		  test/string/mutt_str_find_word.o \
 		  test/string/mutt_str_getenv.o \
 		  test/string/mutt_str_hyphenate.o \

--- a/test/main.c
+++ b/test/main.c
@@ -649,6 +649,7 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_mutt_str_copy)                                        \
   NEOMUTT_TEST_ITEM(test_mutt_str_dup)                                         \
   NEOMUTT_TEST_ITEM(test_mutt_str_equal)                                       \
+  NEOMUTT_TEST_ITEM(test_mutt_str_expand_tabs)                                 \
   NEOMUTT_TEST_ITEM(test_mutt_str_find_word)                                   \
   NEOMUTT_TEST_ITEM(test_mutt_str_getenv)                                      \
   NEOMUTT_TEST_ITEM(test_mutt_str_hyphenate)                                   \

--- a/test/string/mutt_str_expand_tabs.c
+++ b/test/string/mutt_str_expand_tabs.c
@@ -1,0 +1,80 @@
+/**
+ * @file
+ * Test code for mutt_str_expand_tabs()
+ *
+ * @authors
+ * Copyright (C) 2025 Dennis Schön <mail@dennis-schoen.de>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mutt/memory.h"
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <string.h>
+#include "mutt/lib.h"
+#include "test_common.h"
+
+struct TestCase
+{
+  char *in;
+  char *result;
+  int tabwidth;
+};
+
+void test_mutt_str_expand_tabs(void)
+{
+  // char *mutt_str_expand_tabs(char *str, size_t *len, int tabwidth);
+
+  {
+    TEST_CHECK(mutt_str_expand_tabs(NULL, 0, 4) == NULL);
+    TEST_CHECK(mutt_str_expand_tabs("", 0, 4) == NULL);
+  }
+
+  static struct TestCase tests[] = {
+    // clang-format off
+    { "\tapple",      "    apple",     4 },
+    { "X\tapple",     "X   apple",     4 },
+    { "XX\tapple",    "XX  apple",     4 },
+    { "XXX\tapple",   "XXX apple",     4 },
+    { "XXXX\tapple",  "XXXX    apple", 4 },
+    { "XXXXX\tapple", "XXXXX   apple", 4 },
+    { "\tapple\t",    "    apple   ",  4 },
+    { "🐛\tapple",    "🐛  apple",     4 },
+    { "\t🐛\tapple",  "    🐛  apple", 4 },
+    { "\t\tapple",    "        apple", 4 },
+    { "X\t\tapple",   "X       apple", 4 },
+    { "XX\t\tapple",  "XX      apple", 4 },
+    { "XXX\t\tapple", "XXX     apple", 4 },
+    { "\tapple",      "        apple", 8 },
+    { "X\tapple",     "X       apple", 8 },
+    { "XX\tapple",    "XX      apple", 8 },
+    { "XXX\tapple",   "XXX     apple", 8 },
+    // clang-format on
+  };
+
+  {
+    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    {
+      TEST_CASE(tests[i].in);
+      char *str = mutt_str_dup(tests[i].in);
+      size_t len = mutt_str_len(str);
+      char *result = mutt_str_expand_tabs(str, &len, tests[i].tabwidth);
+      TEST_CHECK_STR_EQ(result, tests[i].result);
+      FREE(&result);
+    }
+  }
+}


### PR DESCRIPTION
As reported in (#4534), the message preview in the compose window incorrectly rendered tabs (`\t`) as `?`.

The reason was that `mutt_paddstr()` replaces everything that is not `IsWPrint()` with `?`. To fix this we expand the tabs in each line before we measure the width and print it.