### PR TITLE
pager: fix refresh on <top>

### DIFF
--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -128,7 +128,9 @@ static const struct Mapping PagerNewsHelp[] = {
 void pager_queue_redraw(struct PagerPrivateData *priv, PagerRedrawFlags redraw)
 {
   priv->redraw |= redraw;
-  priv->pview->win_pager->actions |= WA_RECALC;
+
+  if (priv->pview && priv->pview->win_pager)
+    priv->pview->win_pager->actions |= WA_RECALC;
 }
 
 /**

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -959,10 +959,16 @@ static int op_pager_skip_quoted(struct IndexSharedData *shared,
  */
 static int op_pager_top(struct IndexSharedData *shared, struct PagerPrivateData *priv, int op)
 {
-  if (priv->top_line)
-    priv->top_line = 0;
-  else
+  if (priv->top_line == 0)
+  {
     mutt_message(_("Top of message is shown"));
+  }
+  else
+  {
+    priv->top_line = 0;
+    notify_send(priv->notify, NT_PAGER, NT_PAGER_VIEW, priv);
+  }
+
   return FR_SUCCESS;
 }
 

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -265,6 +265,18 @@ static int pager_color_observer(struct NotifyCallback *nc)
     }
     priv->lines_used = 0;
   }
+  else if ((ev_c->cid == MT_COLOR_ATTACHMENT) || (ev_c->cid == MT_COLOR_ATTACH_HEADERS) ||
+           (ev_c->cid == MT_COLOR_BODY) || (ev_c->cid == MT_COLOR_BOLD) ||
+           (ev_c->cid == MT_COLOR_ERROR) || (ev_c->cid == MT_COLOR_HDRDEFAULT) ||
+           (ev_c->cid == MT_COLOR_HEADER) || (ev_c->cid == MT_COLOR_ITALIC) ||
+           (ev_c->cid == MT_COLOR_MARKERS) || (ev_c->cid == MT_COLOR_MESSAGE) ||
+           (ev_c->cid == MT_COLOR_NORMAL) || (ev_c->cid == MT_COLOR_SEARCH) ||
+           (ev_c->cid == MT_COLOR_SIGNATURE) || (ev_c->cid == MT_COLOR_STRIPE_EVEN) ||
+           (ev_c->cid == MT_COLOR_STRIPE_ODD) || (ev_c->cid == MT_COLOR_TILDE) ||
+           (ev_c->cid == MT_COLOR_UNDERLINE) || (ev_c->cid == MT_COLOR_WARNING))
+  {
+    notify_send(priv->notify, NT_PAGER, NT_PAGER_VIEW, priv);
+  }
 
   mutt_debug(LL_DEBUG5, "color done\n");
   return 0;
@@ -287,6 +299,20 @@ static int pager_config_observer(struct NotifyCallback *nc)
   {
     config_pager_index_lines(win_pager);
     mutt_debug(LL_DEBUG5, "config done\n");
+  }
+  else if ((mutt_str_equal(ev_c->name, "allow_ansi")) ||
+           (mutt_str_equal(ev_c->name, "markers")) ||
+           (mutt_str_equal(ev_c->name, "smart_wrap")) ||
+           (mutt_str_equal(ev_c->name, "smileys")) ||
+           (mutt_str_equal(ev_c->name, "tilde")) ||
+           (mutt_str_equal(ev_c->name, "toggle_quoted_show_levels")) ||
+           (mutt_str_equal(ev_c->name, "wrap")))
+  {
+    struct PagerPrivateData *priv = win_pager->parent->wdata;
+    if (!priv)
+      return -1;
+
+    notify_send(priv->notify, NT_PAGER, NT_PAGER_VIEW, priv);
   }
 
   return 0;


### PR DESCRIPTION
Fix `<top>` in the Pager.
The Pager wasn't refreshing itself after the `<top>` function.
This was exposed by b44c6760f.

**Steps**:
- Open a long email
- Page down a bit
- Hit `<top>` (<kbd>Home</kbd>)

**Expected**:
- Top of email is shown