### PR TITLE
debug: Chain old SEGV Handler

### DIFF
--- a/mutt/signal2.h
+++ b/mutt/signal2.h
@@ -45,6 +45,8 @@ extern volatile sig_atomic_t SigWinch; ///< true after SIGWINCH is received
  */
 typedef void (*sig_handler_t)(int sig);
 
+extern sig_handler_t OldSegvHandler; ///< Old SEGV handler, it could have been set by ASAN
+
 void assertion_dump(const char *file, int line, const char *func, const char *cond);
 
 #ifndef NDEBUG

--- a/mutt_signal.c
+++ b/mutt_signal.c
@@ -115,11 +115,16 @@ static void curses_segv_handler(int sig)
   dump_graphviz("segfault", NULL);
 #endif
 
+  // Chain the old SEGV handler, it could have been set by ASAN
+  if (OldSegvHandler)
+    OldSegvHandler(sig);
+
   struct sigaction act = { 0 };
   sigemptyset(&act.sa_mask);
   act.sa_flags = 0;
   act.sa_handler = SIG_DFL;
   sigaction(sig, &act, NULL);
+
   // Re-raise the signal to give outside handlers a chance to deal with it
   raise(sig);
 }


### PR DESCRIPTION
The SEGV Handler may already have been set, e.g. by ASAN.
After NeoMutt has cleaned up, chain the old handler.

---

At startup ASAN sets an signal handler to catch SEGV.

NeoMutt sets its own handler to do cleanup, but this tramples over ASAN.
(NeoMutt's handler, resets the screen back to normal mode)

On startup, store the old value of the SEGV handler.
If NeoMutt crashes, cleanup then chain ASAN's handler.

---

To test:
- Build with ASAN enabled
- Edit the code and set a pointer to NULL
- Crash NeoMutt

Expected result: ASAN log file   

/cc @auouymous 