### PR TITLE
color: fix quoted maths

### DIFF
--- a/color/quoted.c
+++ b/color/quoted.c
@@ -57,7 +57,7 @@ static int quoted_color_observer(struct NotifyCallback *nc)
   {
     if (simple_color_is_set(i))
     {
-      NumQuotedColors = i + 1;
+      NumQuotedColors = i - MT_COLOR_QUOTED0 + 1;
       break;
     }
   }


### PR DESCRIPTION
The quoted colour constants don't start at zero, so remember to subtract the base `MT_COLOR_QUOTED0`.

**Steps**:
- Create an email with multiple quoted levels, e.g. `> > > text`
- Config one colour: `color quoted0 brightgreen default`

**Broken Result**:
- Only the initial `> ` is coloured

**Expected Result**:
- Entire quoted line is coloured

---

Fixed bug introduced in 42d0c273a color: make quoted colours simple

Thanks :heart: to @charles2910 for the bug report and his help debugging. 