### PR TITLE
config: API `has_been_set()`

### DIFF
--- a/address/config_type.c
+++ b/address/config_type.c
@@ -3,7 +3,7 @@
  * Config type representing an email address
  *
  * @authors
- * Copyright (C) 2017-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2017-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2019-2023 Pietro Cerutti <gahr@gahr.ch>
  * Copyright (C) 2023 Dennis Schön <mail@dennis-schoen.de>
  *
@@ -213,6 +213,24 @@ static intptr_t address_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
+ * address_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
+ */
+static bool address_has_been_set(const struct ConfigSet *cs, void *var,
+                                 const struct ConfigDef *cdef)
+{
+  struct Buffer *value = buf_pool_get();
+  struct Address *a = *(struct Address **) var;
+  if (a)
+    mutt_addr_write(value, a, false);
+
+  const char *initial = (const char *) cdef->initial;
+
+  bool rc = !mutt_str_equal(initial, buf_string(value));
+  buf_pool_release(&value);
+  return rc;
+}
+
+/**
  * address_reset - Reset an Address to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
 static int address_reset(const struct ConfigSet *cs, void *var,
@@ -258,6 +276,7 @@ const struct ConfigSetType CstAddress = {
   address_native_get,
   NULL, // string_plus_equals
   NULL, // string_minus_equals
+  address_has_been_set,
   address_reset,
   address_destroy,
 };

--- a/commands.c
+++ b/commands.c
@@ -5,7 +5,7 @@
  * @authors
  * Copyright (C) 1996-2002,2007,2010,2012-2013,2016 Michael R. Elkins <me@mutt.org>
  * Copyright (C) 2004 g10 Code GmbH
- * Copyright (C) 2019-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2019-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Aditya De Saha <adityadesaha@gmail.com>
  * Copyright (C) 2020 Matthew Hughes <matthewhughes934@gmail.com>
  * Copyright (C) 2020 R Primus <rprimus@gmail.com>
@@ -878,14 +878,14 @@ enum CommandResult parse_my_hdr(struct Buffer *buf, struct Buffer *s,
 
 /**
  * set_dump - Dump list of config variables into a file/pager
- * @param flags what configs to dump: see #ConfigDumpFlags
- * @param err buffer for error message
+ * @param flags Which config to dump, e.g. #GEL_CHANGED_CONFIG
+ * @param err   Buffer for error message
  * @return num See #CommandResult
  *
  * FIXME: Move me into parse/set.c.  Note: this function currently depends on
  * pager, which is the reason it is not included in the parse library.
  */
-enum CommandResult set_dump(ConfigDumpFlags flags, struct Buffer *err)
+enum CommandResult set_dump(enum GetElemListFlags flags, struct Buffer *err)
 {
   struct Buffer *tempfile = buf_pool_get();
   buf_mktemp(tempfile);
@@ -900,8 +900,8 @@ enum CommandResult set_dump(ConfigDumpFlags flags, struct Buffer *err)
   }
 
   struct ConfigSet *cs = NeoMutt->sub->cs;
-  struct HashElemArray hea = get_elem_list(cs);
-  dump_config(cs, &hea, flags, fp_out);
+  struct HashElemArray hea = get_elem_list(cs, flags);
+  dump_config(cs, &hea, CS_DUMP_NO_FLAGS, fp_out);
   ARRAY_FREE(&hea);
 
   mutt_file_fclose(&fp_out);

--- a/commands.h
+++ b/commands.h
@@ -52,6 +52,6 @@ int parse_grouplist(struct GroupList *gl, struct Buffer *buf, struct Buffer *s, 
 void source_stack_cleanup(void);
 int source_rc(const char *rcfile_path, struct Buffer *err);
 
-enum CommandResult set_dump(ConfigDumpFlags flags, struct Buffer *err);
+enum CommandResult set_dump(enum GetElemListFlags flags, struct Buffer *err);
 
 #endif /* MUTT_COMMANDS_H */

--- a/complete/helpers.c
+++ b/complete/helpers.c
@@ -3,7 +3,7 @@
  * Auto-completion helpers
  *
  * @authors
- * Copyright (C) 2022-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2022-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2023 Anna Figueiredo Gomes <navi@vlhl.dev>
  * Copyright (C) 2023 Dennis Schön <mail@dennis-schoen.de>
  *
@@ -189,7 +189,7 @@ int mutt_command_complete(struct CompletionData *cd, struct Buffer *buf, int pos
       memset(cd->match_list, 0, cd->match_list_len);
       memset(cd->completed, 0, sizeof(cd->completed));
 
-      struct HashElemArray hea = get_elem_list(NeoMutt->sub->cs);
+      struct HashElemArray hea = get_elem_list(NeoMutt->sub->cs, GEL_ALL_CONFIG);
       struct HashElem **hep = NULL;
       ARRAY_FOREACH(hep, &hea)
       {

--- a/config/bool.c
+++ b/config/bool.c
@@ -3,7 +3,7 @@
  * Type representing a boolean
  *
  * @authors
- * Copyright (C) 2017-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2017-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Pietro Cerutti <gahr@gahr.ch>
  *
  * @copyright
@@ -163,6 +163,15 @@ static intptr_t bool_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
+ * bool_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
+ */
+static bool bool_has_been_set(const struct ConfigSet *cs, void *var,
+                              const struct ConfigDef *cdef)
+{
+  return (cdef->initial != (*(bool *) var));
+}
+
+/**
  * bool_reset - Reset a Bool to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
 static int bool_reset(const struct ConfigSet *cs, void *var,
@@ -240,6 +249,7 @@ const struct ConfigSetType CstBool = {
   bool_native_get,
   NULL, // string_plus_equals
   NULL, // string_minus_equals
+  bool_has_been_set,
   bool_reset,
   NULL, // destroy
 };

--- a/config/enum.c
+++ b/config/enum.c
@@ -3,7 +3,7 @@
  * Type representing an enumeration
  *
  * @authors
- * Copyright (C) 2019-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2019-2025 Richard Russon <rich@flatcap.org>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -31,6 +31,8 @@
  */
 
 #include "config.h"
+#include <limits.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
@@ -157,6 +159,15 @@ static intptr_t enum_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
+ * enum_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
+ */
+static bool enum_has_been_set(const struct ConfigSet *cs, void *var,
+                              const struct ConfigDef *cdef)
+{
+  return (cdef->initial != (*(unsigned char *) var));
+}
+
+/**
  * enum_reset - Reset an Enumeration to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
 static int enum_reset(const struct ConfigSet *cs, void *var,
@@ -192,6 +203,7 @@ const struct ConfigSetType CstEnum = {
   enum_native_get,
   NULL, // string_plus_equals
   NULL, // string_minus_equals
+  enum_has_been_set,
   enum_reset,
   NULL, // destroy
 };

--- a/config/enum.c
+++ b/config/enum.c
@@ -31,7 +31,6 @@
  */
 
 #include "config.h"
-#include <limits.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/config/long.c
+++ b/config/long.c
@@ -3,7 +3,7 @@
  * Type representing a long
  *
  * @authors
- * Copyright (C) 2017-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2017-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Jakub Jindra <jakub.jindra@socialbakers.com>
  * Copyright (C) 2021 Pietro Cerutti <gahr@gahr.ch>
  *
@@ -33,6 +33,7 @@
  */
 
 #include "config.h"
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
@@ -225,6 +226,15 @@ static int long_string_minus_equals(const struct ConfigSet *cs, void *var,
 }
 
 /**
+ * long_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
+ */
+static bool long_has_been_set(const struct ConfigSet *cs, void *var,
+                              const struct ConfigDef *cdef)
+{
+  return (cdef->initial != (*(long *) var));
+}
+
+/**
  * long_reset - Reset a Long to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
 static int long_reset(const struct ConfigSet *cs, void *var,
@@ -260,6 +270,7 @@ const struct ConfigSetType CstLong = {
   long_native_get,
   long_string_plus_equals,
   long_string_minus_equals,
+  long_has_been_set,
   long_reset,
   NULL, // destroy
 };

--- a/config/mbtable.c
+++ b/config/mbtable.c
@@ -3,7 +3,7 @@
  * Type representing a multibyte character table
  *
  * @authors
- * Copyright (C) 2017-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2017-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Pietro Cerutti <gahr@gahr.ch>
  *
  * @copyright
@@ -257,6 +257,20 @@ static intptr_t mbtable_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
+ * mbtable_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
+ */
+static bool mbtable_has_been_set(const struct ConfigSet *cs, void *var,
+                                 const struct ConfigDef *cdef)
+{
+  const char *initial = (const char *) cdef->initial;
+
+  struct MbTable *table = *(struct MbTable **) var;
+  const char *table_str = table ? table->orig_str : NULL;
+
+  return !mutt_str_equal(initial, table_str);
+}
+
+/**
  * mbtable_reset - Reset an MbTable to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
 static int mbtable_reset(const struct ConfigSet *cs, void *var,
@@ -351,6 +365,7 @@ const struct ConfigSetType CstMbtable = {
   mbtable_native_get,
   NULL, // string_plus_equals
   NULL, // string_minus_equals
+  mbtable_has_been_set,
   mbtable_reset,
   mbtable_destroy,
 };

--- a/config/myvar.c
+++ b/config/myvar.c
@@ -3,7 +3,7 @@
  * Type representing a user-defined variable "my_var"
  *
  * @authors
- * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2023-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2023 Rayford Shireman
  *
  * @copyright
@@ -213,6 +213,7 @@ const struct ConfigSetType CstMyVar = {
   myvar_native_get,
   myvar_string_plus_equals,
   NULL, // string_minus_equals
+  NULL, // has_been_set
   myvar_reset,
   myvar_destroy,
 };

--- a/config/number.c
+++ b/config/number.c
@@ -3,7 +3,7 @@
  * Type representing a number
  *
  * @authors
- * Copyright (C) 2017-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2017-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Jakub Jindra <jakub.jindra@socialbakers.com>
  * Copyright (C) 2021 Pietro Cerutti <gahr@gahr.ch>
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
@@ -35,6 +35,7 @@
 
 #include "config.h"
 #include <limits.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
@@ -271,6 +272,15 @@ static int number_string_minus_equals(const struct ConfigSet *cs, void *var,
 }
 
 /**
+ * number_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
+ */
+static bool number_has_been_set(const struct ConfigSet *cs, void *var,
+                                const struct ConfigDef *cdef)
+{
+  return (cdef->initial != native_get(var));
+}
+
+/**
  * number_reset - Reset a Number to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
 static int number_reset(const struct ConfigSet *cs, void *var,
@@ -330,6 +340,7 @@ const struct ConfigSetType CstNumber = {
   number_native_get,
   number_string_plus_equals,
   number_string_minus_equals,
+  number_has_been_set,
   number_reset,
   NULL, // destroy
 };

--- a/config/path.c
+++ b/config/path.c
@@ -4,7 +4,7 @@
  *
  * @authors
  * Copyright (C) 2020 Pietro Cerutti <gahr@gahr.ch>
- * Copyright (C) 2020-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2020-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2023 Dennis Schön <mail@dennis-schoen.de>
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
  *
@@ -215,6 +215,20 @@ static intptr_t path_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
+ * path_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
+ */
+static bool path_has_been_set(const struct ConfigSet *cs, void *var,
+                              const struct ConfigDef *cdef)
+{
+  const char *initial = path_tidy((const char *) cdef->initial, cdef->type & D_PATH_DIR);
+  const char *value = *(const char **) var;
+
+  bool rc = !mutt_str_equal(initial, value);
+  FREE(&initial);
+  return rc;
+}
+
+/**
  * path_reset - Reset a Path to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
 static int path_reset(const struct ConfigSet *cs, void *var,
@@ -270,6 +284,7 @@ const struct ConfigSetType CstPath = {
   path_native_get,
   NULL, // string_plus_equals
   NULL, // string_minus_equals
+  path_has_been_set,
   path_reset,
   path_destroy,
 };

--- a/config/quad.c
+++ b/config/quad.c
@@ -3,7 +3,7 @@
  * Type representing a quad-option
  *
  * @authors
- * Copyright (C) 2017-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2017-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Pietro Cerutti <gahr@gahr.ch>
  *
  * @copyright
@@ -37,6 +37,7 @@
 
 #include "config.h"
 #include <limits.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
@@ -168,6 +169,15 @@ static intptr_t quad_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
+ * quad_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
+ */
+static bool quad_has_been_set(const struct ConfigSet *cs, void *var,
+                              const struct ConfigDef *cdef)
+{
+  return (cdef->initial != (*(char *) var));
+}
+
+/**
  * quad_reset - Reset a Quad-option to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
 static int quad_reset(const struct ConfigSet *cs, void *var,
@@ -248,6 +258,7 @@ const struct ConfigSetType CstQuad = {
   quad_native_get,
   NULL, // string_plus_equals
   NULL, // string_minus_equals
+  quad_has_been_set,
   quad_reset,
   NULL, // destroy
 };

--- a/config/regex.c
+++ b/config/regex.c
@@ -3,7 +3,7 @@
  * Type representing a regular expression
  *
  * @authors
- * Copyright (C) 2017-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2017-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Pietro Cerutti <gahr@gahr.ch>
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
  *
@@ -281,6 +281,20 @@ static intptr_t regex_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
+ * regex_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
+ */
+static bool regex_has_been_set(const struct ConfigSet *cs, void *var,
+                               const struct ConfigDef *cdef)
+{
+  const char *initial = (const char *) cdef->initial;
+
+  struct Regex *currx = *(struct Regex **) var;
+  const char *curval = currx ? currx->pattern : NULL;
+
+  return !mutt_str_equal(initial, curval);
+}
+
+/**
  * regex_reset - Reset a Regex to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
 static int regex_reset(const struct ConfigSet *cs, void *var,
@@ -341,6 +355,7 @@ const struct ConfigSetType CstRegex = {
   regex_native_get,
   NULL, // string_plus_equals
   NULL, // string_minus_equals
+  regex_has_been_set,
   regex_reset,
   regex_destroy,
 };

--- a/config/set.c
+++ b/config/set.c
@@ -3,7 +3,7 @@
  * A collection of config items
  *
  * @authors
- * Copyright (C) 2017-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2017-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Pietro Cerutti <gahr@gahr.ch>
  * Copyright (C) 2023 Rayford Shireman
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
@@ -456,6 +456,50 @@ int cs_str_reset(const struct ConfigSet *cs, const char *name, struct Buffer *er
   }
 
   return cs_he_reset(cs, he, err);
+}
+
+/**
+ * cs_he_has_been_set - Is the config value different to its initial value?
+ * @param cs   Config items
+ * @param he   HashElem representing config item
+ * @retval true  Config has been set
+ * @retval false Config has not been set
+ */
+bool cs_he_has_been_set(const struct ConfigSet *cs, struct HashElem *he)
+{
+  if (!cs || !he)
+    return false;
+
+  const struct ConfigSetType *cst = cs_get_type_def(cs, he->type);
+  if (!cst)
+    return false; // LCOV_EXCL_LINE
+
+  if (!cst->has_been_set) // Probably a my_var
+    return true;
+
+  struct ConfigDef *cdef = he->data;
+  void *var = &cdef->var;
+
+  return cst->has_been_set(cs, var, cdef);
+}
+
+/**
+ * cs_str_has_been_set - Is the config value different to its initial value?
+ * @param cs   Config items
+ * @param name Name of config item
+ * @retval true  Config has been set
+ * @retval false Config has not been set
+ */
+bool cs_str_has_been_set(const struct ConfigSet *cs, const char *name)
+{
+  if (!cs || !name)
+    return false;
+
+  struct HashElem *he = cs_get_elem(cs, name);
+  if (!he)
+    return false;
+
+  return cs_he_has_been_set(cs, he);
 }
 
 /**

--- a/config/set.h
+++ b/config/set.h
@@ -3,7 +3,7 @@
  * A collection of config items
  *
  * @authors
- * Copyright (C) 2017-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2017-2025 Richard Russon <rich@flatcap.org>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -208,6 +208,23 @@ struct ConfigSetType
   int (*string_minus_equals)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, const char *value, struct Buffer *err);
 
   /**
+   * @defgroup cfg_type_has_been_set has_been_set()
+   * @ingroup cfg_type_api
+   *
+   * has_been_set - Is the config value different to its initial value?
+   * @param cs   Config items
+   * @param var  Variable to check
+   * @param cdef Variable definition
+   * @retval true  Value differs from its initial value
+   * @retval false Value is the same as its initial value
+   *
+   * @pre cs   is not NULL
+   * @pre var  is not NULL
+   * @pre cdef is not NULL
+   */
+  bool (*has_been_set)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef);
+
+  /**
    * @defgroup cfg_type_reset reset()
    * @ingroup cfg_type_api
    *
@@ -268,6 +285,7 @@ struct HashElem *cs_create_variable   (const struct ConfigSet *cs, struct Config
 struct HashElem *cs_inherit_variable  (const struct ConfigSet *cs, struct HashElem *he_parent, const char *name);
 void             cs_uninherit_variable(const struct ConfigSet *cs, const char *name);
 
+bool     cs_he_has_been_set        (const struct ConfigSet *cs, struct HashElem *he);
 int      cs_he_initial_get         (const struct ConfigSet *cs, struct HashElem *he,                    struct Buffer *result);
 int      cs_he_initial_set         (const struct ConfigSet *cs, struct HashElem *he, const char *value, struct Buffer *err);
 intptr_t cs_he_native_get          (const struct ConfigSet *cs, struct HashElem *he,                    struct Buffer *err);
@@ -279,6 +297,7 @@ int      cs_he_string_plus_equals  (const struct ConfigSet *cs, struct HashElem 
 int      cs_he_string_set          (const struct ConfigSet *cs, struct HashElem *he, const char *value, struct Buffer *err);
 int      cs_he_delete              (const struct ConfigSet *cs, struct HashElem *he,                    struct Buffer *err);
 
+bool     cs_str_has_been_set       (const struct ConfigSet *cs, const char *name);
 int      cs_str_initial_get        (const struct ConfigSet *cs, const char *name,                       struct Buffer *result);
 int      cs_str_initial_set        (const struct ConfigSet *cs, const char *name,    const char *value, struct Buffer *err);
 int      cs_str_native_set         (const struct ConfigSet *cs, const char *name,    intptr_t value,    struct Buffer *err);

--- a/config/slist.c
+++ b/config/slist.c
@@ -3,7 +3,7 @@
  * Type representing a list of strings
  *
  * @authors
- * Copyright (C) 2019-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2019-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Jakub Jindra <jakub.jindra@socialbakers.com>
  *
  * @copyright
@@ -34,6 +34,8 @@
  */
 
 #include "config.h"
+#include <limits.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
@@ -274,6 +276,23 @@ static int slist_string_minus_equals(const struct ConfigSet *cs, void *var,
 }
 
 /**
+ * slist_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
+ */
+static bool slist_has_been_set(const struct ConfigSet *cs, void *var,
+                               const struct ConfigDef *cdef)
+{
+  struct Slist *list = NULL;
+  const char *initial = (const char *) cdef->initial;
+
+  if (initial)
+    list = slist_parse(initial, cdef->type);
+
+  bool rc = !slist_equal(list, *(struct Slist **) var);
+  slist_free(&list);
+  return rc;
+}
+
+/**
  * slist_reset - Reset a Slist to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
 static int slist_reset(const struct ConfigSet *cs, void *var,
@@ -331,6 +350,7 @@ const struct ConfigSetType CstSlist = {
   slist_native_get,
   slist_string_plus_equals,
   slist_string_minus_equals,
+  slist_has_been_set,
   slist_reset,
   slist_destroy,
 };

--- a/config/slist.c
+++ b/config/slist.c
@@ -34,7 +34,6 @@
  */
 
 #include "config.h"
-#include <limits.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/config/sort.c
+++ b/config/sort.c
@@ -3,7 +3,7 @@
  * Type representing a sort option
  *
  * @authors
- * Copyright (C) 2017-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2017-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2018 Pietro Cerutti <gahr@gahr.ch>
  * Copyright (C) 2020 Aditya De Saha <adityadesaha@gmail.com>
  *
@@ -33,6 +33,7 @@
  */
 
 #include "config.h"
+#include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
 #include "mutt/lib.h"
@@ -194,6 +195,15 @@ static intptr_t sort_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
+ * sort_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
+ */
+static bool sort_has_been_set(const struct ConfigSet *cs, void *var,
+                              const struct ConfigDef *cdef)
+{
+  return (cdef->initial != (*(short *) var));
+}
+
+/**
  * sort_reset - Reset a Sort to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
 static int sort_reset(const struct ConfigSet *cs, void *var,
@@ -229,6 +239,7 @@ const struct ConfigSetType CstSort = {
   sort_native_get,
   NULL, // string_plus_equals
   NULL, // string_minus_equals
+  sort_has_been_set,
   sort_reset,
   NULL, // destroy
 };

--- a/config/string.c
+++ b/config/string.c
@@ -3,7 +3,7 @@
  * Type representing a string
  *
  * @authors
- * Copyright (C) 2017-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2017-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Jakub Jindra <jakub.jindra@socialbakers.com>
  * Copyright (C) 2020 Pietro Cerutti <gahr@gahr.ch>
  *
@@ -35,6 +35,7 @@
  */
 
 #include "config.h"
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
@@ -226,6 +227,18 @@ static int string_string_plus_equals(const struct ConfigSet *cs, void *var,
 }
 
 /**
+ * string_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
+ */
+static bool string_has_been_set(const struct ConfigSet *cs, void *var,
+                                const struct ConfigDef *cdef)
+{
+  const char *initial = (const char *) cdef->initial;
+  const char *value = *(const char **) var;
+
+  return !mutt_str_equal(initial, value);
+}
+
+/**
  * string_reset - Reset a String to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
 static int string_reset(const struct ConfigSet *cs, void *var,
@@ -281,6 +294,7 @@ const struct ConfigSetType CstString = {
   string_native_get,
   string_string_plus_equals,
   NULL, // string_minus_equals
+  string_has_been_set,
   string_reset,
   string_destroy,
 };

--- a/config/subset.c
+++ b/config/subset.c
@@ -3,7 +3,7 @@
  * Subset of config items
  *
  * @authors
- * Copyright (C) 2019-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2019-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Pietro Cerutti <gahr@gahr.ch>
  * Copyright (C) 2023 Rayford Shireman
  *
@@ -73,10 +73,11 @@ int elem_list_sort(const void *a, const void *b, void *sdata)
 
 /**
  * get_elem_list - Create a sorted list of all config items
- * @param cs ConfigSet to read
+ * @param cs    ConfigSet to read
+ * @param flags Flags, e.g. #GEL_ALL_CONFIG
  * @retval ptr Array of HashElem
  */
-struct HashElemArray get_elem_list(struct ConfigSet *cs)
+struct HashElemArray get_elem_list(struct ConfigSet *cs, enum GetElemListFlags flags)
 {
   struct HashElemArray hea = ARRAY_HEAD_INITIALIZER;
 
@@ -87,6 +88,9 @@ struct HashElemArray get_elem_list(struct ConfigSet *cs)
   struct HashElem *he = NULL;
   while ((he = mutt_hash_walk(cs->hash, &walk)))
   {
+    if ((flags == GEL_CHANGED_CONFIG) && !cs_he_has_been_set(cs, he))
+      continue;
+
     ARRAY_ADD(&hea, he);
   }
 
@@ -119,7 +123,7 @@ void cs_subset_free(struct ConfigSubset **ptr)
 
     // We don't know if any config items have been set,
     // so search for anything with a matching scope.
-    struct HashElemArray hea = get_elem_list(sub->cs);
+    struct HashElemArray hea = get_elem_list(sub->cs, GEL_ALL_CONFIG);
     struct HashElem **hep = NULL;
     ARRAY_FOREACH(hep, &hea)
     {

--- a/config/subset.h
+++ b/config/subset.h
@@ -3,7 +3,7 @@
  * Subset of Config Items
  *
  * @authors
- * Copyright (C) 2019-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2019-2025 Richard Russon <rich@flatcap.org>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -73,6 +73,15 @@ struct EventConfig
   struct HashElem *he;            ///< Config item that changed
 };
 
+/**
+ * enum GetElemListFlags - Flags for get_elem_list()
+ */
+enum GetElemListFlags
+{
+  GEL_ALL_CONFIG,        ///< All the normal config (no synonyms or deprecated)
+  GEL_CHANGED_CONFIG,    ///< Only config that has been changed
+};
+
 struct ConfigSubset *cs_subset_new (const char *name, struct ConfigSubset *sub_parent, struct Notify *not_parent);
 void                 cs_subset_free(struct ConfigSubset **ptr);
 
@@ -94,6 +103,6 @@ int      cs_subset_str_string_get         (const struct ConfigSubset *sub, const
 int      cs_subset_str_string_set         (const struct ConfigSubset *sub, const char *name,    const char *value, struct Buffer *err);
 
 int                  elem_list_sort(const void *a, const void *b, void *sdata);
-struct HashElemArray get_elem_list(struct ConfigSet *cs);
+struct HashElemArray get_elem_list(struct ConfigSet *cs, enum GetElemListFlags flags);
 
 #endif /* MUTT_CONFIG_SUBSET_H */

--- a/debug/graphviz.c
+++ b/debug/graphviz.c
@@ -3,7 +3,7 @@
  * Create a GraphViz dot file from the NeoMutt objects
  *
  * @authors
- * Copyright (C) 2018-2024 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2018-2025 Richard Russon <rich@flatcap.org>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -371,7 +371,7 @@ void dot_config(FILE *fp, const char *name, int type, struct ConfigSubset *sub,
     char scope[256];
     snprintf(scope, sizeof(scope), "%s:", sub->name);
 
-    struct HashElemArray hea = get_elem_list(sub->cs);
+    struct HashElemArray hea = get_elem_list(sub->cs, GEL_ALL_CONFIG);
     struct HashElem **hep = NULL;
     ARRAY_FOREACH(hep, &hea)
     {
@@ -401,7 +401,7 @@ void dot_config(FILE *fp, const char *name, int type, struct ConfigSubset *sub,
   }
   else
   {
-    struct HashElemArray hea = get_elem_list(sub->cs);
+    struct HashElemArray hea = get_elem_list(sub->cs, GEL_ALL_CONFIG);
     dot_type_number(fp, "count", ARRAY_SIZE(&hea));
     ARRAY_FREE(&hea);
   }

--- a/expando/config_type.c
+++ b/expando/config_type.c
@@ -4,7 +4,7 @@
  *
  * @authors
  * Copyright (C) 2023-2024 Tóth János <gomba007@gmail.com>
- * Copyright (C) 2023-2024 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2023-2025 Richard Russon <rich@flatcap.org>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -35,6 +35,7 @@
 
 #include "config.h"
 #include <limits.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -276,6 +277,20 @@ static int expando_string_plus_equals(const struct ConfigSet *cs, void *var,
 }
 
 /**
+ * expando_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
+ */
+static bool expando_has_been_set(const struct ConfigSet *cs, void *var,
+                                 const struct ConfigDef *cdef)
+{
+  const char *initial = (const char *) cdef->initial;
+
+  struct Expando *exp = *(struct Expando **) var;
+  const char *exp_str = exp ? exp->string : NULL;
+
+  return !mutt_str_equal(initial, exp_str);
+}
+
+/**
  * expando_reset - Reset an Expando to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
 static int expando_reset(const struct ConfigSet *cs, void *var,
@@ -337,6 +352,7 @@ const struct ConfigSetType CstExpando = {
   expando_native_get,
   expando_string_plus_equals,
   NULL, // string_minus_equals
+  expando_has_been_set,
   expando_reset,
   expando_destroy,
 };

--- a/main.c
+++ b/main.c
@@ -1407,7 +1407,7 @@ main
     struct HashElemArray hea = ARRAY_HEAD_INITIALIZER;
     if (dump_variables)
     {
-      hea = get_elem_list(cs);
+      hea = get_elem_list(cs, GEL_ALL_CONFIG);
       rc = 0;
     }
     else

--- a/parse/set.c
+++ b/parse/set.c
@@ -305,7 +305,7 @@ enum CommandResult command_set_reset(struct Buffer *name, struct Buffer *err)
   // Handle special "reset all" syntax
   if (mutt_str_equal(name->data, "all"))
   {
-    struct HashElemArray hea = get_elem_list(NeoMutt->sub->cs);
+    struct HashElemArray hea = get_elem_list(NeoMutt->sub->cs, GEL_ALL_CONFIG);
     struct HashElem **hep = NULL;
     ARRAY_FOREACH(hep, &hea)
     {
@@ -415,7 +415,7 @@ enum CommandResult command_set_query(struct Buffer *name, struct Buffer *err)
   if (buf_is_empty(name))
   {
     if (StartupComplete)
-      return set_dump(CS_DUMP_ONLY_CHANGED, err);
+      return set_dump(GEL_CHANGED_CONFIG, err);
     else
       return MUTT_CMD_SUCCESS;
   }
@@ -423,7 +423,7 @@ enum CommandResult command_set_query(struct Buffer *name, struct Buffer *err)
   if (mutt_str_equal(name->data, "all"))
   {
     if (StartupComplete)
-      return set_dump(CS_DUMP_NO_FLAGS, err);
+      return set_dump(GEL_ALL_CONFIG, err);
     else
       return MUTT_CMD_SUCCESS;
   }

--- a/test/config/bool.c
+++ b/test/config/bool.c
@@ -3,7 +3,7 @@
  * Test code for the Bool object
  *
  * @authors
- * Copyright (C) 2018-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2018-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
  *
  * @copyright
@@ -227,6 +227,9 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   rc = cs_str_string_set(cs, name, "0", err);
   TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
+  name = "Damson";
+  TEST_CHECK(cs_str_has_been_set(cs, name));
 
   log_line(__func__);
   return true;

--- a/test/config/dump.c
+++ b/test/config/dump.c
@@ -230,7 +230,7 @@ bool test_get_elem_list(void)
 
   {
     struct HashElemArray hea = ARRAY_HEAD_INITIALIZER;
-    hea = get_elem_list(NULL);
+    hea = get_elem_list(NULL, GEL_ALL_CONFIG);
     if (!TEST_CHECK(ARRAY_EMPTY(&hea)))
       return false;
   }
@@ -241,7 +241,7 @@ bool test_get_elem_list(void)
       return false;
 
     struct HashElemArray hea = ARRAY_HEAD_INITIALIZER;
-    hea = get_elem_list(cs);
+    hea = get_elem_list(cs, GEL_ALL_CONFIG);
     if (!TEST_CHECK(!ARRAY_EMPTY(&hea)))
     {
       cs_free(&cs);
@@ -262,7 +262,7 @@ bool test_get_elem_list(void)
     TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS);
 
     struct HashElemArray hea = ARRAY_HEAD_INITIALIZER;
-    hea = get_elem_list(cs);
+    hea = get_elem_list(cs, GEL_CHANGED_CONFIG);
     if (!TEST_CHECK(!ARRAY_EMPTY(&hea)))
     {
       cs_free(&cs);
@@ -349,7 +349,7 @@ bool test_dump_config(void)
     if (!fp)
       return false;
 
-    struct HashElemArray hea = get_elem_list(cs);
+    struct HashElemArray hea = get_elem_list(cs, GEL_ALL_CONFIG);
 
     // Degenerate tests
 

--- a/test/config/dump.c
+++ b/test/config/dump.c
@@ -3,7 +3,7 @@
  * Test code for the Config Dump functions
  *
  * @authors
- * Copyright (C) 2019-2024 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2019-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Aditya De Saha <adityadesaha@gmail.com>
  * Copyright (C) 2020 Pietro Cerutti <gahr@gahr.ch>
  * Copyright (C) 2023 Dennis Schön <mail@dennis-schoen.de>
@@ -239,6 +239,27 @@ bool test_get_elem_list(void)
     struct ConfigSet *cs = create_sample_data();
     if (!cs)
       return false;
+
+    struct HashElemArray hea = ARRAY_HEAD_INITIALIZER;
+    hea = get_elem_list(cs);
+    if (!TEST_CHECK(!ARRAY_EMPTY(&hea)))
+    {
+      cs_free(&cs);
+      return false;
+    }
+
+    ARRAY_FREE(&hea);
+    cs_free(&cs);
+  }
+
+  {
+    struct ConfigSet *cs = create_sample_data();
+    if (!cs)
+      return false;
+
+    const char *name = "Apple";
+    int rc = cs_str_string_set(cs, name, "yes", NULL);
+    TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS);
 
     struct HashElemArray hea = ARRAY_HEAD_INITIALIZER;
     hea = get_elem_list(cs);

--- a/test/config/enum.c
+++ b/test/config/enum.c
@@ -3,7 +3,7 @@
  * Test code for the Enum object
  *
  * @authors
- * Copyright (C) 2019-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2019-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
  *
  * @copyright
@@ -252,6 +252,9 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   rc = cs_str_string_set(cs, name, "Badger", err);
   TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
+  name = "Damson";
+  TEST_CHECK(cs_str_has_been_set(cs, name));
 
   log_line(__func__);
   return true;

--- a/test/config/long.c
+++ b/test/config/long.c
@@ -3,7 +3,7 @@
  * Test code for the Long object
  *
  * @authors
- * Copyright (C) 2018-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2018-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Jakub Jindra <jakub.jindra@socialbakers.com>
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
  *
@@ -214,6 +214,9 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
     TEST_MSG("This test should have failed");
     return false;
   }
+
+  name = "Damson";
+  TEST_CHECK(cs_str_has_been_set(cs, name));
 
   name = "Papaya";
   rc = cs_str_string_set(cs, name, "1", err);

--- a/test/config/mbtable.c
+++ b/test/config/mbtable.c
@@ -3,7 +3,7 @@
  * Test code for the Mbtable object
  *
  * @authors
- * Copyright (C) 2018-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2018-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
  *
  * @copyright
@@ -234,6 +234,9 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   rc = cs_str_string_set(cs, name, "banana", err);
   TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
+  name = "Damson";
+  TEST_CHECK(!cs_str_has_been_set(cs, name));
 
   log_line(__func__);
   return true;

--- a/test/config/number.c
+++ b/test/config/number.c
@@ -3,7 +3,7 @@
  * Test code for the Number object
  *
  * @authors
- * Copyright (C) 2018-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2018-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Jakub Jindra <jakub.jindra@socialbakers.com>
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
  *
@@ -223,6 +223,9 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   rc = cs_str_string_set(cs, name, "0", err);
   TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
+  name = "Damson";
+  TEST_CHECK(!cs_str_has_been_set(cs, name));
 
   log_line(__func__);
   return true;

--- a/test/config/path.c
+++ b/test/config/path.c
@@ -3,7 +3,7 @@
  * Test code for the Path object
  *
  * @authors
- * Copyright (C) 2020-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2020-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
  *
  * @copyright
@@ -248,6 +248,9 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   rc = cs_str_string_set(cs, name, "apple", err);
   TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
+  name = "Damson";
+  TEST_CHECK(!cs_str_has_been_set(cs, name));
 
   log_line(__func__);
   return true;

--- a/test/config/quad.c
+++ b/test/config/quad.c
@@ -3,7 +3,7 @@
  * Test code for the Quad object
  *
  * @authors
- * Copyright (C) 2018-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2018-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
  *
  * @copyright
@@ -221,6 +221,9 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   rc = cs_str_string_set(cs, name, "ask-no", err);
   TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
+  name = "Damson";
+  TEST_CHECK(cs_str_has_been_set(cs, name));
 
   log_line(__func__);
   return true;

--- a/test/config/regex.c
+++ b/test/config/regex.c
@@ -3,7 +3,7 @@
  * Test code for the Regex object
  *
  * @authors
- * Copyright (C) 2018-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2018-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2023 Pietro Cerutti <gahr@gahr.ch>
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
  *
@@ -242,6 +242,9 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   rc = cs_str_string_set(cs, name, "apple.*", err);
   TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
+  name = "Damson";
+  TEST_CHECK(!cs_str_has_been_set(cs, name));
 
   log_line(__func__);
   return true;

--- a/test/config/set.c
+++ b/test/config/set.c
@@ -3,7 +3,7 @@
  * Test code for the ConfigSet object
  *
  * @authors
- * Copyright (C) 2018-2024 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2018-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Jakub Jindra <jakub.jindra@socialbakers.com>
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
  *
@@ -78,6 +78,12 @@ int dummy_minus_equals(const struct ConfigSet *cs, void *var, const struct Confi
   return CSR_ERR_CODE;
 }
 
+static bool dummy_has_been_set(const struct ConfigSet *cs, void *var,
+                               const struct ConfigDef *cdef)
+{
+  return false;
+}
+
 static int dummy_reset(const struct ConfigSet *cs, void *var,
                        const struct ConfigDef *cdef, struct Buffer *err)
 {
@@ -143,6 +149,16 @@ bool degenerate_tests(struct ConfigSet *cs)
   if (!TEST_CHECK(cs_str_reset(NULL, "apple", NULL) != CSR_SUCCESS))
     return false;
   if (!TEST_CHECK(cs_str_reset(cs, NULL, NULL) != CSR_SUCCESS))
+    return false;
+  if (!TEST_CHECK(!cs_he_has_been_set(NULL, he)))
+    return false;
+  if (!TEST_CHECK(!cs_he_has_been_set(cs, NULL)))
+    return false;
+  if (!TEST_CHECK(!cs_str_has_been_set(NULL, "apple")))
+    return false;
+  if (!TEST_CHECK(!cs_str_has_been_set(cs, NULL)))
+    return false;
+  if (!TEST_CHECK(!cs_str_has_been_set(cs, "apple")))
     return false;
   if (!TEST_CHECK(cs_he_initial_set(NULL, he, "42", NULL) != CSR_SUCCESS))
     return false;
@@ -377,6 +393,7 @@ void test_config_set(void)
     dummy_native_get,
     dummy_plus_equals,
     dummy_minus_equals,
+    dummy_has_been_set,
     dummy_reset,
     dummy_destroy,
   };

--- a/test/config/slist.c
+++ b/test/config/slist.c
@@ -3,7 +3,7 @@
  * Test code for the Slist object
  *
  * @authors
- * Copyright (C) 2019-2024 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2019-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020-2023 Pietro Cerutti <gahr@gahr.ch>
  * Copyright (C) 2022 Michal Siedlaczek <michal@siedlaczek.me>
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
@@ -462,6 +462,9 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   rc = cs_str_string_set(cs, name, "banana", err);
   TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
+  name = "Damson";
+  TEST_CHECK(cs_str_has_been_set(cs, name));
 
   return true;
 }

--- a/test/config/sort.c
+++ b/test/config/sort.c
@@ -3,7 +3,7 @@
  * Test code for the Sort object
  *
  * @authors
- * Copyright (C) 2018-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2018-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Aditya De Saha <adityadesaha@gmail.com>
  * Copyright (C) 2020 Pietro Cerutti <gahr@gahr.ch>
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
@@ -273,6 +273,9 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   rc = cs_str_string_set(cs, name, "size", err);
   TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
+  name = "Damson";
+  TEST_CHECK(cs_str_has_been_set(cs, name));
 
   log_line(__func__);
   return true;

--- a/test/config/string.c
+++ b/test/config/string.c
@@ -3,7 +3,7 @@
  * Test code for the String object
  *
  * @authors
- * Copyright (C) 2018-2023 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2018-2025 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2020 Jakub Jindra <jakub.jindra@socialbakers.com>
  * Copyright (C) 2023 Pietro Cerutti <gahr@gahr.ch>
  * Copyright (C) 2023 наб <nabijaczleweli@nabijaczleweli.xyz>
@@ -245,6 +245,9 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   rc = cs_str_string_set(cs, name, "apple", err);
   TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
+  name = "Damson";
+  TEST_CHECK(!cs_str_has_been_set(cs, name));
 
   log_line(__func__);
   return true;

--- a/test/expando/config.c
+++ b/test/expando/config.c
@@ -3,7 +3,7 @@
  * Test code for the Expando object
  *
  * @authors
- * Copyright (C) 2024 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2024-2025 Richard Russon <rich@flatcap.org>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -273,6 +273,9 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   rc = cs_str_string_set(cs, name, "apple", err);
   TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS);
+
+  name = "Damson";
+  TEST_CHECK(!cs_str_has_been_set(cs, name));
 
   log_line(__func__);
   return true;


### PR DESCRIPTION
This adds a new function to the Config API: `has_been_set()`.
This allows us to efficiently determine which config has been changed.

This builds on several recent commits:

- e87c36489 fix dumping of initial values, #4537
- fa841ed1e array: upgrade `get_elem_list()`
- 8d2ea311d query: unify `neomutt -D` and `-Q`

---

### Testing

- Dump all config: `neomutt -D`
- Show changed config in NeoMutt: `:set`
- Show all config in NeoMutt: `:set all`

These can be run with either zero config, or this test config file which sets one option for each type.

**test.rc**
```sh
set assumed_charset = "ascii:utf-8"                        # slist
set attach_format = "attach"                               # expando
set attach_save_dir = "save-dir"                           # path
set editor = "nano"                                        # string
set envelope_from_address = "John Smith <js@example.com>"  # address
set flag_chars = "abcdefghijk"                             # mbtable
set mbox_type = maildir                                    # enum
set pgp_timeout = 1234                                     # long
set print = yes                                            # quad
set quote_regex = "|"                                      # regex
set sidebar_visible = yes                                  # bool
set sleep_time = 99                                        # number
set sort_aux = "label"                                     # sort
```