### PR TITLE
Use FreeBSD 14.2 in Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-14-1
+  image_family: freebsd-14-2
 
 task:
   only_if: $CIRRUS_BRANCH == "main" || $CIRRUS_PR != ""


### PR DESCRIPTION
The docs say FreeBSD is still at 14-1, but for some reasons the jobs fail. Let's see if 14-2 is there already.

See https://github.com/cirruslabs/cirrus-ci-docs/pull/1301