### PR TITLE
config: drop ConfigSet from API functions

### DIFF
--- a/address/config_type.c
+++ b/address/config_type.c
@@ -59,7 +59,7 @@ struct Address *address_new(const char *addr)
 /**
  * address_destroy - Destroy an Address object - Implements ConfigSetType::destroy() - @ingroup cfg_type_destroy
  */
-static void address_destroy(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef)
+static void address_destroy(void *var, const struct ConfigDef *cdef)
 {
   struct Address **a = var;
   if (!*a)
@@ -71,7 +71,7 @@ static void address_destroy(const struct ConfigSet *cs, void *var, const struct 
 /**
  * address_string_set - Set an Address by string - Implements ConfigSetType::string_set() - @ingroup cfg_type_string_set
  */
-static int address_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
+static int address_string_set(void *var, struct ConfigDef *cdef,
                               const char *value, struct Buffer *err)
 {
   /* Store empty address as NULL */
@@ -101,17 +101,17 @@ static int address_string_set(const struct ConfigSet *cs, void *var, struct Conf
   {
     if (cdef->validator)
     {
-      rc = cdef->validator(cs, cdef, (intptr_t) addr, err);
+      rc = cdef->validator(cdef, (intptr_t) addr, err);
 
       if (CSR_RESULT(rc) != CSR_SUCCESS)
       {
-        address_destroy(cs, &addr, cdef);
+        address_destroy(&addr, cdef);
         return rc | CSR_INV_VALIDATOR;
       }
     }
 
     /* ordinary variable setting */
-    address_destroy(cs, var, cdef);
+    address_destroy(var, cdef);
 
     *(struct Address **) var = addr;
 
@@ -134,8 +134,7 @@ static int address_string_set(const struct ConfigSet *cs, void *var, struct Conf
 /**
  * address_string_get - Get an Address as a string - Implements ConfigSetType::string_get() - @ingroup cfg_type_string_get
  */
-static int address_string_get(const struct ConfigSet *cs, void *var,
-                              const struct ConfigDef *cdef, struct Buffer *result)
+static int address_string_get(void *var, const struct ConfigDef *cdef, struct Buffer *result)
 {
   if (var)
   {
@@ -175,15 +174,14 @@ static struct Address *address_dup(struct Address *addr)
 /**
  * address_native_set - Set an Address config item by Address object - Implements ConfigSetType::native_set() - @ingroup cfg_type_native_set
  */
-static int address_native_set(const struct ConfigSet *cs, void *var,
-                              const struct ConfigDef *cdef, intptr_t value,
-                              struct Buffer *err)
+static int address_native_set(void *var, const struct ConfigDef *cdef,
+                              intptr_t value, struct Buffer *err)
 {
   int rc;
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, value, err);
+    rc = cdef->validator(cdef, value, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
@@ -204,8 +202,7 @@ static int address_native_set(const struct ConfigSet *cs, void *var,
 /**
  * address_native_get - Get an Address object from an Address config item - Implements ConfigSetType::native_get() - @ingroup cfg_type_native_get
  */
-static intptr_t address_native_get(const struct ConfigSet *cs, void *var,
-                                   const struct ConfigDef *cdef, struct Buffer *err)
+static intptr_t address_native_get(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   struct Address *addr = *(struct Address **) var;
 
@@ -215,8 +212,7 @@ static intptr_t address_native_get(const struct ConfigSet *cs, void *var,
 /**
  * address_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
  */
-static bool address_has_been_set(const struct ConfigSet *cs, void *var,
-                                 const struct ConfigDef *cdef)
+static bool address_has_been_set(void *var, const struct ConfigDef *cdef)
 {
   struct Buffer *value = buf_pool_get();
   struct Address *a = *(struct Address **) var;
@@ -233,8 +229,7 @@ static bool address_has_been_set(const struct ConfigSet *cs, void *var,
 /**
  * address_reset - Reset an Address to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
-static int address_reset(const struct ConfigSet *cs, void *var,
-                         const struct ConfigDef *cdef, struct Buffer *err)
+static int address_reset(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   struct Address *a = NULL;
   const char *initial = (const char *) cdef->initial;
@@ -246,11 +241,11 @@ static int address_reset(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, (intptr_t) a, err);
+    rc = cdef->validator(cdef, (intptr_t) a, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
     {
-      address_destroy(cs, &a, cdef);
+      address_destroy(&a, cdef);
       return rc | CSR_INV_VALIDATOR;
     }
   }
@@ -258,7 +253,7 @@ static int address_reset(const struct ConfigSet *cs, void *var,
   if (!a)
     rc |= CSR_SUC_EMPTY;
 
-  address_destroy(cs, var, cdef);
+  address_destroy(var, cdef);
 
   *(struct Address **) var = a;
   return rc;

--- a/config/bool.c
+++ b/config/bool.c
@@ -55,8 +55,8 @@ const char *BoolValues[] = {
 /**
  * bool_string_set - Set a Bool by string - Implements ConfigSetType::string_set() - @ingroup cfg_type_string_set
  */
-static int bool_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
-                           const char *value, struct Buffer *err)
+static int bool_string_set(void *var, struct ConfigDef *cdef, const char *value,
+                           struct Buffer *err)
 {
   if (!value)
     return CSR_ERR_CODE; /* LCOV_EXCL_LINE */
@@ -87,7 +87,7 @@ static int bool_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 
     if (cdef->validator)
     {
-      int rc = cdef->validator(cs, cdef, (intptr_t) num, err);
+      int rc = cdef->validator(cdef, (intptr_t) num, err);
 
       if (CSR_RESULT(rc) != CSR_SUCCESS)
         return rc | CSR_INV_VALIDATOR;
@@ -106,8 +106,7 @@ static int bool_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 /**
  * bool_string_get - Get a Bool as a string - Implements ConfigSetType::string_get() - @ingroup cfg_type_string_get
  */
-static int bool_string_get(const struct ConfigSet *cs, void *var,
-                           const struct ConfigDef *cdef, struct Buffer *result)
+static int bool_string_get(void *var, const struct ConfigDef *cdef, struct Buffer *result)
 {
   int index;
 
@@ -126,8 +125,8 @@ static int bool_string_get(const struct ConfigSet *cs, void *var,
 /**
  * bool_native_set - Set a Bool config item by bool - Implements ConfigSetType::native_set() - @ingroup cfg_type_native_set
  */
-static int bool_native_set(const struct ConfigSet *cs, void *var,
-                           const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
+static int bool_native_set(void *var, const struct ConfigDef *cdef,
+                           intptr_t value, struct Buffer *err)
 {
   if ((value < 0) || (value > 1))
   {
@@ -143,7 +142,7 @@ static int bool_native_set(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, value, err);
+    int rc = cdef->validator(cdef, value, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
@@ -156,8 +155,7 @@ static int bool_native_set(const struct ConfigSet *cs, void *var,
 /**
  * bool_native_get - Get a bool from a Bool config item - Implements ConfigSetType::native_get() - @ingroup cfg_type_native_get
  */
-static intptr_t bool_native_get(const struct ConfigSet *cs, void *var,
-                                const struct ConfigDef *cdef, struct Buffer *err)
+static intptr_t bool_native_get(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   return *(bool *) var;
 }
@@ -165,8 +163,7 @@ static intptr_t bool_native_get(const struct ConfigSet *cs, void *var,
 /**
  * bool_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
  */
-static bool bool_has_been_set(const struct ConfigSet *cs, void *var,
-                              const struct ConfigDef *cdef)
+static bool bool_has_been_set(void *var, const struct ConfigDef *cdef)
 {
   return (cdef->initial != (*(bool *) var));
 }
@@ -174,8 +171,7 @@ static bool bool_has_been_set(const struct ConfigSet *cs, void *var,
 /**
  * bool_reset - Reset a Bool to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
-static int bool_reset(const struct ConfigSet *cs, void *var,
-                      const struct ConfigDef *cdef, struct Buffer *err)
+static int bool_reset(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   if (cdef->initial == (*(bool *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
@@ -185,7 +181,7 @@ static int bool_reset(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, cdef->initial, err);
+    int rc = cdef->validator(cdef, cdef->initial, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;

--- a/config/charset.c
+++ b/config/charset.c
@@ -42,8 +42,7 @@
  *
  * Validate the config variables that contain a single charset.
  */
-int charset_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                      intptr_t value, struct Buffer *err)
+int charset_validator(const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
 {
   if (value == 0)
     return CSR_SUCCESS;
@@ -82,8 +81,7 @@ int charset_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
  *
  * Validate the config variables that can contain a multiple charsets.
  */
-int charset_slist_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                            intptr_t value, struct Buffer *err)
+int charset_slist_validator(const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
 {
   if (value == 0)
     return CSR_SUCCESS;

--- a/config/charset.h
+++ b/config/charset.h
@@ -29,7 +29,7 @@ struct Buffer;
 struct ConfigDef;
 struct ConfigSet;
 
-int charset_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
-int charset_slist_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
+int charset_slist_validator(const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
+int charset_validator      (const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
 
 #endif /* MUTT_CONFIG_CHARSET_H */

--- a/config/enum.c
+++ b/config/enum.c
@@ -42,10 +42,10 @@
 /**
  * enum_string_set - Set an Enumeration by string - Implements ConfigSetType::string_set() - @ingroup cfg_type_string_set
  */
-static int enum_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
-                           const char *value, struct Buffer *err)
+static int enum_string_set(void *var, struct ConfigDef *cdef, const char *value,
+                           struct Buffer *err)
 {
-  if (!cs || !cdef || !value)
+  if (!value)
     return CSR_ERR_CODE; /* LCOV_EXCL_LINE */
 
   struct EnumDef *ed = (struct EnumDef *) cdef->data;
@@ -69,7 +69,7 @@ static int enum_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 
     if (cdef->validator)
     {
-      int rc = cdef->validator(cs, cdef, (intptr_t) num, err);
+      int rc = cdef->validator(cdef, (intptr_t) num, err);
 
       if (CSR_RESULT(rc) != CSR_SUCCESS)
         return rc | CSR_INV_VALIDATOR;
@@ -88,8 +88,7 @@ static int enum_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 /**
  * enum_string_get - Get an Enumeration as a string - Implements ConfigSetType::string_get() - @ingroup cfg_type_string_get
  */
-static int enum_string_get(const struct ConfigSet *cs, void *var,
-                           const struct ConfigDef *cdef, struct Buffer *result)
+static int enum_string_get(void *var, const struct ConfigDef *cdef, struct Buffer *result)
 {
   unsigned int value;
 
@@ -116,8 +115,8 @@ static int enum_string_get(const struct ConfigSet *cs, void *var,
 /**
  * enum_native_set - Set an Enumeration config item by int - Implements ConfigSetType::native_set() - @ingroup cfg_type_native_set
  */
-static int enum_native_set(const struct ConfigSet *cs, void *var,
-                           const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
+static int enum_native_set(void *var, const struct ConfigDef *cdef,
+                           intptr_t value, struct Buffer *err)
 {
   struct EnumDef *ed = (struct EnumDef *) cdef->data;
   if (!ed || !ed->lookup)
@@ -138,7 +137,7 @@ static int enum_native_set(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, value, err);
+    int rc = cdef->validator(cdef, value, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
@@ -151,8 +150,7 @@ static int enum_native_set(const struct ConfigSet *cs, void *var,
 /**
  * enum_native_get - Get an int object from an Enumeration config item - Implements ConfigSetType::native_get() - @ingroup cfg_type_native_get
  */
-static intptr_t enum_native_get(const struct ConfigSet *cs, void *var,
-                                const struct ConfigDef *cdef, struct Buffer *err)
+static intptr_t enum_native_get(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   return *(unsigned char *) var;
 }
@@ -160,8 +158,7 @@ static intptr_t enum_native_get(const struct ConfigSet *cs, void *var,
 /**
  * enum_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
  */
-static bool enum_has_been_set(const struct ConfigSet *cs, void *var,
-                              const struct ConfigDef *cdef)
+static bool enum_has_been_set(void *var, const struct ConfigDef *cdef)
 {
   return (cdef->initial != (*(unsigned char *) var));
 }
@@ -169,8 +166,7 @@ static bool enum_has_been_set(const struct ConfigSet *cs, void *var,
 /**
  * enum_reset - Reset an Enumeration to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
-static int enum_reset(const struct ConfigSet *cs, void *var,
-                      const struct ConfigDef *cdef, struct Buffer *err)
+static int enum_reset(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   if (cdef->initial == (*(unsigned char *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
@@ -180,7 +176,7 @@ static int enum_reset(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, cdef->initial, err);
+    int rc = cdef->validator(cdef, cdef->initial, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;

--- a/config/long.c
+++ b/config/long.c
@@ -43,8 +43,8 @@
 /**
  * long_string_set - Set a Long by string - Implements ConfigSetType::string_set() - @ingroup cfg_type_string_set
  */
-static int long_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
-                           const char *value, struct Buffer *err)
+static int long_string_set(void *var, struct ConfigDef *cdef, const char *value,
+                           struct Buffer *err)
 {
   if (!value || (value[0] == '\0'))
   {
@@ -75,7 +75,7 @@ static int long_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 
     if (cdef->validator)
     {
-      int rc = cdef->validator(cs, cdef, (intptr_t) num, err);
+      int rc = cdef->validator(cdef, (intptr_t) num, err);
 
       if (CSR_RESULT(rc) != CSR_SUCCESS)
         return rc | CSR_INV_VALIDATOR;
@@ -94,8 +94,7 @@ static int long_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 /**
  * long_string_get - Get a Long as a string - Implements ConfigSetType::string_get() - @ingroup cfg_type_string_get
  */
-static int long_string_get(const struct ConfigSet *cs, void *var,
-                           const struct ConfigDef *cdef, struct Buffer *result)
+static int long_string_get(void *var, const struct ConfigDef *cdef, struct Buffer *result)
 {
   int value;
 
@@ -111,8 +110,8 @@ static int long_string_get(const struct ConfigSet *cs, void *var,
 /**
  * long_native_set - Set a Long config item by long - Implements ConfigSetType::native_set() - @ingroup cfg_type_native_set
  */
-static int long_native_set(const struct ConfigSet *cs, void *var,
-                           const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
+static int long_native_set(void *var, const struct ConfigDef *cdef,
+                           intptr_t value, struct Buffer *err)
 {
   if ((value < 0) && (cdef->type & D_INTEGER_NOT_NEGATIVE))
   {
@@ -128,7 +127,7 @@ static int long_native_set(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, value, err);
+    int rc = cdef->validator(cdef, value, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
@@ -141,8 +140,7 @@ static int long_native_set(const struct ConfigSet *cs, void *var,
 /**
  * long_native_get - Get a long from a Long config item - Implements ConfigSetType::native_get() - @ingroup cfg_type_native_get
  */
-static intptr_t long_native_get(const struct ConfigSet *cs, void *var,
-                                const struct ConfigDef *cdef, struct Buffer *err)
+static intptr_t long_native_get(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   return *(long *) var;
 }
@@ -150,8 +148,7 @@ static intptr_t long_native_get(const struct ConfigSet *cs, void *var,
 /**
  * long_string_plus_equals - Add to a Long by string - Implements ConfigSetType::string_plus_equals() - @ingroup cfg_type_string_plus_equals
  */
-static int long_string_plus_equals(const struct ConfigSet *cs, void *var,
-                                   const struct ConfigDef *cdef,
+static int long_string_plus_equals(void *var, const struct ConfigDef *cdef,
                                    const char *value, struct Buffer *err)
 {
   long num = 0;
@@ -176,7 +173,7 @@ static int long_string_plus_equals(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, (intptr_t) result, err);
+    int rc = cdef->validator(cdef, (intptr_t) result, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
@@ -189,8 +186,7 @@ static int long_string_plus_equals(const struct ConfigSet *cs, void *var,
 /**
  * long_string_minus_equals - Subtract from a Long by string - Implements ConfigSetType::string_minus_equals() - @ingroup cfg_type_string_minus_equals
  */
-static int long_string_minus_equals(const struct ConfigSet *cs, void *var,
-                                    const struct ConfigDef *cdef,
+static int long_string_minus_equals(void *var, const struct ConfigDef *cdef,
                                     const char *value, struct Buffer *err)
 {
   long num = 0;
@@ -215,7 +211,7 @@ static int long_string_minus_equals(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, (intptr_t) result, err);
+    int rc = cdef->validator(cdef, (intptr_t) result, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
@@ -228,8 +224,7 @@ static int long_string_minus_equals(const struct ConfigSet *cs, void *var,
 /**
  * long_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
  */
-static bool long_has_been_set(const struct ConfigSet *cs, void *var,
-                              const struct ConfigDef *cdef)
+static bool long_has_been_set(void *var, const struct ConfigDef *cdef)
 {
   return (cdef->initial != (*(long *) var));
 }
@@ -237,8 +232,7 @@ static bool long_has_been_set(const struct ConfigSet *cs, void *var,
 /**
  * long_reset - Reset a Long to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
-static int long_reset(const struct ConfigSet *cs, void *var,
-                      const struct ConfigDef *cdef, struct Buffer *err)
+static int long_reset(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   if (cdef->initial == (*(long *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
@@ -248,7 +242,7 @@ static int long_reset(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, cdef->initial, err);
+    int rc = cdef->validator(cdef, cdef->initial, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;

--- a/config/mbtable.c
+++ b/config/mbtable.c
@@ -107,7 +107,7 @@ struct MbTable *mbtable_parse(const char *s)
 /**
  * mbtable_destroy - Destroy an MbTable object - Implements ConfigSetType::destroy() - @ingroup cfg_type_destroy
  */
-static void mbtable_destroy(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef)
+static void mbtable_destroy(void *var, const struct ConfigDef *cdef)
 {
   struct MbTable **m = var;
   if (!*m)
@@ -119,7 +119,7 @@ static void mbtable_destroy(const struct ConfigSet *cs, void *var, const struct 
 /**
  * mbtable_string_set - Set an MbTable by string - Implements ConfigSetType::string_set() - @ingroup cfg_type_string_set
  */
-static int mbtable_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
+static int mbtable_string_set(void *var, struct ConfigDef *cdef,
                               const char *value, struct Buffer *err)
 {
   /* Store empty mbtables as NULL */
@@ -143,7 +143,7 @@ static int mbtable_string_set(const struct ConfigSet *cs, void *var, struct Conf
 
     if (cdef->validator)
     {
-      rc = cdef->validator(cs, cdef, (intptr_t) table, err);
+      rc = cdef->validator(cdef, (intptr_t) table, err);
 
       if (CSR_RESULT(rc) != CSR_SUCCESS)
       {
@@ -152,7 +152,7 @@ static int mbtable_string_set(const struct ConfigSet *cs, void *var, struct Conf
       }
     }
 
-    mbtable_destroy(cs, var, cdef);
+    mbtable_destroy(var, cdef);
 
     *(struct MbTable **) var = table;
 
@@ -174,8 +174,7 @@ static int mbtable_string_set(const struct ConfigSet *cs, void *var, struct Conf
 /**
  * mbtable_string_get - Get a MbTable as a string - Implements ConfigSetType::string_get() - @ingroup cfg_type_string_get
  */
-static int mbtable_string_get(const struct ConfigSet *cs, void *var,
-                              const struct ConfigDef *cdef, struct Buffer *result)
+static int mbtable_string_get(void *var, const struct ConfigDef *cdef, struct Buffer *result)
 {
   const char *str = NULL;
 
@@ -213,9 +212,8 @@ static struct MbTable *mbtable_dup(struct MbTable *table)
 /**
  * mbtable_native_set - Set an MbTable config item by MbTable object - Implements ConfigSetType::native_set() - @ingroup cfg_type_native_set
  */
-static int mbtable_native_set(const struct ConfigSet *cs, void *var,
-                              const struct ConfigDef *cdef, intptr_t value,
-                              struct Buffer *err)
+static int mbtable_native_set(void *var, const struct ConfigDef *cdef,
+                              intptr_t value, struct Buffer *err)
 {
   int rc;
 
@@ -227,7 +225,7 @@ static int mbtable_native_set(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, value, err);
+    rc = cdef->validator(cdef, value, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
@@ -248,8 +246,7 @@ static int mbtable_native_set(const struct ConfigSet *cs, void *var,
 /**
  * mbtable_native_get - Get an MbTable object from a MbTable config item - Implements ConfigSetType::native_get() - @ingroup cfg_type_native_get
  */
-static intptr_t mbtable_native_get(const struct ConfigSet *cs, void *var,
-                                   const struct ConfigDef *cdef, struct Buffer *err)
+static intptr_t mbtable_native_get(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   struct MbTable *table = *(struct MbTable **) var;
 
@@ -259,8 +256,7 @@ static intptr_t mbtable_native_get(const struct ConfigSet *cs, void *var,
 /**
  * mbtable_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
  */
-static bool mbtable_has_been_set(const struct ConfigSet *cs, void *var,
-                                 const struct ConfigDef *cdef)
+static bool mbtable_has_been_set(void *var, const struct ConfigDef *cdef)
 {
   const char *initial = (const char *) cdef->initial;
 
@@ -273,8 +269,7 @@ static bool mbtable_has_been_set(const struct ConfigSet *cs, void *var,
 /**
  * mbtable_reset - Reset an MbTable to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
-static int mbtable_reset(const struct ConfigSet *cs, void *var,
-                         const struct ConfigDef *cdef, struct Buffer *err)
+static int mbtable_reset(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   struct MbTable *table = NULL;
   const char *initial = (const char *) cdef->initial;
@@ -297,11 +292,11 @@ static int mbtable_reset(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, (intptr_t) table, err);
+    rc = cdef->validator(cdef, (intptr_t) table, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
     {
-      mbtable_destroy(cs, &table, cdef);
+      mbtable_destroy(&table, cdef);
       return rc | CSR_INV_VALIDATOR;
     }
   }
@@ -309,7 +304,7 @@ static int mbtable_reset(const struct ConfigSet *cs, void *var,
   if (!table)
     rc |= CSR_SUC_EMPTY;
 
-  mbtable_destroy(cs, var, cdef);
+  mbtable_destroy(var, cdef);
 
   *(struct MbTable **) var = table;
   return rc;

--- a/config/myvar.c
+++ b/config/myvar.c
@@ -42,7 +42,7 @@
 /**
  * myvar_destroy - Destroy a MyVar - Implements ConfigSetType::destroy() - @ingroup cfg_type_destroy
  */
-static void myvar_destroy(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef)
+static void myvar_destroy(void *var, const struct ConfigDef *cdef)
 {
   const char **str = (const char **) var;
   if (!*str)
@@ -54,7 +54,7 @@ static void myvar_destroy(const struct ConfigSet *cs, void *var, const struct Co
 /**
  * myvar_string_set - Set a MyVar by string - Implements ConfigSetType::string_set() - @ingroup cfg_type_string_set
  */
-static int myvar_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
+static int myvar_string_set(void *var, struct ConfigDef *cdef,
                             const char *value, struct Buffer *err)
 {
   /* Store empty myvars as NULL */
@@ -68,7 +68,7 @@ static int myvar_string_set(const struct ConfigSet *cs, void *var, struct Config
     if (mutt_str_equal(value, (*(char **) var)))
       return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
-    myvar_destroy(cs, var, cdef);
+    myvar_destroy(var, cdef);
 
     const char *str = mutt_str_dup(value);
     if (!str)
@@ -91,8 +91,7 @@ static int myvar_string_set(const struct ConfigSet *cs, void *var, struct Config
 /**
  * myvar_string_get - Get a MyVar as a string - Implements ConfigSetType::string_get() - @ingroup cfg_type_string_get
  */
-static int myvar_string_get(const struct ConfigSet *cs, void *var,
-                            const struct ConfigDef *cdef, struct Buffer *result)
+static int myvar_string_get(void *var, const struct ConfigDef *cdef, struct Buffer *result)
 {
   const char *str = NULL;
 
@@ -111,8 +110,8 @@ static int myvar_string_get(const struct ConfigSet *cs, void *var,
 /**
  * myvar_native_set - Set a MyVar config item by string - Implements ConfigSetType::native_set() - @ingroup cfg_type_native_set
  */
-static int myvar_native_set(const struct ConfigSet *cs, void *var,
-                            const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
+static int myvar_native_set(void *var, const struct ConfigDef *cdef,
+                            intptr_t value, struct Buffer *err)
 {
   const char *str = (const char *) value;
 
@@ -125,7 +124,7 @@ static int myvar_native_set(const struct ConfigSet *cs, void *var,
 
   int rc;
 
-  myvar_destroy(cs, var, cdef);
+  myvar_destroy(var, cdef);
 
   str = mutt_str_dup(str);
   rc = CSR_SUCCESS;
@@ -139,8 +138,7 @@ static int myvar_native_set(const struct ConfigSet *cs, void *var,
 /**
  * myvar_native_get - Get a string from a MyVar config item - Implements ConfigSetType::native_get() - @ingroup cfg_type_native_get
  */
-static intptr_t myvar_native_get(const struct ConfigSet *cs, void *var,
-                                 const struct ConfigDef *cdef, struct Buffer *err)
+static intptr_t myvar_native_get(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   const char *str = *(const char **) var;
 
@@ -150,8 +148,7 @@ static intptr_t myvar_native_get(const struct ConfigSet *cs, void *var,
 /**
  * myvar_string_plus_equals - Add to a MyVar by string - Implements ConfigSetType::string_plus_equals() - @ingroup cfg_type_string_plus_equals
  */
-static int myvar_string_plus_equals(const struct ConfigSet *cs, void *var,
-                                    const struct ConfigDef *cdef,
+static int myvar_string_plus_equals(void *var, const struct ConfigDef *cdef,
                                     const char *value, struct Buffer *err)
 {
   /* Skip if the value is missing or empty string*/
@@ -168,7 +165,7 @@ static int myvar_string_plus_equals(const struct ConfigSet *cs, void *var,
   else
     str = mutt_str_dup(value);
 
-  myvar_destroy(cs, var, cdef);
+  myvar_destroy(var, cdef);
   *var_str = str;
 
   return rc;
@@ -177,8 +174,7 @@ static int myvar_string_plus_equals(const struct ConfigSet *cs, void *var,
 /**
  * myvar_reset - Reset a MyVar to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
-static int myvar_reset(const struct ConfigSet *cs, void *var,
-                       const struct ConfigDef *cdef, struct Buffer *err)
+static int myvar_reset(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   int rc = CSR_SUCCESS;
 
@@ -192,7 +188,7 @@ static int myvar_reset(const struct ConfigSet *cs, void *var,
     return rc | CSR_SUC_NO_CHANGE;
   }
 
-  myvar_destroy(cs, var, cdef);
+  myvar_destroy(var, cdef);
 
   if (!str)
     rc |= CSR_SUC_EMPTY;

--- a/config/number.c
+++ b/config/number.c
@@ -76,7 +76,7 @@ static void native_toggle(void *var)
 /**
  * number_string_set - Set a Number by string - Implements ConfigSetType::string_set() - @ingroup cfg_type_string_set
  */
-static int number_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
+static int number_string_set(void *var, struct ConfigDef *cdef,
                              const char *value, struct Buffer *err)
 {
   int num = 0;
@@ -105,7 +105,7 @@ static int number_string_set(const struct ConfigSet *cs, void *var, struct Confi
 
     if (cdef->validator)
     {
-      int rc = cdef->validator(cs, cdef, (intptr_t) num, err);
+      int rc = cdef->validator(cdef, (intptr_t) num, err);
 
       if (CSR_RESULT(rc) != CSR_SUCCESS)
         return rc | CSR_INV_VALIDATOR;
@@ -127,8 +127,7 @@ static int number_string_set(const struct ConfigSet *cs, void *var, struct Confi
 /**
  * number_string_get - Get a Number as a string - Implements ConfigSetType::string_get() - @ingroup cfg_type_string_get
  */
-static int number_string_get(const struct ConfigSet *cs, void *var,
-                             const struct ConfigDef *cdef, struct Buffer *result)
+static int number_string_get(void *var, const struct ConfigDef *cdef, struct Buffer *result)
 {
   int value;
 
@@ -144,9 +143,8 @@ static int number_string_get(const struct ConfigSet *cs, void *var,
 /**
  * number_native_set - Set a Number config item by int - Implements ConfigSetType::native_set() - @ingroup cfg_type_native_set
  */
-static int number_native_set(const struct ConfigSet *cs, void *var,
-                             const struct ConfigDef *cdef, intptr_t value,
-                             struct Buffer *err)
+static int number_native_set(void *var, const struct ConfigDef *cdef,
+                             intptr_t value, struct Buffer *err)
 {
   if ((value < SHRT_MIN) || (value > SHRT_MAX))
   {
@@ -165,7 +163,7 @@ static int number_native_set(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, value, err);
+    int rc = cdef->validator(cdef, value, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
@@ -181,8 +179,7 @@ static int number_native_set(const struct ConfigSet *cs, void *var,
 /**
  * number_native_get - Get an int from a Number config item - Implements ConfigSetType::native_get() - @ingroup cfg_type_native_get
  */
-static intptr_t number_native_get(const struct ConfigSet *cs, void *var,
-                                  const struct ConfigDef *cdef, struct Buffer *err)
+static intptr_t number_native_get(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   return native_get(var);
 }
@@ -190,8 +187,7 @@ static intptr_t number_native_get(const struct ConfigSet *cs, void *var,
 /**
  * number_string_plus_equals - Add to a Number by string - Implements ConfigSetType::string_plus_equals() - @ingroup cfg_type_string_plus_equals
  */
-static int number_string_plus_equals(const struct ConfigSet *cs, void *var,
-                                     const struct ConfigDef *cdef,
+static int number_string_plus_equals(void *var, const struct ConfigDef *cdef,
                                      const char *value, struct Buffer *err)
 {
   int num = 0;
@@ -201,7 +197,7 @@ static int number_string_plus_equals(const struct ConfigSet *cs, void *var,
     return CSR_ERR_INVALID | CSR_INV_TYPE;
   }
 
-  int result = number_native_get(NULL, var, NULL, NULL) + num;
+  int result = number_native_get(var, NULL, NULL) + num;
   if ((result < SHRT_MIN) || (result > SHRT_MAX))
   {
     buf_printf(err, _("Number is too big: %s"), value);
@@ -216,7 +212,7 @@ static int number_string_plus_equals(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, (intptr_t) result, err);
+    int rc = cdef->validator(cdef, (intptr_t) result, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
@@ -232,8 +228,7 @@ static int number_string_plus_equals(const struct ConfigSet *cs, void *var,
 /**
  * number_string_minus_equals - Subtract from a Number by string - Implements ConfigSetType::string_minus_equals() - @ingroup cfg_type_string_minus_equals
  */
-static int number_string_minus_equals(const struct ConfigSet *cs, void *var,
-                                      const struct ConfigDef *cdef,
+static int number_string_minus_equals(void *var, const struct ConfigDef *cdef,
                                       const char *value, struct Buffer *err)
 {
   int num = 0;
@@ -258,7 +253,7 @@ static int number_string_minus_equals(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, (intptr_t) result, err);
+    int rc = cdef->validator(cdef, (intptr_t) result, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
@@ -274,8 +269,7 @@ static int number_string_minus_equals(const struct ConfigSet *cs, void *var,
 /**
  * number_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
  */
-static bool number_has_been_set(const struct ConfigSet *cs, void *var,
-                                const struct ConfigDef *cdef)
+static bool number_has_been_set(void *var, const struct ConfigDef *cdef)
 {
   return (cdef->initial != native_get(var));
 }
@@ -283,15 +277,14 @@ static bool number_has_been_set(const struct ConfigSet *cs, void *var,
 /**
  * number_reset - Reset a Number to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
-static int number_reset(const struct ConfigSet *cs, void *var,
-                        const struct ConfigDef *cdef, struct Buffer *err)
+static int number_reset(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   if (cdef->initial == native_get(var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, cdef->initial, err);
+    int rc = cdef->validator(cdef, cdef->initial, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;

--- a/config/path.c
+++ b/config/path.c
@@ -75,7 +75,7 @@ static char *path_tidy(const char *path, bool is_dir)
 /**
  * path_destroy - Destroy a Path - Implements ConfigSetType::destroy() - @ingroup cfg_type_destroy
  */
-static void path_destroy(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef)
+static void path_destroy(void *var, const struct ConfigDef *cdef)
 {
   const char **str = (const char **) var;
   if (!*str)
@@ -87,8 +87,8 @@ static void path_destroy(const struct ConfigSet *cs, void *var, const struct Con
 /**
  * path_string_set - Set a Path by string - Implements ConfigSetType::string_set() - @ingroup cfg_type_string_set
  */
-static int path_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
-                           const char *value, struct Buffer *err)
+static int path_string_set(void *var, struct ConfigDef *cdef, const char *value,
+                           struct Buffer *err)
 {
   /* Store empty paths as NULL */
   if (value && (value[0] == '\0'))
@@ -112,13 +112,13 @@ static int path_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 
     if (cdef->validator)
     {
-      rc = cdef->validator(cs, cdef, (intptr_t) value, err);
+      rc = cdef->validator(cdef, (intptr_t) value, err);
 
       if (CSR_RESULT(rc) != CSR_SUCCESS)
         return rc | CSR_INV_VALIDATOR;
     }
 
-    path_destroy(cs, var, cdef);
+    path_destroy(var, cdef);
 
     const char *str = path_tidy(value, cdef->type & D_PATH_DIR);
     if (!str)
@@ -141,8 +141,7 @@ static int path_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 /**
  * path_string_get - Get a Path as a string - Implements ConfigSetType::string_get() - @ingroup cfg_type_string_get
  */
-static int path_string_get(const struct ConfigSet *cs, void *var,
-                           const struct ConfigDef *cdef, struct Buffer *result)
+static int path_string_get(void *var, const struct ConfigDef *cdef, struct Buffer *result)
 {
   const char *str = NULL;
 
@@ -161,8 +160,8 @@ static int path_string_get(const struct ConfigSet *cs, void *var,
 /**
  * path_native_set - Set a Path config item by string - Implements ConfigSetType::native_set() - @ingroup cfg_type_native_set
  */
-static int path_native_set(const struct ConfigSet *cs, void *var,
-                           const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
+static int path_native_set(void *var, const struct ConfigDef *cdef,
+                           intptr_t value, struct Buffer *err)
 {
   const char *str = (const char *) value;
 
@@ -186,13 +185,13 @@ static int path_native_set(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, value, err);
+    rc = cdef->validator(cdef, value, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
   }
 
-  path_destroy(cs, var, cdef);
+  path_destroy(var, cdef);
 
   str = path_tidy(str, cdef->type & D_PATH_DIR);
   rc = CSR_SUCCESS;
@@ -206,8 +205,7 @@ static int path_native_set(const struct ConfigSet *cs, void *var,
 /**
  * path_native_get - Get a string from a Path config item - Implements ConfigSetType::native_get() - @ingroup cfg_type_native_get
  */
-static intptr_t path_native_get(const struct ConfigSet *cs, void *var,
-                                const struct ConfigDef *cdef, struct Buffer *err)
+static intptr_t path_native_get(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   const char *str = *(const char **) var;
 
@@ -217,8 +215,7 @@ static intptr_t path_native_get(const struct ConfigSet *cs, void *var,
 /**
  * path_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
  */
-static bool path_has_been_set(const struct ConfigSet *cs, void *var,
-                              const struct ConfigDef *cdef)
+static bool path_has_been_set(void *var, const struct ConfigDef *cdef)
 {
   const char *initial = path_tidy((const char *) cdef->initial, cdef->type & D_PATH_DIR);
   const char *value = *(const char **) var;
@@ -231,8 +228,7 @@ static bool path_has_been_set(const struct ConfigSet *cs, void *var,
 /**
  * path_reset - Reset a Path to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
-static int path_reset(const struct ConfigSet *cs, void *var,
-                      const struct ConfigDef *cdef, struct Buffer *err)
+static int path_reset(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   int rc = CSR_SUCCESS;
 
@@ -254,7 +250,7 @@ static int path_reset(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, cdef->initial, err);
+    rc = cdef->validator(cdef, cdef->initial, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
     {
@@ -263,7 +259,7 @@ static int path_reset(const struct ConfigSet *cs, void *var,
     }
   }
 
-  path_destroy(cs, var, cdef);
+  path_destroy(var, cdef);
 
   if (!str)
     rc |= CSR_SUC_EMPTY;

--- a/config/quad.c
+++ b/config/quad.c
@@ -58,8 +58,8 @@ const char *QuadValues[] = {
 /**
  * quad_string_set - Set a Quad-option by string - Implements ConfigSetType::string_set() - @ingroup cfg_type_string_set
  */
-static int quad_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
-                           const char *value, struct Buffer *err)
+static int quad_string_set(void *var, struct ConfigDef *cdef, const char *value,
+                           struct Buffer *err)
 {
   if (!value)
     return CSR_ERR_CODE; /* LCOV_EXCL_LINE */
@@ -90,7 +90,7 @@ static int quad_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 
     if (cdef->validator)
     {
-      int rc = cdef->validator(cs, cdef, (intptr_t) num, err);
+      int rc = cdef->validator(cdef, (intptr_t) num, err);
 
       if (CSR_RESULT(rc) != CSR_SUCCESS)
         return rc | CSR_INV_VALIDATOR;
@@ -109,8 +109,7 @@ static int quad_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 /**
  * quad_string_get - Get a Quad-option as a string - Implements ConfigSetType::string_get() - @ingroup cfg_type_string_get
  */
-static int quad_string_get(const struct ConfigSet *cs, void *var,
-                           const struct ConfigDef *cdef, struct Buffer *result)
+static int quad_string_get(void *var, const struct ConfigDef *cdef, struct Buffer *result)
 {
   unsigned int value;
 
@@ -132,8 +131,8 @@ static int quad_string_get(const struct ConfigSet *cs, void *var,
 /**
  * quad_native_set - Set a Quad-option config item by int - Implements ConfigSetType::native_set() - @ingroup cfg_type_native_set
  */
-static int quad_native_set(const struct ConfigSet *cs, void *var,
-                           const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
+static int quad_native_set(void *var, const struct ConfigDef *cdef,
+                           intptr_t value, struct Buffer *err)
 {
   if ((value < 0) || (value >= (mutt_array_size(QuadValues) - 1)))
   {
@@ -149,7 +148,7 @@ static int quad_native_set(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, value, err);
+    int rc = cdef->validator(cdef, value, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
@@ -162,8 +161,7 @@ static int quad_native_set(const struct ConfigSet *cs, void *var,
 /**
  * quad_native_get - Get an int object from a Quad-option config item - Implements ConfigSetType::native_get() - @ingroup cfg_type_native_get
  */
-static intptr_t quad_native_get(const struct ConfigSet *cs, void *var,
-                                const struct ConfigDef *cdef, struct Buffer *err)
+static intptr_t quad_native_get(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   return *(char *) var;
 }
@@ -171,8 +169,7 @@ static intptr_t quad_native_get(const struct ConfigSet *cs, void *var,
 /**
  * quad_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
  */
-static bool quad_has_been_set(const struct ConfigSet *cs, void *var,
-                              const struct ConfigDef *cdef)
+static bool quad_has_been_set(void *var, const struct ConfigDef *cdef)
 {
   return (cdef->initial != (*(char *) var));
 }
@@ -180,8 +177,7 @@ static bool quad_has_been_set(const struct ConfigSet *cs, void *var,
 /**
  * quad_reset - Reset a Quad-option to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
-static int quad_reset(const struct ConfigSet *cs, void *var,
-                      const struct ConfigDef *cdef, struct Buffer *err)
+static int quad_reset(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   if (cdef->initial == (*(char *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
@@ -191,7 +187,7 @@ static int quad_reset(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, cdef->initial, err);
+    int rc = cdef->validator(cdef, cdef->initial, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;

--- a/config/regex.c
+++ b/config/regex.c
@@ -82,7 +82,7 @@ void regex_free(struct Regex **ptr)
 /**
  * regex_destroy - Destroy a Regex object - Implements ConfigSetType::destroy() - @ingroup cfg_type_destroy
  */
-static void regex_destroy(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef)
+static void regex_destroy(void *var, const struct ConfigDef *cdef)
 {
   struct Regex **r = var;
   if (!*r)
@@ -139,7 +139,7 @@ struct Regex *regex_new(const char *str, uint32_t flags, struct Buffer *err)
 /**
  * regex_string_set - Set a Regex by string - Implements ConfigSetType::string_set() - @ingroup cfg_type_string_set
  */
-static int regex_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
+static int regex_string_set(void *var, struct ConfigDef *cdef,
                             const char *value, struct Buffer *err)
 {
   /* Store empty regexes as NULL */
@@ -168,7 +168,7 @@ static int regex_string_set(const struct ConfigSet *cs, void *var, struct Config
 
     if (cdef->validator)
     {
-      rc = cdef->validator(cs, cdef, (intptr_t) r, err);
+      rc = cdef->validator(cdef, (intptr_t) r, err);
 
       if (CSR_RESULT(rc) != CSR_SUCCESS)
       {
@@ -177,7 +177,7 @@ static int regex_string_set(const struct ConfigSet *cs, void *var, struct Config
       }
     }
 
-    regex_destroy(cs, var, cdef);
+    regex_destroy(var, cdef);
 
     *(struct Regex **) var = r;
 
@@ -199,8 +199,7 @@ static int regex_string_set(const struct ConfigSet *cs, void *var, struct Config
 /**
  * regex_string_get - Get a Regex as a string - Implements ConfigSetType::string_get() - @ingroup cfg_type_string_get
  */
-static int regex_string_get(const struct ConfigSet *cs, void *var,
-                            const struct ConfigDef *cdef, struct Buffer *result)
+static int regex_string_get(void *var, const struct ConfigDef *cdef, struct Buffer *result)
 {
   const char *str = NULL;
 
@@ -225,8 +224,8 @@ static int regex_string_get(const struct ConfigSet *cs, void *var,
 /**
  * regex_native_set - Set a Regex config item by Regex object - Implements ConfigSetType::native_set() - @ingroup cfg_type_native_set
  */
-static int regex_native_set(const struct ConfigSet *cs, void *var,
-                            const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
+static int regex_native_set(void *var, const struct ConfigDef *cdef,
+                            intptr_t value, struct Buffer *err)
 {
   int rc;
 
@@ -238,7 +237,7 @@ static int regex_native_set(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, value, err);
+    rc = cdef->validator(cdef, value, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
@@ -272,8 +271,7 @@ static int regex_native_set(const struct ConfigSet *cs, void *var,
 /**
  * regex_native_get - Get a Regex object from a Regex config item - Implements ConfigSetType::native_get() - @ingroup cfg_type_native_get
  */
-static intptr_t regex_native_get(const struct ConfigSet *cs, void *var,
-                                 const struct ConfigDef *cdef, struct Buffer *err)
+static intptr_t regex_native_get(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   struct Regex *r = *(struct Regex **) var;
 
@@ -283,8 +281,7 @@ static intptr_t regex_native_get(const struct ConfigSet *cs, void *var,
 /**
  * regex_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
  */
-static bool regex_has_been_set(const struct ConfigSet *cs, void *var,
-                               const struct ConfigDef *cdef)
+static bool regex_has_been_set(void *var, const struct ConfigDef *cdef)
 {
   const char *initial = (const char *) cdef->initial;
 
@@ -297,8 +294,7 @@ static bool regex_has_been_set(const struct ConfigSet *cs, void *var,
 /**
  * regex_reset - Reset a Regex to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
-static int regex_reset(const struct ConfigSet *cs, void *var,
-                       const struct ConfigDef *cdef, struct Buffer *err)
+static int regex_reset(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   struct Regex *r = NULL;
   const char *initial = (const char *) cdef->initial;
@@ -325,11 +321,11 @@ static int regex_reset(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, (intptr_t) r, err);
+    rc = cdef->validator(cdef, (intptr_t) r, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
     {
-      regex_destroy(cs, &r, cdef);
+      regex_destroy(&r, cdef);
       return rc | CSR_INV_VALIDATOR;
     }
   }
@@ -337,7 +333,7 @@ static int regex_reset(const struct ConfigSet *cs, void *var,
   if (!r)
     rc |= CSR_SUC_EMPTY;
 
-  regex_destroy(cs, var, cdef);
+  regex_destroy(var, cdef);
 
   *(struct Regex **) var = r;
   return rc;

--- a/config/set.c
+++ b/config/set.c
@@ -64,7 +64,7 @@ static void cs_hashelem_free(int type, void *obj, intptr_t data)
 
     cst = cs_get_type_def(cs, he_base->type);
     if (cst && cst->destroy)
-      cst->destroy(cs, (void **) &i->var, cdef);
+      cst->destroy((void **) &i->var, cdef);
 
     FREE(&i->name);
     FREE(&i);
@@ -75,7 +75,7 @@ static void cs_hashelem_free(int type, void *obj, intptr_t data)
 
     cst = cs_get_type_def(cs, type);
     if (cst && cst->destroy)
-      cst->destroy(cs, &cdef->var, cdef);
+      cst->destroy(&cdef->var, cdef);
 
     /* If we allocated the initial value, clean it up */
     if (cdef->type & D_INTERNAL_INITIAL_SET)
@@ -268,12 +268,12 @@ struct HashElem *cs_register_variable(const struct ConfigSet *cs,
 
   // Temporarily disable the validator
   // (trust that the hard-coded initial values are sane)
-  int (*validator)(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                   intptr_t value, struct Buffer *err) = cdef->validator;
+  int (*validator)(const struct ConfigDef *cdef, intptr_t value,
+                   struct Buffer *err) = cdef->validator;
   cdef->validator = NULL;
 
   if (cst->reset)
-    cst->reset(cs, &cdef->var, cdef, err);
+    cst->reset(&cdef->var, cdef, err);
 
   cdef->validator = validator;
 
@@ -418,7 +418,7 @@ int cs_he_reset(const struct ConfigSet *cs, struct HashElem *he, struct Buffer *
 
     const struct ConfigSetType *cst = cs_get_type_def(cs, he_base->type);
     if (cst && cst->destroy)
-      cst->destroy(cs, (void **) &i->var, cdef);
+      cst->destroy((void **) &i->var, cdef);
 
     he->type = D_INTERNAL_INHERITED;
   }
@@ -430,7 +430,7 @@ int cs_he_reset(const struct ConfigSet *cs, struct HashElem *he, struct Buffer *
 
     const struct ConfigSetType *cst = cs_get_type_def(cs, he->type);
     if (cst)
-      rc = cst->reset(cs, &cdef->var, cdef, err);
+      rc = cst->reset(&cdef->var, cdef, err);
   }
 
   return rc;
@@ -480,7 +480,7 @@ bool cs_he_has_been_set(const struct ConfigSet *cs, struct HashElem *he)
   struct ConfigDef *cdef = he->data;
   void *var = &cdef->var;
 
-  return cst->has_been_set(cs, var, cdef);
+  return cst->has_been_set(var, cdef);
 }
 
 /**
@@ -537,7 +537,7 @@ int cs_he_initial_set(const struct ConfigSet *cs, struct HashElem *he,
     return CSR_ERR_CODE;
   }
 
-  int rc = cst->string_set(cs, NULL, cdef, value, err);
+  int rc = cst->string_set(NULL, cdef, value, err);
   if (CSR_RESULT(rc) != CSR_SUCCESS)
     return rc;
 
@@ -601,7 +601,7 @@ int cs_he_initial_get(const struct ConfigSet *cs, struct HashElem *he, struct Bu
   if (!cst)
     return CSR_ERR_CODE; // LCOV_EXCL_LINE
 
-  return cst->string_get(cs, NULL, cdef, result);
+  return cst->string_get(NULL, cdef, result);
 }
 
 /**
@@ -671,7 +671,7 @@ int cs_he_string_set(const struct ConfigSet *cs, struct HashElem *he,
     return CSR_ERR_CODE;
   }
 
-  int rc = cst->string_set(cs, var, cdef, value, err);
+  int rc = cst->string_set(var, cdef, value, err);
   if (CSR_RESULT(rc) != CSR_SUCCESS)
     return rc;
 
@@ -746,7 +746,7 @@ int cs_he_string_get(const struct ConfigSet *cs, struct HashElem *he, struct Buf
   if (!cdef || !cst)
     return CSR_ERR_CODE; // LCOV_EXCL_LINE
 
-  return cst->string_get(cs, var, cdef, result);
+  return cst->string_get(var, cdef, result);
 }
 
 /**
@@ -791,7 +791,7 @@ int cs_he_native_set(const struct ConfigSet *cs, struct HashElem *he,
   if (!var || !cdef)
     return CSR_ERR_CODE; // LCOV_EXCL_LINE
 
-  int rc = cst->native_set(cs, var, cdef, value, err);
+  int rc = cst->native_set(var, cdef, value, err);
   if (CSR_RESULT(rc) != CSR_SUCCESS)
     return rc;
 
@@ -844,7 +844,7 @@ int cs_str_native_set(const struct ConfigSet *cs, const char *name,
   if (!cst || !var || !cdef)
     return CSR_ERR_CODE; /* LCOV_EXCL_LINE */
 
-  int rc = cst->native_set(cs, var, cdef, value, err);
+  int rc = cst->native_set(var, cdef, value, err);
   if (CSR_RESULT(rc) != CSR_SUCCESS)
     return rc;
 
@@ -902,7 +902,7 @@ intptr_t cs_he_native_get(const struct ConfigSet *cs, struct HashElem *he, struc
     return INT_MIN;
   }
 
-  return cst->native_get(cs, var, cdef, err);
+  return cst->native_get(var, cdef, err);
 }
 
 /**
@@ -954,7 +954,7 @@ int cs_he_string_plus_equals(const struct ConfigSet *cs, struct HashElem *he,
     return CSR_ERR_INVALID | CSV_INV_NOT_IMPL;
   }
 
-  int rc = cst->string_plus_equals(cs, var, cdef, value, err);
+  int rc = cst->string_plus_equals(var, cdef, value, err);
   if (CSR_RESULT(rc) != CSR_SUCCESS)
     return rc;
 
@@ -1013,7 +1013,7 @@ int cs_he_string_minus_equals(const struct ConfigSet *cs, struct HashElem *he,
     return CSR_ERR_INVALID | CSV_INV_NOT_IMPL;
   }
 
-  int rc = cst->string_minus_equals(cs, var, cdef, value, err);
+  int rc = cst->string_minus_equals(var, cdef, value, err);
   if (CSR_RESULT(rc) != CSR_SUCCESS)
     return rc;
 

--- a/config/set.h
+++ b/config/set.h
@@ -72,14 +72,13 @@ struct ConfigDef
    * @ingroup cfg_def_api
    *
    * validator - Validate a config variable
-   * @param cs    Config items
    * @param cdef  Config definition
    * @param value Native value
    * @param err   Message for the user
    * @retval #CSR_SUCCESS     Success
    * @retval #CSR_ERR_INVALID Failure
    */
-  int (*validator)(const struct ConfigSet *cs, const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
+  int (*validator)(const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
 
   const char *docs; ///< One-liner description
   intptr_t    var;  ///< Storage for the variable
@@ -102,7 +101,6 @@ struct ConfigSetType
    * @ingroup cfg_type_api
    *
    * string_set - Set a config item by string
-   * @param cs    Config items
    * @param var   Variable to set (may be NULL)
    * @param cdef  Variable definition
    * @param value Value to set (may be NULL)
@@ -111,17 +109,15 @@ struct ConfigSetType
    *
    * If var is NULL, then the config item's initial value will be set.
    *
-   * @pre cs   is not NULL
    * @pre cdef is not NULL
    */
-  int (*string_set)(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef, const char *value, struct Buffer *err);
+  int (*string_set)(void *var, struct ConfigDef *cdef, const char *value, struct Buffer *err);
 
   /**
    * @defgroup cfg_type_string_get string_get()
    * @ingroup cfg_type_api
    *
    * string_get - Get a config item as a string
-   * @param cs     Config items
    * @param var    Variable to get (may be NULL)
    * @param cdef   Variable definition
    * @param result Buffer for results or error messages
@@ -129,132 +125,117 @@ struct ConfigSetType
    *
    * If var is NULL, then the config item's initial value will be returned.
    *
-   * @pre cs     is not NULL
    * @pre cdef   is not NULL
    * @pre result is not NULL
    */
-  int (*string_get)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, struct Buffer *result);
+  int (*string_get)(void *var, const struct ConfigDef *cdef, struct Buffer *result);
 
   /**
    * @defgroup cfg_type_native_set native_set()
    * @ingroup cfg_type_api
    *
    * native_set - Set a config item by string
-   * @param cs    Config items
    * @param var   Variable to set
    * @param cdef  Variable definition
    * @param value Native pointer/value to set
    * @param err   Buffer for error messages (may be NULL)
    * @retval num Result, e.g. #CSR_SUCCESS
    *
-   * @pre cs   is not NULL
    * @pre var  is not NULL
    * @pre cdef is not NULL
    */
-  int (*native_set)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
+  int (*native_set)(void *var, const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
 
   /**
    * @defgroup cfg_type_native_get native_get()
    * @ingroup cfg_type_api
    *
    * native_get - Get a string from a config item
-   * @param cs   Config items
    * @param var  Variable to get
    * @param cdef Variable definition
    * @param err  Buffer for error messages (may be NULL)
    * @retval intptr_t Config item string
    * @retval INT_MIN  Error
    *
-   * @pre cs   is not NULL
    * @pre var  is not NULL
    * @pre cdef is not NULL
    */
-  intptr_t (*native_get)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, struct Buffer *err);
+  intptr_t (*native_get)(void *var, const struct ConfigDef *cdef, struct Buffer *err);
 
   /**
    * @defgroup cfg_type_string_plus_equals string_plus_equals()
    * @ingroup cfg_type_api
    *
    * string_plus_equals - Add to a config item by string
-   * @param cs    Config items
    * @param var   Variable to set
    * @param cdef  Variable definition
    * @param value Value to set
    * @param err   Buffer for error messages (may be NULL)
    * @retval num Result, e.g. #CSR_SUCCESS
    *
-   * @pre cs   is not NULL
    * @pre var  is not NULL
    * @pre cdef is not NULL
    */
-  int (*string_plus_equals)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, const char *value, struct Buffer *err);
+  int (*string_plus_equals)(void *var, const struct ConfigDef *cdef, const char *value, struct Buffer *err);
 
   /**
    * @defgroup cfg_type_string_minus_equals string_minus_equals()
    * @ingroup cfg_type_api
    *
    * string_minus_equals - Remove from a config item as a string
-   * @param cs    Config items
    * @param var   Variable to set
    * @param cdef  Variable definition
    * @param value Value to set
    * @param err   Buffer for error messages (may be NULL)
    * @retval num Result, e.g. #CSR_SUCCESS
    *
-   * @pre cs   is not NULL
    * @pre var  is not NULL
    * @pre cdef is not NULL
    */
-  int (*string_minus_equals)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, const char *value, struct Buffer *err);
+  int (*string_minus_equals)(void *var, const struct ConfigDef *cdef, const char *value, struct Buffer *err);
 
   /**
    * @defgroup cfg_type_has_been_set has_been_set()
    * @ingroup cfg_type_api
    *
    * has_been_set - Is the config value different to its initial value?
-   * @param cs   Config items
    * @param var  Variable to check
    * @param cdef Variable definition
    * @retval true  Value differs from its initial value
    * @retval false Value is the same as its initial value
    *
-   * @pre cs   is not NULL
    * @pre var  is not NULL
    * @pre cdef is not NULL
    */
-  bool (*has_been_set)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef);
+  bool (*has_been_set)(void *var, const struct ConfigDef *cdef);
 
   /**
    * @defgroup cfg_type_reset reset()
    * @ingroup cfg_type_api
    *
    * reset - Reset a config item to its initial value
-   * @param cs   Config items
    * @param var  Variable to reset
    * @param cdef Variable definition
    * @param err  Buffer for error messages (may be NULL)
    * @retval num Result, e.g. #CSR_SUCCESS
    *
-   * @pre cs   is not NULL
    * @pre var  is not NULL
    * @pre cdef is not NULL
    */
-  int (*reset)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, struct Buffer *err);
+  int (*reset)(void *var, const struct ConfigDef *cdef, struct Buffer *err);
 
   /**
    * @defgroup cfg_type_destroy destroy()
    * @ingroup cfg_type_api
    *
    * destroy - Destroy a config item
-   * @param cs   Config items
    * @param var  Variable to destroy
    * @param cdef Variable definition
    *
-   * @pre cs   is not NULL
    * @pre var  is not NULL
    * @pre cdef is not NULL
    */
-  void (*destroy)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef);
+  void (*destroy)(void *var, const struct ConfigDef *cdef);
 };
 
 /**

--- a/config/slist.c
+++ b/config/slist.c
@@ -44,7 +44,7 @@
 /**
  * slist_destroy - Destroy an Slist object - Implements ConfigSetType::destroy() - @ingroup cfg_type_destroy
  */
-static void slist_destroy(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef)
+static void slist_destroy(void *var, const struct ConfigDef *cdef)
 {
   struct Slist **l = (struct Slist **) var;
   if (!*l)
@@ -56,12 +56,9 @@ static void slist_destroy(const struct ConfigSet *cs, void *var, const struct Co
 /**
  * slist_string_set - Set a Slist by string - Implements ConfigSetType::string_set() - @ingroup cfg_type_string_set
  */
-static int slist_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
+static int slist_string_set(void *var, struct ConfigDef *cdef,
                             const char *value, struct Buffer *err)
 {
-  if (!cs || !cdef)
-    return CSR_ERR_CODE; /* LCOV_EXCL_LINE */
-
   /* Store empty string list as NULL */
   if (value && (value[0] == '\0'))
     value = NULL;
@@ -88,7 +85,7 @@ static int slist_string_set(const struct ConfigSet *cs, void *var, struct Config
 
     if (cdef->validator)
     {
-      rc = cdef->validator(cs, cdef, (intptr_t) list, err);
+      rc = cdef->validator(cdef, (intptr_t) list, err);
 
       if (CSR_RESULT(rc) != CSR_SUCCESS)
       {
@@ -97,7 +94,7 @@ static int slist_string_set(const struct ConfigSet *cs, void *var, struct Config
       }
     }
 
-    slist_destroy(cs, var, cdef);
+    slist_destroy(var, cdef);
 
     *(struct Slist **) var = list;
 
@@ -119,8 +116,7 @@ static int slist_string_set(const struct ConfigSet *cs, void *var, struct Config
 /**
  * slist_string_get - Get a Slist as a string - Implements ConfigSetType::string_get() - @ingroup cfg_type_string_get
  */
-static int slist_string_get(const struct ConfigSet *cs, void *var,
-                            const struct ConfigDef *cdef, struct Buffer *result)
+static int slist_string_get(void *var, const struct ConfigDef *cdef, struct Buffer *result)
 {
   if (var)
   {
@@ -145,8 +141,8 @@ static int slist_string_get(const struct ConfigSet *cs, void *var,
 /**
  * slist_native_set - Set a Slist config item by Slist - Implements ConfigSetType::native_set() - @ingroup cfg_type_native_set
  */
-static int slist_native_set(const struct ConfigSet *cs, void *var,
-                            const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
+static int slist_native_set(void *var, const struct ConfigDef *cdef,
+                            intptr_t value, struct Buffer *err)
 {
   int rc;
 
@@ -158,7 +154,7 @@ static int slist_native_set(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, value, err);
+    rc = cdef->validator(cdef, value, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
@@ -179,8 +175,7 @@ static int slist_native_set(const struct ConfigSet *cs, void *var,
 /**
  * slist_native_get - Get a Slist from a Slist config item - Implements ConfigSetType::native_get() - @ingroup cfg_type_native_get
  */
-static intptr_t slist_native_get(const struct ConfigSet *cs, void *var,
-                                 const struct ConfigDef *cdef, struct Buffer *err)
+static intptr_t slist_native_get(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   struct Slist *list = *(struct Slist **) var;
 
@@ -190,8 +185,7 @@ static intptr_t slist_native_get(const struct ConfigSet *cs, void *var,
 /**
  * slist_string_plus_equals - Add to a Slist by string - Implements ConfigSetType::string_plus_equals() - @ingroup cfg_type_string_plus_equals
  */
-static int slist_string_plus_equals(const struct ConfigSet *cs, void *var,
-                                    const struct ConfigDef *cdef,
+static int slist_string_plus_equals(void *var, const struct ConfigDef *cdef,
                                     const char *value, struct Buffer *err)
 {
   int rc = CSR_SUCCESS;
@@ -218,7 +212,7 @@ static int slist_string_plus_equals(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, (intptr_t) copy, err);
+    rc = cdef->validator(cdef, (intptr_t) copy, err);
     if (CSR_RESULT(rc) != CSR_SUCCESS)
     {
       slist_free(&copy);
@@ -235,8 +229,7 @@ static int slist_string_plus_equals(const struct ConfigSet *cs, void *var,
 /**
  * slist_string_minus_equals - Remove from a Slist by string - Implements ConfigSetType::string_minus_equals() - @ingroup cfg_type_string_minus_equals
  */
-static int slist_string_minus_equals(const struct ConfigSet *cs, void *var,
-                                     const struct ConfigDef *cdef,
+static int slist_string_minus_equals(void *var, const struct ConfigDef *cdef,
                                      const char *value, struct Buffer *err)
 {
   int rc = CSR_SUCCESS;
@@ -260,7 +253,7 @@ static int slist_string_minus_equals(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, (intptr_t) copy, err);
+    rc = cdef->validator(cdef, (intptr_t) copy, err);
     if (CSR_RESULT(rc) != CSR_SUCCESS)
     {
       slist_free(&copy);
@@ -277,8 +270,7 @@ static int slist_string_minus_equals(const struct ConfigSet *cs, void *var,
 /**
  * slist_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
  */
-static bool slist_has_been_set(const struct ConfigSet *cs, void *var,
-                               const struct ConfigDef *cdef)
+static bool slist_has_been_set(void *var, const struct ConfigDef *cdef)
 {
   struct Slist *list = NULL;
   const char *initial = (const char *) cdef->initial;
@@ -294,8 +286,7 @@ static bool slist_has_been_set(const struct ConfigSet *cs, void *var,
 /**
  * slist_reset - Reset a Slist to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
-static int slist_reset(const struct ConfigSet *cs, void *var,
-                       const struct ConfigDef *cdef, struct Buffer *err)
+static int slist_reset(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   struct Slist *list = NULL;
   const char *initial = (const char *) cdef->initial;
@@ -319,11 +310,11 @@ static int slist_reset(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, (intptr_t) list, err);
+    rc = cdef->validator(cdef, (intptr_t) list, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
     {
-      slist_destroy(cs, &list, cdef);
+      slist_destroy(&list, cdef);
       return rc | CSR_INV_VALIDATOR;
     }
   }
@@ -331,7 +322,7 @@ static int slist_reset(const struct ConfigSet *cs, void *var,
   if (!list)
     rc |= CSR_SUC_EMPTY;
 
-  slist_destroy(cs, var, cdef);
+  slist_destroy(var, cdef);
 
   *(struct Slist **) var = list;
   return rc;

--- a/config/sort.c
+++ b/config/sort.c
@@ -47,8 +47,8 @@
 /**
  * sort_string_set - Set a Sort by string - Implements ConfigSetType::string_set() - @ingroup cfg_type_string_set
  */
-static int sort_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
-                           const char *value, struct Buffer *err)
+static int sort_string_set(void *var, struct ConfigDef *cdef, const char *value,
+                           struct Buffer *err)
 {
   intptr_t id = -1;
   uint16_t flags = 0;
@@ -101,7 +101,7 @@ static int sort_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 
     if (cdef->validator)
     {
-      int rc = cdef->validator(cs, cdef, (intptr_t) id, err);
+      int rc = cdef->validator(cdef, (intptr_t) id, err);
 
       if (CSR_RESULT(rc) != CSR_SUCCESS)
         return rc | CSR_INV_VALIDATOR;
@@ -120,8 +120,7 @@ static int sort_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 /**
  * sort_string_get - Get a Sort as a string - Implements ConfigSetType::string_get() - @ingroup cfg_type_string_get
  */
-static int sort_string_get(const struct ConfigSet *cs, void *var,
-                           const struct ConfigDef *cdef, struct Buffer *result)
+static int sort_string_get(void *var, const struct ConfigDef *cdef, struct Buffer *result)
 {
   int sort;
 
@@ -154,8 +153,8 @@ static int sort_string_get(const struct ConfigSet *cs, void *var,
 /**
  * sort_native_set - Set a Sort config item by int - Implements ConfigSetType::native_set() - @ingroup cfg_type_native_set
  */
-static int sort_native_set(const struct ConfigSet *cs, void *var,
-                           const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
+static int sort_native_set(void *var, const struct ConfigDef *cdef,
+                           intptr_t value, struct Buffer *err)
 {
   const char *str = NULL;
 
@@ -175,7 +174,7 @@ static int sort_native_set(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, value, err);
+    int rc = cdef->validator(cdef, value, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
@@ -188,8 +187,7 @@ static int sort_native_set(const struct ConfigSet *cs, void *var,
 /**
  * sort_native_get - Get an int from a Sort config item - Implements ConfigSetType::native_get() - @ingroup cfg_type_native_get
  */
-static intptr_t sort_native_get(const struct ConfigSet *cs, void *var,
-                                const struct ConfigDef *cdef, struct Buffer *err)
+static intptr_t sort_native_get(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   return *(short *) var;
 }
@@ -197,8 +195,7 @@ static intptr_t sort_native_get(const struct ConfigSet *cs, void *var,
 /**
  * sort_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
  */
-static bool sort_has_been_set(const struct ConfigSet *cs, void *var,
-                              const struct ConfigDef *cdef)
+static bool sort_has_been_set(void *var, const struct ConfigDef *cdef)
 {
   return (cdef->initial != (*(short *) var));
 }
@@ -206,8 +203,7 @@ static bool sort_has_been_set(const struct ConfigSet *cs, void *var,
 /**
  * sort_reset - Reset a Sort to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
-static int sort_reset(const struct ConfigSet *cs, void *var,
-                      const struct ConfigDef *cdef, struct Buffer *err)
+static int sort_reset(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   if (cdef->initial == (*(short *) var))
     return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
@@ -217,7 +213,7 @@ static int sort_reset(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    int rc = cdef->validator(cs, cdef, cdef->initial, err);
+    int rc = cdef->validator(cdef, cdef->initial, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;

--- a/config/string.c
+++ b/config/string.c
@@ -45,7 +45,7 @@
 /**
  * string_destroy - Destroy a String - Implements ConfigSetType::destroy() - @ingroup cfg_type_destroy
  */
-static void string_destroy(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef)
+static void string_destroy(void *var, const struct ConfigDef *cdef)
 {
   const char **str = (const char **) var;
   if (!*str)
@@ -57,7 +57,7 @@ static void string_destroy(const struct ConfigSet *cs, void *var, const struct C
 /**
  * string_string_set - Set a String by string - Implements ConfigSetType::string_set() - @ingroup cfg_type_string_set
  */
-static int string_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
+static int string_string_set(void *var, struct ConfigDef *cdef,
                              const char *value, struct Buffer *err)
 {
   /* Store empty strings as NULL */
@@ -82,13 +82,13 @@ static int string_string_set(const struct ConfigSet *cs, void *var, struct Confi
 
     if (cdef->validator)
     {
-      rc = cdef->validator(cs, cdef, (intptr_t) value, err);
+      rc = cdef->validator(cdef, (intptr_t) value, err);
 
       if (CSR_RESULT(rc) != CSR_SUCCESS)
         return rc | CSR_INV_VALIDATOR;
     }
 
-    string_destroy(cs, var, cdef);
+    string_destroy(var, cdef);
 
     const char *str = mutt_str_dup(value);
     if (!str)
@@ -111,8 +111,7 @@ static int string_string_set(const struct ConfigSet *cs, void *var, struct Confi
 /**
  * string_string_get - Get a String as a string - Implements ConfigSetType::string_get() - @ingroup cfg_type_string_get
  */
-static int string_string_get(const struct ConfigSet *cs, void *var,
-                             const struct ConfigDef *cdef, struct Buffer *result)
+static int string_string_get(void *var, const struct ConfigDef *cdef, struct Buffer *result)
 {
   const char *str = NULL;
 
@@ -131,9 +130,8 @@ static int string_string_get(const struct ConfigSet *cs, void *var,
 /**
  * string_native_set - Set a String config item by string - Implements ConfigSetType::native_set() - @ingroup cfg_type_native_set
  */
-static int string_native_set(const struct ConfigSet *cs, void *var,
-                             const struct ConfigDef *cdef, intptr_t value,
-                             struct Buffer *err)
+static int string_native_set(void *var, const struct ConfigDef *cdef,
+                             intptr_t value, struct Buffer *err)
 {
   const char *str = (const char *) value;
 
@@ -157,13 +155,13 @@ static int string_native_set(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, value, err);
+    rc = cdef->validator(cdef, value, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
   }
 
-  string_destroy(cs, var, cdef);
+  string_destroy(var, cdef);
 
   str = mutt_str_dup(str);
   rc = CSR_SUCCESS;
@@ -177,8 +175,7 @@ static int string_native_set(const struct ConfigSet *cs, void *var,
 /**
  * string_native_get - Get a string from a String config item - Implements ConfigSetType::native_get() - @ingroup cfg_type_native_get
  */
-static intptr_t string_native_get(const struct ConfigSet *cs, void *var,
-                                  const struct ConfigDef *cdef, struct Buffer *err)
+static intptr_t string_native_get(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   const char *str = *(const char **) var;
 
@@ -188,8 +185,7 @@ static intptr_t string_native_get(const struct ConfigSet *cs, void *var,
 /**
  * string_string_plus_equals - Add to a String by string - Implements ConfigSetType::string_plus_equals() - @ingroup cfg_type_string_plus_equals
  */
-static int string_string_plus_equals(const struct ConfigSet *cs, void *var,
-                                     const struct ConfigDef *cdef,
+static int string_string_plus_equals(void *var, const struct ConfigDef *cdef,
                                      const char *value, struct Buffer *err)
 {
   /* Skip if the value is missing or empty string*/
@@ -211,7 +207,7 @@ static int string_string_plus_equals(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, (intptr_t) str, err);
+    rc = cdef->validator(cdef, (intptr_t) str, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
     {
@@ -220,7 +216,7 @@ static int string_string_plus_equals(const struct ConfigSet *cs, void *var,
     }
   }
 
-  string_destroy(cs, var, cdef);
+  string_destroy(var, cdef);
   *var_str = str;
 
   return rc;
@@ -229,8 +225,7 @@ static int string_string_plus_equals(const struct ConfigSet *cs, void *var,
 /**
  * string_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
  */
-static bool string_has_been_set(const struct ConfigSet *cs, void *var,
-                                const struct ConfigDef *cdef)
+static bool string_has_been_set(void *var, const struct ConfigDef *cdef)
 {
   const char *initial = (const char *) cdef->initial;
   const char *value = *(const char **) var;
@@ -241,8 +236,7 @@ static bool string_has_been_set(const struct ConfigSet *cs, void *var,
 /**
  * string_reset - Reset a String to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
-static int string_reset(const struct ConfigSet *cs, void *var,
-                        const struct ConfigDef *cdef, struct Buffer *err)
+static int string_reset(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   int rc = CSR_SUCCESS;
 
@@ -264,7 +258,7 @@ static int string_reset(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, cdef->initial, err);
+    rc = cdef->validator(cdef, cdef->initial, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
     {
@@ -273,7 +267,7 @@ static int string_reset(const struct ConfigSet *cs, void *var,
     }
   }
 
-  string_destroy(cs, var, cdef);
+  string_destroy(var, cdef);
 
   if (!str)
     rc |= CSR_SUC_EMPTY;

--- a/expando/config_type.c
+++ b/expando/config_type.c
@@ -46,7 +46,7 @@
 /**
  * expando_destroy - Destroy an Expando object - Implements ConfigSetType::destroy() - @ingroup cfg_type_destroy
  */
-static void expando_destroy(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef)
+static void expando_destroy(void *var, const struct ConfigDef *cdef)
 {
   struct Expando **a = var;
   if (!*a)
@@ -58,7 +58,7 @@ static void expando_destroy(const struct ConfigSet *cs, void *var, const struct 
 /**
  * expando_string_set - Set an Expando by string - Implements ConfigSetType::string_set() - @ingroup cfg_type_string_set
  */
-static int expando_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
+static int expando_string_set(void *var, struct ConfigDef *cdef,
                               const char *value, struct Buffer *err)
 {
   /* Store empty string list as NULL */
@@ -101,7 +101,7 @@ static int expando_string_set(const struct ConfigSet *cs, void *var, struct Conf
 
     if (cdef->validator)
     {
-      rc = cdef->validator(cs, cdef, (intptr_t) exp, err);
+      rc = cdef->validator(cdef, (intptr_t) exp, err);
 
       if (CSR_RESULT(rc) != CSR_SUCCESS)
       {
@@ -110,7 +110,7 @@ static int expando_string_set(const struct ConfigSet *cs, void *var, struct Conf
       }
     }
 
-    expando_destroy(cs, var, cdef);
+    expando_destroy(var, cdef);
 
     *(struct Expando **) var = exp;
 
@@ -132,8 +132,7 @@ static int expando_string_set(const struct ConfigSet *cs, void *var, struct Conf
 /**
  * expando_string_get - Get an Expando as a string - Implements ConfigSetType::string_get() - @ingroup cfg_type_string_get
  */
-static int expando_string_get(const struct ConfigSet *cs, void *var,
-                              const struct ConfigDef *cdef, struct Buffer *result)
+static int expando_string_get(void *var, const struct ConfigDef *cdef, struct Buffer *result)
 {
   const char *str = NULL;
 
@@ -158,9 +157,8 @@ static int expando_string_get(const struct ConfigSet *cs, void *var,
 /**
  * expando_native_set - Set an Expando object from an Expando config item - Implements ConfigSetType::native_get() - @ingroup cfg_type_native_get
  */
-static int expando_native_set(const struct ConfigSet *cs, void *var,
-                              const struct ConfigDef *cdef, intptr_t value,
-                              struct Buffer *err)
+static int expando_native_set(void *var, const struct ConfigDef *cdef,
+                              intptr_t value, struct Buffer *err)
 {
   int rc;
 
@@ -180,7 +178,7 @@ static int expando_native_set(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, value, err);
+    rc = cdef->validator(cdef, value, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
       return rc | CSR_INV_VALIDATOR;
@@ -208,8 +206,7 @@ static int expando_native_set(const struct ConfigSet *cs, void *var,
 /**
  * expando_native_get - Get an Expando object from an Expando config item - Implements ConfigSetType::native_get() - @ingroup cfg_type_native_get
  */
-static intptr_t expando_native_get(const struct ConfigSet *cs, void *var,
-                                   const struct ConfigDef *cdef, struct Buffer *err)
+static intptr_t expando_native_get(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   struct Expando *exp = *(struct Expando **) var;
 
@@ -219,8 +216,7 @@ static intptr_t expando_native_get(const struct ConfigSet *cs, void *var,
 /**
  * expando_string_plus_equals - Add to an Expando by string - Implements ConfigSetType::string_plus_equals() - @ingroup cfg_type_string_plus_equals
  */
-static int expando_string_plus_equals(const struct ConfigSet *cs, void *var,
-                                      const struct ConfigDef *cdef,
+static int expando_string_plus_equals(void *var, const struct ConfigDef *cdef,
                                       const char *value, struct Buffer *err)
 {
   /* Skip if the value is missing or empty string*/
@@ -261,7 +257,7 @@ static int expando_string_plus_equals(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, (intptr_t) exp_new, err);
+    rc = cdef->validator(cdef, (intptr_t) exp_new, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
     {
@@ -270,7 +266,7 @@ static int expando_string_plus_equals(const struct ConfigSet *cs, void *var,
     }
   }
 
-  expando_destroy(cs, var, cdef);
+  expando_destroy(var, cdef);
   *(struct Expando **) var = exp_new;
 
   return rc;
@@ -279,8 +275,7 @@ static int expando_string_plus_equals(const struct ConfigSet *cs, void *var,
 /**
  * expando_has_been_set - Is the config value different to its initial value? - Implements ConfigSetType::has_been_set() - @ingroup cfg_type_has_been_set
  */
-static bool expando_has_been_set(const struct ConfigSet *cs, void *var,
-                                 const struct ConfigDef *cdef)
+static bool expando_has_been_set(void *var, const struct ConfigDef *cdef)
 {
   const char *initial = (const char *) cdef->initial;
 
@@ -293,8 +288,7 @@ static bool expando_has_been_set(const struct ConfigSet *cs, void *var,
 /**
  * expando_reset - Reset an Expando to its initial value - Implements ConfigSetType::reset() - @ingroup cfg_type_reset
  */
-static int expando_reset(const struct ConfigSet *cs, void *var,
-                         const struct ConfigDef *cdef, struct Buffer *err)
+static int expando_reset(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   struct Expando *exp = NULL;
   const char *initial = (const char *) cdef->initial;
@@ -322,11 +316,11 @@ static int expando_reset(const struct ConfigSet *cs, void *var,
 
   if (cdef->validator)
   {
-    rc = cdef->validator(cs, cdef, (intptr_t) exp, err);
+    rc = cdef->validator(cdef, (intptr_t) exp, err);
 
     if (CSR_RESULT(rc) != CSR_SUCCESS)
     {
-      expando_destroy(cs, &exp, cdef);
+      expando_destroy(&exp, cdef);
       return rc | CSR_INV_VALIDATOR;
     }
   }
@@ -334,7 +328,7 @@ static int expando_reset(const struct ConfigSet *cs, void *var,
   if (!exp)
     rc |= CSR_SUC_EMPTY;
 
-  expando_destroy(cs, var, cdef);
+  expando_destroy(var, cdef);
 
   *(struct Expando **) var = exp;
   return rc;

--- a/hcache/config.c
+++ b/hcache/config.c
@@ -41,8 +41,7 @@
 /**
  * hcache_validator - Validate the "header_cache_backend" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator
  */
-static int hcache_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                            intptr_t value, struct Buffer *err)
+static int hcache_validator(const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
 {
 #ifdef USE_HCACHE
   if (value == 0)
@@ -64,8 +63,7 @@ static int hcache_validator(const struct ConfigSet *cs, const struct ConfigDef *
 /**
  * compress_method_validator - Validate the "header_cache_compress_method" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator
  */
-static int compress_method_validator(const struct ConfigSet *cs,
-                                     const struct ConfigDef *cdef,
+static int compress_method_validator(const struct ConfigDef *cdef,
                                      intptr_t value, struct Buffer *err)
 {
 #ifdef USE_HCACHE_COMPRESSION
@@ -87,7 +85,7 @@ static int compress_method_validator(const struct ConfigSet *cs,
 /**
  * compress_level_validator - Validate the "header_cache_compress_level" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator
  */
-static int compress_level_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
+static int compress_level_validator(const struct ConfigDef *cdef,
                                     intptr_t value, struct Buffer *err)
 {
 #ifdef USE_HCACHE_COMPRESSION

--- a/imap/config.c
+++ b/imap/config.c
@@ -42,8 +42,7 @@
 /**
  * imap_auth_validator - Validate the "imap_authenticators" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator
  */
-static int imap_auth_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                               intptr_t value, struct Buffer *err)
+static int imap_auth_validator(const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
 {
   const struct Slist *imap_auth_methods = (const struct Slist *) value;
   if (!imap_auth_methods || (imap_auth_methods->count == 0))

--- a/maildir/config.c
+++ b/maildir/config.c
@@ -41,8 +41,7 @@
  *
  * Ensure maildir_field_delimiter is a single non-alphanumeric non-(-.\/) character.
  */
-static int maildir_field_delimiter_validator(const struct ConfigSet *cs,
-                                             const struct ConfigDef *cdef,
+static int maildir_field_delimiter_validator(const struct ConfigDef *cdef,
                                              intptr_t value, struct Buffer *err)
 {
   const char *delim = (const char *) value;

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -108,8 +108,7 @@ const struct Mapping SortMethods[] = {
 /**
  * multipart_validator - Validate the "show_multipart_alternative" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator
  */
-static int multipart_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                               intptr_t value, struct Buffer *err)
+static int multipart_validator(const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
 {
   if (value == 0)
     return CSR_SUCCESS;

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -267,8 +267,7 @@ int mutt_log_start(void)
 /**
  * level_validator - Validate the "debug_level" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator
  */
-int level_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                    intptr_t value, struct Buffer *err)
+int level_validator(const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
 {
   if ((value < 0) || (value >= LL_MAX))
   {

--- a/mutt_logging.h
+++ b/mutt_logging.h
@@ -41,7 +41,7 @@ int  mutt_log_set_level(enum LogLevel level, bool verbose);
 int  mutt_log_set_file(const char *file);
 
 int  main_log_observer(struct NotifyCallback *nc);
-int  level_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
+int  level_validator(const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
 
 void mutt_clear_error(void);
 

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -104,8 +104,7 @@ const char *get_use_threads_str(enum UseThreads value)
 /**
  * sort_validator - Validate the "sort" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator
  */
-int sort_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                   intptr_t value, struct Buffer *err)
+int sort_validator(const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
 {
   if (((value & SORT_MASK) == EMAIL_SORT_THREADS) && (value & SORT_LAST))
   {

--- a/mutt_thread.h
+++ b/mutt_thread.h
@@ -113,8 +113,7 @@ int mutt_traverse_thread(struct Email *e, MuttThreadFlags flag);
 enum UseThreads mutt_thread_style(void);
 #define mutt_using_threads() (mutt_thread_style() > UT_FLAT)
 const char *get_use_threads_str(enum UseThreads value);
-int sort_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                   intptr_t value, struct Buffer *err);
+int sort_validator(const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
 
 int mutt_aside_thread(struct Email *e, bool forwards, bool subthreads);
 #define mutt_next_thread(e)        mutt_aside_thread(e, true,  false)

--- a/notmuch/config.c
+++ b/notmuch/config.c
@@ -55,7 +55,7 @@ static bool is_valid_notmuch_url(const char *url)
  *
  * Ensure nm_default_url is of the form notmuch://[absolute path]
  */
-static int nm_default_url_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
+static int nm_default_url_validator(const struct ConfigDef *cdef,
                                     intptr_t value, struct Buffer *err)
 {
 #ifdef USE_NOTMUCH
@@ -81,8 +81,7 @@ static int nm_default_url_validator(const struct ConfigSet *cs, const struct Con
  * - month
  * - year
  */
-static int nm_query_window_timebase_validator(const struct ConfigSet *cs,
-                                              const struct ConfigDef *cdef,
+static int nm_query_window_timebase_validator(const struct ConfigDef *cdef,
                                               intptr_t value, struct Buffer *err)
 {
 #ifdef USE_NOTMUCH

--- a/pop/config.c
+++ b/pop/config.c
@@ -42,8 +42,7 @@
 /**
  * pop_auth_validator - Validate the "pop_authenticators" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator
  */
-static int pop_auth_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                              intptr_t value, struct Buffer *err)
+static int pop_auth_validator(const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
 {
   const struct Slist *pop_auth_methods = (const struct Slist *) value;
   if (!pop_auth_methods || (pop_auth_methods->count == 0))

--- a/send/config.c
+++ b/send/config.c
@@ -55,8 +55,8 @@ extern const struct ExpandoDefinition NntpFormatDef[];
 /**
  * wrapheaders_validator - Validate the "wrap_headers" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator
  */
-static int wrapheaders_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                                 intptr_t value, struct Buffer *err)
+static int wrapheaders_validator(const struct ConfigDef *cdef, intptr_t value,
+                                 struct Buffer *err)
 {
   const int min_length = 78; // Recommendations from RFC5233
   const int max_length = 998;
@@ -73,8 +73,7 @@ static int wrapheaders_validator(const struct ConfigSet *cs, const struct Config
 /**
  * smtp_auth_validator - Validate the "smtp_authenticators" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator
  */
-static int smtp_auth_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                               intptr_t value, struct Buffer *err)
+static int smtp_auth_validator(const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
 {
   const struct Slist *smtp_auth_methods = (const struct Slist *) value;
   if (!smtp_auth_methods || (smtp_auth_methods->count == 0))
@@ -99,7 +98,7 @@ static int smtp_auth_validator(const struct ConfigSet *cs, const struct ConfigDe
 /**
  * simple_command_validator - Validate the "sendmail" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator
  */
-static int simple_command_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
+static int simple_command_validator(const struct ConfigDef *cdef,
                                     intptr_t value, struct Buffer *err)
 {
   // Check for shell metacharacters that won't do what the user expects

--- a/test/config/common.c
+++ b/test/config/common.c
@@ -41,8 +41,7 @@ const char *divider_line = "----------------------------------------------------
 
 bool dont_fail = false;
 
-int validator_fail(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                   intptr_t value, struct Buffer *result)
+int validator_fail(const struct ConfigDef *cdef, intptr_t value, struct Buffer *result)
 {
   if (dont_fail)
     return CSR_SUCCESS;
@@ -54,8 +53,7 @@ int validator_fail(const struct ConfigSet *cs, const struct ConfigDef *cdef,
   return CSR_ERR_INVALID;
 }
 
-int validator_warn(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                   intptr_t value, struct Buffer *result)
+int validator_warn(const struct ConfigDef *cdef, intptr_t value, struct Buffer *result)
 {
   if (value > 1000000)
     buf_printf(result, "%s: %s, (ptr)", __func__, cdef->name);
@@ -64,8 +62,7 @@ int validator_warn(const struct ConfigSet *cs, const struct ConfigDef *cdef,
   return CSR_SUCCESS | CSR_SUC_WARNING;
 }
 
-int validator_succeed(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                      intptr_t value, struct Buffer *result)
+int validator_succeed(const struct ConfigDef *cdef, intptr_t value, struct Buffer *result)
 {
   if (value > 1000000)
     buf_printf(result, "%s: %s, (ptr)", __func__, cdef->name);
@@ -167,7 +164,7 @@ void cs_dump_set(const struct ConfigSet *cs)
     buf_reset(result);
     struct ConfigDef *cdef = he->data;
 
-    int rc = cst->string_get(cs, &cdef->var, cdef, result);
+    int rc = cst->string_get(&cdef->var, cdef, result);
     if (CSR_RESULT(rc) == CSR_SUCCESS)
       snprintf(tmp, sizeof(tmp), "%s %s = %s", cst->name, name, buf_string(result));
     else

--- a/test/config/common.h
+++ b/test/config/common.h
@@ -49,9 +49,9 @@ extern const struct ConfigSetType CstSlist;
 extern const struct ConfigSetType CstSort;
 extern const struct ConfigSetType CstString;
 
-int validator_succeed(const struct ConfigSet *cs, const struct ConfigDef *cdef, intptr_t value, struct Buffer *result);
-int validator_warn   (const struct ConfigSet *cs, const struct ConfigDef *cdef, intptr_t value, struct Buffer *result);
-int validator_fail   (const struct ConfigSet *cs, const struct ConfigDef *cdef, intptr_t value, struct Buffer *result);
+int validator_succeed(const struct ConfigDef *cdef, intptr_t value, struct Buffer *result);
+int validator_warn   (const struct ConfigDef *cdef, intptr_t value, struct Buffer *result);
+int validator_fail   (const struct ConfigDef *cdef, intptr_t value, struct Buffer *result);
 
 void log_line(const char *fn);
 void short_line(void);

--- a/test/config/set.c
+++ b/test/config/set.c
@@ -42,55 +42,51 @@ static struct ConfigDef Vars[] = {
 };
 // clang-format on
 
-static int dummy_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
+static int dummy_string_set(void *var, struct ConfigDef *cdef,
                             const char *value, struct Buffer *err)
 {
   return CSR_ERR_CODE;
 }
 
-static int dummy_string_get(const struct ConfigSet *cs, void *var,
-                            const struct ConfigDef *cdef, struct Buffer *result)
+static int dummy_string_get(void *var, const struct ConfigDef *cdef, struct Buffer *result)
 {
   return CSR_ERR_CODE;
 }
 
-static int dummy_native_set(const struct ConfigSet *cs, void *var,
-                            const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
+static int dummy_native_set(void *var, const struct ConfigDef *cdef,
+                            intptr_t value, struct Buffer *err)
 {
   return CSR_ERR_CODE;
 }
 
-static intptr_t dummy_native_get(const struct ConfigSet *cs, void *var,
-                                 const struct ConfigDef *cdef, struct Buffer *err)
+static intptr_t dummy_native_get(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   return INT_MIN;
 }
 
-int dummy_plus_equals(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef,
+int dummy_plus_equals(void *var, const struct ConfigDef *cdef,
                       const char *value, struct Buffer *err)
 {
   return CSR_ERR_CODE;
 }
 
-int dummy_minus_equals(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef,
+int dummy_minus_equals(void *var, const struct ConfigDef *cdef,
                        const char *value, struct Buffer *err)
 {
   return CSR_ERR_CODE;
 }
 
-static bool dummy_has_been_set(const struct ConfigSet *cs, void *var,
-                               const struct ConfigDef *cdef)
+static bool dummy_has_been_set(void *var, const struct ConfigDef *cdef)
 {
   return false;
 }
 
-static int dummy_reset(const struct ConfigSet *cs, void *var,
-                       const struct ConfigDef *cdef, struct Buffer *err)
+static int dummy_reset(void *var, const struct ConfigDef *cdef, struct Buffer *err)
 {
   return CSR_ERR_CODE;
 }
 
-void dummy_destroy(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef)
+void dummy_destroy(void *var, const struct ConfigDef *cdef)
 {
 }
 

--- a/test/expando/config.c
+++ b/test/expando/config.c
@@ -35,12 +35,9 @@
 
 extern bool dont_fail;
 
-int validator_fail(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                   intptr_t value, struct Buffer *result);
-int validator_warn(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                   intptr_t value, struct Buffer *result);
-int validator_succeed(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                      intptr_t value, struct Buffer *result);
+int validator_fail(const struct ConfigDef *cdef, intptr_t value, struct Buffer *result);
+int validator_warn(const struct ConfigDef *cdef, intptr_t value, struct Buffer *result);
+int validator_succeed(const struct ConfigDef *cdef, intptr_t value, struct Buffer *result);
 int log_observer(struct NotifyCallback *nc);
 void set_list(const struct ConfigSet *cs);
 void log_line(const char *fn);


### PR DESCRIPTION
The types, such as number or string, only deal with a single config item.
They don't need access to the ConfigSet.