### PR TITLE
query: allow <>s around email addresses

### DIFF
--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -234,7 +234,12 @@ int query_run(const char *s, bool verbose, struct AliasList *al, const struct Co
       if (next_tok)
         *next_tok++ = '\0';
 
-      buf_printf(addr, "\"%s\" <%s>", tok, buf);
+      // The address shouldn't be wrapped with <>s, but historically, this was suppported
+      if (buf[0] == '<')
+        buf_printf(addr, "\"%s\" %s", tok, buf);
+      else
+        buf_printf(addr, "\"%s\" <%s>", tok, buf);
+
       mutt_addrlist_parse(&alias->addr, buf_string(addr));
 
       parse_alias_comments(alias, next_tok);


### PR DESCRIPTION
External address queries should be of the form:

    name@example.com<tab>Real Name

Historically, (Neo)Mutt would accept email addresses that were wrapped in `<>`s.

This feature stopped working in 5d8a41679 alias: unify query parsing

---

**This PR restores the old (undocumented) behaviour.**

**Is this what we want?**