### PR TITLE
expando: move EnvList out of library

### DIFF
--- a/alias/dlg_alias.c
+++ b/alias/dlg_alias.c
@@ -92,6 +92,7 @@
 #include "alias.h"
 #include "expando.h"
 #include "functions.h"
+#include "globals.h"
 #include "gui.h"
 #include "mutt_logging.h"
 
@@ -130,7 +131,7 @@ static int alias_make_entry(struct Menu *menu, int line, int max_cols, struct Bu
 
   const struct Expando *c_alias_format = cs_subset_expando(mdata->sub, "alias_format");
   return expando_filter(c_alias_format, AliasRenderCallbacks, av,
-                        MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
+                        MUTT_FORMAT_ARROWCURSOR, max_cols, EnvList, buf);
 }
 
 /**

--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -159,7 +159,7 @@ static int query_make_entry(struct Menu *menu, int line, int max_cols, struct Bu
 
   const struct Expando *c_query_format = cs_subset_expando(mdata->sub, "query_format");
   return expando_filter(c_query_format, QueryRenderCallbacks, av,
-                        MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
+                        MUTT_FORMAT_ARROWCURSOR, max_cols, EnvList, buf);
 }
 
 /**

--- a/attach/dlg_attach.c
+++ b/attach/dlg_attach.c
@@ -82,6 +82,7 @@
 #include "attach.h"
 #include "attachments.h"
 #include "functions.h"
+#include "globals.h"
 #include "hook.h"
 #include "mutt_logging.h"
 #include "mview.h"
@@ -145,7 +146,7 @@ static int attach_make_entry(struct Menu *menu, int line, int max_cols, struct B
   const struct Expando *c_attach_format = cs_subset_expando(NeoMutt->sub, "attach_format");
   return expando_filter(c_attach_format, AttachRenderCallbacks,
                         (actx->idx[actx->v2r[line]]), MUTT_FORMAT_ARROWCURSOR,
-                        max_cols, buf);
+                        max_cols, EnvList, buf);
 }
 
 /**

--- a/autocrypt/dlg_autocrypt.c
+++ b/autocrypt/dlg_autocrypt.c
@@ -82,6 +82,7 @@
 #include "autocrypt_data.h"
 #include "expando.h"
 #include "functions.h"
+#include "globals.h"
 #include "mutt_logging.h"
 
 /// Help Bar for the Autocrypt Account selection dialog
@@ -133,7 +134,7 @@ static int autocrypt_make_entry(struct Menu *menu, int line, int max_cols, struc
 
   const struct Expando *c_autocrypt_acct_format = cs_subset_expando(NeoMutt->sub, "autocrypt_acct_format");
   return expando_filter(c_autocrypt_acct_format, AutocryptRenderCallbacks,
-                        *pentry, MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
+                        *pentry, MUTT_FORMAT_ARROWCURSOR, max_cols, EnvList, buf);
 }
 
 /**

--- a/browser/dlg_browser.c
+++ b/browser/dlg_browser.c
@@ -532,20 +532,20 @@ static int folder_make_entry(struct Menu *menu, int line, int max_cols, struct B
   if (OptNews)
   {
     const struct Expando *c_group_index_format = cs_subset_expando(NeoMutt->sub, "group_index_format");
-    return expando_filter(c_group_index_format, GroupIndexRenderCallbacks,
-                          &folder, MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
+    return expando_filter(c_group_index_format, GroupIndexRenderCallbacks, &folder,
+                          MUTT_FORMAT_ARROWCURSOR, max_cols, EnvList, buf);
   }
 
   if (bstate->is_mailbox_list)
   {
     const struct Expando *c_mailbox_folder_format = cs_subset_expando(NeoMutt->sub, "mailbox_folder_format");
-    return expando_filter(c_mailbox_folder_format, FolderRenderCallbacks,
-                          &folder, MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
+    return expando_filter(c_mailbox_folder_format, FolderRenderCallbacks, &folder,
+                          MUTT_FORMAT_ARROWCURSOR, max_cols, EnvList, buf);
   }
 
   const struct Expando *c_folder_format = cs_subset_expando(NeoMutt->sub, "folder_format");
   return expando_filter(c_folder_format, FolderRenderCallbacks, &folder,
-                        MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
+                        MUTT_FORMAT_ARROWCURSOR, max_cols, EnvList, buf);
 }
 
 /**

--- a/compose/attach.c
+++ b/compose/attach.c
@@ -71,6 +71,7 @@
 #include "expando/lib.h"
 #include "menu/lib.h"
 #include "attach_data.h"
+#include "globals.h"
 #include "shared_data.h"
 
 /**
@@ -233,7 +234,8 @@ static int compose_make_entry(struct Menu *menu, int line, int max_cols, struct 
   const struct Expando *c_attach_format = cs_subset_expando(sub, "attach_format");
   return expando_filter(c_attach_format, AttachRenderCallbacks,
                         (actx->idx[actx->v2r[line]]),
-                        MUTT_FORMAT_STAT_FILE | MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
+                        MUTT_FORMAT_STAT_FILE | MUTT_FORMAT_ARROWCURSOR,
+                        max_cols, EnvList, buf);
 }
 
 /**

--- a/compose/cbar.c
+++ b/compose/cbar.c
@@ -71,6 +71,7 @@
 #include "index/lib.h"
 #include "cbar_data.h"
 #include "expando.h"
+#include "globals.h"
 #include "shared_data.h"
 
 /**
@@ -85,7 +86,7 @@ static int cbar_recalc(struct MuttWindow *win)
 
   const struct Expando *c_compose_format = cs_subset_expando(shared->sub, "compose_format");
   expando_filter(c_compose_format, ComposeRenderCallbacks, shared,
-                 MUTT_FORMAT_NO_FLAGS, win->state.cols, buf);
+                 MUTT_FORMAT_NO_FLAGS, win->state.cols, EnvList, buf);
 
   struct ComposeBarData *cbar_data = win->wdata;
   if (!mutt_str_equal(buf_string(buf), cbar_data->compose_format))

--- a/expando/filter.c
+++ b/expando/filter.c
@@ -86,7 +86,7 @@ bool check_for_pipe(struct ExpandoNode *root)
  * The text is passed unchanged to the shell.
  * The first line of any output (minus the newline) is stored back in buf.
  */
-void filter_text(struct Buffer *buf)
+void filter_text(struct Buffer *buf, char **env_list)
 {
   // Trim the | (pipe) character
   size_t len = buf_len(buf);
@@ -98,7 +98,7 @@ void filter_text(struct Buffer *buf)
 
   mutt_debug(LL_DEBUG3, "execute: %s\n", buf_string(buf));
   FILE *fp_filter = NULL;
-  pid_t pid = filter_create(buf_string(buf), NULL, &fp_filter, NULL, EnvList);
+  pid_t pid = filter_create(buf_string(buf), NULL, &fp_filter, NULL, env_list);
   if (pid < 0)
     return; // LCOV_EXCL_LINE
 
@@ -132,11 +132,13 @@ void filter_text(struct Buffer *buf)
  * @param[in]  data     Callback data
  * @param[in]  flags    Callback flags
  * @param[in]  max_cols Number of screen columns (-1 means unlimited)
+ * @param[in]  env_list Environment to pass to filter
  * @param[out] buf      Buffer in which to save string
  * @retval obj Number of bytes written to buf and screen columns used
  */
 int expando_filter(const struct Expando *exp, const struct ExpandoRenderCallback *erc,
-                   void *data, MuttFormatFlags flags, int max_cols, struct Buffer *buf)
+                   void *data, MuttFormatFlags flags, int max_cols,
+                   char **env_list, struct Buffer *buf)
 {
   if (!exp || !exp->node)
     return 0;
@@ -153,7 +155,7 @@ int expando_filter(const struct Expando *exp, const struct ExpandoRenderCallback
   if (!is_pipe)
     return rc;
 
-  filter_text(buf);
+  filter_text(buf, env_list);
 
   // Strictly truncate to size
   size_t width = 0;

--- a/expando/filter.h
+++ b/expando/filter.h
@@ -29,6 +29,7 @@ struct Buffer;
 struct Expando;
 
 int expando_filter(const struct Expando *exp, const struct ExpandoRenderCallback *erc,
-                   void *data, MuttFormatFlags flags, int max_cols, struct Buffer *buf);
+                   void *data, MuttFormatFlags flags, int max_cols,
+                   char **env_list, struct Buffer *buf);
 
 #endif /* MUTT_EXPANDO_FILTER_H */

--- a/history/dlg_history.c
+++ b/history/dlg_history.c
@@ -69,6 +69,7 @@
 #include "menu/lib.h"
 #include "expando.h"
 #include "functions.h"
+#include "globals.h"
 #include "mutt_logging.h"
 
 /// Help Bar for the History Selection dialog
@@ -105,7 +106,7 @@ static int history_make_entry(struct Menu *menu, int line, int max_cols, struct 
 
   const struct Expando *c_history_format = cs_subset_expando(NeoMutt->sub, "history_format");
   return expando_filter(c_history_format, HistoryRenderCallbacks, &h,
-                        MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
+                        MUTT_FORMAT_ARROWCURSOR, max_cols, EnvList, buf);
 }
 
 /**

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -814,7 +814,7 @@ int mutt_make_string(struct Buffer *buf, size_t max_cols,
   efi.msg_in_pager = inpgr;
   efi.pager_progress = progress;
 
-  return expando_filter(exp, IndexRenderCallbacks, &efi, flags, max_cols, buf);
+  return expando_filter(exp, IndexRenderCallbacks, &efi, flags, max_cols, EnvList, buf);
 }
 
 /**

--- a/index/expando_index.c
+++ b/index/expando_index.c
@@ -52,6 +52,7 @@
 #include "color/lib.h"
 #include "expando/lib.h"
 #include "ncrypt/lib.h"
+#include "globals.h"
 #include "hook.h"
 #include "maillist.h"
 #include "mutt_thread.h"
@@ -724,7 +725,8 @@ static void email_index_hook(const struct ExpandoNode *node, void *data,
   if (!exp)
     return;
 
-  expando_filter(exp, IndexRenderCallbacks, data, MUTT_FORMAT_NO_FLAGS, buf->dsize, buf);
+  expando_filter(exp, IndexRenderCallbacks, data, MUTT_FORMAT_NO_FLAGS,
+                 buf->dsize, EnvList, buf);
 }
 
 /**

--- a/index/status.c
+++ b/index/status.c
@@ -36,6 +36,7 @@
 #include "status.h"
 #include "expando/lib.h"
 #include "expando_status.h"
+#include "globals.h"
 
 /**
  * menu_status_line - Create the status line
@@ -52,5 +53,6 @@ void menu_status_line(struct Buffer *buf, struct IndexSharedData *shared,
 {
   struct MenuStatusLineData data = { shared, menu };
 
-  expando_filter(exp, StatusRenderCallbacks, &data, MUTT_FORMAT_NO_FLAGS, max_cols, buf);
+  expando_filter(exp, StatusRenderCallbacks, &data, MUTT_FORMAT_NO_FLAGS,
+                 max_cols, EnvList, buf);
 }

--- a/ncrypt/dlg_gpgme.c
+++ b/ncrypt/dlg_gpgme.c
@@ -84,6 +84,7 @@
 #include "menu/lib.h"
 #include "crypt_gpgme.h"
 #include "expando_gpgme.h"
+#include "globals.h"
 #include "gpgme_functions.h"
 #include "mutt_logging.h"
 #include "sort.h"
@@ -123,7 +124,7 @@ static int crypt_make_entry(struct Menu *menu, int line, int max_cols, struct Bu
 
   const struct Expando *c_pgp_entry_format = cs_subset_expando(NeoMutt->sub, "pgp_entry_format");
   return expando_filter(c_pgp_entry_format, PgpEntryGpgmeRenderCallbacks,
-                        &entry, MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
+                        &entry, MUTT_FORMAT_ARROWCURSOR, max_cols, EnvList, buf);
 }
 
 /**

--- a/ncrypt/dlg_pgp.c
+++ b/ncrypt/dlg_pgp.c
@@ -82,6 +82,7 @@
 #include "key/lib.h"
 #include "menu/lib.h"
 #include "expando_pgp.h"
+#include "globals.h"
 #include "mutt_logging.h"
 #include "pgp_functions.h"
 #include "pgplib.h"
@@ -122,7 +123,7 @@ static int pgp_make_entry(struct Menu *menu, int line, int max_cols, struct Buff
 
   const struct Expando *c_pgp_entry_format = cs_subset_expando(NeoMutt->sub, "pgp_entry_format");
   return expando_filter(c_pgp_entry_format, PgpEntryRenderCallbacks, &entry,
-                        MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
+                        MUTT_FORMAT_ARROWCURSOR, max_cols, EnvList, buf);
 }
 
 /**

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -53,6 +53,7 @@
 #include "adata.h"
 #include "edata.h"
 #include "expando_newsrc.h"
+#include "globals.h"
 #include "mdata.h"
 #include "mutt_logging.h"
 #include "mutt_socket.h"
@@ -1028,7 +1029,7 @@ struct NntpAccountData *nntp_select_server(struct Mailbox *m, const char *server
     const struct Expando *c_newsrc = cs_subset_expando(NeoMutt->sub, "newsrc");
     struct Buffer *buf = buf_pool_get();
     expando_filter(c_newsrc, NntpRenderCallbacks, adata, MUTT_FORMAT_NO_FLAGS,
-                   buf->dsize, buf);
+                   buf->dsize, EnvList, buf);
     buf_expand_path(buf);
     adata->newsrc_file = buf_strdup(buf);
     buf_pool_release(&buf);

--- a/pattern/dlg_pattern.c
+++ b/pattern/dlg_pattern.c
@@ -81,6 +81,7 @@
 #include "menu/lib.h"
 #include "expando.h"
 #include "functions.h"
+#include "globals.h"
 #include "mutt_logging.h"
 #include "pattern_data.h"
 
@@ -115,7 +116,7 @@ static int pattern_make_entry(struct Menu *menu, int line, int max_cols, struct 
 
   const struct Expando *c_pattern_format = cs_subset_expando(NeoMutt->sub, "pattern_format");
   return expando_filter(c_pattern_format, PatternRenderCallbacks, entry,
-                        MUTT_FORMAT_ARROWCURSOR, max_cols, buf);
+                        MUTT_FORMAT_ARROWCURSOR, max_cols, EnvList, buf);
 }
 
 /**

--- a/send/send.c
+++ b/send/send.c
@@ -690,7 +690,8 @@ static void mutt_make_greeting(struct Email *e, FILE *fp_out, struct ConfigSubse
 
   struct Buffer *buf = buf_pool_get();
 
-  expando_filter(c_greeting, GreetingRenderCallbacks, e, TOKEN_NO_FLAGS, buf->dsize, buf);
+  expando_filter(c_greeting, GreetingRenderCallbacks, e, TOKEN_NO_FLAGS,
+                 buf->dsize, EnvList, buf);
 
   fputs(buf_string(buf), fp_out);
   fputc('\n', fp_out);

--- a/send/sendmail.c
+++ b/send/sendmail.c
@@ -312,7 +312,8 @@ int mutt_invoke_sendmail(struct Mailbox *m, struct AddressList *from,
     struct Buffer *cmd = buf_pool_get();
 
     const struct Expando *c_inews = cs_subset_expando(sub, "inews");
-    expando_filter(c_inews, NntpRenderCallbacks, 0, MUTT_FORMAT_NO_FLAGS, cmd->dsize, cmd);
+    expando_filter(c_inews, NntpRenderCallbacks, 0, MUTT_FORMAT_NO_FLAGS,
+                   cmd->dsize, EnvList, cmd);
     if (buf_is_empty(cmd))
     {
       i = nntp_post(m, msg);

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -80,6 +80,7 @@
 #include "expando/lib.h"
 #include "index/lib.h"
 #include "expando.h"
+#include "globals.h"
 
 /**
  * imap_is_prefix - Check if folder matches the beginning of mbox
@@ -320,7 +321,7 @@ static void make_sidebar_entry(char *buf, size_t buflen, int width,
   struct Buffer *tmp = buf_pool_get();
   const struct Expando *c_sidebar_format = cs_subset_expando(NeoMutt->sub, "sidebar_format");
   expando_filter(c_sidebar_format, SidebarRenderCallbacks, &sdata,
-                 MUTT_FORMAT_NO_FLAGS, width, tmp);
+                 MUTT_FORMAT_NO_FLAGS, width, EnvList, tmp);
   mutt_str_copy(buf, buf_string(tmp), buflen);
   buf_pool_release(&tmp);
 

--- a/test/expando/filter.c
+++ b/test/expando/filter.c
@@ -31,6 +31,8 @@
 #include "common.h" // IWYU pragma: keep
 #include "test_common.h"
 
+extern char **EnvList;
+
 bool check_for_pipe(struct ExpandoNode *root);
 void filter_text(struct Buffer *buf);
 
@@ -123,7 +125,7 @@ void test_expando_filter(void)
       // clang-format on
     };
 
-    TEST_CHECK(expando_filter(NULL, NULL, NULL, MUTT_FORMAT_NO_FLAGS, 0, NULL) == 0);
+    TEST_CHECK(expando_filter(NULL, NULL, NULL, MUTT_FORMAT_NO_FLAGS, 0, EnvList, NULL) == 0);
 
     struct Buffer *err = buf_pool_get();
     struct Buffer *buf = buf_pool_get();
@@ -133,7 +135,7 @@ void test_expando_filter(void)
     const char *str = ">%a<";
     exp = expando_parse(str, TestFormatDef, err);
     TEST_CHECK(exp != NULL);
-    rc = expando_filter(exp, TestRenderCallback, NULL, MUTT_FORMAT_NO_FLAGS, -1, buf);
+    rc = expando_filter(exp, TestRenderCallback, NULL, MUTT_FORMAT_NO_FLAGS, -1, EnvList, buf);
     TEST_CHECK_NUM_EQ(rc, 7);
     TEST_MSG("rc = %d", rc);
     TEST_CHECK_STR_EQ(buf_string(buf), ">apple<");
@@ -143,7 +145,7 @@ void test_expando_filter(void)
     buf_reset(buf);
     exp = expando_parse(str, TestFormatDef, err);
     TEST_CHECK(exp != NULL);
-    rc = expando_filter(exp, TestRenderCallback, NULL, MUTT_FORMAT_NO_FLAGS, -1, buf);
+    rc = expando_filter(exp, TestRenderCallback, NULL, MUTT_FORMAT_NO_FLAGS, -1, EnvList, buf);
     TEST_CHECK_NUM_EQ(rc, 7);
     TEST_MSG("rc = %d", rc);
     TEST_CHECK_STR_EQ(buf_string(buf), ">apple<");


### PR DESCRIPTION
`EnvList` is NeoMutt's copy of the global environment variables.
It lives in `globals.[ch]` (along with many other globals).

This PR changes `expando_filter()` and `filter_text()` to take `EnvList` as a parameter.
This reduces the dependencies of `libexpando` (by pushing the problem outwards).

Anyone have a better solution?