### PR TITLE
Remove unused import from mutt_oauth2.py

### DIFF
--- a/contrib/oauth2/mutt_oauth2.py
+++ b/contrib/oauth2/mutt_oauth2.py
@@ -39,7 +39,6 @@ import shlex
 import socket
 import http.server
 import subprocess
-import readline
 
 # The token file must be encrypted because it contains multi-use bearer tokens
 # whose usage does not require additional verification. Specify whichever


### PR DESCRIPTION
* **What does this PR do?**

There was an unused import in `contrib/oauth2/mutt_oauth2.py`, so I just removed it.