### PR TITLE
add comma to single <complete-query> match

### DIFF
--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -427,6 +427,7 @@ int query_complete(struct Buffer *buf, struct ConfigSubset *sub)
       mutt_addrlist_write(&addr, buf, false);
       mutt_addrlist_clear(&addr);
       mutt_clear_error();
+      buf_addstr(buf, ", ");
     }
     goto done;
   }


### PR DESCRIPTION
Append a comma-space to the end of a <complete-query> match.

This behaviour matches the other locations where the user edits addresses.

**To test**:
- Start composing an email: `<mail>` (<kbd>m</kbd>)
- Enter a partial, but unique, address: `john smith`
- Auto-Complete, using `<complete-query>` (<kbd>Ctrl-T</kbd> by default)

**Expected**:
- Address is completed
- A comma and a space is appended
 `John Smith <js@example.com>, `
