### PR TITLE
Allow nested ARRAY_FOREACH()

### DIFF
--- a/alias/dlg_alias.c
+++ b/alias/dlg_alias.c
@@ -283,7 +283,7 @@ static bool dlg_alias(struct AliasMenuData *mdata)
   struct AliasView *avp = NULL;
   ARRAY_FOREACH(avp, &mdata->ava)
   {
-    avp->num = ARRAY_FOREACH_IDX;
+    avp->num = ARRAY_FOREACH_IDX_avp;
   }
 
   struct MuttWindow *old_focus = window_set_focus(menu->win);

--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -353,7 +353,7 @@ static bool dlg_query(struct Buffer *buf, struct AliasMenuData *mdata)
   struct AliasView *avp = NULL;
   ARRAY_FOREACH(avp, &mdata->ava)
   {
-    avp->num = ARRAY_FOREACH_IDX;
+    avp->num = ARRAY_FOREACH_IDX_avp;
   }
 
   struct MuttWindow *old_focus = window_set_focus(menu->win);

--- a/alias/functions.c
+++ b/alias/functions.c
@@ -232,7 +232,7 @@ static int op_generic_select_entry(struct AliasMenuData *mdata, int op)
     const int idx = menu_get_index(menu);
     ARRAY_FOREACH(avp, &mdata->ava)
     {
-      avp->is_tagged = (ARRAY_FOREACH_IDX == idx);
+      avp->is_tagged = (ARRAY_FOREACH_IDX_avp == idx);
     }
   }
 

--- a/alias/sort.c
+++ b/alias/sort.c
@@ -253,6 +253,6 @@ void alias_array_sort(struct AliasViewArray *ava, const struct ConfigSubset *sub
   struct AliasView *avp = NULL;
   ARRAY_FOREACH(avp, ava)
   {
-    avp->num = ARRAY_FOREACH_IDX;
+    avp->num = ARRAY_FOREACH_IDX_avp;
   }
 }

--- a/autocrypt/dlg_autocrypt.c
+++ b/autocrypt/dlg_autocrypt.c
@@ -161,7 +161,7 @@ bool populate_menu(struct Menu *menu)
   {
     struct AccountEntry *entry = MUTT_MEM_CALLOC(1, struct AccountEntry);
 
-    entry->num = ARRAY_FOREACH_IDX + 1;
+    entry->num = ARRAY_FOREACH_IDX_pac + 1;
     /* note: we are transferring the account pointer to the entries
      * array, and freeing the accounts array below.  the account
      * will be freed in autocrypt_menu_free().  */

--- a/browser/dlg_browser.c
+++ b/browser/dlg_browser.c
@@ -668,7 +668,7 @@ void init_menu(struct BrowserState *state, struct Menu *menu, struct Mailbox *m,
     {
       if (mutt_str_equal(ff->name, target_dir))
       {
-        menu_set_index(menu, ARRAY_FOREACH_IDX);
+        menu_set_index(menu, ARRAY_FOREACH_IDX_ff);
         matched = true;
         break;
       }

--- a/expando/node_padding.c
+++ b/expando/node_padding.c
@@ -310,18 +310,18 @@ void node_padding_repad(struct ExpandoNode **ptr)
     struct ExpandoNode *node_left = node_container_new();
     struct ExpandoNode *node_right = node_container_new();
 
-    if (ARRAY_FOREACH_IDX > 0)
+    if (ARRAY_FOREACH_IDX_np > 0)
     {
-      for (int i = 0; i < ARRAY_FOREACH_IDX; i++)
+      for (int i = 0; i < ARRAY_FOREACH_IDX_np; i++)
       {
         node_add_child(node_left, node_get_child(parent, i));
       }
     }
 
     size_t count = ARRAY_SIZE(&parent->children);
-    if ((ARRAY_FOREACH_IDX + 1) < count)
+    if ((ARRAY_FOREACH_IDX_np + 1) < count)
     {
-      for (int i = ARRAY_FOREACH_IDX + 1; i < count; i++)
+      for (int i = ARRAY_FOREACH_IDX_np + 1; i < count; i++)
       {
         node_add_child(node_right, node_get_child(parent, i));
       }

--- a/maildir/mailbox.c
+++ b/maildir/mailbox.c
@@ -350,7 +350,7 @@ static void maildir_delayed_parsing(struct Mailbox *m, struct MdEmailArray *mda,
     if (!md || !md->email || md->header_parsed)
       continue;
 
-    progress_update(progress, ARRAY_FOREACH_IDX, -1);
+    progress_update(progress, ARRAY_FOREACH_IDX_mdp, -1);
 
     snprintf(fn, sizeof(fn), "%s/%s", mailbox_path(m), md->email->path);
 

--- a/mh/mh.c
+++ b/mh/mh.c
@@ -564,7 +564,7 @@ static void mh_delayed_parsing(struct Mailbox *m, struct MhEmailArray *mha,
     if (!md || !md->email || md->header_parsed)
       continue;
 
-    progress_update(progress, ARRAY_FOREACH_IDX, -1);
+    progress_update(progress, ARRAY_FOREACH_IDX_mdp, -1);
 
 #ifdef USE_HCACHE
     const char *key = md->email->path;

--- a/mutt/array.h
+++ b/mutt/array.h
@@ -210,7 +210,7 @@
  * @param head Pointer to a struct defined using ARRAY_HEAD()
  */
 #define ARRAY_FOREACH(elem, head)                                              \
-  ARRAY_FOREACH_FROM_TO((elem), (head), 0, (head)->size)
+  ARRAY_FOREACH_FROM_TO(elem, (head), 0, (head)->size)
 
 /**
  * ARRAY_FOREACH_FROM - Iterate from an index to the end
@@ -221,7 +221,7 @@
  * @note The from index must be between 0 and ARRAY_SIZE(head)
  */
 #define ARRAY_FOREACH_FROM(elem, head, from)                                   \
-  ARRAY_FOREACH_FROM_TO((elem), (head), (from), (head)->size)
+  ARRAY_FOREACH_FROM_TO(elem, (head), (from), (head)->size)
 
 /**
  * ARRAY_FOREACH_TO - Iterate from the beginning to an index
@@ -232,7 +232,7 @@
  * @note The to index must be between 0 and ARRAY_SIZE(head)
  */
 #define ARRAY_FOREACH_TO(elem, head, to)                                       \
-  ARRAY_FOREACH_FROM_TO((elem), (head), 0, (to))
+  ARRAY_FOREACH_FROM_TO(elem, (head), 0, (to))
 
 /**
  * ARRAY_FOREACH_FROM_TO - Iterate between two indexes
@@ -245,10 +245,10 @@
  *       the from index must not be bigger than to index.
  */
 #define ARRAY_FOREACH_FROM_TO(elem, head, from, to)                            \
-  for (size_t ARRAY_FOREACH_IDX = (from);                                      \
-       (ARRAY_FOREACH_IDX < (to)) &&                                           \
-       ((elem) = ARRAY_GET((head), ARRAY_FOREACH_IDX));                        \
-       ARRAY_FOREACH_IDX++)
+  for (size_t ARRAY_FOREACH_IDX_##elem = (from);                               \
+       (ARRAY_FOREACH_IDX_##elem < (to)) &&                                    \
+       (elem = ARRAY_GET((head), ARRAY_FOREACH_IDX_##elem));                   \
+       ARRAY_FOREACH_IDX_##elem++)
 
 /**
  * ARRAY_IDX - Return the index of an element of the array

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -240,7 +240,7 @@ int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata,
   struct AliasView *avp = NULL;
   ARRAY_FOREACH(avp, &mdata->ava)
   {
-    progress_update(progress, ARRAY_FOREACH_IDX, -1);
+    progress_update(progress, ARRAY_FOREACH_IDX_avp, -1);
 
     if (match_all ||
         mutt_pattern_alias_exec(SLIST_FIRST(pat), MUTT_MATCH_FULL_ADDRESS, avp, NULL))

--- a/send/send.c
+++ b/send/send.c
@@ -1176,7 +1176,7 @@ static int generate_body(FILE *fp_tmp, struct Email *e, SendFlags flags,
           mutt_error(_("Could not include all requested messages"));
           return -1;
         }
-        if (ARRAY_FOREACH_IDX < count)
+        if (ARRAY_FOREACH_IDX_ep < count)
         {
           fputc('\n', fp_tmp);
         }

--- a/sidebar/functions.c
+++ b/sidebar/functions.c
@@ -51,7 +51,7 @@ bool sb_next(struct SidebarWindowData *wdata)
   {
     if (!(*sbep)->is_hidden)
     {
-      wdata->hil_index = ARRAY_FOREACH_IDX;
+      wdata->hil_index = ARRAY_FOREACH_IDX_sbep;
       return true;
     }
   }

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -135,21 +135,21 @@ void sb_remove_mailbox(struct SidebarWindowData *wdata, const struct Mailbox *m)
     ARRAY_REMOVE(&wdata->entries, sbep);
     FREE(&sbe_remove);
 
-    if (wdata->opn_index == ARRAY_FOREACH_IDX)
+    if (wdata->opn_index == ARRAY_FOREACH_IDX_sbep)
     {
       // Open item was deleted
       wdata->opn_index = -1;
     }
-    else if ((wdata->opn_index > 0) && (wdata->opn_index > ARRAY_FOREACH_IDX))
+    else if ((wdata->opn_index > 0) && (wdata->opn_index > ARRAY_FOREACH_IDX_sbep))
     {
       // Open item is still visible, so adjust the index
       wdata->opn_index--;
     }
 
-    if (wdata->hil_index == ARRAY_FOREACH_IDX)
+    if (wdata->hil_index == ARRAY_FOREACH_IDX_sbep)
     {
       // If possible, keep the highlight where it is
-      struct SbEntry **sbep_cur = ARRAY_GET(&wdata->entries, ARRAY_FOREACH_IDX);
+      struct SbEntry **sbep_cur = ARRAY_GET(&wdata->entries, ARRAY_FOREACH_IDX_sbep);
       if (!sbep_cur)
       {
         // The last entry was deleted, so backtrack
@@ -162,7 +162,7 @@ void sb_remove_mailbox(struct SidebarWindowData *wdata, const struct Mailbox *m)
           wdata->hil_index = -1;
       }
     }
-    else if ((wdata->hil_index > 0) && (wdata->hil_index > ARRAY_FOREACH_IDX))
+    else if ((wdata->hil_index > 0) && (wdata->hil_index > ARRAY_FOREACH_IDX_sbep))
     {
       // Highlighted item is still visible, so adjust the index
       wdata->hil_index--;
@@ -187,8 +187,8 @@ void sb_set_current_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
     {
       if (mutt_str_equal((*sbep)->mailbox->realpath, m->realpath))
       {
-        wdata->opn_index = ARRAY_FOREACH_IDX;
-        wdata->hil_index = ARRAY_FOREACH_IDX;
+        wdata->opn_index = ARRAY_FOREACH_IDX_sbep;
+        wdata->hil_index = ARRAY_FOREACH_IDX_sbep;
         break;
       }
     }

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -365,7 +365,7 @@ static void update_entries_visibility(struct SidebarWindowData *wdata)
   struct SbEntry **sbep = NULL;
   ARRAY_FOREACH(sbep, &wdata->entries)
   {
-    int i = ARRAY_FOREACH_IDX;
+    int i = ARRAY_FOREACH_IDX_sbep;
     sbe = *sbep;
 
     sbe->is_hidden = false;
@@ -441,9 +441,9 @@ static bool prepare_sidebar(struct SidebarWindowData *wdata, int page_size)
     ARRAY_FOREACH(sbep, &wdata->entries)
     {
       if ((opn_entry == *sbep) && (*sbep)->mailbox->visible)
-        wdata->opn_index = ARRAY_FOREACH_IDX;
+        wdata->opn_index = ARRAY_FOREACH_IDX_sbep;
       if ((hil_entry == *sbep) && (*sbep)->mailbox->visible)
-        wdata->hil_index = ARRAY_FOREACH_IDX;
+        wdata->hil_index = ARRAY_FOREACH_IDX_sbep;
     }
   }
 
@@ -551,7 +551,7 @@ int sb_recalc(struct MuttWindow *win)
     struct SbEntry *entry = (*sbep);
     struct Mailbox *m = entry->mailbox;
 
-    const int entryidx = ARRAY_FOREACH_IDX;
+    const int entryidx = ARRAY_FOREACH_IDX_sbep;
     entry->color = calc_color(m, (entryidx == wdata->opn_index),
                               (entryidx == wdata->hil_index));
 

--- a/test/array/mutt_array_api.c
+++ b/test/array/mutt_array_api.c
@@ -346,7 +346,7 @@ void test_mutt_array_api(void)
     struct Dummy *elem = NULL;
     ARRAY_FOREACH_FROM(elem, &d, 1)
     {
-      int prev = ARRAY_GET(&d, ARRAY_FOREACH_IDX - 1)->i;
+      int prev = ARRAY_GET(&d, ARRAY_FOREACH_IDX_elem - 1)->i;
       int curr = elem->i;
       if (!TEST_CHECK(curr < prev))
       {


### PR DESCRIPTION
## Overview

`ARRAY_FOREACH_FROM_TO()` uses a loop variable, `ARRAY_FOREACH_IDX`.

If you compile with `-Wshadow` you get warnings if `ARRAY_FOREACH()` are nested.
(There aren't any examples in the code yet, but I'd like to be able to).

The problem can be worked around by manually creating a `for` loop.

## How it works

The change works by replacing `ARRAY_FOREACH_IDX` with a new "templated" loop variable.
The variable is a macro concatenation of literal `idx_` and the `elem` param.

e.g.
```c
struct Object *obj = NULL;
ARRAY_FOREACH(obj, object_array)
{
    printf("%ld\n", idx_obj);
}
```

**Note**: In a couple of the `FOREACH` macros, I've removed the `()` from the `elem` param, so that it can be concatenated.

## Alternative Naming

One possible problem with the naming is that it's not immediately obvious where the variable comes from.

I've chosen (arbitrarily), a prefix of `idx_`.
Given an `elem` name of **`obj`**, some possible alternatives are:

- `obj_idx`
- `ARRAY_IDX_obj`
- `obj_ARRAY_IDX`
- `ARRAY_FOREACH_IDX_obj`
- `obj_ARRAY_FOREACH_IDX`

## Commits

- 842f3e831 array: allow nested `ARRAY_FOREACH()`
  Small changes to `mutt/array.h`

- 39faffbb2 array: use new index variable
  Code changes to match

- 6b739c2c3 nested array sample code
  Sample code [nested-array.c](https://github.com/neomutt/neomutt/pull/4545/files#diff-8fd0b694390466db9dbb488eb34bb4260e83198a791ce4ec362dcb66b5ea1801) for test compiling