### PR TITLE
Change description of verify-key to be crypto-scheme agnostic

### DIFF
--- a/gui/opcodes.h
+++ b/gui/opcodes.h
@@ -934,7 +934,7 @@ const char *opcodes_get_name       (int op);
   /* L10N: Help screen description for OP_VERIFY_KEY */ \
   /*       GPGME Key Selection Dialog: <op_verify_key> */ \
   /*       PGP Key Selection Dialog: <op_verify_key> */ \
-  _fmt(OP_VERIFY_KEY,                         N_("verify a PGP public key")) \
+  _fmt(OP_VERIFY_KEY,                         N_("verify a public key")) \
   /* L10N: Help screen description for OP_VIEW_ID */ \
   /*       GPGME Key Selection Dialog: <op_view_id> */ \
   /*       PGP Key Selection Dialog: <op_view_id> */ \

--- a/po/bg.po
+++ b/po/bg.po
@@ -4204,8 +4204,9 @@ msgstr "изпраща PGP публичен ключ"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "потвърждава PGP публичен ключ"
+#, fuzzy
+msgid "verify a public key"
+msgstr "потвърждава публичен ключ"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/ca.po
+++ b/po/ca.po
@@ -4256,8 +4256,9 @@ msgstr "Envia una clau pública PGP."
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "Verifica una clau pública PGP."
+#, fuzzy
+msgid "verify a public key"
+msgstr "Verifica una clau pública ."
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/cs.po
+++ b/po/cs.po
@@ -4076,8 +4076,9 @@ msgstr "odeslat veřejný klíč PGP"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "ověřit veřejný klíč PGP"
+#, fuzzy
+msgid "verify a public key"
+msgstr "ověřit veřejný klíč "
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/da.po
+++ b/po/da.po
@@ -4164,8 +4164,9 @@ msgstr "send en offentlig PGP-nøgle"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "verificér en offentlig PGP-nøgle"
+#, fuzzy
+msgid "verify a public key"
+msgstr "verificér en offentlig -nøgle"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/de.po
+++ b/po/de.po
@@ -4053,8 +4053,9 @@ msgstr "Verschicke öffentlichen PGP-Schlüssel"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "Prüfe öffentlichen PGP-Schlüssel"
+#, fuzzy
+msgid "verify a public key"
+msgstr "Prüfe öffentlichen -Schlüssel"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/el.po
+++ b/po/el.po
@@ -4141,8 +4141,9 @@ msgstr "ταχυδρόμηση δημόσιου κλειδιού PGP"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "επιβεβαίωση ενός δημόσιου κλειδιού PGP"
+#, fuzzy
+msgid "verify a public key"
+msgstr "επιβεβαίωση ενός δημόσιου κλειδιού "
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -4046,8 +4046,8 @@ msgstr "mail a PGP public key"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "verify a PGP public key"
+msgid "verify a public key"
+msgstr "verify a public key"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/eo.po
+++ b/po/eo.po
@@ -4146,8 +4146,9 @@ msgstr "sendi publikan PGP-ŝlosilon"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "kontroli publikan PGP-ŝlosilon"
+#, fuzzy
+msgid "verify a public key"
+msgstr "kontroli publikan ŝlosilon"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/es.po
+++ b/po/es.po
@@ -4057,8 +4057,9 @@ msgstr "enviar clave PGP pública"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "verificar clave PGP pública"
+#, fuzzy
+msgid "verify a public key"
+msgstr "verificar clave pública"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/et.po
+++ b/po/et.po
@@ -4206,8 +4206,9 @@ msgstr "saada PGP avalik võti"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "kontrolli PGP avalikku võtit"
+#, fuzzy
+msgid "verify a public key"
+msgstr "kontrolli avalikku võtit"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/eu.po
+++ b/po/eu.po
@@ -4189,8 +4189,9 @@ msgstr "PGP gako publikoa epostaz bidali"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "PGP gako publikoa egiaztatu"
+#, fuzzy
+msgid "verify a public key"
+msgstr " gako publikoa egiaztatu"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/fi.po
+++ b/po/fi.po
@@ -4094,8 +4094,9 @@ msgstr "lähetä julkinen PGP-avain"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "varmista julkinen PGP-avain"
+#, fuzzy
+msgid "verify a public key"
+msgstr "varmista julkinen -avain"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/fr.po
+++ b/po/fr.po
@@ -4212,8 +4212,9 @@ msgstr "envoyer une clé publique PGP"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "vérifier une clé publique PGP"
+#, fuzzy
+msgid "verify a public key"
+msgstr "vérifier une clé publique "
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/ga.po
+++ b/po/ga.po
@@ -4227,8 +4227,9 @@ msgstr "seol eochair phoiblí PGP"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "fíoraigh eochair phoiblí PGP"
+#, fuzzy
+msgid "verify a public key"
+msgstr "fíoraigh eochair phoiblí "
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/gl.po
+++ b/po/gl.po
@@ -4220,8 +4220,9 @@ msgstr "enviar por correo unha chave pública PGP"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "verificar unha chave pública PGP"
+#, fuzzy
+msgid "verify a public key"
+msgstr "verificar unha chave pública "
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/hu.po
+++ b/po/hu.po
@@ -4058,8 +4058,9 @@ msgstr "a PGP nyilvános kulcs elküldése"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "a PGP nyilvános kulcs ellenőrzése"
+#, fuzzy
+msgid "verify a public key"
+msgstr "a nyilvános kulcs ellenőrzése"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/id.po
+++ b/po/id.po
@@ -4170,8 +4170,9 @@ msgstr "kirim PGP public key lewat surat"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "periksa PGP public key"
+#, fuzzy
+msgid "verify a public key"
+msgstr "periksa public key"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/it.po
+++ b/po/it.po
@@ -4187,8 +4187,9 @@ msgstr "spedisci una chiave pubblica PGP"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "verifica una chiave pubblica PGP"
+#, fuzzy
+msgid "verify a public key"
+msgstr "verifica una chiave pubblica "
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/ja.po
+++ b/po/ja.po
@@ -4134,8 +4134,9 @@ msgstr "PGP 公開鍵をメール送信"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "PGP 公開鍵を検証"
+#, fuzzy
+msgid "verify a public key"
+msgstr " 公開鍵を検証"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/ko.po
+++ b/po/ko.po
@@ -4185,8 +4185,9 @@ msgstr "PGP 공개 열쇠 발송"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "PGP 공개 열쇠 확인"
+#, fuzzy
+msgid "verify a public key"
+msgstr " 공개 열쇠 확인"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/lt.po
+++ b/po/lt.po
@@ -4060,8 +4060,9 @@ msgstr "siųsti PGP viešą raktą"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "patikrinti PGP viešą raktą"
+#, fuzzy
+msgid "verify a public key"
+msgstr "patikrinti viešą raktą"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -4057,8 +4057,9 @@ msgstr "send en offentlig PGP-nøkkel"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "bekreft en offentlig PGP-nøkkel"
+#, fuzzy
+msgid "verify a public key"
+msgstr "bekreft en offentlig -nøkkel"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/nl.po
+++ b/po/nl.po
@@ -4175,8 +4175,9 @@ msgstr "mail een PGP publieke sleutel"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "controleer een PGP publieke sleutel"
+#, fuzzy
+msgid "verify a public key"
+msgstr "controleer een publieke sleutel"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/pl.po
+++ b/po/pl.po
@@ -4069,8 +4069,9 @@ msgstr "wyślij własny klucz publiczny PGP"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "zweryfikuj klucz publiczny PGP"
+#, fuzzy
+msgid "verify a public key"
+msgstr "zweryfikuj klucz publiczny "
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4059,8 +4059,9 @@ msgstr "envia uma chave pública do PGP"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "verifica uma chave pública do PGP"
+#, fuzzy
+msgid "verify a public key"
+msgstr "verifica uma chave pública do "
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/ru.po
+++ b/po/ru.po
@@ -4132,8 +4132,9 @@ msgstr "отправить открытый PGP-ключ"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "проверить открытый PGP-ключ"
+#, fuzzy
+msgid "verify a public key"
+msgstr "проверить открытый -ключ"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/sk.po
+++ b/po/sk.po
@@ -4064,8 +4064,9 @@ msgstr "poslať verejný kľúč PGP poštou"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "overiť verejný kľúč PGP"
+#, fuzzy
+msgid "verify a public key"
+msgstr "overiť verejný kľúč "
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/sr.po
+++ b/po/sr.po
@@ -4059,8 +4059,9 @@ msgstr "слање јавног PGP кључа мејлом"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "верификација јавног PGP кључа"
+#, fuzzy
+msgid "verify a public key"
+msgstr "верификација јавног кључа"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/sv.po
+++ b/po/sv.po
@@ -4188,8 +4188,9 @@ msgstr "skicka en publik nyckel (PGP)"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "verifiera en publik nyckel (PGP)"
+#, fuzzy
+msgid "verify a public key"
+msgstr "verifiera en publik nyckel ( )"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/tr.po
+++ b/po/tr.po
@@ -4049,8 +4049,9 @@ msgstr "bir PGP genel anahtarı gönder"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "bir PGP genel anahtarı doğrula"
+#, fuzzy
+msgid "verify a public key"
+msgstr "bir genel anahtarı doğrula"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/uk.po
+++ b/po/uk.po
@@ -4076,8 +4076,9 @@ msgstr "відіслати відкритий ключ PGP"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "перевірити відкритий ключ PGP"
+#, fuzzy
+msgid "verify a public key"
+msgstr "перевірити відкритий ключ "
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4059,8 +4059,9 @@ msgstr "邮寄 PGP 公钥"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "验证 PGP 公钥"
+#, fuzzy
+msgid "verify a public key"
+msgstr "验证 公钥"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -4175,8 +4175,9 @@ msgstr "寄出 PGP 公共鑰匙"
 #. GPGME Key Selection Dialog: <op_verify_key>
 #. PGP Key Selection Dialog: <op_verify_key>
 #: gui/opcodes.h:937
-msgid "verify a PGP public key"
-msgstr "檢驗 PGP 公共鑰匙"
+#, fuzzy
+msgid "verify a public key"
+msgstr "檢驗公共鑰匙"
 
 #. L10N: Help screen description for OP_VIEW_ID
 #. GPGME Key Selection Dialog: <op_view_id>


### PR DESCRIPTION
The GPGME backend provides the verify-key (OP_VERIFY_KEY) function in the PGP and the S/MIME key select menu.  Change the description of that function to be crypto-scheme agnostic, i.e. do not mention "PGP public key" but use "public key" instead.

Related #4558