### PR TITLE
Split CLI Usage into sections

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,8 +28,12 @@ task:
         - (cd ${NEOMUTT_TEST_DIR} && ./setup.sh)
       configure_script: ./configure --autocrypt --disable-doc --disable-idn --idn2 --notmuch --testing
       build_script: make
-      version_script: ./neomutt -v
-      test_script: make test
+      version_script:
+        - ./neomutt -v
+        - ./neomutt -h all
+      test_script:
+        - make test/neomutt-test
+        - make test
 
     - name: FreeBSD / OpenSSL
       install_script:
@@ -37,7 +41,9 @@ task:
         - ${PKG_INSTALL} ${PKG_COMMON} openssl
       configure_script: ./configure ${CONFIGURE_COMMON} --ssl
       build_script: make
-      version_script: ./neomutt -v
+      version_script:
+        - ./neomutt -v
+        - ./neomutt -h all
 
     - name: FreeBSD / LibreSSL
       install_script:
@@ -45,7 +51,9 @@ task:
         - ${PKG_INSTALL} ${PKG_COMMON} libressl
       configure_script: ./configure ${CONFIGURE_COMMON} --ssl
       build_script: make
-      version_script: ./neomutt -v
+      version_script:
+        - ./neomutt -v
+        - ./neomutt -h all
 
     - name: FreeBSD / GnuTLS
       install_script:
@@ -53,4 +61,6 @@ task:
         - ${PKG_INSTALL} ${PKG_COMMON} gnutls
       configure_script: ./configure ${CONFIGURE_COMMON} --gnutls
       build_script: make
-      version_script: ./neomutt -v
+      version_script:
+        - ./neomutt -v
+        - ./neomutt -h all

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -43,6 +43,14 @@ jobs:
     - name: Configure Neomutt
       run: ./configure $CONFIGURE_OPTIONS
 
+    - name: Build Neomutt
+      run: make -j ${{steps.cpu-cores.outputs.count}} neomutt
+
+    - name: Neomutt Version
+      run: |
+        ./neomutt -v
+        ./neomutt -h all
+
     - name: Build Tests
       run: make -j ${{steps.cpu-cores.outputs.count}} test/neomutt-test
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,6 +64,7 @@ jobs:
       run: |
         cd build-${{ matrix.cfg.name }}
         ./neomutt -v
+        ./neomutt -h all
 
     - name: Test Docs
       run: |

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -45,7 +45,9 @@ jobs:
       run: make -j ${{steps.cpu-cores.outputs.count}} neomutt
 
     - name: Neomutt Version
-      run: ./neomutt -v
+      run: |
+        ./neomutt -v
+        ./neomutt -h all
 
     - name: Build Tests
       run: make -j ${{steps.cpu-cores.outputs.count}} test/neomutt-test

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -82,6 +82,7 @@ jobs:
     - name: Neomutt Version
       run: |
         test -f neomutt && ./neomutt -v || :
+        test -f neomutt && ./neomutt -h all || :
 
     - name: Build Tests
       run: |

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -57,7 +57,9 @@ jobs:
       run: make -j ${{steps.cpu-cores.outputs.count}} neomutt
 
     - name: Neomutt Version
-      run: ./neomutt -v
+      run: |
+        ./neomutt -v
+        ./neomutt -h all
 
     - name: Build Tests
       run: make -j ${{steps.cpu-cores.outputs.count}} test/neomutt-test

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,13 +44,15 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1
 
     - name: Configure Neomutt
-      run: ./configure --disable-doc --disable-nls --notmuch --with-notmuch=/opt/homebrew/opt/notmuch --lmdb --zlib --idn2 --with-idn=/opt/homebrew/opt/libidn2 --with-iconv=/opt/homebrew/opt/libiconv --with-ncurses=/opt/homebrew/opt/ncurses 
+      run: ./configure --disable-doc --disable-nls --notmuch --with-notmuch=/opt/homebrew/opt/notmuch --lmdb --zlib --idn2 --with-idn=/opt/homebrew/opt/libidn2 --with-iconv=/opt/homebrew/opt/libiconv --with-ncurses=/opt/homebrew/opt/ncurses
 
     - name: Build Neomutt
       run: make -j ${{steps.cpu-cores.outputs.count}} neomutt
 
     - name: Neomutt Version
-      run: ./neomutt -v
+      run: |
+        ./neomutt -v
+        ./neomutt -h all
 
     - name: Build Tests
       run: make -j ${{steps.cpu-cores.outputs.count}} test/neomutt-test

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -69,7 +69,8 @@ NEOMUTTOBJS=	alternates.o commands.o conststrings.o copy.o editmsg.o \
 		help.o hook.o mailcap.o maillist.o muttlib.o mutt_body.o \
 		mutt_config.o mutt_header.o mutt_logging.o mutt_mailbox.o \
 		mutt_signal.o mutt_socket.o mutt_thread.o mview.o mx.o \
-		recvcmd.o rfc3676.o score.o subjectrx.o system.o version.o
+		recvcmd.o rfc3676.o score.o subjectrx.o system.o usage.o \
+		version.o
 @if !ENABLE_FUZZ_TESTS
 NEOMUTTOBJS+=	main.o
 @endif

--- a/cli/objects.h
+++ b/cli/objects.h
@@ -29,6 +29,20 @@
 ARRAY_HEAD(StringArray, char *);
 
 /**
+ * enum HelpMode - Show detailed help
+ */
+enum HelpMode
+{
+  HM_NONE,         ///< No extra help
+  HM_SHARED,       ///< Help about shared config options
+  HM_HELP,         ///< Help about help
+  HM_INFO,         ///< Help about info options
+  HM_SEND,         ///< Help about sending email options
+  HM_TUI,          ///< Help about starting the tui options
+  HM_ALL,          ///< Help about all options
+};
+
+/**
  * struct CliShared - Shared Command Line options
  */
 struct CliShared
@@ -54,6 +68,8 @@ struct CliHelp
   bool help;                        ///< `-h`  Print help
   bool version;                     ///< `-v`  Print version
   bool license;                     ///< `-vv` Print license
+
+  enum HelpMode mode;               ///< Display detailed help
 };
 
 /**

--- a/cli/parse.c
+++ b/cli/parse.c
@@ -34,6 +34,28 @@
 #include "objects.h"
 
 /**
+ * check_help_mode - Check for help mode
+ * @param mode String to check
+ * @retval enum #HelpMode, e.g. HM_CONFIG
+ */
+int check_help_mode(const char *mode)
+{
+  if (mutt_istr_equal(mode, "shared"))
+    return HM_SHARED;
+  if (mutt_istr_equal(mode, "help"))
+    return HM_HELP;
+  if (mutt_istr_equal(mode, "info"))
+    return HM_INFO;
+  if (mutt_istr_equal(mode, "send"))
+    return HM_SEND;
+  if (mutt_istr_equal(mode, "tui"))
+    return HM_TUI;
+  if (mutt_istr_equal(mode, "all"))
+    return HM_ALL;
+  return 0;
+}
+
+/**
  * mop_up - Eat multiple arguments
  * @param[in]  argc  Size of argument array
  * @param[in]  argv  Array of argument strings
@@ -141,6 +163,12 @@ bool cli_parse(int argc, char **argv, struct CommandLine *cli)
       // Help
       case 'h': // help
       {
+        if (optind < argc)
+        {
+          cli->help.mode = check_help_mode(argv[optind]);
+          if (cli->help.mode != HM_NONE)
+            optind++;
+        }
         cli->help.help = true;
         cli->help.is_set = true;
         break;

--- a/test/cli/cli_parse.c
+++ b/test/cli/cli_parse.c
@@ -72,6 +72,8 @@ static void serialise_help(struct CliHelp *help, struct Buffer *res)
   serialise_bool(help->version, res);
   serialise_bool(help->license, res);
 
+  buf_addch(res, '0' + help->mode);
+
   buf_addstr(res, ")");
 }
 
@@ -239,12 +241,12 @@ void test_cli_parse(void)
       { "",                      "" },
 
       // Help
-      { "-h",                    "H(YNN)" },
-      { "-v",                    "H(NYN)" },
-      { "-h -v",                 "H(YYN)" },
-      { "-v -v",                 "H(NYY)" },
-      { "-vv",                   "H(NYY)" },
-      { "-vhv",                  "H(YYY)" },
+      { "-h",                    "H(YNN0)" },
+      { "-v",                    "H(NYN0)" },
+      { "-h -v",                 "H(YYN0)" },
+      { "-v -v",                 "H(NYY0)" },
+      { "-vv",                   "H(NYY0)" },
+      { "-vhv",                  "H(YYY0)" },
 
       // Shared
       { "-n",                    "X(:{}Y:{}:-:-:-)" },
@@ -319,6 +321,15 @@ void test_cli_parse(void)
       { "apple -- banana",                  "S(NN:{}:{}:{}:{apple,banana}:-:-:-)" },
       { "-A apple banana -- cherry",        "I(NNNN:{apple,banana}:{})S(NN:{}:{}:{}:{cherry}:-:-:-)" },
       { "-Q apple banana -- cherry damson", "I(NNNN:{}:{apple,banana})S(NN:{}:{}:{}:{cherry,damson}:-:-:-)" },
+
+      // Help modes
+      { "-h",                    "H(YNN0)" },
+      { "-h shared",             "H(YNN1)" },
+      { "-h help",               "H(YNN2)" },
+      { "-h info",               "H(YNN3)" },
+      { "-h send",               "H(YNN4)" },
+      { "-h tui",                "H(YNN5)" },
+      { "-h all",                "H(YNN6)" },
       // clang-format on
     };
 
@@ -369,7 +380,7 @@ void test_cli_parse(void)
       TEST_CHECK(rc == false);
 
       serialise_cli(cli, res);
-      TEST_CHECK_STR_EQ(buf_string(res), "H(YNN)");
+      TEST_CHECK_STR_EQ(buf_string(res), "H(YNN0)");
 
       args_clear(&sa);
       command_line_free(&cli);

--- a/usage.c
+++ b/usage.c
@@ -1,0 +1,366 @@
+/**
+ * @file
+ * Display Usage Information for NeoMutt
+ *
+ * @authors
+ * Copyright (C) 2025 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page neo_usage Display Usage Information for NeoMutt
+ *
+ * Display Usage Information for NeoMutt
+ */
+
+#include "config.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include "mutt/lib.h"
+#include "cli/lib.h"
+#include "muttlib.h"
+
+/**
+ * print_header - Print a section header
+ * @param section   Help section
+ * @param desc      Description
+ * @param use_color Highlight parts of the text
+ */
+static void print_header(const char *section, const char *desc, bool use_color)
+{
+  if (use_color)
+    printf("\033[1;4m%s\033[0m: %s\n", section, desc);
+  else
+    printf("%s: %s\n", section, desc);
+}
+
+/**
+ * show_cli_overview - Display NeoMutt command line
+ * @param use_color Highlight parts of the text
+ */
+static void show_cli_overview(bool use_color)
+{
+  printf("%s ", _("NeoMutt has four modes of operation:"));
+  if (use_color)
+    puts("\033[1;4mhelp\033[0m, \033[1;4minfo\033[0m, \033[1;4msend\033[0m, \033[1;4mtui\033[0m");
+  else
+    puts("help, info, send, tui");
+
+  puts(_("The default mode, if no command line arguments are specified, is tui."));
+  puts("");
+
+  print_header("shared", _("Options that apply to all modes"), use_color);
+  puts(_("neomutt -F <config>                  Use this user config file"));
+  puts(_("        -n                           Don't read system config file"));
+  puts(_("        -e <command>                 Run extra commands"));
+  puts(_("        -m <type>                    Set default mailbox type"));
+  puts(_("        -d <level>                   Set logging level (1..5)"));
+  puts(_("        -l <file>                    Set logging file"));
+  puts("");
+
+  print_header("help", _("Get command line help for NeoMutt"), use_color);
+  puts(_("neomutt -h <mode>                    Detailed help for a mode"));
+  puts(_("        -v[v]                        Version or license"));
+  puts("");
+
+  print_header("info", _("Ask NeoMutt for config information"), use_color);
+  puts(_("neomutt -A <alias> [...]             Lookup email aliases"));
+  puts(_("        -D [-D] [-O] [-S]            Dump the config"));
+  puts(_("        -Q <option> [...] [-O] [-S]  Query config options"));
+  puts("");
+
+  print_header("send", _("Send an email from the command line"), use_color);
+  puts(_("neomutt -a <file> [...]              Attach files"));
+  puts(_("        -b <address>                 Add Bcc: address"));
+  puts(_("        -C                           Use crypto (signing/encryption)"));
+  puts(_("        -c <address>                 Add Cc: address"));
+  puts(_("        -E                           Edit message"));
+  puts(_("        -H <draft>                   Use draft email"));
+  puts(_("        -i <include>                 Include body file"));
+  puts(_("        -s <subject>                 Set Subject:"));
+  puts(_("        -- <address> [...]           Add To: addresses"));
+  puts("");
+
+  print_header("tui", _("Start NeoMutt's TUI (Terminal User Interface)"), use_color);
+  puts(_("neomutt                              Start NeoMutt's TUI"));
+  puts(_("        -f <mailbox>                 Open this mailbox"));
+  puts(_("        -G                           Open NNTP browser"));
+  puts(_("        -g <server>                  Use this NNTP server"));
+  puts(_("        -p                           Resume postponed email"));
+  puts(_("        -R                           Open mailbox read-only"));
+  puts(_("        -y                           Open mailbox browser"));
+  puts(_("        -Z                           Check for new mail"));
+  puts(_("        -z                           Check for any mail"));
+  puts("");
+
+  if (use_color)
+    printf("%s \033[1m%s\033[0m\n", _("For detailed help, run:"), "neomutt -h all");
+  else
+    printf("%s %s\n", _("For detailed help, run:"), "neomutt -h all");
+}
+
+/**
+ * show_cli_shared - Show Command Line Help for Shared
+ * @param use_color Highlight parts of the text
+ */
+static void show_cli_shared(bool use_color)
+{
+  print_header("shared", _("Options that apply to all modes"), use_color);
+  puts("");
+
+  puts(_("By default NeoMutt loads one system and one user config file,"));
+  puts(_("e.g. /etc/neomuttrc and ~/.neomuttrc"));
+  puts(_("  -n            Don't read system config file"));
+  puts(_("  -F <config>   Use this user config file"));
+  puts(_("                May be used multiple times"));
+  puts("");
+
+  puts(_("These options override the config:"));
+  puts(_("  -m <type>     Set default mailbox type"));
+  puts(_("                May be: maildir, mbox, mh, mmdf"));
+  puts(_("  -e <command>  Run extra commands"));
+  puts(_("                May be used multiple times"));
+  puts("");
+
+  puts(_("These logging override the config:"));
+  puts(_("  -d <level>    Set logging level"));
+  puts(_("                0 (off), 1 (low) .. 5 (high)"));
+  puts(_("  -l <file>     Set logging file"));
+  puts(_("                Default file '~/.neomuttdebug0'"));
+  puts("");
+
+  if (use_color)
+    printf("\033[1m%s\033[0m\n", _("Examples:"));
+  else
+    printf("%s\n", _("Examples:"));
+
+  puts(_("  neomutt -n"));
+  puts(_("  neomutt -F work.rc"));
+  puts(_("  neomutt -F work.rc -F colours.rc"));
+  puts("");
+
+  puts(_("  neomutt -m maildir"));
+  puts(_("  neomutt -e 'set ask_cc = yes'"));
+  puts("");
+
+  puts(_("  neomutt -d 2"));
+  puts(_("  neomutt -d 5 -l neolog"));
+  puts("");
+
+  puts(_("See also:"));
+  puts(_("- Config files: https://neomutt.org/guide/configuration"));
+}
+
+/**
+ * show_cli_help - Show Command Line Help for Help
+ * @param use_color Highlight parts of the text
+ */
+static void show_cli_help(bool use_color)
+{
+  print_header("help", _("Get command line help for NeoMutt"), use_color);
+  puts("");
+
+  puts(_("  -h         Overview of command line options"));
+  puts(_("  -h <mode>  Detailed help for: shared, help, info, send, tui, all"));
+  puts(_("  -v         NeoMutt version and build parameters"));
+  puts(_("  -vv        NeoMutt Copyright and license"));
+  puts("");
+
+  if (use_color)
+    printf("\033[1m%s\033[0m\n", _("Examples:"));
+  else
+    printf("%s\n", _("Examples:"));
+
+  puts(_("  neomutt -h info"));
+  puts(_("  neomutt -vv"));
+}
+
+/**
+ * show_cli_info - Show Command Line Help for Info
+ * @param use_color Highlight parts of the text
+ */
+static void show_cli_info(bool use_color)
+{
+  print_header("info", _("Ask NeoMutt for config information"), use_color);
+  puts("");
+
+  puts(_("  -A <alias> [...]  Lookup email aliases"));
+  puts(_("                    Multiple aliases can be looked up (space-separated)"));
+  puts("");
+
+  puts(_("  -D                Dump all the config options"));
+  puts(_("  -D -D             (or -DD) Like -D, but only show changed config"));
+  puts("");
+
+  puts(_("  -Q <option> [...] Query config options"));
+  puts(_("                    Multiple options can be looked up (space-separated)"));
+
+  puts(_("Modify the -D and -Q options:"));
+  puts(_("  -O                Add one-liner documentation"));
+  puts(_("  -S                Hide the value of sensitive options"));
+  puts("");
+
+  if (use_color)
+    printf("\033[1m%s\033[0m\n", _("Examples:"));
+  else
+    printf("%s\n", _("Examples:"));
+
+  puts(_("  neomutt -A flatcap gahr"));
+  puts(_("  neomutt -D -O"));
+  puts(_("  neomutt -DD -S"));
+  puts(_("  neomutt -O -Q alias_format index_format"));
+}
+
+/**
+ * show_cli_send - Show Command Line Help for Send
+ * @param use_color Highlight parts of the text
+ */
+static void show_cli_send(bool use_color)
+{
+  print_header("send", _("Send an email from the command line"), use_color);
+  puts("");
+
+  puts(_("These options can supply everything NeoMutt needs to send an email."));
+  puts(_("If any parts are missing, NeoMutt will start the TUI to ask for them."));
+  puts(_("Addresses may be used before the options, or after a -- marker."));
+  puts(_("Aliases may be used in place of addresses."));
+  puts("");
+
+  puts(_("  -a <file> [...]     Attach files"));
+  puts(_("                      Terminated by -- or another option"));
+  puts(_("  -b <address>        Add Bcc: address"));
+  puts(_("  -C                  Use crypto (signing/encryption)"));
+  puts(_("                      Must be set up in the config file"));
+  puts(_("  -c <address>        Add Cc: address"));
+  puts(_("  -E                  Edit message"));
+  puts(_("                      (supplied by -H or -i)"));
+  puts(_("  -H <draft>          Use draft email"));
+  puts(_("                      Full email with headers and body"));
+  puts(_("  -i <include>        Include body file"));
+  puts(_("  -s <subject>        Set Subject:"));
+  puts(_("  -- <address> [...]  Add To: addresses"));
+  puts("");
+
+  if (use_color)
+    printf("\033[1m%s\033[0m\n", _("Examples:"));
+  else
+    printf("%s\n", _("Examples:"));
+
+  puts(_("  neomutt flatcap -s 'Meeting' < meeting.txt"));
+  puts(_("  neomutt jim@example.com -c bob@example.com -s 'Party' -i party.txt"));
+  puts(_("  neomutt -s 'Receipts' -a receipt1.pdf receipt2.pdf -- rocco"));
+  puts(_("  cat secret.txt | neomutt gahr -s 'Secret' -C"));
+}
+
+/**
+ * show_cli_tui - Show Command Line Help for Tui
+ * @param use_color Highlight parts of the text
+ */
+static void show_cli_tui(bool use_color)
+{
+  print_header("tui", _("Start NeoMutt's TUI (Terminal User Interface)"), use_color);
+  puts("");
+
+  puts(_("Running NeoMutt with no options will read the config and start the TUI."));
+  puts(_("By default, it will open the Index Dialog with the $spool_file Mailbox."));
+  puts("");
+
+  puts(_("These options cause NeoMutt to check a mailbox for mail."));
+  puts(_("If the condition isn't matched, NeoMutt exits."));
+  puts(_("  -p            Resume postponed email"));
+  puts(_("  -Z            Check for new mail"));
+  puts(_("  -z            Check for any mail"));
+  puts("");
+
+  puts(_("These options change the starting behavior:"));
+  puts(_("  -f <mailbox>  Open this mailbox"));
+  puts(_("  -G            Open NNTP browser"));
+  puts(_("  -g <server>   Use this NNTP server"));
+  puts(_("  -R            Open mailbox read-only"));
+  puts(_("  -y            Open mailbox browser"));
+  puts("");
+
+  if (use_color)
+    printf("\033[1m%s\033[0m\n", _("Examples:"));
+  else
+    printf("%s\n", _("Examples:"));
+
+  puts(_("  neomutt -f ~/mail -Z"));
+  puts(_("  neomutt -p"));
+  puts(_("  neomutt -y"));
+}
+
+/**
+ * show_cli - Show Instructions on how to run NeoMutt
+ * @param mode      Details, e.g. #HM_SHARED
+ * @param use_color Highlight parts of the text
+ */
+void show_cli(enum HelpMode mode, bool use_color)
+{
+  if (use_color)
+    printf("\033[38;5;255m%s\033[0m\n\n", mutt_make_version());
+  else
+    printf("%s\n\n", mutt_make_version());
+
+  switch (mode)
+  {
+    case HM_NONE:
+    {
+      show_cli_overview(use_color);
+      break;
+    }
+    case HM_SHARED:
+    {
+      show_cli_shared(use_color);
+      break;
+    }
+    case HM_HELP:
+    {
+      show_cli_help(use_color);
+      break;
+    }
+    case HM_INFO:
+    {
+      show_cli_info(use_color);
+      break;
+    }
+    case HM_SEND:
+    {
+      show_cli_send(use_color);
+      break;
+    }
+    case HM_TUI:
+    {
+      show_cli_tui(use_color);
+      break;
+    }
+    case HM_ALL:
+    {
+      printf("------------------------------------------------------------\n");
+      show_cli_shared(use_color);
+      printf("\n------------------------------------------------------------\n");
+      show_cli_help(use_color);
+      printf("\n------------------------------------------------------------\n");
+      show_cli_info(use_color);
+      printf("\n------------------------------------------------------------\n");
+      show_cli_send(use_color);
+      printf("\n------------------------------------------------------------\n");
+      show_cli_tui(use_color);
+      printf("\n------------------------------------------------------------\n");
+      break;
+    }
+  }
+}


### PR DESCRIPTION
**WIP** -- Overview done; Still working on the sections

The "help" page is very dense and hard to understand.

**Changes**:
- Change `neomutt -h` to print a legible overview of options
- Create six sections of detailed help, with examples.
  e.g. `neomutt -h config`