### PR TITLE
imap: check for incomplete Mailboxes on sync

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1481,6 +1481,8 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
 
   struct ImapAccountData *adata = imap_adata_get(m);
   struct ImapMboxData *mdata = imap_mdata_get(m);
+  if (!adata || !mdata)
+    return MX_STATUS_ERROR;
 
   if (adata->state < IMAP_SELECTED)
   {


### PR DESCRIPTION
When syncing an IMAP Mailbox, check that we have all we need.

Fixes: #4611 