### PR TITLE
libcli - parse the command line

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,8 +28,12 @@ task:
         - (cd ${NEOMUTT_TEST_DIR} && ./setup.sh)
       configure_script: ./configure --autocrypt --disable-doc --disable-idn --idn2 --notmuch --testing
       build_script: make
-      version_script: ./neomutt -v
-      test_script: make test
+      version_script:
+        - ./neomutt -v
+        - ./neomutt -h all
+      test_script:
+        - make test/neomutt-test
+        - make test
 
     - name: FreeBSD / OpenSSL
       install_script:
@@ -37,7 +41,9 @@ task:
         - ${PKG_INSTALL} ${PKG_COMMON} openssl
       configure_script: ./configure ${CONFIGURE_COMMON} --ssl
       build_script: make
-      version_script: ./neomutt -v
+      version_script:
+        - ./neomutt -v
+        - ./neomutt -h all
 
     - name: FreeBSD / LibreSSL
       install_script:
@@ -45,7 +51,9 @@ task:
         - ${PKG_INSTALL} ${PKG_COMMON} libressl
       configure_script: ./configure ${CONFIGURE_COMMON} --ssl
       build_script: make
-      version_script: ./neomutt -v
+      version_script:
+        - ./neomutt -v
+        - ./neomutt -h all
 
     - name: FreeBSD / GnuTLS
       install_script:
@@ -53,4 +61,6 @@ task:
         - ${PKG_INSTALL} ${PKG_COMMON} gnutls
       configure_script: ./configure ${CONFIGURE_COMMON} --gnutls
       build_script: make
-      version_script: ./neomutt -v
+      version_script:
+        - ./neomutt -v
+        - ./neomutt -h all

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -43,6 +43,14 @@ jobs:
     - name: Configure Neomutt
       run: ./configure $CONFIGURE_OPTIONS
 
+    - name: Build Neomutt
+      run: make -j ${{steps.cpu-cores.outputs.count}} neomutt
+
+    - name: Neomutt Version
+      run: |
+        ./neomutt -v
+        ./neomutt -h all
+
     - name: Build Tests
       run: make -j ${{steps.cpu-cores.outputs.count}} test/neomutt-test
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,6 +64,7 @@ jobs:
       run: |
         cd build-${{ matrix.cfg.name }}
         ./neomutt -v
+        ./neomutt -h all
 
     - name: Test Docs
       run: |

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -45,7 +45,9 @@ jobs:
       run: make -j ${{steps.cpu-cores.outputs.count}} neomutt
 
     - name: Neomutt Version
-      run: ./neomutt -v
+      run: |
+        ./neomutt -v
+        ./neomutt -h all
 
     - name: Build Tests
       run: make -j ${{steps.cpu-cores.outputs.count}} test/neomutt-test

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -82,6 +82,7 @@ jobs:
     - name: Neomutt Version
       run: |
         test -f neomutt && ./neomutt -v || :
+        test -f neomutt && ./neomutt -h all || :
 
     - name: Build Tests
       run: |

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -57,7 +57,9 @@ jobs:
       run: make -j ${{steps.cpu-cores.outputs.count}} neomutt
 
     - name: Neomutt Version
-      run: ./neomutt -v
+      run: |
+        ./neomutt -v
+        ./neomutt -h all
 
     - name: Build Tests
       run: make -j ${{steps.cpu-cores.outputs.count}} test/neomutt-test

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,13 +44,15 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1
 
     - name: Configure Neomutt
-      run: ./configure --disable-doc --disable-nls --notmuch --with-notmuch=/opt/homebrew/opt/notmuch --lmdb --zlib --idn2 --with-idn=/opt/homebrew/opt/libidn2 --with-iconv=/opt/homebrew/opt/libiconv --with-ncurses=/opt/homebrew/opt/ncurses 
+      run: ./configure --disable-doc --disable-nls --notmuch --with-notmuch=/opt/homebrew/opt/notmuch --lmdb --zlib --idn2 --with-idn=/opt/homebrew/opt/libidn2 --with-iconv=/opt/homebrew/opt/libiconv --with-ncurses=/opt/homebrew/opt/ncurses
 
     - name: Build Neomutt
       run: make -j ${{steps.cpu-cores.outputs.count}} neomutt
 
     - name: Neomutt Version
-      run: ./neomutt -v
+      run: |
+        ./neomutt -v
+        ./neomutt -h all
 
     - name: Build Tests
       run: make -j ${{steps.cpu-cores.outputs.count}} test/neomutt-test

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -183,6 +183,19 @@ $(PWD)/browser:
 	$(MKDIR_P) $(PWD)/browser
 
 ###############################################################################
+# libcli
+LIBCLI=		libcli.a
+LIBCLIOBJS=	cli/objects.o cli/parse.o
+CLEANFILES+=	$(LIBCLI) $(LIBCLIOBJS)
+ALLOBJS+=	$(LIBCLIOBJS)
+
+$(LIBCLI): $(PWD)/cli $(LIBCLIOBJS)
+	$(AR) cr $@ $(LIBCLIOBJS)
+	$(RANLIB) $@
+$(PWD)/cli:
+	$(MKDIR_P) $(PWD)/cli
+
+###############################################################################
 # libcolor
 LIBCOLOR=	libcolor.a
 LIBCOLOROBJS=	color/ansi.o color/attr.o color/color.o color/command.o \
@@ -911,7 +924,7 @@ MUTTLIBS+=	$(LIBINDEX) $(LIBPAGER) $(LIBINDEX) $(LIBPAGER) $(LIBAUTOCRYPT) $(LIB
 		$(LIBNCRYPT) $(LIBIMAP) $(LIBCONN) $(LIBHCACHE) \
 		$(LIBCOMPRESS) $(LIBSIDEBAR) $(LIBBCACHE) $(LIBHISTORY) \
 		$(LIBCORE) $(LIBPARSE) $(LIBEXPANDO) $(LIBCONFIG) $(LIBEMAIL) $(LIBADDRESS) \
-		$(LIBDEBUG) $(LIBMUTT)
+		$(LIBDEBUG) $(LIBCLI) $(LIBMUTT)
 
 # neomutt
 $(NEOMUTT): $(GENERATED) $(NEOMUTTOBJS) $(MUTTLIBS)
@@ -987,6 +1000,7 @@ coverage: all test
 	$(RM) mutt/exit.gc??
 	lcov --test-name "test" --output-file coverage.info --capture \
 	  --directory address \
+	  --directory cli \
 	  --directory color \
 	  --directory compress \
 	  --directory config \

--- a/cli/lib.h
+++ b/cli/lib.h
@@ -1,0 +1,44 @@
+/**
+ * @file
+ * Parse the Command Line
+ *
+ * @authors
+ * Copyright (C) 2025 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page lib_cli Parse the Command Line
+ *
+ * | File             | Description             |
+ * | :--------------- | :---------------------- |
+ * | cli/parse.h      | @subpage cli_parse      |
+ * | cli/objects.c    | @subpage cli_objects    |
+ */
+
+#ifndef MUTT_CLI_LIB_H
+#define MUTT_CLI_LIB_H
+
+// IWYU pragma: begin_keep
+#include <stdbool.h>
+#include "objects.h"
+// IWYU pragma: end_keep
+
+bool cli_parse(int argc, char **argv, struct CommandLine *cli);
+
+void command_line_clear(struct CommandLine *cl);
+
+#endif /* MUTT_CLI_LIB_H */

--- a/cli/objects.c
+++ b/cli/objects.c
@@ -1,0 +1,128 @@
+/**
+ * @file
+ * Parse objects
+ *
+ * @authors
+ * Copyright (C) 2025 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page cli_objects Parse objects
+ *
+ * Parse objects
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include "mutt/lib.h"
+#include "objects.h"
+
+/**
+ * sa_clear - Empty a StringArray
+ * @param sa String Array
+ *
+ * @note The Array itself isn't freed
+ */
+static void sa_clear(struct StringArray *sa)
+{
+  char **cp = NULL;
+  ARRAY_FOREACH(cp, sa)
+  {
+    FREE(cp);
+  }
+
+  ARRAY_FREE(sa);
+}
+
+/**
+ * cli_shared_clear - Clear a CliShared
+ * @param shared CliShared to clear
+ */
+static void cli_shared_clear(struct CliShared *shared)
+{
+  buf_dealloc(&shared->log_file);
+  buf_dealloc(&shared->log_level);
+  buf_dealloc(&shared->mbox_type);
+
+  sa_clear(&shared->commands);
+  sa_clear(&shared->user_files);
+}
+
+/**
+ * cli_info_clear - Clear a CliInfo
+ * @param info CliInfo to clear
+ */
+static void cli_info_clear(struct CliInfo *info)
+{
+  sa_clear(&info->alias_queries);
+  sa_clear(&info->queries);
+}
+
+/**
+ * cli_send_clear - Clear a CliSend
+ * @param send CliSend to clear
+ */
+static void cli_send_clear(struct CliSend *send)
+{
+  sa_clear(&send->addresses);
+  sa_clear(&send->attach);
+  sa_clear(&send->bcc_list);
+  sa_clear(&send->cc_list);
+
+  buf_dealloc(&send->draft_file);
+  buf_dealloc(&send->include_file);
+  buf_dealloc(&send->subject);
+}
+
+/**
+ * cli_tui_clear - Clear a CliTui
+ * @param tui CliTui to clear
+ */
+static void cli_tui_clear(struct CliTui *tui)
+{
+  buf_dealloc(&tui->folder);
+  buf_dealloc(&tui->nntp_server);
+}
+
+/**
+ * command_line_new - Create a new CommandLine
+ * @retval ptr New CommandLine
+ */
+struct CommandLine *command_line_new(void)
+{
+  return MUTT_MEM_CALLOC(1, struct CommandLine);
+}
+
+/**
+ * command_line_free - Free a CommandLine
+ * @param ptr CommandLine to free
+ */
+void command_line_free(struct CommandLine **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct CommandLine *cl = *ptr;
+
+  // cl->help - nothing to do
+  cli_shared_clear(&cl->shared);
+  cli_info_clear(&cl->info);
+  cli_send_clear(&cl->send);
+  cli_tui_clear(&cl->tui);
+
+  FREE(ptr);
+}

--- a/cli/objects.h
+++ b/cli/objects.h
@@ -1,0 +1,125 @@
+/**
+ * @file
+ * Parse the Command Line
+ *
+ * @authors
+ * Copyright (C) 2025 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_CLI_OBJECTS_H
+#define MUTT_CLI_OBJECTS_H
+
+#include <stdbool.h>
+#include "mutt/lib.h"
+
+ARRAY_HEAD(StringArray, char *);
+
+/**
+ * struct CliShared - Shared Command Line options
+ */
+struct CliShared
+{
+  bool is_set;                      ///< This struct has been used
+
+  struct StringArray user_files;    ///< `-F` Use these user config files
+  bool disable_system;              ///< `-n` Don't read the system config file
+
+  struct StringArray commands;      ///< `-e` Run these commands
+  struct Buffer mbox_type;          ///< `-m` Set the default Mailbox type
+
+  struct Buffer log_level;          ///< `-d` Debug log level
+  struct Buffer log_file;           ///< `-l` Debug log file
+};
+
+/**
+ * struct CliHelp - Help Mode Command Line options
+ */
+struct CliHelp
+{
+  bool is_set;                      ///< This struct has been used
+  bool help;                        ///< `-h`  Print help
+  bool version;                     ///< `-v`  Print version
+  bool license;                     ///< `-vv` Print license
+};
+
+/**
+ * struct CliInfo - Info Mode Command Line options
+ */
+struct CliInfo
+{
+  bool is_set;                      ///< This struct has been used
+  bool dump_config;                 ///< `-D`  Dump the config
+  bool dump_changed;                ///< `-DD` Dump the changed config
+  bool show_help;                   ///< `-O`  Show one-liner help
+  bool hide_sensitive;              ///< `-S`  Hide sensitive config
+
+  struct StringArray alias_queries; ///< `-A`  Lookup an alias
+  struct StringArray queries;       ///< `-Q`  Query a config option
+};
+
+/**
+ * struct CliSend - Send Mode Command Line options
+ */
+struct CliSend
+{
+  bool is_set;                      ///< This struct has been used
+  bool use_crypto;                  ///< `-C` Use CLI crypto
+  bool edit_infile;                 ///< `-E` Edit the draft/include
+
+  struct StringArray attach;        ///< `-a` Attach a file
+  struct StringArray bcc_list;      ///< `-b` Add a Bcc:
+  struct StringArray cc_list;       ///< `-c` Add a Cc:
+  struct StringArray addresses;     ///< Send to these addresses
+
+  struct Buffer draft_file;         ///< `-H` Use this draft file
+  struct Buffer include_file;       ///< `-i` Use this include file
+  struct Buffer subject;            ///< `-s` Use this Subject:
+};
+
+/**
+ * struct CliTui - TUI Mode Command Line options
+ */
+struct CliTui
+{
+  bool is_set;                      ///< This struct has been used
+  bool read_only;                   ///< `-R` Open Mailbox read-only
+  bool start_postponed;             ///< `-p` Open Postponed emails
+  bool start_browser;               ///< `-y` Open the Mailbox Browser
+  bool start_nntp;                  ///< `-G` Open an NNTP Mailbox
+  bool start_new_mail;              ///< `-Z` Check for New Mail
+  bool start_any_mail;              ///< `-z` Check for Any Mail
+
+  struct Buffer folder;             ///< `-f` Open this Mailbox
+  struct Buffer nntp_server;        ///< `-g` Open this NNTP Mailbox
+};
+
+/**
+ * struct CommandLine - Command Line options
+ */
+struct CommandLine
+{
+  struct CliShared  shared;        ///< Shared    command line options
+  struct CliHelp    help;          ///< Help Mode command line options
+  struct CliInfo    info;          ///< Info Mode command line options
+  struct CliSend    send;          ///< Send Mode command line options
+  struct CliTui     tui;           ///< Tui  Mode command line options
+};
+
+struct CommandLine *command_line_new(void);
+void                command_line_free(struct CommandLine **ptr);
+
+#endif /* MUTT_CLI_OBJECTS_H */

--- a/cli/parse.c
+++ b/cli/parse.c
@@ -28,6 +28,7 @@
 
 #include "config.h"
 #include <stdbool.h>
+#include <sys/param.h> // IWYU pragma: keep
 #include <unistd.h>
 #include "mutt/lib.h"
 #include "objects.h"
@@ -84,6 +85,13 @@ bool cli_parse(int argc, char **argv, struct CommandLine *cli)
   bool rc = true;
 
   opterr = 0; // We'll handle the errors
+// Always initialise getopt() or the tests will fail
+#if defined(BSD) || defined(__APPLE__)
+  optreset = 1;
+  optind = 1;
+#else
+  optind = 0;
+#endif
 
   while (rc && (argc > 1) && (optind < argc))
   {

--- a/cli/parse.c
+++ b/cli/parse.c
@@ -1,0 +1,324 @@
+/**
+ * @file
+ * Parse the Command Line
+ *
+ * @authors
+ * Copyright (C) 2025 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page cli_parse Parse the Command Line
+ *
+ * Parse the Command Line
+ */
+
+#include "config.h"
+#include <stdbool.h>
+#include <unistd.h>
+#include "mutt/lib.h"
+#include "objects.h"
+
+/**
+ * mop_up - Eat multiple arguments
+ * @param[in]  argc  Size of argument array
+ * @param[in]  argv  Array of argument strings
+ * @param[in]  index Where to start eating
+ * @param[out] sa    Array for the results
+ * @retval num Number of arguments eaten
+ *
+ * Some options, like `-A`, can take multiple arguments.
+ * e.g. `-A apple` or `-A apple banana cherry`
+ *
+ * Copy the arguments into an array.
+ */
+static int mop_up(int argc, char **argv, int index, struct StringArray *sa)
+{
+  int count = 0;
+  for (int i = index; i < argc; i++, count++)
+  {
+    // Stop if we find '--' or '-X'
+    if ((argv[i][0] == '-') && (argv[i][1] != '\0'))
+      break;
+
+    ARRAY_ADD(sa, mutt_str_dup(argv[i]));
+  }
+
+  return count;
+}
+
+/**
+ * cli_parse - Parse the Command Line
+ * @param[in]  argc Number of arguments
+ * @param[in]  argv Arguments
+ * @param[out] cli  Results
+ * @retval true Success
+ */
+bool cli_parse(int argc, char **argv, struct CommandLine *cli)
+{
+  if ((argc < 1) || !argv || !cli)
+    return false;
+
+  // Any leading non-options must be addresses
+  int count = mop_up(argc, argv, 1, &cli->send.addresses);
+  if (count > 0)
+  {
+    cli->send.is_set = true;
+    argc -= count;
+    argv += count;
+  }
+
+  bool rc = true;
+
+  opterr = 0; // We'll handle the errors
+
+  while (rc && (argc > 1) && (optind < argc))
+  {
+    int opt = getopt(argc, argv, "+:A:a:b:Cc:Dd:Ee:F:f:Gg:H:hi:l:m:nOpQ:RSs:TvyZz");
+    switch (opt)
+    {
+      // ------------------------------------------------------------
+      // Shared
+      case 'F': // user config file
+      {
+        ARRAY_ADD(&cli->shared.user_files, mutt_str_dup(optarg));
+        cli->shared.is_set = true;
+        break;
+      }
+      case 'n': // no system config file
+      {
+        cli->shared.disable_system = true;
+        cli->shared.is_set = true;
+        break;
+      }
+      case 'e': // enter commands
+      {
+        ARRAY_ADD(&cli->shared.commands, mutt_str_dup(optarg));
+        cli->shared.is_set = true;
+        break;
+      }
+      case 'm': // mbox type
+      {
+        buf_strcpy(&cli->shared.mbox_type, optarg);
+        cli->shared.is_set = true;
+        break;
+      }
+      case 'd': // log level
+      {
+        buf_strcpy(&cli->shared.log_level, optarg);
+        cli->shared.is_set = true;
+        break;
+      }
+      case 'l': // log file
+      {
+        buf_strcpy(&cli->shared.log_file, optarg);
+        cli->shared.is_set = true;
+        break;
+      }
+
+      // ------------------------------------------------------------
+      // Help
+      case 'h': // help
+      {
+        cli->help.help = true;
+        cli->help.is_set = true;
+        break;
+      }
+      case 'v': // version, license
+      {
+        if (cli->help.version)
+          cli->help.license = true;
+        else
+          cli->help.version = true;
+
+        cli->help.is_set = true;
+        break;
+      }
+
+      // ------------------------------------------------------------
+      // Info
+      case 'A': // alias lookup
+      {
+        ARRAY_ADD(&cli->info.alias_queries, mutt_str_dup(optarg));
+        // '-A' can take multiple arguments
+        optind += mop_up(argc, argv, optind, &cli->info.alias_queries);
+        cli->info.is_set = true;
+        break;
+      }
+      case 'D': // dump config, dump changed
+      {
+        if (cli->info.dump_config)
+          cli->info.dump_changed = true;
+        else
+          cli->info.dump_config = true;
+
+        cli->info.is_set = true;
+        break;
+      }
+      case 'O': // one-liner help
+      {
+        cli->info.show_help = true;
+        cli->info.is_set = true;
+        break;
+      }
+      case 'Q': // query config&cli->send.attach
+      {
+        ARRAY_ADD(&cli->info.queries, mutt_str_dup(optarg));
+        // '-Q' can take multiple arguments
+        optind += mop_up(argc, argv, optind, &cli->info.queries);
+        cli->info.is_set = true;
+        break;
+      }
+      case 'S': // hide sensitive
+      {
+        cli->info.hide_sensitive = true;
+        cli->info.is_set = true;
+        break;
+      }
+
+      // ------------------------------------------------------------
+      // Send
+      case 'a': // attach file
+      {
+        ARRAY_ADD(&cli->send.attach, mutt_str_dup(optarg));
+        // `-a` can take multiple arguments
+        optind += mop_up(argc, argv, optind, &cli->send.attach);
+        cli->send.is_set = true;
+        break;
+      }
+      case 'b': // bcc:
+      {
+        ARRAY_ADD(&cli->send.bcc_list, mutt_str_dup(optarg));
+        cli->send.is_set = true;
+        break;
+      }
+      case 'C': // crypto
+      {
+        cli->send.use_crypto = true;
+        cli->send.is_set = true;
+        break;
+      }
+      case 'c': // cc:
+      {
+        ARRAY_ADD(&cli->send.cc_list, mutt_str_dup(optarg));
+        cli->send.is_set = true;
+        break;
+      }
+      case 'E': // edit file
+      {
+        cli->send.edit_infile = true;
+        cli->send.is_set = true;
+        break;
+      }
+      case 'H': // draft file
+      {
+        buf_strcpy(&cli->send.draft_file, optarg);
+        cli->send.is_set = true;
+        break;
+      }
+      case 'i': // include file
+      {
+        buf_strcpy(&cli->send.include_file, optarg);
+        cli->send.is_set = true;
+        break;
+      }
+      case 's': // subject:
+      {
+        buf_strcpy(&cli->send.subject, optarg);
+        cli->send.is_set = true;
+        break;
+      }
+
+      // ------------------------------------------------------------
+      // TUI
+      case 'f': // start folder
+      {
+        buf_strcpy(&cli->tui.folder, optarg);
+        cli->tui.is_set = true;
+        break;
+      }
+      case 'G': // list newsgroups
+      {
+        cli->tui.start_nntp = true;
+        cli->tui.is_set = true;
+        break;
+      }
+      case 'g': // news server
+      {
+        cli->tui.start_nntp = true;
+        buf_strcpy(&cli->tui.nntp_server, optarg);
+        cli->tui.is_set = true;
+        break;
+      }
+      case 'p': // postponed
+      {
+        cli->tui.start_postponed = true;
+        cli->tui.is_set = true;
+        break;
+      }
+      case 'R': // read-only
+      {
+        cli->tui.read_only = true;
+        cli->tui.is_set = true;
+        break;
+      }
+      case 'y': // browser
+      {
+        cli->tui.start_browser = true;
+        cli->tui.is_set = true;
+        break;
+      }
+      case 'Z': // new mail
+      {
+        cli->tui.start_new_mail = true;
+        cli->tui.is_set = true;
+        break;
+      }
+      case 'z': // any mail
+      {
+        cli->tui.start_any_mail = true;
+        cli->tui.is_set = true;
+        break;
+      }
+
+      // ------------------------------------------------------------
+      case -1: // end of options
+      {
+        for (int i = optind; i < argc; i++)
+        {
+          ARRAY_ADD(&cli->send.addresses, mutt_str_dup(argv[i]));
+        }
+        cli->send.is_set = true;
+        optind = argc; // finish parsing
+        break;
+      }
+      default: // error
+      {
+        if (opt == '?')
+          mutt_warning("Invalid option: %c", optopt);
+        else if (opt == ':')
+          mutt_warning("Option %c requires an argument", optopt);
+
+        cli->help.help = true;
+        cli->help.is_set = true;
+        rc = false; // stop parsing
+        break;
+      }
+    }
+  }
+
+  return rc;
+}

--- a/globals.c
+++ b/globals.c
@@ -45,7 +45,6 @@ struct ListHead AlternativeOrderList = STAILQ_HEAD_INITIALIZER(AlternativeOrderL
 struct ListHead AutoViewList         = STAILQ_HEAD_INITIALIZER(AutoViewList);         ///< List of mime types to auto view
 struct ListHead HeaderOrderList      = STAILQ_HEAD_INITIALIZER(HeaderOrderList);      ///< List of header fields in the order they should be displayed
 struct ListHead MimeLookupList       = STAILQ_HEAD_INITIALIZER(MimeLookupList);       ///< List of mime types that that shouldn't use the mailcap entry
-struct ListHead Muttrc               = STAILQ_HEAD_INITIALIZER(Muttrc);               ///< List of config files to read
 struct ListHead TempAttachmentsList  = STAILQ_HEAD_INITIALIZER(TempAttachmentsList);  ///< List of temporary files for displaying attachments
 struct ListHead UserHeader           = STAILQ_HEAD_INITIALIZER(UserHeader);           ///< List of custom headers to add to outgoing emails
 // clang-format on

--- a/globals.h
+++ b/globals.h
@@ -41,7 +41,6 @@ extern struct ListHead AlternativeOrderList; ///< List of preferred mime types t
 extern struct ListHead AutoViewList;         ///< List of mime types to auto view
 extern struct ListHead HeaderOrderList;      ///< List of header fields in the order they should be displayed
 extern struct ListHead MimeLookupList;       ///< List of mime types that that shouldn't use the mailcap entry
-extern struct ListHead Muttrc;               ///< List of config files to read
 extern struct ListHead TempAttachmentsList;  ///< List of temporary files for displaying attachments
 extern struct ListHead UserHeader;           ///< List of custom headers to add to outgoing emails
 

--- a/main.c
+++ b/main.c
@@ -52,13 +52,13 @@
  *
  * Libraries:
  * @ref lib_address, @ref lib_alias, @ref lib_attach, @ref lib_autocrypt,
- * @ref lib_bcache, @ref lib_browser, @ref lib_color, @ref lib_complete,
- * @ref lib_compmbox, @ref lib_compose, @ref lib_compress, @ref lib_config,
- * @ref lib_conn, @ref lib_convert, @ref lib_core, @ref lib_editor,
- * @ref lib_email, @ref lib_envelope, @ref lib_expando, @ref lib_gui,
- * @ref lib_hcache, @ref lib_helpbar, @ref lib_history, @ref lib_imap,
- * @ref lib_index, @ref lib_key, @ref lib_maildir, @ref lib_mh, @ref lib_mbox,
- * @ref lib_menu, @ref lib_mutt, @ref lib_ncrypt,
+ * @ref lib_bcache, @ref lib_browser, @ref lib_cli, @ref lib_color,
+ * @ref lib_complete, @ref lib_compmbox, @ref lib_compose, @ref lib_compress,
+ * @ref lib_config, @ref lib_conn, @ref lib_convert, @ref lib_core,
+ * @ref lib_editor, @ref lib_email, @ref lib_envelope, @ref lib_expando,
+ * @ref lib_gui, @ref lib_hcache, @ref lib_helpbar, @ref lib_history,
+ * @ref lib_imap, @ref lib_index, @ref lib_key, @ref lib_maildir,
+ * @ref lib_mh, @ref lib_mbox, @ref lib_menu, @ref lib_mutt, @ref lib_ncrypt,
  * @ref lib_nntp, @ref lib_notmuch, @ref lib_pager, @ref lib_parse,
  * @ref lib_pattern, @ref lib_pop, @ref lib_postpone, @ref lib_progress,
  * @ref lib_question, @ref lib_send, @ref lib_sidebar, @ref lib_store.

--- a/main.c
+++ b/main.c
@@ -150,6 +150,7 @@
 #include "mutt.h"
 #include "attach/lib.h"
 #include "browser/lib.h"
+#include "cli/lib.h"
 #include "color/lib.h"
 #include "compmbox/lib.h"
 #include "history/lib.h"
@@ -197,32 +198,21 @@
 
 bool StartupComplete = false; ///< When the config has been read
 
-// clang-format off
-typedef uint8_t CliFlags;         ///< Flags for command line options, e.g. #MUTT_CLI_IGNORE
-#define MUTT_CLI_NO_FLAGS      0  ///< No flags are set
-#define MUTT_CLI_IGNORE  (1 << 0) ///< -z Open first mailbox if it has mail
-#define MUTT_CLI_MAILBOX (1 << 1) ///< -Z Open first mailbox if is has new mail
-#define MUTT_CLI_NOSYSRC (1 << 2) ///< -n Do not read the system-wide config file
-#define MUTT_CLI_RO      (1 << 3) ///< -R Open mailbox in read-only mode
-#define MUTT_CLI_SELECT  (1 << 4) ///< -y Start with a list of all mailboxes
-#define MUTT_CLI_NEWS    (1 << 5) ///< -g/-G Start with a list of all newsgroups
-// clang-format on
-
 /**
  * execute_commands - Execute a set of NeoMutt commands
- * @param p List of command strings
+ * @param sa Array of command strings
  * @retval  0 Success, all the commands succeeded
  * @retval -1 Error
  */
-static int execute_commands(struct ListHead *p)
+static int execute_commands(struct StringArray *sa)
 {
   int rc = 0;
   struct Buffer *err = buf_pool_get();
 
-  struct ListNode *np = NULL;
-  STAILQ_FOREACH(np, p, entries)
+  char **cp = NULL;
+  ARRAY_FOREACH(cp, sa)
   {
-    enum CommandResult rc2 = parse_rc_line(np->data, err);
+    enum CommandResult rc2 = parse_rc_line(*cp, err);
     if (rc2 == MUTT_CMD_ERROR)
       mutt_error(_("Error in command line: %s"), buf_string(err));
     else if (rc2 == MUTT_CMD_WARNING)
@@ -401,17 +391,20 @@ static bool get_hostname(struct ConfigSet *cs)
  * @param dlevel      Command line debug level
  * @param dfile       Command line debug file
  * @param skip_sys_rc If true, don't read the system config file
- * @param commands    List of config commands to execute
+ * @param user_files  Array of user config files
+ * @param commands    Array of config commands to execute
  * @retval 0 Success
  * @retval 1 Error
  */
-static int mutt_init(struct ConfigSet *cs, const char *dlevel, const char *dfile,
-                     bool skip_sys_rc, struct ListHead *commands)
+static int mutt_init(struct ConfigSet *cs, struct Buffer *dlevel,
+                     struct Buffer *dfile, bool skip_sys_rc,
+                     struct StringArray *user_files, struct StringArray *commands)
 {
   bool need_pause = false;
   int rc = 1;
   struct Buffer *err = buf_pool_get();
   struct Buffer *buf = buf_pool_get();
+  char **cp = NULL;
 
 #ifdef NEOMUTT_DIRECT_COLORS
   /* Test if we run in a terminal which supports direct colours.
@@ -536,7 +529,7 @@ static int mutt_init(struct ConfigSet *cs, const char *dlevel, const char *dfile
   add_to_stailq(&MailToAllow, "in-reply-to");
   add_to_stailq(&MailToAllow, "references");
 
-  if (STAILQ_EMPTY(&Muttrc))
+  if (ARRAY_EMPTY(user_files))
   {
     const char *xdg_cfg_home = mutt_str_getenv("XDG_CONFIG_HOME");
 
@@ -549,32 +542,30 @@ static int mutt_init(struct ConfigSet *cs, const char *dlevel, const char *dfile
     char *config = find_cfg(NeoMutt->home_dir, xdg_cfg_home);
     if (config)
     {
-      mutt_list_insert_tail(&Muttrc, config);
+      ARRAY_ADD(user_files, mutt_str_dup(config));
     }
   }
   else
   {
-    struct ListNode *np = NULL;
-    STAILQ_FOREACH(np, &Muttrc, entries)
+    ARRAY_FOREACH(cp, user_files)
     {
-      buf_strcpy(buf, np->data);
-      FREE(&np->data);
+      buf_strcpy(buf, *cp);
+      FREE(cp);
       buf_expand_path(buf);
-      np->data = buf_strdup(buf);
-      if (access(np->data, F_OK))
+      ARRAY_SET(user_files, ARRAY_FOREACH_IDX_cp, buf_strdup(buf));
+      if (access(buf_string(buf), F_OK))
       {
-        mutt_perror("%s", np->data);
+        mutt_perror("%s", buf_string(buf));
         goto done; // TEST10: neomutt -F missing
       }
     }
   }
 
-  struct ListNode *np = NULL;
-  STAILQ_FOREACH(np, &Muttrc, entries)
+  ARRAY_FOREACH(cp, user_files)
   {
-    if (np->data && !mutt_str_equal(np->data, "/dev/null"))
+    if (*cp && !mutt_str_equal(*cp, "/dev/null"))
     {
-      cs_str_string_set(cs, "alias_file", np->data, NULL);
+      cs_str_string_set(cs, "alias_file", *cp, NULL);
       break;
     }
   }
@@ -614,11 +605,11 @@ static int mutt_init(struct ConfigSet *cs, const char *dlevel, const char *dfile
   }
 
   /* Read the user's initialization file.  */
-  STAILQ_FOREACH(np, &Muttrc, entries)
+  ARRAY_FOREACH(cp, user_files)
   {
-    if (np->data)
+    if (*cp)
     {
-      if (source_rc(np->data, err) != 0)
+      if (source_rc(*cp, err) != 0)
       {
         mutt_error("%s", buf_string(err));
         need_pause = true; // TEST12: neomutt (error in ~/.neomuttrc)
@@ -633,9 +624,9 @@ static int mutt_init(struct ConfigSet *cs, const char *dlevel, const char *dfile
     goto done;
 
   /* The command line overrides the config */
-  if (dlevel)
+  if (!buf_is_empty(dlevel))
     cs_str_reset(cs, "debug_level", NULL);
-  if (dfile)
+  if (!buf_is_empty(dfile))
     cs_str_reset(cs, "debug_file", NULL);
 
   if (mutt_log_start() < 0)
@@ -668,28 +659,28 @@ done:
 
 /**
  * get_elem_queries - Lookup the HashElems for a set of queries
- * @param[in]  queries List of query strings
+ * @param[in]  queries Array of query strings
  * @param[out] hea     Array for Config HashElems
  * @retval 0 Success, all queries exist
  * @retval 1 Error
  */
-static int get_elem_queries(struct ListHead *queries, struct HashElemArray *hea)
+static int get_elem_queries(struct StringArray *queries, struct HashElemArray *hea)
 {
   int rc = 0;
-  struct ListNode *np = NULL;
-  STAILQ_FOREACH(np, queries, entries)
+  char **cp = NULL;
+  ARRAY_FOREACH(cp, queries)
   {
-    struct HashElem *he = cs_subset_lookup(NeoMutt->sub, np->data);
+    struct HashElem *he = cs_subset_lookup(NeoMutt->sub, *cp);
     if (!he)
     {
-      mutt_warning(_("Unknown option %s"), np->data);
+      mutt_warning(_("Unknown option %s"), *cp);
       rc = 1;
       continue;
     }
 
     if (he->type & D_INTERNAL_DEPRECATED)
     {
-      mutt_warning(_("Option %s is deprecated"), np->data);
+      mutt_warning(_("Option %s is deprecated"), *cp);
       rc = 1;
       continue;
     }
@@ -1013,6 +1004,154 @@ done:
 }
 
 /**
+ * show_help - Show the Help
+ * @param help Command Line Options
+ * @retval true Success, continue
+ */
+static bool show_help(struct CliHelp *help)
+{
+  if (!help->is_set)
+    return true;
+
+  log_queue_flush(log_disp_terminal);
+
+  if (help->help)
+  {
+    usage();
+  }
+  else if (help->license)
+  {
+    print_copyright();
+  }
+  else
+  {
+    print_version(stdout);
+  }
+
+  return false; // Stop
+}
+
+/**
+ * init_logging - Initialise the Logging
+ * @param shared Shared Command line Options
+ * @param cs     Config Set
+ * @retval true Succes
+ */
+static bool init_logging(struct CliShared *shared, struct ConfigSet *cs)
+{
+  if (!shared->is_set)
+    return true;
+
+  if (!buf_is_empty(&shared->log_file))
+    config_str_set_initial(cs, "debug_file", buf_string(&shared->log_file));
+
+  if (!buf_is_empty(&shared->log_level))
+  {
+    const char *dlevel = buf_string(&shared->log_level);
+    short num = 0;
+    if (!mutt_str_atos_full(dlevel, &num) || (num < LL_MESSAGE) || (num >= LL_MAX))
+    {
+      mutt_error(_("Error: value '%s' is invalid for -d"), dlevel);
+      return false;
+    }
+
+    config_str_set_initial(cs, "debug_level", dlevel);
+  }
+
+  return true;
+}
+
+/**
+ * init_nntp - Initialise the NNTP config
+ * @param server NNTP Server to use
+ * @param cs     Config Set
+ */
+static void init_nntp(struct Buffer *server, struct ConfigSet *cs)
+{
+  const char *cli_nntp = NULL;
+  if (!buf_is_empty(server))
+    cli_nntp = buf_string(server);
+
+  /* "$news_server" precedence: command line, config file, environment, system file */
+  if (cli_nntp)
+    cli_nntp = cs_subset_string(NeoMutt->sub, "news_server");
+
+  if (!cli_nntp)
+    cli_nntp = mutt_str_getenv("NNTPSERVER");
+
+  if (!cli_nntp)
+  {
+    char buf[1024] = { 0 };
+    cli_nntp = mutt_file_read_keyword(SYSCONFDIR "/nntpserver", buf, sizeof(buf));
+  }
+
+  if (cli_nntp)
+    config_str_set_initial(cs, "news_server", cli_nntp);
+}
+
+/**
+ * dump_info - Show config info
+ * @param ci Command line Options
+ * @param cs Config Set
+ * @retval true Success
+ */
+static bool dump_info(struct CliInfo *ci, struct ConfigSet *cs)
+{
+  if (!ci->is_set)
+    return true;
+
+  if (ci->dump_config || !ARRAY_EMPTY(&ci->queries))
+  {
+    const bool tty = isatty(STDOUT_FILENO);
+
+    ConfigDumpFlags cdflags = CS_DUMP_NO_FLAGS;
+    if (tty)
+      cdflags |= CS_DUMP_LINK_DOCS;
+    if (ci->hide_sensitive)
+      cdflags |= CS_DUMP_HIDE_SENSITIVE;
+    if (ci->show_help)
+      cdflags |= CS_DUMP_SHOW_DOCS;
+
+    struct HashElemArray hea = ARRAY_HEAD_INITIALIZER;
+    if (ci->dump_config)
+    {
+      enum GetElemListFlags gel_flags = ci->dump_changed ? GEL_CHANGED_CONFIG : GEL_ALL_CONFIG;
+      hea = get_elem_list(cs, gel_flags);
+    }
+    else
+    {
+      get_elem_queries(&ci->queries, &hea);
+    }
+
+    dump_config(cs, &hea, cdflags, stdout);
+    ARRAY_FREE(&hea);
+  }
+  else if (!ARRAY_EMPTY(&ci->alias_queries))
+  {
+    char **cp = NULL;
+    ARRAY_FOREACH(cp, &ci->alias_queries)
+    {
+      struct AddressList *al = alias_lookup(*cp);
+      if (al)
+      {
+        /* output in machine-readable form */
+        mutt_addrlist_to_intl(al, NULL);
+        struct Buffer *buf = buf_pool_get();
+        mutt_addrlist_write(al, buf, false);
+        printf("%s\n", buf_string(buf));
+        buf_pool_release(&buf);
+      }
+      else
+      {
+        printf("%s\n", NONULL(*cp)); // TEST19: neomutt -A unknown
+      }
+    }
+  }
+
+  return false; // Stop
+}
+
+/**
  * main - Start NeoMutt
  * @param argc Number of command line arguments
  * @param argv List of command line arguments
@@ -1022,37 +1161,14 @@ done:
  */
 int main(int argc, char *argv[], char *envp[])
 {
-  char *subject = NULL;
-  char *include_file = NULL;
-  char *draft_file = NULL;
-  char *new_type = NULL;
-  char *dlevel = NULL;
-  char *dfile = NULL;
-  const char *cli_nntp = NULL;
   struct Email *e = NULL;
-  struct ListHead attach = STAILQ_HEAD_INITIALIZER(attach);
-  struct ListHead commands = STAILQ_HEAD_INITIALIZER(commands);
-  struct ListHead queries = STAILQ_HEAD_INITIALIZER(queries);
-  struct ListHead alias_queries = STAILQ_HEAD_INITIALIZER(alias_queries);
-  struct ListHead cc_list = STAILQ_HEAD_INITIALIZER(cc_list);
-  struct ListHead bcc_list = STAILQ_HEAD_INITIALIZER(bcc_list);
   SendFlags sendflags = SEND_NO_FLAGS;
-  CliFlags flags = MUTT_CLI_NO_FLAGS;
-  int version = 0;
-  int i;
-  bool explicit_folder = false;
-  bool dump_variables = false;
-  bool dump_changed = false;
-  bool one_liner = false;
-  bool hide_sensitive = false;
-  bool edit_infile = false;
-  int double_dash = argc, nargc = 1;
   int rc = 1;
   bool repeat_error = false;
-  struct Buffer *folder = buf_pool_get();
   struct Buffer *expanded_infile = buf_pool_get();
   struct Buffer *tempfile = buf_pool_get();
   struct ConfigSet *cs = NULL;
+  struct CommandLine *cli = command_line_new();
 
   MuttLogger = log_disp_terminal;
 
@@ -1077,152 +1193,10 @@ int main(int argc, char *argv[], char *envp[])
 
   init_config(cs);
 
-  for (optind = 1; optind < double_dash;)
-  {
-    /* We're getopt'ing POSIXLY, so we'll be here every time getopt()
-     * encounters a non-option.  That could be a file to attach
-     * (all non-options between -a and --) or it could be an address
-     * (which gets collapsed to the front of argv).  */
-    for (; optind < argc; optind++)
-    {
-      if ((argv[optind][0] == '-') && (argv[optind][1] != '\0'))
-      {
-        if ((argv[optind][1] == '-') && (argv[optind][2] == '\0'))
-          double_dash = optind; /* quit outer loop after getopt */
-        break;                  /* drop through to getopt */
-      }
+  cli_parse(argc, argv, cli);
 
-      /* non-option, either an attachment or address */
-      if (!STAILQ_EMPTY(&attach))
-        mutt_list_insert_tail(&attach, mutt_str_dup(argv[optind]));
-      else
-        argv[nargc++] = argv[optind];
-    }
-
-    i = getopt(argc, argv, "+A:a:b:F:f:Cc:Dd:l:Ee:g:GH:i:hm:nOpQ:RSs:TvyzZ");
-    if (i != EOF)
-    {
-      switch (i)
-      {
-        case 'A':
-          mutt_list_insert_tail(&alias_queries, mutt_str_dup(optarg));
-          break;
-        case 'a':
-          mutt_list_insert_tail(&attach, mutt_str_dup(optarg));
-          break;
-        case 'b':
-          mutt_list_insert_tail(&bcc_list, mutt_str_dup(optarg));
-          break;
-        case 'C':
-          sendflags |= SEND_CLI_CRYPTO;
-          break;
-        case 'c':
-          mutt_list_insert_tail(&cc_list, mutt_str_dup(optarg));
-          break;
-        case 'D':
-          if (dump_variables)
-            dump_changed = true;
-          else
-            dump_variables = true;
-          break;
-        case 'd':
-          dlevel = optarg;
-          break;
-        case 'E':
-          edit_infile = true;
-          break;
-        case 'e':
-          mutt_list_insert_tail(&commands, mutt_str_dup(optarg));
-          break;
-        case 'F':
-          mutt_list_insert_tail(&Muttrc, mutt_str_dup(optarg));
-          break;
-        case 'f':
-          buf_strcpy(folder, optarg);
-          explicit_folder = true;
-          break;
-        case 'g': /* Specify a news server */
-          cli_nntp = optarg;
-          FALLTHROUGH;
-
-        case 'G': /* List of newsgroups */
-          flags |= MUTT_CLI_SELECT | MUTT_CLI_NEWS;
-          break;
-        case 'H':
-          draft_file = optarg;
-          break;
-        case 'i':
-          include_file = optarg;
-          break;
-        case 'l':
-          dfile = optarg;
-          break;
-        case 'm':
-          new_type = optarg;
-          break;
-        case 'n':
-          flags |= MUTT_CLI_NOSYSRC;
-          break;
-        case 'O':
-          one_liner = true;
-          break;
-        case 'p':
-          sendflags |= SEND_POSTPONED;
-          break;
-        case 'Q':
-          mutt_list_insert_tail(&queries, mutt_str_dup(optarg));
-          break;
-        case 'R':
-          flags |= MUTT_CLI_RO; /* read-only mode */
-          break;
-        case 'S':
-          hide_sensitive = true;
-          break;
-        case 's':
-          subject = optarg;
-          break;
-        case 'v':
-          version++;
-          break;
-        case 'y': /* My special hack mode */
-          flags |= MUTT_CLI_SELECT;
-          break;
-        case 'Z':
-          flags |= MUTT_CLI_MAILBOX | MUTT_CLI_IGNORE;
-          break;
-        case 'z':
-          flags |= MUTT_CLI_IGNORE;
-          break;
-        default:
-          OptNoCurses = true;
-          if (usage())
-            goto main_ok; // TEST03: neomutt -9
-          else
-            goto main_curses;
-      }
-    }
-  }
-
-  /* collapse remaining argv */
-  while (optind < argc)
-    argv[nargc++] = argv[optind++];
-  optind = 1;
-  argc = nargc;
-
-  if (version > 0)
-  {
-    log_queue_flush(log_disp_terminal);
-    bool done;
-    if (version == 1)
-      done = print_version(stdout);
-    else
-      done = print_copyright();
-    OptNoCurses = true;
-    if (done)
-      goto main_ok; // TEST04: neomutt -v
-    else
-      goto main_curses;
-  }
+  if (!show_help(&cli->help))
+    goto main_ok;
 
   // Change the current umask, and save the original one
   NeoMutt->user_default_umask = umask(077);
@@ -1242,20 +1216,8 @@ int main(int argc, char *argv[], char *envp[])
   localise_config(cs);
 #endif
 
-  if (dfile)
-    config_str_set_initial(cs, "debug_file", dfile);
-
-  if (dlevel)
-  {
-    short num = 0;
-    if (!mutt_str_atos_full(dlevel, &num) || (num < LL_MESSAGE) || (num >= LL_MAX))
-    {
-      mutt_error(_("Error: value '%s' is invalid for -d"), dlevel);
-      goto main_exit; // TEST07: neomutt -d xyz
-    }
-
-    config_str_set_initial(cs, "debug_level", dlevel);
-  }
+  if (!init_logging(&cli->shared, cs))
+    goto main_exit;
 
   mutt_log_prep();
   MuttLogger = log_disp_queue;
@@ -1263,29 +1225,9 @@ int main(int argc, char *argv[], char *envp[])
   mutt_debug(LL_DEBUG1, "user's umask %03o\n", NeoMutt->user_default_umask);
   mutt_debug(LL_DEBUG3, "umask set to 077\n");
 
-  if (!STAILQ_EMPTY(&cc_list) || !STAILQ_EMPTY(&bcc_list))
-  {
-    e = email_new();
-    e->env = mutt_env_new();
-
-    struct ListNode *np = NULL;
-    STAILQ_FOREACH(np, &bcc_list, entries)
-    {
-      mutt_addrlist_parse(&e->env->bcc, np->data);
-    }
-
-    STAILQ_FOREACH(np, &cc_list, entries)
-    {
-      mutt_addrlist_parse(&e->env->cc, np->data);
-    }
-
-    mutt_list_free(&bcc_list);
-    mutt_list_free(&cc_list);
-  }
-
   /* Check for a batch send. */
-  if (!isatty(STDIN_FILENO) || !STAILQ_EMPTY(&queries) ||
-      !STAILQ_EMPTY(&alias_queries) || dump_variables)
+  if (!isatty(STDIN_FILENO) || !ARRAY_EMPTY(&cli->info.queries) ||
+      !ARRAY_EMPTY(&cli->info.alias_queries) || cli->info.dump_config)
   {
     OptNoCurses = true;
     sendflags |= SEND_BATCH;
@@ -1336,7 +1278,9 @@ int main(int argc, char *argv[], char *envp[])
 #endif
 
   /* set defaults and read init files */
-  int rc2 = mutt_init(cs, dlevel, dfile, flags & MUTT_CLI_NOSYSRC, &commands);
+  int rc2 = mutt_init(cs, &cli->shared.log_level, &cli->shared.log_file,
+                      cli->shared.disable_system, &cli->shared.user_files,
+                      &cli->shared.commands);
   if (rc2 != 0)
     goto main_curses;
 
@@ -1359,84 +1303,19 @@ int main(int argc, char *argv[], char *envp[])
 
   mutt_init_abort_key();
 
-  /* "$news_server" precedence: command line, config file, environment, system file */
-  if (!cli_nntp)
-    cli_nntp = cs_subset_string(NeoMutt->sub, "news_server");
-
-  if (!cli_nntp)
-    cli_nntp = mutt_str_getenv("NNTPSERVER");
-
-  if (!cli_nntp)
-  {
-    char buf[1024] = { 0 };
-    cli_nntp = mutt_file_read_keyword(SYSCONFDIR "/nntpserver", buf, sizeof(buf));
-  }
-
-  if (cli_nntp)
-    config_str_set_initial(cs, "news_server", cli_nntp);
+  init_nntp(&cli->tui.nntp_server, cs);
 
   /* Initialize crypto backends.  */
   crypt_init();
 
-  if (new_type && !config_str_set_initial(cs, "mbox_type", new_type))
-    goto main_curses;
-
-  if (dump_variables || !STAILQ_EMPTY(&queries))
+  if (!buf_is_empty(&cli->shared.mbox_type) &&
+      !config_str_set_initial(cs, "mbox_type", buf_string(&cli->shared.mbox_type)))
   {
-    const bool tty = isatty(STDOUT_FILENO);
-
-    ConfigDumpFlags cdflags = CS_DUMP_NO_FLAGS;
-    if (tty)
-      cdflags |= CS_DUMP_LINK_DOCS;
-    if (hide_sensitive)
-      cdflags |= CS_DUMP_HIDE_SENSITIVE;
-    if (one_liner)
-      cdflags |= CS_DUMP_SHOW_DOCS;
-
-    struct HashElemArray hea = ARRAY_HEAD_INITIALIZER;
-    if (dump_variables)
-    {
-      enum GetElemListFlags gel_flags = dump_changed ? GEL_CHANGED_CONFIG : GEL_ALL_CONFIG;
-      hea = get_elem_list(cs, gel_flags);
-      rc = 0;
-    }
-    else
-    {
-      rc = get_elem_queries(&queries, &hea);
-    }
-
-    dump_config(cs, &hea, cdflags, stdout);
-    ARRAY_FREE(&hea);
     goto main_curses;
   }
 
-  if (!STAILQ_EMPTY(&alias_queries))
-  {
-    rc = 0;
-    for (; optind < argc; optind++)
-      mutt_list_insert_tail(&alias_queries, mutt_str_dup(argv[optind]));
-    struct ListNode *np = NULL;
-    STAILQ_FOREACH(np, &alias_queries, entries)
-    {
-      struct AddressList *al = alias_lookup(np->data);
-      if (al)
-      {
-        /* output in machine-readable form */
-        mutt_addrlist_to_intl(al, NULL);
-        struct Buffer *buf = buf_pool_get();
-        mutt_addrlist_write(al, buf, false);
-        printf("%s\n", buf_string(buf));
-        buf_pool_release(&buf);
-      }
-      else
-      {
-        rc = 1;
-        printf("%s\n", NONULL(np->data)); // TEST19: neomutt -A unknown
-      }
-    }
-    mutt_list_free(&alias_queries);
-    goto main_curses; // TEST20: neomutt -A alias
-  }
+  if (!dump_info(&cli->info, cs))
+    goto main_curses;
 
   if (!OptNoCurses)
   {
@@ -1489,7 +1368,7 @@ int main(int argc, char *argv[], char *envp[])
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, main_config_observer, NULL);
   notify_observer_add(NeoMutt->notify, NT_TIMEOUT, main_timeout_observer, NULL);
 
-  if (sendflags & SEND_POSTPONED)
+  if (cli->tui.start_postponed)
   {
     if (!OptNoCurses)
       mutt_flushinp();
@@ -1501,12 +1380,11 @@ int main(int argc, char *argv[], char *envp[])
     repeat_error = true;
     goto main_curses;
   }
-  else if (subject || e || draft_file || include_file ||
-           !STAILQ_EMPTY(&attach) || (optind < argc))
+  else if (cli->send.is_set)
   {
     FILE *fp_in = NULL;
     FILE *fp_out = NULL;
-    char *infile = NULL;
+    const char *infile = NULL;
     char *bodytext = NULL;
     const char *bodyfile = NULL;
     int rv = 0;
@@ -1514,16 +1392,25 @@ int main(int argc, char *argv[], char *envp[])
     if (!OptNoCurses)
       mutt_flushinp();
 
-    if (!e)
-      e = email_new();
-    if (!e->env)
-      e->env = mutt_env_new();
+    e = email_new();
+    e->env = mutt_env_new();
 
-    for (i = optind; i < argc; i++)
+    char **cp = NULL;
+    ARRAY_FOREACH(cp, &cli->send.bcc_list)
     {
-      if (url_check_scheme(argv[i]) == U_MAILTO)
+      mutt_addrlist_parse(&e->env->bcc, *cp);
+    }
+
+    ARRAY_FOREACH(cp, &cli->send.cc_list)
+    {
+      mutt_addrlist_parse(&e->env->cc, *cp);
+    }
+
+    ARRAY_FOREACH(cp, &cli->send.addresses)
+    {
+      if (url_check_scheme(*cp) == U_MAILTO)
       {
-        if (!mutt_parse_mailto(e->env, &bodytext, argv[i]))
+        if (!mutt_parse_mailto(e->env, &bodytext, *cp))
         {
           mutt_error(_("Failed to parse mailto: link"));
           email_free(&e);
@@ -1532,38 +1419,37 @@ int main(int argc, char *argv[], char *envp[])
       }
       else
       {
-        mutt_addrlist_parse(&e->env->to, argv[i]);
+        mutt_addrlist_parse(&e->env->to, *cp);
       }
     }
 
     const bool c_auto_edit = cs_subset_bool(NeoMutt->sub, "auto_edit");
-    if (!draft_file && c_auto_edit && TAILQ_EMPTY(&e->env->to) &&
-        TAILQ_EMPTY(&e->env->cc))
+    if (buf_is_empty(&cli->send.draft_file) && c_auto_edit &&
+        TAILQ_EMPTY(&e->env->to) && TAILQ_EMPTY(&e->env->cc))
     {
       mutt_error(_("No recipients specified"));
       email_free(&e);
       goto main_curses; // TEST26: neomutt -s test (with auto_edit=yes)
     }
 
-    if (subject)
+    if (!buf_is_empty(&cli->send.subject))
     {
       /* prevent header injection */
-      mutt_filter_commandline_header_value(subject);
-      mutt_env_set_subject(e->env, subject);
+      mutt_filter_commandline_header_value(cli->send.subject.data);
+      mutt_env_set_subject(e->env, buf_string(&cli->send.subject));
     }
 
-    if (draft_file)
+    if (!buf_is_empty(&cli->send.draft_file))
     {
-      infile = draft_file;
-      include_file = NULL;
+      infile = buf_string(&cli->send.draft_file);
     }
-    else if (include_file)
+    else if (!buf_is_empty(&cli->send.include_file))
     {
-      infile = include_file;
+      infile = buf_string(&cli->send.include_file);
     }
     else
     {
-      edit_infile = false;
+      cli->send.edit_infile = false;
     }
 
     if (infile || bodytext)
@@ -1573,7 +1459,7 @@ int main(int argc, char *argv[], char *envp[])
       {
         if (mutt_str_equal("-", infile))
         {
-          if (edit_infile)
+          if (cli->send.edit_infile)
           {
             mutt_error(_("Can't use -E flag with stdin"));
             email_free(&e);
@@ -1595,7 +1481,7 @@ int main(int argc, char *argv[], char *envp[])
         }
       }
 
-      if (edit_infile)
+      if (cli->send.edit_infile)
       {
         /* If editing the infile, keep it around afterwards so
          * it doesn't get unlinked, and we can rebuild the draft_file */
@@ -1642,7 +1528,7 @@ int main(int argc, char *argv[], char *envp[])
       /* Parse the draft_file into the full Email/Body structure.
        * Set SEND_DRAFT_FILE so mutt_send_message doesn't overwrite
        * our e->body.  */
-      if (draft_file)
+      if (!buf_is_empty(&cli->send.draft_file))
       {
         struct Envelope *opts_env = e->env;
         struct stat st = { 0 };
@@ -1656,7 +1542,7 @@ int main(int argc, char *argv[], char *envp[])
         e_tmp->body = mutt_body_new();
         if (fstat(fileno(fp_in), &st) != 0)
         {
-          mutt_perror("%s", draft_file);
+          mutt_perror("%s", buf_string(&cli->send.draft_file));
           email_free(&e);
           email_free(&e_tmp);
           goto main_curses; // TEST31: can't test
@@ -1665,15 +1551,17 @@ int main(int argc, char *argv[], char *envp[])
 
         if (mutt_prepare_template(fp_in, NULL, e, e_tmp, false) < 0)
         {
-          mutt_error(_("Can't parse message template: %s"), draft_file);
+          mutt_error(_("Can't parse message template: %s"),
+                     buf_string(&cli->send.draft_file));
           email_free(&e);
           email_free(&e_tmp);
           goto main_curses;
         }
 
         /* Scan for neomutt header to set `$resume_draft_files` */
-        struct ListNode *np = NULL, *tmp = NULL;
+        struct ListNode *tmp = NULL;
         const bool c_resume_edited_draft_files = cs_subset_bool(NeoMutt->sub, "resume_edited_draft_files");
+        struct ListNode *np = NULL;
         STAILQ_FOREACH_SAFE(np, &e->env->userhdrs, entries, tmp)
         {
           if (mutt_istr_startswith(np->data, "X-Mutt-Resume-Draft:"))
@@ -1696,7 +1584,7 @@ int main(int argc, char *argv[], char *envp[])
         mutt_env_free(&opts_env);
         email_free(&e_tmp);
       }
-      else if (edit_infile)
+      else if (cli->send.edit_infile)
       {
         /* Editing the include_file: pass it directly in.
          * Note that SEND_NO_FREE_HEADER is set above so it isn't unlinked.  */
@@ -1713,35 +1601,32 @@ int main(int argc, char *argv[], char *envp[])
 
     FREE(&bodytext);
 
-    if (!STAILQ_EMPTY(&attach))
+    if (!ARRAY_EMPTY(&cli->send.attach))
     {
       struct Body *b = e->body;
 
       while (b && b->next)
         b = b->next;
 
-      struct ListNode *np = NULL;
-      STAILQ_FOREACH(np, &attach, entries)
+      ARRAY_FOREACH(cp, &cli->send.attach)
       {
         if (b)
         {
-          b->next = mutt_make_file_attach(np->data, NeoMutt->sub);
+          b->next = mutt_make_file_attach(*cp, NeoMutt->sub);
           b = b->next;
         }
         else
         {
-          b = mutt_make_file_attach(np->data, NeoMutt->sub);
+          b = mutt_make_file_attach(*cp, NeoMutt->sub);
           e->body = b;
         }
         if (!b)
         {
-          mutt_error(_("%s: unable to attach file"), np->data);
-          mutt_list_free(&attach);
+          mutt_error(_("%s: unable to attach file"), *cp);
           email_free(&e);
           goto main_curses; // TEST32: neomutt john@example.com -a missing
         }
       }
-      mutt_list_free(&attach);
     }
 
     rv = mutt_send_message(sendflags, e, bodyfile, NULL, NULL, NeoMutt->sub);
@@ -1750,9 +1635,9 @@ int main(int argc, char *argv[], char *envp[])
     if (ErrorBufMessage)
       mutt_message("%s", ErrorBuf);
 
-    if (edit_infile)
+    if (cli->send.edit_infile)
     {
-      if (draft_file)
+      if (!buf_is_empty(&cli->send.draft_file))
       {
         if (truncate(buf_string(expanded_infile), 0) == -1)
         {
@@ -1818,7 +1703,8 @@ int main(int argc, char *argv[], char *envp[])
   }
   else
   {
-    if (flags & MUTT_CLI_MAILBOX)
+    struct Buffer *folder = &cli->tui.folder;
+    if (cli->tui.start_new_mail)
     {
       const bool c_imap_passive = cs_subset_bool(NeoMutt->sub, "imap_passive");
       cs_subset_str_native_set(NeoMutt->sub, "imap_passive", false, NULL);
@@ -1833,9 +1719,9 @@ int main(int argc, char *argv[], char *envp[])
       mutt_mailbox_next(NULL, folder);
       cs_subset_str_native_set(NeoMutt->sub, "imap_passive", c_imap_passive, NULL);
     }
-    else if (flags & MUTT_CLI_SELECT)
+    else if (cli->tui.start_nntp || cli->tui.start_browser)
     {
-      if (flags & MUTT_CLI_NEWS)
+      if (cli->tui.start_nntp)
       {
         const char *const c_news_server = cs_subset_string(NeoMutt->sub, "news_server");
         OptNews = true;
@@ -1889,7 +1775,7 @@ int main(int argc, char *argv[], char *envp[])
     mutt_str_replace(&CurrentFolder, buf_string(folder));
     mutt_str_replace(&LastFolder, buf_string(folder));
 
-    if (flags & MUTT_CLI_IGNORE)
+    if (cli->tui.start_any_mail || cli->tui.start_new_mail)
     {
       /* check to see if there are any messages in the folder */
       switch (mx_path_is_empty(folder))
@@ -1918,7 +1804,7 @@ int main(int argc, char *argv[], char *envp[])
     repeat_error = true;
     struct Mailbox *m = mx_resolve(buf_string(folder));
     const bool c_read_only = cs_subset_bool(NeoMutt->sub, "read_only");
-    if (!mx_mbox_open(m, ((flags & MUTT_CLI_RO) || c_read_only) ? MUTT_READONLY : MUTT_OPEN_NO_FLAGS))
+    if (!mx_mbox_open(m, (cli->tui.read_only || c_read_only) ? MUTT_READONLY : MUTT_OPEN_NO_FLAGS))
     {
       if (m->account)
         account_mailbox_remove(m->account, m);
@@ -1927,7 +1813,7 @@ int main(int argc, char *argv[], char *envp[])
       mutt_error(_("Unable to open mailbox %s"), buf_string(folder));
       repeat_error = false;
     }
-    if (m || !explicit_folder)
+    if (m || buf_is_empty(folder))
     {
       struct MuttWindow *dlg = index_pager_init();
       dialog_push(dlg);
@@ -1972,12 +1858,9 @@ main_exit:
     notify_observer_remove(NeoMutt->sub->notify, main_config_observer, NULL);
     notify_observer_remove(NeoMutt->notify, main_timeout_observer, NULL);
   }
-  mutt_list_free(&commands);
   MuttLogger = log_disp_queue;
-  buf_pool_release(&folder);
   buf_pool_release(&expanded_infile);
   buf_pool_release(&tempfile);
-  mutt_list_free(&queries);
   crypto_module_cleanup();
   rootwin_cleanup();
   buf_pool_cleanup();
@@ -1988,6 +1871,7 @@ main_exit:
   menu_cleanup();
   crypt_cleanup();
   mutt_ch_cache_cleanup();
+  command_line_free(&cli);
 
   source_stack_cleanup();
 
@@ -2010,7 +1894,6 @@ main_exit:
   mutt_list_free(&Ignore);
   mutt_list_free(&MailToAllow);
   mutt_list_free(&MimeLookupList);
-  mutt_list_free(&Muttrc);
   mutt_list_free(&UnIgnore);
   mutt_list_free(&UserHeader);
 

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -118,6 +118,8 @@ CHARSET_OBJS	= test/charset/mutt_ch_canonical_charset.o \
 		  test/charset/mutt_ch_lookup_remove.o \
 		  test/charset/mutt_ch_set_charset.o
 
+CLI_OBJS	= test/cli/cli_parse.o
+
 COLOR_OBJS	= test/color/ansi.o \
 		  test/color/ansi_color_parse_single.o \
 		  test/color/attr.o \
@@ -666,16 +668,17 @@ URL_OBJS	= test/url/url_check_scheme.o \
 BUILD_DIRS	= $(PWD)/test/account $(PWD)/test/address $(PWD)/test/array \
 		  $(PWD)/test/atoi $(PWD)/test/attach $(PWD)/test/base64 \
 		  $(PWD)/test/body $(PWD)/test/buffer $(PWD)/test/charset \
-		  $(PWD)/test/color $(PWD)/test/compress $(PWD)/test/config \
-		  $(PWD)/test/convert $(PWD)/test/core $(PWD)/test/date \
-		  $(PWD)/test/editor $(PWD)/test/email $(PWD)/test/envelope \
-		  $(PWD)/test/envlist $(PWD)/test/eqi $(PWD)/test/expando $(PWD)/test/file \
-		  $(PWD)/test/filter $(PWD)/test/from $(PWD)/test/group \
-		  $(PWD)/test/gui $(PWD)/test/hash $(PWD)/test/history \
-		  $(PWD)/test/idna $(PWD)/test/imap $(PWD)/test/list \
-		  $(PWD)/test/logging $(PWD)/test/mailbox $(PWD)/test/mapping \
-		  $(PWD)/test/mbyte $(PWD)/test/md5 $(PWD)/test/memory \
-		  $(PWD)/test/neo $(PWD)/test/notify $(PWD)/test/notmuch \
+		  $(PWD)/test/cli $(PWD)/test/color $(PWD)/test/compress \
+		  $(PWD)/test/config $(PWD)/test/convert $(PWD)/test/core \
+		  $(PWD)/test/date $(PWD)/test/editor $(PWD)/test/email \
+		  $(PWD)/test/envelope $(PWD)/test/envlist $(PWD)/test/eqi \
+		  $(PWD)/test/expando $(PWD)/test/file $(PWD)/test/filter \
+		  $(PWD)/test/from $(PWD)/test/group $(PWD)/test/gui \
+		  $(PWD)/test/hash $(PWD)/test/history $(PWD)/test/idna \
+		  $(PWD)/test/imap $(PWD)/test/list $(PWD)/test/logging \
+		  $(PWD)/test/mailbox $(PWD)/test/mapping $(PWD)/test/mbyte \
+		  $(PWD)/test/md5 $(PWD)/test/memory $(PWD)/test/neo \
+		  $(PWD)/test/notify $(PWD)/test/notmuch \
 		  $(PWD)/test/parameter $(PWD)/test/parse $(PWD)/test/path \
 		  $(PWD)/test/pattern $(PWD)/test/pool $(PWD)/test/prex \
 		  $(PWD)/test/random $(PWD)/test/regex $(PWD)/test/rfc2047 \
@@ -693,6 +696,7 @@ TEST_OBJS	= test/common.o test/main.o \
 		  $(BODY_OBJS) \
 		  $(BUFFER_OBJS) \
 		  $(CHARSET_OBJS) \
+		  $(CLI_OBJS) \
 		  $(COLOR_OBJS) \
 		  $(COMPRESS_OBJS) \
 		  $(CONFIG_OBJS) \

--- a/test/cli/cli_parse.c
+++ b/test/cli/cli_parse.c
@@ -1,0 +1,380 @@
+/**
+ * @file
+ * Test code for Command Line Parsing
+ *
+ * @authors
+ * Copyright (C) 2025 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <unistd.h>
+#include "mutt/lib.h"
+#include "cli/lib.h"
+#include "test_common.h"
+
+static void serialise_bool(bool b, struct Buffer *res)
+{
+  if (b)
+    buf_addch(res, 'Y');
+  else
+    buf_addch(res, 'N');
+}
+
+static void serialise_buffer(struct Buffer *value, struct Buffer *res)
+{
+  if (buf_is_empty(value))
+    buf_add_printf(res, ":-");
+  else
+    buf_add_printf(res, ":%s", buf_string(value));
+}
+
+static void serialise_array(const struct StringArray *sa, struct Buffer *res)
+{
+  buf_addstr(res, ":{");
+
+  char **cp = NULL;
+  ARRAY_FOREACH(cp, sa)
+  {
+    buf_addstr(res, *cp);
+    if (ARRAY_FOREACH_IDX_cp < (ARRAY_SIZE(sa) - 1))
+      buf_addch(res, ',');
+  }
+
+  buf_addch(res, '}');
+}
+
+static void serialise_help(struct CliHelp *help, struct Buffer *res)
+{
+  if (!help->is_set)
+    return;
+
+  buf_addstr(res, "H(");
+
+  serialise_bool(help->help, res);
+  serialise_bool(help->version, res);
+  serialise_bool(help->license, res);
+
+  buf_addstr(res, ")");
+}
+
+static void serialise_shared(struct CliShared *shared, struct Buffer *res)
+{
+  if (!shared->is_set)
+    return;
+
+  buf_addstr(res, "X(");
+
+  serialise_array(&shared->user_files, res);
+  serialise_bool(shared->disable_system, res);
+
+  serialise_array(&shared->commands, res);
+  serialise_buffer(&shared->mbox_type, res);
+
+  serialise_buffer(&shared->log_level, res);
+  serialise_buffer(&shared->log_file, res);
+
+  buf_addstr(res, ")");
+}
+
+static void serialise_info(struct CliInfo *info, struct Buffer *res)
+{
+  if (!info->is_set)
+    return;
+
+  buf_addstr(res, "I(");
+
+  serialise_bool(info->dump_config, res);
+  serialise_bool(info->dump_changed, res);
+  serialise_bool(info->show_help, res);
+  serialise_bool(info->hide_sensitive, res);
+
+  serialise_array(&info->alias_queries, res);
+  serialise_array(&info->queries, res);
+
+  buf_addstr(res, ")");
+}
+
+static void serialise_send(struct CliSend *send, struct Buffer *res)
+{
+  if (!send->is_set)
+    return;
+
+  buf_addstr(res, "S(");
+
+  serialise_bool(send->use_crypto, res);
+  serialise_bool(send->edit_infile, res);
+
+  serialise_array(&send->attach, res);
+  serialise_array(&send->bcc_list, res);
+  serialise_array(&send->cc_list, res);
+  serialise_array(&send->addresses, res);
+
+  serialise_buffer(&send->draft_file, res);
+  serialise_buffer(&send->include_file, res);
+  serialise_buffer(&send->subject, res);
+
+  buf_addstr(res, ")");
+}
+
+static void serialise_tui(struct CliTui *tui, struct Buffer *res)
+{
+  if (!tui->is_set)
+    return;
+
+  buf_addstr(res, "T(");
+
+  serialise_bool(tui->read_only, res);
+  serialise_bool(tui->start_postponed, res);
+  serialise_bool(tui->start_browser, res);
+  serialise_bool(tui->start_nntp, res);
+  serialise_bool(tui->start_new_mail, res);
+  serialise_bool(tui->start_any_mail, res);
+
+  serialise_buffer(&tui->folder, res);
+  serialise_buffer(&tui->nntp_server, res);
+
+  buf_addstr(res, ")");
+}
+
+static void serialise_cli(struct CommandLine *cli, struct Buffer *res)
+{
+  buf_reset(res);
+  serialise_shared(&cli->shared, res);
+  serialise_help(&cli->help, res);
+  serialise_info(&cli->info, res);
+  serialise_send(&cli->send, res);
+  serialise_tui(&cli->tui, res);
+}
+
+static void args_split(const char *args, struct StringArray *sa)
+{
+  // Fake entry at argv[0]
+  ARRAY_ADD(sa, mutt_str_dup("neomutt"));
+
+  char *src = mutt_str_dup(args);
+  if (!src)
+    return;
+
+  char *start = src;
+  for (char *p = start; *p; p++)
+  {
+    if (p[0] != ' ')
+      continue;
+
+    p[0] = '\0';
+    ARRAY_ADD(sa, mutt_str_dup(start));
+
+    start = p + 1;
+  }
+
+  ARRAY_ADD(sa, mutt_str_dup(start));
+
+  FREE(&src);
+}
+
+static void args_clear(struct StringArray *sa)
+{
+  char **cp = NULL;
+  ARRAY_FOREACH(cp, sa)
+  {
+    FREE(cp);
+  }
+
+  ARRAY_FREE(sa);
+}
+
+void test_cli_parse(void)
+{
+  // bool cli_parse(int argc, char **argv, struct CommandLine *cli);
+
+  MuttLogger = log_disp_null;
+
+  bool rc;
+
+  // Degenerate
+  {
+    char *args = "apple banana";
+    struct CommandLine *cli = command_line_new();
+    struct StringArray sa = ARRAY_HEAD_INITIALIZER;
+    args_split(args, &sa);
+
+    rc = cli_parse(0, sa.entries, cli);
+    TEST_CHECK(rc == false);
+
+    rc = cli_parse(2, NULL, cli);
+    TEST_CHECK(rc == false);
+
+    rc = cli_parse(2, sa.entries, NULL);
+    TEST_CHECK(rc == false);
+
+    args_clear(&sa);
+    command_line_free(&cli);
+
+    command_line_free(NULL);
+  }
+
+  // Simple tests
+  {
+    static const char *Tests[][2] = {
+      // clang-format off
+      // No args
+      { "",                      "" },
+
+      // Help
+      { "-h",                    "H(YNN)" },
+      { "-v",                    "H(NYN)" },
+      { "-h -v",                 "H(YYN)" },
+      { "-v -v",                 "H(NYY)" },
+      { "-vv",                   "H(NYY)" },
+      { "-vhv",                  "H(YYY)" },
+
+      // Shared
+      { "-n",                    "X(:{}Y:{}:-:-:-)" },
+      { "-F apple",              "X(:{apple}N:{}:-:-:-)" },
+      { "-F apple -F banana",    "X(:{apple,banana}N:{}:-:-:-)" },
+      { "-nF apple",             "X(:{apple}Y:{}:-:-:-)" },
+      { "-F apple -n -F banana", "X(:{apple,banana}Y:{}:-:-:-)" },
+      { "-e apple",              "X(:{}N:{apple}:-:-:-)" },
+      { "-e apple -e banana",    "X(:{}N:{apple,banana}:-:-:-)" },
+      { "-m apple",              "X(:{}N:{}:apple:-:-)" },
+      { "-m apple -m banana",    "X(:{}N:{}:banana:-:-)" },
+      { "-d 3",                  "X(:{}N:{}:-:3:-)" },
+      { "-d3",                   "X(:{}N:{}:-:3:-)" },
+      { "-l apple",              "X(:{}N:{}:-:-:apple)" },
+      { "-lapple",               "X(:{}N:{}:-:-:apple)" },
+      { "-d 3 -l apple",         "X(:{}N:{}:-:3:apple)" },
+      { "-d3 -lapple",           "X(:{}N:{}:-:3:apple)" },
+
+      // Info
+      { "-D",                    "I(YNNN:{}:{})" },
+      { "-D -D",                 "I(YYNN:{}:{})" },
+      { "-D -O",                 "I(YNYN:{}:{})" },
+      { "-D -S",                 "I(YNNY:{}:{})" },
+      { "-DOSD",                 "I(YYYY:{}:{})" },
+      { "-A apple",              "I(NNNN:{apple}:{})" },
+      { "-A apple -A banana",    "I(NNNN:{apple,banana}:{})" },
+      { "-A apple banana",       "I(NNNN:{apple,banana}:{})" },
+      { "-Q apple",              "I(NNNN:{}:{apple})" },
+      { "-Q apple -Q banana",    "I(NNNN:{}:{apple,banana})" },
+      { "-Q apple banana",       "I(NNNN:{}:{apple,banana})" },
+
+      // Send
+      { "-C",                    "S(YN:{}:{}:{}:{}:-:-:-)" },
+      { "-E",                    "S(NY:{}:{}:{}:{}:-:-:-)" },
+      { "-EC",                   "S(YY:{}:{}:{}:{}:-:-:-)" },
+      { "-a apple",              "S(NN:{apple}:{}:{}:{}:-:-:-)" },
+      { "-a apple -a banana",    "S(NN:{apple,banana}:{}:{}:{}:-:-:-)" },
+      { "-a apple banana",       "S(NN:{apple,banana}:{}:{}:{}:-:-:-)" },
+      { "-b apple",              "S(NN:{}:{apple}:{}:{}:-:-:-)" },
+      { "-b apple -b banana",    "S(NN:{}:{apple,banana}:{}:{}:-:-:-)" },
+      { "-c apple",              "S(NN:{}:{}:{apple}:{}:-:-:-)" },
+      { "-c apple -c banana",    "S(NN:{}:{}:{apple,banana}:{}:-:-:-)" },
+      { "apple",                 "S(NN:{}:{}:{}:{apple}:-:-:-)" },
+      { "apple banana",          "S(NN:{}:{}:{}:{apple,banana}:-:-:-)" },
+      { "apple banana cherry",   "S(NN:{}:{}:{}:{apple,banana,cherry}:-:-:-)" },
+      { "-H apple",              "S(NN:{}:{}:{}:{}:apple:-:-)" },
+      { "-H apple -H banana",    "S(NN:{}:{}:{}:{}:banana:-:-)" },
+      { "-i apple",              "S(NN:{}:{}:{}:{}:-:apple:-)" },
+      { "-i apple -i banana",    "S(NN:{}:{}:{}:{}:-:banana:-)" },
+      { "-s apple",              "S(NN:{}:{}:{}:{}:-:-:apple)" },
+      { "-s apple -s banana",    "S(NN:{}:{}:{}:{}:-:-:banana)" },
+
+      // TUI
+      { "-R",                    "T(YNNNNN:-:-)" },
+      { "-p",                    "T(NYNNNN:-:-)" },
+      { "-y",                    "T(NNYNNN:-:-)" },
+      { "-G",                    "T(NNNYNN:-:-)" },
+      { "-Z",                    "T(NNNNYN:-:-)" },
+      { "-z",                    "T(NNNNNY:-:-)" },
+      { "-R -y -G -Z",           "T(YNYYYN:-:-)" },
+      { "-R -p -G -z",           "T(YYNYNY:-:-)" },
+      { "-y -p -G -Z",           "T(NYYYYN:-:-)" },
+      { "-f apple",              "T(NNNNNN:apple:-)" },
+      { "-f apple -f banana",    "T(NNNNNN:banana:-)" },
+      { "-g apple",              "T(NNNYNN:-:apple)" },
+      { "-g apple -g banana",    "T(NNNYNN:-:banana)" },
+
+      // Complex tests
+      { "apple",                            "S(NN:{}:{}:{}:{apple}:-:-:-)" },
+      { "apple --",                         "S(NN:{}:{}:{}:{apple}:-:-:-)" },
+      { "apple -- banana",                  "S(NN:{}:{}:{}:{apple,banana}:-:-:-)" },
+      { "apple -- banana",                  "S(NN:{}:{}:{}:{apple,banana}:-:-:-)" },
+      { "-A apple banana -- cherry",        "I(NNNN:{apple,banana}:{})S(NN:{}:{}:{}:{cherry}:-:-:-)" },
+      { "-Q apple banana -- cherry damson", "I(NNNN:{}:{apple,banana})S(NN:{}:{}:{}:{cherry,damson}:-:-:-)" },
+      // clang-format on
+    };
+
+    struct Buffer *res = buf_pool_get();
+
+    for (size_t i = 0; i < mutt_array_size(Tests); i++)
+    {
+      struct CommandLine *cli = command_line_new();
+      struct StringArray sa = ARRAY_HEAD_INITIALIZER;
+
+      TEST_CASE(Tests[i][0]);
+      args_split(Tests[i][0], &sa);
+
+      rc = cli_parse(ARRAY_SIZE(&sa), sa.entries, cli);
+      TEST_CHECK(rc == true);
+
+      serialise_cli(cli, res);
+      TEST_CHECK_STR_EQ(buf_string(res), Tests[i][1]);
+
+      args_clear(&sa);
+      command_line_free(&cli);
+    }
+
+    buf_pool_release(&res);
+  }
+
+  // Failing tests
+  {
+    // One bad option and plenty that should take a parameter
+    static const char *Tests[] = {
+      "-9", "-A", "-a", "-b", "-F", "-f", "-c", "-d",
+      "-l", "-e", "-g", "-H", "-i", "-m", "-Q", "-s",
+    };
+
+    struct Buffer *res = buf_pool_get();
+
+    opterr = 0; // Disable stderr warnings
+
+    for (size_t i = 0; i < mutt_array_size(Tests); i++)
+    {
+      struct CommandLine *cli = command_line_new();
+      struct StringArray sa = ARRAY_HEAD_INITIALIZER;
+
+      TEST_CASE(Tests[i]);
+      args_split(Tests[i], &sa);
+
+      rc = cli_parse(ARRAY_SIZE(&sa), sa.entries, cli);
+      TEST_CHECK(rc == false);
+
+      serialise_cli(cli, res);
+      TEST_CHECK_STR_EQ(buf_string(res), "H(YNN)");
+
+      args_clear(&sa);
+      command_line_free(&cli);
+    }
+
+    buf_pool_release(&res);
+  }
+}

--- a/test/main.c
+++ b/test/main.c
@@ -162,6 +162,9 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_mutt_ch_lookup_remove)                                \
   NEOMUTT_TEST_ITEM(test_mutt_ch_set_charset)                                  \
                                                                                \
+  /* cli */                                                                    \
+  NEOMUTT_TEST_ITEM(test_cli_parse)                                            \
+                                                                               \
   /* color */                                                                  \
   NEOMUTT_TEST_ITEM(test_ansi_color)                                           \
   NEOMUTT_TEST_ITEM(test_ansi_color_parse_single)                              \

--- a/version.c
+++ b/version.c
@@ -503,8 +503,7 @@ bool print_version(FILE *fp)
   fprintf(fp, "\n");
   fputs(_(ReachingUs), fp);
 
-  fflush(fp);
-  return !ferror(fp);
+  return true;
 }
 
 /**


### PR DESCRIPTION
**WIP** -- Create a new library solely to parse the command line.

- bfd89eb52 libcli - parse the command line
- ec6f130bc test: libcli - test the command line
- a34d5f0e7 main: refactor command line parsing

The **current parser** has problems,

- It's buried deep within `main()`
- It uses lots of variables, which are lost amongst the others of `main()`
- It mixes parsing and acting
- It doesn't do the entire job -- some processing happens later

The **new parser** is:
- self-contained
- testable -- full coverage
- only a parser

NeoMutt has six distinct modes of operation (see [comment below](https://github.com/neomutt/neomutt/pull/4571#issuecomment-2652541997)).
Each of these has a separate `struct` for the results.

The parser works well, but its integration into `main()` is naive.

Now that I understand how the command line is meant to work,
I can tease apart the remaining large block of `main()` that does the work.