### PR TITLE
browser: tag select rather than descend

### DIFF
--- a/browser/functions.c
+++ b/browser/functions.c
@@ -641,8 +641,12 @@ static int op_generic_select_entry(struct BrowserPrivateData *priv, int op)
 
   int index = menu_get_index(priv->menu);
   struct FolderFile *ff = ARRAY_GET(&priv->state.entry, index);
-  if (S_ISDIR(ff->mode) ||
-      (S_ISLNK(ff->mode) && link_is_dir(buf_string(&LastDir), ff->name)) || ff->inferiors)
+  if ((priv->menu->tag_prefix) && (op == OP_GENERIC_SELECT_ENTRY))
+  {
+    // Do nothing
+  }
+  else if (S_ISDIR(ff->mode) ||
+           (S_ISLNK(ff->mode) && link_is_dir(buf_string(&LastDir), ff->name)) || ff->inferiors)
   {
     /* make sure this isn't a MH or maildir mailbox */
     struct Buffer *buf = buf_pool_get();


### PR DESCRIPTION
Change the behaviour of the browser to honour `<tag-prefix><select-entry>` when the cursor is on a directory.

The user's *intent* is to select, not descend into a directory.

**Steps**:
- Compose email
- Attach file (opening file browser)
- Select several files
- Position the cursor on a directory
- Press `<tag-prefix><select-entry>` (`;<enter>`)

**Old Behaviour**:
- NeoMutt descends into directory

**New Behaviour**:
- NeoMutt attaches selected files

This behaviour is also exhibited by Mutt.