### PR TITLE
fix dumping of initial values

### DIFF
--- a/config/dump.c
+++ b/config/dump.c
@@ -247,7 +247,7 @@ bool dump_config(struct ConfigSet *cs, ConfigDumpFlags flags, FILE *fp)
         if (((type == DT_PATH) || IS_MAILBOX(he->type)) && (value->data[0] == '/'))
           mutt_pretty_mailbox(value->data, value->dsize);
 
-        // These values of these config options don't need quoting / escaping
+        // Quote/escape the values of config options NOT of these types
         if ((type != DT_BOOL) && (type != DT_NUMBER) && (type != DT_LONG) &&
             (type != DT_QUAD) && (type != DT_ENUM) && (type != DT_SORT) &&
             !(flags & CS_DUMP_NO_ESCAPING))
@@ -268,11 +268,13 @@ bool dump_config(struct ConfigSet *cs, ConfigDumpFlags flags, FILE *fp)
           break;          /* LCOV_EXCL_LINE */
         }
 
-        if (((type == DT_PATH) || IS_MAILBOX(he->type)) && !(he->type & D_STRING_MAILBOX))
+        if (((type == DT_PATH) || IS_MAILBOX(he->type)) && (initial->data[0] == '/'))
           mutt_pretty_mailbox(initial->data, initial->dsize);
 
+        // Quote/escape the values of config options NOT of these types
         if ((type != DT_BOOL) && (type != DT_NUMBER) && (type != DT_LONG) &&
-            (type != DT_QUAD) && !(flags & CS_DUMP_NO_ESCAPING))
+            (type != DT_QUAD) && (type != DT_ENUM) && (type != DT_SORT) &&
+            !(flags & CS_DUMP_NO_ESCAPING))
         {
           buf_reset(tmp);
           pretty_var(initial->data, tmp);

--- a/config/set.c
+++ b/config/set.c
@@ -266,8 +266,16 @@ struct HashElem *cs_register_variable(const struct ConfigSet *cs,
   if (!he)
     return NULL; /* LCOV_EXCL_LINE */
 
+  // Temporarily disable the validator
+  // (trust that the hard-coded initial values are sane)
+  int (*validator)(const struct ConfigSet *cs, const struct ConfigDef *cdef,
+                   intptr_t value, struct Buffer *err) = cdef->validator;
+  cdef->validator = NULL;
+
   if (cst->reset)
     cst->reset(cs, &cdef->var, cdef, err);
+
+  cdef->validator = validator;
 
   return he;
 }


### PR DESCRIPTION
The `:set` command without any arguments opens a pager showing all the config variables that have been set (changed from their defaults).

If the user runs **`neomutt -n -F /dev/null`**, this list **ought to be empty**.

Fix a few minor bugs in the code dealing with initial values:

- `dump_config()`
  Make sure the quoting/escaping is the same for both value and initial value.

- `cs_register_variable()`
  Temporarily disable the validator when setting the initial values.
  The config options may be set in an order that the validator doesn't like.

- `mutt_init()`
  Use an `Slist` to de-dupe the initial value of `$mailcap_path`.

- `mutt_init()`
  Don't set `$alias_file` to `/dev/null` in response to `-F /dev/null`.