### PR TITLE
fix label completion crash

### DIFF
--- a/editor/window.c
+++ b/editor/window.c
@@ -394,9 +394,9 @@ int mw_get_field(const char *prompt, struct Buffer *buf, CompletionFlags complet
   bye:
     mutt_hist_reset_state(wdata.hclass);
     FREE(&wdata.tempbuf);
-    completion_data_free(&wdata.cd);
   } while (rc == 1);
 
+  completion_data_free(&wdata.cd);
   msgcont_pop_window();
   window_set_focus(old_focus);
   mutt_window_free(&win);


### PR DESCRIPTION
Don't free the completion data until we're done with it.

Thanks to @jxlambda for finding, debugging and fixing this problem.

---

**Steps**:
- Open an IMAP folder
  None of the emails in the folder should have labels
- `<edit-label>` (<kbd>Y</kbd>)
- Type a letter, then hit <kbd>\<Tab\></kbd> (`<complete>`) twice

**Expected**:
- No crash
- No change to text