### PR TITLE
main: don't stop if /var/spool/mail is missing

### DIFF
--- a/main.c
+++ b/main.c
@@ -1638,6 +1638,8 @@ int main(int argc, char *argv[], char *envp[])
   else
   {
     struct Buffer *folder = &cli->tui.folder;
+    bool explicit_folder = !buf_is_empty(folder);
+
     if (cli->tui.start_new_mail)
     {
       const bool c_imap_passive = cs_subset_bool(NeoMutt->sub, "imap_passive");
@@ -1747,7 +1749,7 @@ int main(int argc, char *argv[], char *envp[])
       mutt_error(_("Unable to open mailbox %s"), buf_string(folder));
       repeat_error = false;
     }
-    if (m || buf_is_empty(folder))
+    if (m || !explicit_folder)
     {
       struct MuttWindow *dlg = index_pager_init();
       dialog_push(dlg);


### PR DESCRIPTION
If /var/spool/mail/USER is missing, continue to the GUI and display an error message.

Fixes: #4599 

---

If you supply an explicit Mailbox on the command line and it doesn't exist,
then display an error message on the command line and stop. 

This was the behaviour before 699657c main: refactor command line parsing

---

First make sure that `$MAIL` isn't set.

**Test cases**:

1. `/var/spool/mail/USER` exists
  `neomutt -n -F /dev/null`
  **Result**: NeoMutt TUI starts and opens the mailbox

1. `/var/spool/mail/USER` does **not** exist
  `neomutt -n -F /dev/null`
  **Result**: NeoMutt TUI starts and displays an error

1. Explicit Mailbox exists
  `neomutt -n -F /dev/null -f ~/mail`
  **Result**: NeoMutt TUI starts and opens the mailbox

1. Explicit Mailbox does **not** exist
  `neomutt -n -F /dev/null -f ~/missing`
  **Result**: NeoMutt displays an error on the command line