### PR TITLE
array: foreach_reverse()

### DIFF
--- a/debug/pager.c
+++ b/debug/pager.c
@@ -40,7 +40,7 @@ void dump_text_syntax_array(struct TextSyntaxArray *tsa)
   if (!tsa || ARRAY_EMPTY(tsa))
     return;
 
-  mutt_debug(LL_DEBUG1, "\tsyntax: %ld\n", ARRAY_SIZE(tsa));
+  mutt_debug(LL_DEBUG1, "\tsyntax: %d\n", ARRAY_SIZE(tsa));
 
   struct TextSyntax *ts = NULL;
   ARRAY_FOREACH(ts, tsa)

--- a/mutt/array.h
+++ b/mutt/array.h
@@ -256,6 +256,57 @@
        ARRAY_FOREACH_IDX_##elem++)
 
 /**
+ * ARRAY_FOREACH_REVERSE - Iterate backwards over all elements of the array
+ * @param elem Variable to be used as pointer to the element at each iteration
+ * @param head Pointer to a struct defined using ARRAY_HEAD()
+ * 
+ * @note Range: (ARRAY_SIZE(head)-1) .. 0
+ */
+#define ARRAY_FOREACH_REVERSE(elem, head)                                      \
+  ARRAY_FOREACH_REVERSE_FROM_TO(elem, (head), (head)->size, 0)
+
+/**
+ * ARRAY_FOREACH_REVERSE_FROM - Iterate from an index to the beginning
+ * @param elem Variable to be used as pointer to the element at each iteration
+ * @param head Pointer to a struct defined using ARRAY_HEAD()
+ * @param from Starting index (exclusive)
+ *
+ * @note Range: (from-1) .. 0
+ * @note 'from' must be between 0 and ARRAY_SIZE(head)
+ */
+#define ARRAY_FOREACH_REVERSE_FROM(elem, head, from)                           \
+  ARRAY_FOREACH_REVERSE_FROM_TO(elem, (head), (from), 0)
+
+/**
+ * ARRAY_FOREACH_REVERSE_TO - Iterate from the end to an index
+ * @param elem Variable to be used as pointer to the element at each iteration
+ * @param head Pointer to a struct defined using ARRAY_HEAD()
+ * @param to   Terminating index (inclusive)
+ *
+ * @note Range: (ARRAY_SIZE(head)-1) .. to
+ * @note 'to' must be between 0 and ARRAY_SIZE(head)
+ */
+#define ARRAY_FOREACH_REVERSE_TO(elem, head, to)                               \
+  ARRAY_FOREACH_REVERSE_FROM_TO(elem, (head), (head)->size, (to))
+
+/**
+ * ARRAY_FOREACH_REVERSE_FROM_TO - Iterate between two indexes
+ * @param elem Variable to be used as pointer to the element at each iteration
+ * @param head Pointer to a struct defined using ARRAY_HEAD()
+ * @param from Starting index (exclusive)
+ * @param to   Terminating index (inclusive)
+ *
+ * @note Range: (from-1) .. to
+ * @note 'from' and 'to' must be between 0 and ARRAY_SIZE(head).
+ * @note 'from' must not be smaller than 'to'.
+ */
+#define ARRAY_FOREACH_REVERSE_FROM_TO(elem, head, from, to)                    \
+  for (size_t ARRAY_FOREACH_IDX_##elem = (from) - 1;                           \
+       (ARRAY_FOREACH_IDX_##elem >= (to)) &&                                   \
+       (elem = ARRAY_GET((head), ARRAY_FOREACH_IDX_##elem));                   \
+       ARRAY_FOREACH_IDX_##elem--)
+
+/**
  * ARRAY_IDX - Return the index of an element of the array
  * @param head Pointer to a struct defined using ARRAY_HEAD()
  * @param elem Pointer to an element of the array

--- a/mutt/array.h
+++ b/mutt/array.h
@@ -47,8 +47,8 @@
 #define ARRAY_HEAD(name, type)                                                 \
   struct name                                                                  \
   {                                                                            \
-    size_t size;     /**< Number of items in the array */                      \
-    size_t capacity; /**< Maximum number of items in the array */              \
+    int size;        /**< Number of items in the array */                      \
+    int capacity;    /**< Maximum number of items in the array */              \
     type *entries;   /**< A C array of the items */                            \
   }
 
@@ -107,7 +107,7 @@
  *       explicitly set. In that case, the memory returned is all zeroes.
  */
 #define ARRAY_GET(head, idx)                                                   \
-  ((head)->size > (idx) ? &(head)->entries[(idx)] : NULL)
+  ((idx >= 0) && ((head)->size > (idx)) ? &(head)->entries[(idx)] : NULL)
 
 /**
  * ARRAY_SET - Set an element in the array
@@ -250,7 +250,7 @@
  * @note 'from' must not be bigger than 'to'.
  */
 #define ARRAY_FOREACH_FROM_TO(elem, head, from, to)                            \
-  for (size_t ARRAY_FOREACH_IDX_##elem = (from);                               \
+  for (int ARRAY_FOREACH_IDX_##elem = (from);                                  \
        (ARRAY_FOREACH_IDX_##elem < (to)) &&                                    \
        (elem = ARRAY_GET((head), ARRAY_FOREACH_IDX_##elem));                   \
        ARRAY_FOREACH_IDX_##elem++)
@@ -301,7 +301,7 @@
  * @note 'from' must not be smaller than 'to'.
  */
 #define ARRAY_FOREACH_REVERSE_FROM_TO(elem, head, from, to)                    \
-  for (size_t ARRAY_FOREACH_IDX_##elem = (from) - 1;                           \
+  for (int ARRAY_FOREACH_IDX_##elem = (from) - 1;                              \
        (ARRAY_FOREACH_IDX_##elem >= (to)) &&                                   \
        (elem = ARRAY_GET((head), ARRAY_FOREACH_IDX_##elem));                   \
        ARRAY_FOREACH_IDX_##elem--)

--- a/mutt/array.h
+++ b/mutt/array.h
@@ -208,6 +208,8 @@
  * ARRAY_FOREACH - Iterate over all elements of the array
  * @param elem Variable to be used as pointer to the element at each iteration
  * @param head Pointer to a struct defined using ARRAY_HEAD()
+ * 
+ * @note Range: 0 .. (ARRAY_SIZE(head)-1)
  */
 #define ARRAY_FOREACH(elem, head)                                              \
   ARRAY_FOREACH_FROM_TO(elem, (head), 0, (head)->size)
@@ -218,7 +220,8 @@
  * @param head Pointer to a struct defined using ARRAY_HEAD()
  * @param from Starting index (inclusive)
  *
- * @note The from index must be between 0 and ARRAY_SIZE(head)
+ * @note Range: from .. (ARRAY_SIZE(head)-1)
+ * @note 'from' must be between 0 and ARRAY_SIZE(head)
  */
 #define ARRAY_FOREACH_FROM(elem, head, from)                                   \
   ARRAY_FOREACH_FROM_TO(elem, (head), (from), (head)->size)
@@ -229,7 +232,8 @@
  * @param head Pointer to a struct defined using ARRAY_HEAD()
  * @param to   Terminating index (exclusive)
  *
- * @note The to index must be between 0 and ARRAY_SIZE(head)
+ * @note Range: 0 .. (to-1)
+ * @note 'to' must be between 0 and ARRAY_SIZE(head)
  */
 #define ARRAY_FOREACH_TO(elem, head, to)                                       \
   ARRAY_FOREACH_FROM_TO(elem, (head), 0, (to))
@@ -241,8 +245,9 @@
  * @param from Starting index (inclusive)
  * @param to   Terminating index (exclusive)
  *
- * @note The from and to indexes must be between 0 and ARRAY_SIZE(head);
- *       the from index must not be bigger than to index.
+ * @note Range: from .. (to-1)
+ * @note 'from' and 'to' must be between 0 and ARRAY_SIZE(head).
+ * @note 'from' must not be bigger than 'to'.
  */
 #define ARRAY_FOREACH_FROM_TO(elem, head, from, to)                            \
   for (size_t ARRAY_FOREACH_IDX_##elem = (from);                               \

--- a/test/array/mutt_array_api.c
+++ b/test/array/mutt_array_api.c
@@ -329,6 +329,80 @@ void test_mutt_array_api(void)
     }
   }
 
+  /* Reverse Iteration */
+  {
+    struct Dummy *elem = NULL;
+    size_t count = ARRAY_SIZE(&d);
+    size_t i = count - 1;
+    ARRAY_FOREACH_REVERSE(elem, &d)
+    {
+      if (!TEST_CHECK(elem == ARRAY_GET(&d, i)))
+      {
+        TEST_MSG("Expected: %lp", ARRAY_GET(&d, i));
+        TEST_MSG("Actual  : %lp", elem);
+      }
+      i--;
+    }
+  }
+
+  /* Partial reverse iteration - from */
+  {
+    struct Dummy *elem = NULL;
+    size_t from = 4;
+    ARRAY_FOREACH_REVERSE_FROM(elem, &d, from)
+    {
+      if (!TEST_CHECK(elem == ARRAY_GET(&d, from - 1)))
+      {
+        TEST_MSG("Expected: %lp", ARRAY_GET(&d, from - 1));
+        TEST_MSG("Actual  : %lp", elem);
+      }
+      from--;
+    }
+  }
+
+  /* Partial reverse iteration - to */
+  {
+    struct Dummy *elem = NULL;
+    size_t count = ARRAY_SIZE(&d);
+    size_t i = count - 1;
+    size_t to = 10;
+    ARRAY_FOREACH_REVERSE_TO(elem, &d, to)
+    {
+      if (!TEST_CHECK(elem == ARRAY_GET(&d, i)))
+      {
+        TEST_MSG("Expected: %lp", ARRAY_GET(&d, i));
+        TEST_MSG("Actual  : %lp", elem);
+      }
+      i--;
+    }
+    if (!TEST_CHECK(i == (to - 1)))
+    {
+      TEST_MSG("Expected: %zu", to - 1);
+      TEST_MSG("Actual  : %zu", i);
+    }
+  }
+
+  /* Partial reverse iteration - from+to */
+  {
+    struct Dummy *elem = NULL;
+    size_t from = 10;
+    size_t to = 4;
+    ARRAY_FOREACH_REVERSE_FROM_TO(elem, &d, from, to)
+    {
+      if (!TEST_CHECK(elem == ARRAY_GET(&d, from - 1)))
+      {
+        TEST_MSG("Expected: %lp", ARRAY_GET(&d, from - 1));
+        TEST_MSG("Actual  : %lp", elem);
+      }
+      from--;
+    }
+    if (!TEST_CHECK(from == to))
+    {
+      TEST_MSG("Expected: %zu", to);
+      TEST_MSG("Actual  : %zu", from);
+    }
+  }
+
   /* Sorting */
   {
     struct DummyArray empty = ARRAY_HEAD_INITIALIZER;


### PR DESCRIPTION
Add new ARRAY functions to iterate backwards.

- `ARRAY_FOREACH_REVERSE(elem, head)`
- `ARRAY_FOREACH_REVERSE_FROM(elem, head, from)`
- `ARRAY_FOREACH_REVERSE_TO(elem, head, to)`
- `ARRAY_FOREACH_REVERSE_FROM_TO(elem, head, from, to)`

I'd like to add these for my (so-far-mythical) Simple Pager.

---

The first commit adds functions and tests.
Unfortunately, they trigger a build warning:
```
warning: comparison of unsigned expression in ‘>= 0’ is always true [-Wtype-limits]
```

This comes from a test: `(ARRAY_FOREACH_IDX_##elem >= (to))` where `to` is 0.
`-Wtype-limits` is enabled by `-Wextra`.

---

The second commit changes a couple of types from `size_t` to `int`.
This works around the build warning.