### PR TITLE
buffer: fix seek

### DIFF
--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -621,13 +621,11 @@ size_t buf_copy(struct Buffer *dst, const struct Buffer *src)
  */
 void buf_seek(struct Buffer *buf, size_t offset)
 {
-  if (!buf)
+  if (!buf || !buf->data)
     return;
 
-  if ((offset < buf_len(buf)))
-  {
-    buf->dptr = buf->data ? buf->data + offset : NULL;
-  }
+  if (offset < buf->dsize)
+    buf->dptr = buf->data + offset;
 }
 
 /**


### PR DESCRIPTION
If `Buffer.dptr` hasn't been set yet, then `buf_len(buf)` will return 0. This means that `buf_seek()` will also fail.

Instead, use `Buffer.dsize` as a guide to where we can seek to.

---

Fixes: #4548

This bug caused Autocrypt Peer Discovery to fail.
NeoMutt decoded the key, but then used a zero length when using the value.