### PR TITLE
Fix gpg-json output

### DIFF
--- a/data/account-command/gpg-json/credentials.sh
+++ b/data/account-command/gpg-json/credentials.sh
@@ -16,4 +16,5 @@ done
 [ -z "$cred" ] || [ -z "$host" ] || [ -z "$user" ] && exit 1
 
 query=$(printf '.host == "%s" and .user == "%s"' "$host" "$user")
+printf "password: "
 gpg -qd "$cred" | jq -r ".[] | select($query) | .pass"


### PR DESCRIPTION
* **What does this PR do?**

The gpg-json example doesn't spit out passwords in the format the account_command expects them, see 