### PR TITLE
CLI: `neomutt -DD` -- Dump Different

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -19821,6 +19821,13 @@ neomutt -a image.jpg *.png -- address1 address2
               </entry>
             </row>
             <row>
+              <entry>-D -D (or -DD)</entry>
+              <entry>
+                Like <emphasis role="bold">-D</emphasis>, but only show the
+                config that has changed
+              </entry>
+            </row>
+            <row>
               <entry>-D -O</entry>
               <entry>
                 Like <emphasis role="bold">-D</emphasis>, but show one-liner documentation

--- a/docs/neomutt.man
+++ b/docs/neomutt.man
@@ -261,6 +261,11 @@ Dump all configuration variables as
 pairs to stdout
 .
 .TP
+.B \-D\ \-D
+.B \-DD
+Like \fB\-D\fP, but only show the config that has changed
+.
+.TP
 .B \-D\ \-O
 Like \fB\-D\fP, but show one-liner documentation
 .

--- a/main.c
+++ b/main.c
@@ -1054,7 +1054,8 @@ main
   int version = 0;
   int i;
   bool explicit_folder = false;
-  int dump_variables = 0;
+  bool dump_variables = false;
+  bool dump_changed = false;
   bool one_liner = false;
   bool hide_sensitive = false;
   bool batch_mode = false;
@@ -1125,7 +1126,10 @@ main
           mutt_list_insert_tail(&cc_list, mutt_str_dup(optarg));
           break;
         case 'D':
-          dump_variables++;
+          if (dump_variables)
+            dump_changed = true;
+          else
+            dump_variables = true;
           break;
         case 'd':
           dlevel = optarg;
@@ -1297,7 +1301,7 @@ main
 
   /* Check for a batch send. */
   if (!isatty(0) || !STAILQ_EMPTY(&queries) || !STAILQ_EMPTY(&alias_queries) ||
-      (dump_variables > 0) || batch_mode)
+      dump_variables || batch_mode)
   {
     OptNoCurses = true;
     sendflags |= SEND_BATCH;
@@ -1393,7 +1397,7 @@ main
   if (new_type && !config_str_set_initial(cs, "mbox_type", new_type))
     goto main_curses;
 
-  if ((dump_variables > 0) || !STAILQ_EMPTY(&queries))
+  if (dump_variables || !STAILQ_EMPTY(&queries))
   {
     const bool tty = isatty(STDOUT_FILENO);
 
@@ -1406,9 +1410,9 @@ main
       cdflags |= CS_DUMP_SHOW_DOCS;
 
     struct HashElemArray hea = ARRAY_HEAD_INITIALIZER;
-    if (dump_variables > 0)
+    if (dump_variables)
     {
-      enum GetElemListFlags gel_flags = (dump_variables > 1) ? GEL_CHANGED_CONFIG : GEL_ALL_CONFIG;
+      enum GetElemListFlags gel_flags = dump_changed ? GEL_CHANGED_CONFIG : GEL_ALL_CONFIG;
       hea = get_elem_list(cs, gel_flags);
       rc = 0;
     }


### PR DESCRIPTION
Add a new command line sub-option `-D -D` or `-DD`

This simple addition to the command line only shows the **changed** config.
It can be used with the other dump options, e.g. `-O` (one-liner).

---

### Testing

- Dump all config: `neomutt -D`
- Dump changed config: `neomutt -DD`

This is particularly effective when using zero config, or a simple test config, below:

- `neomutt -n -F /dev/null -DD`
  Shows nothing

- `neomutt -n -F test.rc -DD`
  Shows just the config frrom `test.rc`
  (plus `$alias_file`, which is automatic)

**test.rc**
```sh
set assumed_charset = "ascii:utf-8"                        # slist
set attach_format = "attach"                               # expando
set attach_save_dir = "save-dir"                           # path
set editor = "nano"                                        # string
set envelope_from_address = "John Smith <js@example.com>"  # address
set flag_chars = "abcdefghijk"                             # mbtable
set mbox_type = maildir                                    # enum
set pgp_timeout = 1234                                     # long
set print = yes                                            # quad
set quote_regex = "|"                                      # regex
set sidebar_visible = yes                                  # bool
set sleep_time = 99                                        # number
set sort_aux = "label"                                     # sort
```