### PR TITLE
Preparation for `main()` refactoring

### DIFF
--- a/color/command.c
+++ b/color/command.c
@@ -192,7 +192,7 @@ static enum CommandResult parse_object(struct Buffer *buf, struct Buffer *s,
 static enum CommandResult parse_uncolor_command(struct Buffer *buf, struct Buffer *s,
                                                 struct Buffer *err, bool uncolor)
 {
-  if (OptNoCurses) // No GUI, so quietly discard the command
+  if (!OptGui) // No GUI, so quietly discard the command
   {
     while (MoreArgs(s))
     {
@@ -426,7 +426,7 @@ done:
 enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
                                  intptr_t data, struct Buffer *err)
 {
-  if (OptNoCurses) // No GUI, so quietly discard the command
+  if (!OptGui) // No GUI, so quietly discard the command
   {
     while (MoreArgs(s))
     {
@@ -458,7 +458,7 @@ enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
                                intptr_t data, struct Buffer *err)
 {
   // No GUI, or no colours, so quietly discard the command
-  if (OptNoCurses || (COLORS == 0))
+  if (!OptGui || (COLORS == 0))
   {
     while (MoreArgs(s))
     {
@@ -480,7 +480,7 @@ enum CommandResult parse_mono(struct Buffer *buf, struct Buffer *s,
                               intptr_t data, struct Buffer *err)
 {
   // No GUI, or colours available, so quietly discard the command
-  if (OptNoCurses || (COLORS != 0))
+  if (!OptGui || (COLORS != 0))
   {
     while (MoreArgs(s))
     {

--- a/conn/connaccount.c
+++ b/conn/connaccount.c
@@ -64,11 +64,11 @@ int mutt_account_getuser(struct ConnAccount *cac)
   else if (mutt_account_call_external_cmd(cac) != MUTT_ACCT_NO_FLAGS)
   {
     /* The external command might interact with the screen */
-    if (!OptNoCurses)
+    if (OptGui)
       mutt_need_hard_redraw();
     return 0;
   }
-  else if (OptNoCurses)
+  else if (!OptGui)
   {
     return -1;
   }
@@ -143,11 +143,11 @@ int mutt_account_getpass(struct ConnAccount *cac)
   else if (mutt_account_call_external_cmd(cac) != MUTT_ACCT_NO_FLAGS)
   {
     /* The external command might interact with the screen */
-    if (!OptNoCurses)
+    if (OptGui)
       mutt_need_hard_redraw();
     return 0;
   }
-  else if (OptNoCurses)
+  else if (!OptGui)
   {
     return -1;
   }
@@ -227,7 +227,7 @@ char *mutt_account_getoauthbearer(struct ConnAccount *cac, bool xoauth2)
   filter_wait(pid);
 
   /* The refresh cmd in some cases will invoke gpg to decrypt a token */
-  if (!OptNoCurses)
+  if (OptGui)
     mutt_need_hard_redraw();
 
   if (!token || (*token == '\0'))

--- a/conn/gnutls.c
+++ b/conn/gnutls.c
@@ -485,7 +485,7 @@ static int tls_check_one_certificate(const gnutls_datum_t *certdata,
   if (tls_check_preauth(certdata, certstat, hostname, idx, &certerr, &savedcert) == 0)
     return 1;
 
-  if (OptNoCurses)
+  if (!OptGui)
   {
     mutt_debug(LL_DEBUG1, "unable to prompt for certificate in batch mode\n");
     mutt_error(_("Untrusted server certificate"));
@@ -967,7 +967,7 @@ static int tls_negotiate(struct Connection *conn)
 
   tls_get_client_cert(conn);
 
-  if (!OptNoCurses)
+  if (OptGui)
   {
     mutt_message(_("SSL/TLS connection using %s (%s/%s/%s)"),
                  gnutls_protocol_get_name(gnutls_protocol_get_version(data->session)),

--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -890,7 +890,7 @@ static void add_cert(const char *title, X509 *cert, bool issuer, struct CertArra
  */
 static bool interactive_check_cert(X509 *cert, int idx, size_t len, SSL *ssl, bool allow_always)
 {
-  if (OptNoCurses)
+  if (!OptGui)
   {
     mutt_debug(LL_DEBUG1, "unable to prompt for certificate in batch mode\n");
     mutt_error(_("Untrusted server certificate"));

--- a/conn/raw.c
+++ b/conn/raw.c
@@ -181,7 +181,7 @@ int raw_socket_open(struct Connection *conn)
   host_idna = conn->account.host;
 #endif
 
-  if (!OptNoCurses)
+  if (OptGui)
     mutt_message(_("Looking up %s..."), conn->account.host);
 
   rc = getaddrinfo(host_idna, port, &hints, &res);
@@ -196,7 +196,7 @@ int raw_socket_open(struct Connection *conn)
     return -1;
   }
 
-  if (!OptNoCurses)
+  if (OptGui)
     mutt_message(_("Connecting to %s..."), conn->account.host);
 
   rc = -1;
@@ -238,7 +238,7 @@ int raw_socket_open(struct Connection *conn)
   host_idna = conn->account.host;
 #endif
 
-  if (!OptNoCurses)
+  if (OptGui)
     mutt_message(_("Looking up %s..."), conn->account.host);
 
   he = gethostbyname(host_idna);
@@ -254,7 +254,7 @@ int raw_socket_open(struct Connection *conn)
     return -1;
   }
 
-  if (!OptNoCurses)
+  if (OptGui)
     mutt_message(_("Connecting to %s..."), conn->account.host);
 
   rc = -1;

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -714,7 +714,7 @@ int mutt_sasl_interact(sasl_interact_t *interaction)
     snprintf(prompt, sizeof(prompt), "%s: ", interaction->prompt);
     buf_reset(resp);
 
-    if (OptNoCurses ||
+    if (!OptGui ||
         (mw_get_field(prompt, resp, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) != 0))
     {
       rc = SASL_FAIL;

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -19787,12 +19787,6 @@ neomutt -a image.jpg *.png -- address1 address2
               </entry>
             </row>
             <row>
-              <entry>-B</entry>
-              <entry>
-                Run in batch mode (do not start the ncurses UI)
-              </entry>
-            </row>
-            <row>
               <entry>-b <literal>address</literal></entry>
               <entry>
                 Specify a blind carbon copy (Bcc) recipient

--- a/docs/neomutt.man
+++ b/docs/neomutt.man
@@ -227,10 +227,6 @@ Add any addresses after the \(aq\fB\-\-\fP\(aq argument, e.g.:
 .RE
 .
 .TP
-.B \-B
-Run in batch mode (do not start the ncurses UI)
-.
-.TP
 .BI \-b " address"
 Specify a blind carbon copy (Bcc) recipient
 .

--- a/fuzz/address.c
+++ b/fuzz/address.c
@@ -8,7 +8,6 @@
 #include "email/lib.h"
 #include "core/lib.h"
 #include "mutt.h"
-#include "globals.h"
 #include "protos.h"
 
 bool StartupComplete = true;
@@ -28,7 +27,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   struct ConfigSet *cs = cs_new(16);
   NeoMutt = neomutt_new(cs);
   init_config(cs);
-  OptNoCurses = true;
   char file[] = "/tmp/mutt-fuzz";
   FILE *fp = fopen(file, "wb");
   if (!fp)

--- a/globals.c
+++ b/globals.c
@@ -57,13 +57,13 @@ bool OptAutocryptGpgme;     ///< (pseudo) use Autocrypt context inside ncrypt/cr
 #endif
 bool OptDontHandlePgpKeys;  ///< (pseudo) used to extract PGP keys
 bool OptForceRefresh;       ///< (pseudo) refresh even during macros
+bool OptGui;                ///< (pseudo) when the gui (and curses) are started
 bool OptKeepQuiet;          ///< (pseudo) shut up the message and refresh functions while we are executing an external program
 bool OptMsgErr;             ///< (pseudo) used by mutt_error/mutt_message
 bool OptNeedRescore;        ///< (pseudo) set when the 'score' command is used
 bool OptNeedResort;         ///< (pseudo) used to force a re-sort
 bool OptNews;               ///< (pseudo) used to change reader mode
 bool OptNewsSend;           ///< (pseudo) used to change behavior when posting
-bool OptNoCurses;           ///< (pseudo) when sending in batch mode
 bool OptPgpCheckTrust;      ///< (pseudo) used by dlg_pgp()
 bool OptResortInit;         ///< (pseudo) used to force the next resort to be from scratch
 bool OptSortSubthreads;     ///< (pseudo) used when $sort_aux changes

--- a/globals.h
+++ b/globals.h
@@ -51,13 +51,13 @@ extern bool OptAutocryptGpgme;      ///< (pseudo) use Autocrypt context inside n
 #endif
 extern bool OptDontHandlePgpKeys;   ///< (pseudo) used to extract PGP keys
 extern bool OptForceRefresh;        ///< (pseudo) refresh even during macros
+extern bool OptGui;                 ///< (pseudo) when the gui (and curses) are started
 extern bool OptKeepQuiet;           ///< (pseudo) shut up the message and refresh functions while we are executing an external program
 extern bool OptMsgErr;              ///< (pseudo) used by mutt_error/mutt_message
 extern bool OptNeedRescore;         ///< (pseudo) set when the 'score' command is used
 extern bool OptNeedResort;          ///< (pseudo) used to force a re-sort
 extern bool OptNews;                ///< (pseudo) used to change reader mode
 extern bool OptNewsSend;            ///< (pseudo) used to change behavior when posting
-extern bool OptNoCurses;            ///< (pseudo) when sending in batch mode
 extern bool OptPgpCheckTrust;       ///< (pseudo) used by dlg_pgp()
 extern bool OptResortInit;          ///< (pseudo) used to force the next resort to be from scratch
 extern bool OptSortSubthreads;      ///< (pseudo) used when $sort_aux changes

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -151,7 +151,7 @@ void mutt_query_exit(void)
  */
 void mutt_endwin(void)
 {
-  if (OptNoCurses)
+  if (!OptGui)
     return;
 
   int e = errno;

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -308,7 +308,7 @@ int mutt_window_move(struct MuttWindow *win, int row, int col)
  */
 void mutt_window_reflow(struct MuttWindow *win)
 {
-  if (OptNoCurses)
+  if (!OptGui)
     return;
 
   if (!win)

--- a/key/get.c
+++ b/key/get.c
@@ -213,7 +213,7 @@ struct KeyEvent mutt_getch(GetChFlags flags)
   static const struct KeyEvent event_repaint = { 0, OP_REPAINT };
   static const struct KeyEvent event_timeout = { 0, OP_TIMEOUT };
 
-  if (OptNoCurses)
+  if (!OptGui)
     return event_abort;
 
   struct KeyEvent *event_key = array_pop(&UngetKeyEvents);

--- a/main.c
+++ b/main.c
@@ -770,7 +770,6 @@ static bool usage(void)
          "          [-s <subject>] [-a <file> [...] --] <address> [...] < message"));
   puts(_("  neomutt [-nRy] [-e <command>] [-F <config>] [-f <mailbox>] [-m <type>]"));
   puts(_("  neomutt [-n] [-e <command>] [-F <config>] -A <alias>"));
-  puts(_("  neomutt [-n] [-e <command>] [-F <config>] -B"));
   puts(_("  neomutt [-n] [-e <command>] [-F <config>] -D [-D] [-O] [-S]"));
   puts(_("  neomutt [-n] [-e <command>] [-F <config>] -d <level> -l <file>"));
   puts(_("  neomutt [-n] [-e <command>] [-F <config>] -G"));
@@ -788,7 +787,6 @@ static bool usage(void)
   puts(_("  -A <alias>    Print an expanded version of the given alias to stdout and exit"));
   puts(_("  -a <file>     Attach one or more files to a message (must be the last option)\n"
          "                Add any addresses after the '--' argument"));
-  puts(_("  -B            Run in batch mode (do not start the ncurses UI)"));
   puts(_("  -b <address>  Specify a blind carbon copy (Bcc) recipient"));
   puts(_("  -c <address>  Specify a carbon copy (Cc) recipient"));
   puts(_("  -C            Enable Command-line Crypto (signing/encryption)"));
@@ -1047,7 +1045,6 @@ int main(int argc, char *argv[], char *envp[])
   bool dump_changed = false;
   bool one_liner = false;
   bool hide_sensitive = false;
-  bool batch_mode = false;
   bool edit_infile = false;
   int double_dash = argc, nargc = 1;
   int rc = 1;
@@ -1102,7 +1099,7 @@ int main(int argc, char *argv[], char *envp[])
         argv[nargc++] = argv[optind];
     }
 
-    i = getopt(argc, argv, "+A:a:Bb:F:f:Cc:Dd:l:Ee:g:GH:i:hm:nOpQ:RSs:TvyzZ");
+    i = getopt(argc, argv, "+A:a:b:F:f:Cc:Dd:l:Ee:g:GH:i:hm:nOpQ:RSs:TvyzZ");
     if (i != EOF)
     {
       switch (i)
@@ -1112,9 +1109,6 @@ int main(int argc, char *argv[], char *envp[])
           break;
         case 'a':
           mutt_list_insert_tail(&attach, mutt_str_dup(optarg));
-          break;
-        case 'B':
-          batch_mode = true;
           break;
         case 'b':
           mutt_list_insert_tail(&bcc_list, mutt_str_dup(optarg));
@@ -1291,7 +1285,7 @@ int main(int argc, char *argv[], char *envp[])
 
   /* Check for a batch send. */
   if (!isatty(STDIN_FILENO) || !STAILQ_EMPTY(&queries) ||
-      !STAILQ_EMPTY(&alias_queries) || dump_variables || batch_mode)
+      !STAILQ_EMPTY(&alias_queries) || dump_variables)
   {
     OptNoCurses = true;
     sendflags |= SEND_BATCH;
@@ -1488,10 +1482,6 @@ int main(int argc, char *argv[], char *envp[])
     buf_pool_release(&fpath);
   }
 
-  if (batch_mode)
-  {
-    goto main_ok; // TEST22: neomutt -B
-  }
   StartupComplete = true;
 
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, main_hist_observer, NULL);

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -78,7 +78,7 @@ void mutt_clear_error(void)
     error_pause();
 
   ErrorBufMessage = false;
-  if (!OptNoCurses)
+  if (OptGui)
     msgwin_clear_text(NULL);
 }
 

--- a/pager/message.c
+++ b/pager/message.c
@@ -330,7 +330,7 @@ int external_pager(struct MailboxView *mv, struct Email *e, const char *command)
   unlink(buf_string(tempfile));
   buf_pool_release(&cmd);
 
-  if (!OptNoCurses)
+  if (OptGui)
     keypad(stdscr, true);
   if (r != -1)
     mutt_set_flag(m, e, MUTT_READ, true, true);

--- a/po/bg.po
+++ b/po/bg.po
@@ -5655,10 +5655,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -5724,10 +5724,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -5490,10 +5490,6 @@ msgstr ""
 "  -a <soubor>   Připojí ke zprávě soubor(y), musí to být poslední přepínač.\n"
 "                Další adresy lze přidat až za přepínač „--“"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr "  -B            Dávkový režim (nespustí se uživatelské rozhraní)"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <adresa>   Určuje adresu pro utajenou kopii (BCC)"

--- a/po/da.po
+++ b/po/da.po
@@ -5589,10 +5589,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -5456,10 +5456,6 @@ msgstr ""
 "  -a <file>     Hänge eine/mehrere Dateien der Nachricht an (Option muss zuletzt\n"
 "                notiert und mittels '--' von Empfängeradressen separiert werden)"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr "  -B            Benutze den Batch-Modus (startet ohne ncurses Oberfläche)"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <address>  Verwende Adresse für unsichtbare Kopie (Bcc:) an Empfänger"

--- a/po/el.po
+++ b/po/el.po
@@ -5577,10 +5577,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -5448,10 +5448,6 @@ msgstr ""
 "  -a <file>     Attach one or more files to a message (must be the last option)\n"
 "                Add any addresses after the '--' argument"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr "  -B            Run in batch mode (do not start the ncurses UI)"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <address>  Specify a blind carbon copy (Bcc) recipient"

--- a/po/eo.po
+++ b/po/eo.po
@@ -5566,10 +5566,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -5462,10 +5462,6 @@ msgstr ""
 "                parámetro)\n"
 "                Añadir las direcciones después del parámetro '--'"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr "  -B            Abrir en modo batch (no activar la interfaz 'ncurses')"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <dirección>  Especificar un destinatario para copia (Cc)"

--- a/po/et.po
+++ b/po/et.po
@@ -5660,10 +5660,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/eu.po
+++ b/po/eu.po
@@ -5640,10 +5640,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -5502,10 +5502,6 @@ msgstr ""
 "  -a <file>     Liitä yksi tai useampia tiedostoja (pitää olla viimeinen valitsin)\n"
 "                osoitteita voi lisätä merkinnän -- jälkeen"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr "  -B            Eräajotila (ei käynnistä ncurses-käyttöliittymää)"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <address>  Lisää piilokopion (Bcc) osoite"

--- a/po/fr.po
+++ b/po/fr.po
@@ -5686,12 +5686,6 @@ msgstr ""
 "                dernière option). Ajoutez l'adresses ou les adresses après\n"
 "                l'argument « -- »"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-"  -B            Partir en mode traitement par lots (ne pas démarrer\n"
-"                l'interface utilisateur ncurses)"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <adress>   Indiquer un destinataire en copie conforme invisible (CCI)"

--- a/po/ga.po
+++ b/po/ga.po
@@ -5702,10 +5702,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -5682,10 +5682,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -5461,10 +5461,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr "  -a <file>     Egy vagy több file üzentehez csatolása (utolsó opció legyen)                Adjon akárhány címet a '--' argumentum után"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr "  -B           Kötegelt mód (batch) (nincs ncourses felület)"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <cím>  Titkos másolatot kapó címzett (Bcc) megadása"

--- a/po/id.po
+++ b/po/id.po
@@ -5611,10 +5611,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -5637,10 +5637,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -5555,10 +5555,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -5628,10 +5628,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -5471,10 +5471,6 @@ msgstr ""
 "  -a <priedas>  Prikabinti vieną ar daugiau bylų prie laiško (turi būti\n"
 "                paskutinis parametras).  Gavėjus nurodykite po '--'"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr "  -B            Veikti automatiniame režime (be ncurses sąsajos)"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <adresas>  Nurodyti slaptos kopijos (Bcc) gavėją"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -5462,10 +5462,6 @@ msgstr ""
 "  -a <file>     Legg til én eller flere filer i en melding (må være siste valg)\n"
 "                Legg til adresser etter '--' -argumentet"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr "  -B            Kjør i knippe-modus (ikke start ncurses-grensesnittet)"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <adresse>  Angi en blindkopi (Bcc)-mottager"

--- a/po/nl.po
+++ b/po/nl.po
@@ -5603,10 +5603,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -5484,10 +5484,6 @@ msgstr ""
 "\n"
 "                opcją). Dołącz adresy po argumencie '--'"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr "  -B            Wykonaj w trybie wsadowym (nie uruchamiaj UI)"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <address>  Wyszczególnij odbiorcę blind carbon copy (Bcc)"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5464,10 +5464,6 @@ msgstr ""
 "  -a <arquivo> [...] --   anexa arquivo à mensagem (deve ser o último argumento)\n"
 "                Adicione endereços após a opção '--'"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr "  -B            Executa no modo 'batch' (não inicia interface ncurses)"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <endereço> Especifica endereço destinatário em cópia oculta (BCC)"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5560,10 +5560,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/sk.po
+++ b/po/sk.po
@@ -5475,10 +5475,6 @@ msgstr ""
 "  -a <súbor>    Pripojí k správe súbor(y), musí to byť posledný prepínač\n"
 "                Další adresy lze přidat až za přepínač „--“"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr "  -B            Dávkový režim (nespustí sa užívateľské rozhranie)"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <adresa>   Určuje adresu pre utajenú kópiu (Bcc)"

--- a/po/sr.po
+++ b/po/sr.po
@@ -5471,10 +5471,6 @@ msgstr ""
 "  -a <датотека> Додаје једну или више датотека поруци (мора бити последња опција)\n"
 "                Додајте евентуалне адресе после аргумента „--“"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr "  -B            Рад у аутоматском режиму (не покреће ncurses КС)"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <адреса>   Задавање примаоца невидљиве копије (Bcc)"

--- a/po/sv.po
+++ b/po/sv.po
@@ -5639,10 +5639,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -5453,10 +5453,6 @@ msgstr ""
 "  -a <dosya>    İletiye bir/birden çok dosya iliştir (son seçenek olmalıdır)\n"
 "                '--' argümanından sonra herhangi bir adresi ekle"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr "  -B            Toplu iş kipinde çalıştır (ncurses arabirimini çalıştırma)"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <adres>    Bir gizli karbon kopya (Bcc) alıcısı belirt"

--- a/po/uk.po
+++ b/po/uk.po
@@ -5489,10 +5489,6 @@ msgstr ""
 "  -a <файл>     Прикріпити один або більше файлів до листа (має бути останнім\n"
 "                параметром). Додати будь-яку адресу після арґумента '--'"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr "  -B            Запустити в пакетному режимі (без запуску КІ ncurses)"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <адреса>  Визначає отримувача прихованої перебивної копії (Bcc)"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -5456,10 +5456,6 @@ msgstr ""
 "  -a <文件>     给信件添加一个或多个附件（必须是最后一个参数）\n"
 "                在 '--' 参数后添加地址"
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr "  -B            以批处理模式运行（不启动 ncurses 用户界面）"
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr "  -b <地址>     指定一个密送(BCC)收件人"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5609,10 +5609,6 @@ msgid ""
 "                Add any addresses after the '--' argument"
 msgstr ""
 
-#: main.c:796
-msgid "  -B            Run in batch mode (do not start the ncurses UI)"
-msgstr ""
-
 #: main.c:797
 msgid "  -b <address>  Specify a blind carbon copy (Bcc) recipient"
 msgstr ""

--- a/progress/progress.c
+++ b/progress/progress.c
@@ -138,7 +138,7 @@ void progress_free(struct Progress **ptr)
  */
 struct Progress *progress_new(enum ProgressType type, size_t size)
 {
-  if (OptNoCurses)
+  if (!OptGui)
     return NULL;
 
   const size_t size_inc = choose_increment(type);

--- a/send/send.c
+++ b/send/send.c
@@ -2765,7 +2765,7 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
       free_clear_content = true;
   }
 
-  if (!OptNoCurses)
+  if (OptGui)
     mutt_message(_("Sending message..."));
 
   mutt_prepare_envelope(e_templ->env, true, sub);
@@ -2820,7 +2820,7 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
   if (!c_fcc_before_send)
     save_fcc(m, e_templ, fcc, clear_content, pgpkeylist, flags, &finalpath, sub);
 
-  if (!OptNoCurses)
+  if (OptGui)
   {
     mutt_message((i != 0)            ? _("Sending in background") :
                  (flags & SEND_NEWS) ? _("Article posted") :

--- a/send/sendmail.c
+++ b/send/sendmail.c
@@ -422,13 +422,13 @@ int mutt_invoke_sendmail(struct Mailbox *m, struct AddressList *from,
   ARRAY_ADD(&args, NULL);
 
   const short c_sendmail_wait = cs_subset_number(sub, "sendmail_wait");
-  i = send_msg(path, &args, msg, OptNoCurses ? NULL : &childout, c_sendmail_wait);
+  i = send_msg(path, &args, msg, OptGui ? &childout : NULL, c_sendmail_wait);
 
   /* Some user's $sendmail command uses gpg for password decryption,
    * and is set up to prompt using ncurses pinentry.  If we
    * mutt_endwin() it leaves other users staring at a blank screen.
    * So instead, just force a hard redraw on the next refresh. */
-  if (!OptNoCurses)
+  if (OptGui)
   {
     mutt_need_hard_redraw();
   }

--- a/send/smtp.c
+++ b/send/smtp.c
@@ -533,7 +533,7 @@ static int smtp_auth_gsasl(struct SmtpAccountData *adata, const char *mechlist)
     return SMTP_AUTH_UNAVAIL;
   }
 
-  if (!OptNoCurses)
+  if (OptGui)
     mutt_message(_("Authenticating (%s)..."), chosen_mech);
 
   input_buf = buf_pool_get();
@@ -650,7 +650,7 @@ static int smtp_auth_sasl(struct SmtpAccountData *adata, const char *mechlist)
     return SMTP_AUTH_UNAVAIL;
   }
 
-  if (!OptNoCurses)
+  if (OptGui)
   {
     // L10N: (%s) is the method name, e.g. Anonymous, CRAM-MD5, GSSAPI, SASL
     mutt_message(_("Authenticating (%s)..."), mech);

--- a/test/gui/visible.c
+++ b/test/gui/visible.c
@@ -27,6 +27,7 @@
 #include <stddef.h>
 #include "mutt/lib.h"
 #include "gui/lib.h"
+#include "globals.h"
 
 enum TestEvent
 {
@@ -119,6 +120,8 @@ void test_window_visible(void)
     { true,  true,  TE_NONE,    true,  true,  TE_NONE    },
     // clang-format on
   };
+
+  OptGui = true;
 
   struct MuttWindow *parent = mutt_window_new(WT_ROOT, MUTT_WIN_ORIENT_VERTICAL,
                                               MUTT_WIN_SIZE_FIXED, 80, 24);

--- a/test/pattern/dummy.c
+++ b/test/pattern/dummy.c
@@ -89,7 +89,7 @@ bool g_is_mail_list = false;
 bool g_is_subscribed_list = false;
 bool OptForceRefresh;
 bool OptKeepQuiet;
-bool OptNoCurses;
+bool OptGui;
 
 const struct MenuFuncOp OpAlias = { 0 };
 const struct MenuFuncOp OpAttachment = { 0 };


### PR DESCRIPTION
A couple of small steps towards tidying `main()`

- bf650cc9c main: drop `-B` (batch mode) command line option
  This option never actually did anything.
  (Apart from occasionally being a handy place to put a breakpoint)

- c60ddd10a global invert `OptNoCurses` to `OptGui`
  Conceptually, `if (OptGui)` is simpler that `if (!OptNoCurses)`
  Ideally, we'd eliminate all these ugly globals, but in the mean time...
