### PR TITLE
ncrypt/crypt.c: Protect Message-ID

### DIFF
--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -283,6 +283,7 @@ int mutt_protect(struct Email *e, char *keylist, bool postpone)
       mutt_addrlist_copy(&protected_headers->mail_followup_to,
                          &e->env->mail_followup_to, false);
       mutt_addrlist_copy(&protected_headers->x_original_to, &e->env->x_original_to, false);
+      mutt_str_replace(&protected_headers->message_id, e->env->message_id);
       mutt_list_copy_tail(&protected_headers->references, &e->env->references);
       mutt_list_copy_tail(&protected_headers->in_reply_to, &e->env->in_reply_to);
       mutt_env_to_intl(protected_headers, NULL, NULL);


### PR DESCRIPTION
* **What does this PR do?**

Cryptographically protect the Message-ID header field.

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

     We still have pending some documentation for the entire set of crypto stuff.  It's still hidden as experimental, though, so we have time for that.

   - All builds and tests are passing

     I did build neomutt from source, and tested sending myself some emails, one with message-id, and one without.  Both worked as expected.

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

     N/A

   - Code follows the [style guide](https://neomutt.org/dev/code)

     N/A

* **What are the relevant issue numbers?**

   Not specific, but related:

   -  <https://github.com/neomutt/neomutt/discussions/4251>
   -  <https://github.com/neomutt/neomutt/issues/4382>