### PR TITLE
Use the standard `countof` instead of our `mutt_array_size()`

### DIFF
--- a/config/quad.c
+++ b/config/quad.c
@@ -118,7 +118,7 @@ static int quad_string_get(void *var, const struct ConfigDef *cdef, struct Buffe
   else
     value = (int) cdef->initial;
 
-  if (value >= (mutt_array_size(QuadValues) - 1))
+  if (value >= (countof(QuadValues) - 1))
   {
     mutt_debug(LL_DEBUG1, "Variable has an invalid value: %d\n", value); /* LCOV_EXCL_LINE */
     return CSR_ERR_INVALID | CSR_INV_TYPE; /* LCOV_EXCL_LINE */
@@ -134,7 +134,7 @@ static int quad_string_get(void *var, const struct ConfigDef *cdef, struct Buffe
 static int quad_native_set(void *var, const struct ConfigDef *cdef,
                            intptr_t value, struct Buffer *err)
 {
-  if ((value < 0) || (value >= (mutt_array_size(QuadValues) - 1)))
+  if ((value < 0) || (value >= (countof(QuadValues) - 1)))
   {
     buf_printf(err, _("Invalid quad value: %ld"), (long) value);
     return CSR_ERR_INVALID | CSR_INV_TYPE;

--- a/config/set.c
+++ b/config/set.c
@@ -201,7 +201,7 @@ const struct ConfigSetType *cs_get_type_def(const struct ConfigSet *cs, unsigned
     return NULL;
 
   type = CONFIG_TYPE(type);
-  if (type >= mutt_array_size(cs->types))
+  if (type >= countof(cs->types))
     return NULL; // LCOV_EXCL_LINE
 
   if (!cs->types[type].name)
@@ -227,7 +227,7 @@ bool cs_register_type(struct ConfigSet *cs, const struct ConfigSetType *cst)
     return false;
   }
 
-  if (cst->type >= mutt_array_size(cs->types))
+  if (cst->type >= countof(cs->types))
     return false;
 
   if (cs->types[cst->type].name)

--- a/conn/gnutls.c
+++ b/conn/gnutls.c
@@ -443,7 +443,7 @@ static void add_cert(const char *title, gnutls_x509_crt_t cert, bool issuer,
   // Allocate formatted strings and let the array take ownership
   ARRAY_ADD(carr, mutt_str_dup(title));
 
-  for (size_t i = 0; i < mutt_array_size(part); i++)
+  for (size_t i = 0; i < countof(part); i++)
   {
     size_t buflen = sizeof(buf);
     if (issuer)

--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -867,7 +867,7 @@ static void add_cert(const char *title, X509 *cert, bool issuer, struct CertArra
 
   char *line = NULL;
   char *text = NULL;
-  for (size_t i = 0; i < mutt_array_size(part); i++)
+  for (size_t i = 0; i < countof(part); i++)
   {
     text = x509_get_part(x509, part[i]);
     if (text)

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -135,7 +135,7 @@ static sasl_secret_t *SecretPtr = NULL;
  */
 bool sasl_auth_validator(const char *authenticator)
 {
-  for (size_t i = 0; i < mutt_array_size(SaslAuthenticators); i++)
+  for (size_t i = 0; i < countof(SaslAuthenticators); i++)
   {
     const char *auth = SaslAuthenticators[i];
     if (mutt_istr_equal(auth, authenticator))

--- a/core/mailbox.c
+++ b/core/mailbox.c
@@ -298,7 +298,7 @@ static struct EmailGarbageCollector GC = { 0 };
 void mailbox_gc_add(struct Email *e)
 {
   ASSERT(e);
-  if (GC.idx == mutt_array_size(GC.arr))
+  if (GC.idx == countof(GC.arr))
   {
     mailbox_gc_run();
   }

--- a/imap/auth.c
+++ b/imap/auth.c
@@ -94,7 +94,7 @@ static const struct ImapAuth ImapAuthenticators[] = {
  */
 bool imap_auth_is_valid(const char *authenticator)
 {
-  for (size_t i = 0; i < mutt_array_size(ImapAuthenticators); i++)
+  for (size_t i = 0; i < countof(ImapAuthenticators); i++)
   {
     const struct ImapAuth *auth = &ImapAuthenticators[i];
     if (auth->method && mutt_istr_equal(auth->method, authenticator))
@@ -127,7 +127,7 @@ int imap_authenticate(struct ImapAccountData *adata)
     {
       mutt_debug(LL_DEBUG2, "Trying method %s\n", np->data);
 
-      for (size_t i = 0; i < mutt_array_size(ImapAuthenticators); i++)
+      for (size_t i = 0; i < countof(ImapAuthenticators); i++)
       {
         const struct ImapAuth *auth = &ImapAuthenticators[i];
         if (!auth->method || mutt_istr_equal(auth->method, np->data))
@@ -146,7 +146,7 @@ int imap_authenticate(struct ImapAccountData *adata)
     /* Fall back to default: any authenticator */
     mutt_debug(LL_DEBUG2, "Trying pre-defined imap_authenticators\n");
 
-    for (size_t i = 0; i < mutt_array_size(ImapAuthenticators); i++)
+    for (size_t i = 0; i < countof(ImapAuthenticators); i++)
     {
       rc = ImapAuthenticators[i].authenticate(adata, NULL);
       if (rc == IMAP_AUTH_SUCCESS)

--- a/index/index.c
+++ b/index/index.c
@@ -370,7 +370,7 @@ bool config_check_index(const char *option)
     "ts_icon_format",     "ts_status_format"
   };
 
-  for (size_t i = 0; i < mutt_array_size(index_options); i++)
+  for (size_t i = 0; i < countof(index_options); i++)
   {
     if (mutt_str_equal(option, index_options[i]))
       return true;

--- a/key/init.c
+++ b/key/init.c
@@ -229,7 +229,7 @@ void mutt_init_abort_key(void)
 {
   keycode_t buf[2];
   const char *const c_abort_key = cs_subset_string(NeoMutt->sub, "abort_key");
-  size_t len = parsekeys(c_abort_key, buf, mutt_array_size(buf));
+  size_t len = parsekeys(c_abort_key, buf, countof(buf));
   if (len == 0)
   {
     mutt_error(_("Abort key is not set, defaulting to Ctrl-G"));

--- a/key/parse.c
+++ b/key/parse.c
@@ -384,7 +384,7 @@ enum CommandResult parse_bind(struct Buffer *buf, struct Buffer *s,
   int num_menus = 0;
   enum CommandResult rc = MUTT_CMD_SUCCESS;
 
-  char *key = parse_keymap(mtypes, s, mutt_array_size(mtypes), &num_menus, err, true);
+  char *key = parse_keymap(mtypes, s, countof(mtypes), &num_menus, err, true);
   if (!key)
     return MUTT_CMD_ERROR;
 
@@ -584,7 +584,7 @@ enum CommandResult parse_macro(struct Buffer *buf, struct Buffer *s,
   int num_menus = 0;
   enum CommandResult rc = MUTT_CMD_ERROR;
 
-  char *key = parse_keymap(mtypes, s, mutt_array_size(mtypes), &num_menus, err, false);
+  char *key = parse_keymap(mtypes, s, countof(mtypes), &num_menus, err, false);
   if (!key)
     return MUTT_CMD_ERROR;
 
@@ -693,7 +693,7 @@ enum CommandResult parse_exec(struct Buffer *buf, struct Buffer *s,
       return MUTT_CMD_ERROR;
     }
     nops++;
-  } while (MoreArgs(s) && nops < mutt_array_size(ops));
+  } while (MoreArgs(s) && nops < countof(ops));
 
   while (nops)
     mutt_push_macro_event(0, ops[--nops]);

--- a/maildir/path.c
+++ b/maildir/path.c
@@ -98,7 +98,7 @@ enum MailboxType maildir_path_probe(const char *path, const struct stat *st)
   char sub[PATH_MAX] = { 0 };
   struct stat stsub = { 0 };
   char *subs[] = { "cur", "new" };
-  for (size_t i = 0; i < mutt_array_size(subs); i++)
+  for (size_t i = 0; i < countof(subs); i++)
   {
     snprintf(sub, sizeof(sub), "%s/%s", path, subs[i]);
     if ((stat(sub, &stsub) == 0) && S_ISDIR(stsub.st_mode))

--- a/main.c
+++ b/main.c
@@ -290,7 +290,7 @@ static char *getmailname(void)
   char *mailname = NULL;
   static const char *mn_files[] = { "/etc/mailname", "/etc/mail/mailname" };
 
-  for (size_t i = 0; i < mutt_array_size(mn_files); i++)
+  for (size_t i = 0; i < countof(mn_files); i++)
   {
     FILE *fp = mutt_file_fopen(mn_files[i], "r");
     if (!fp)
@@ -708,7 +708,7 @@ static void reset_tilde(struct ConfigSet *cs)
   static const char *names[] = { "folder", "mbox", "postponed", "record" };
 
   struct Buffer *value = buf_pool_get();
-  for (size_t i = 0; i < mutt_array_size(names); i++)
+  for (size_t i = 0; i < countof(names); i++)
   {
     struct HashElem *he = cs_get_elem(cs, names[i]);
     if (!he)

--- a/menu/type.c
+++ b/menu/type.c
@@ -57,4 +57,4 @@ const struct Mapping MenuNames[] = {
 };
 
 /// Number of entries in the #MenuNames array
-const int MenuNamesLen = mutt_array_size(MenuNames) - 1;
+const int MenuNamesLen = countof(MenuNames) - 1;

--- a/mutt/date.c
+++ b/mutt/date.c
@@ -186,7 +186,7 @@ static time_t add_tz_offset(time_t t, bool w, time_t h, time_t m)
  */
 static const struct Tz *find_tz(const char *s, size_t len)
 {
-  for (size_t i = 0; i < mutt_array_size(TimeZones); i++)
+  for (size_t i = 0; i < countof(TimeZones); i++)
   {
     if (mutt_istrn_equal(TimeZones[i].tzname, s, len))
       return &TimeZones[i];
@@ -244,7 +244,7 @@ time_t mutt_date_make_time(struct tm *t, bool local)
   if (!t)
     return TIME_T_MIN;
 
-  static const int AccumDaysPerMonth[mutt_array_size(Months)] = {
+  static const int AccumDaysPerMonth[countof(Months)] = {
     0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334,
   };
 
@@ -265,7 +265,7 @@ time_t mutt_date_make_time(struct tm *t, bool local)
     return TIME_T_MAX;
 
   /* Compute the number of days since January 1 in the same year */
-  int yday = AccumDaysPerMonth[t->tm_mon % mutt_array_size(Months)];
+  int yday = AccumDaysPerMonth[t->tm_mon % countof(Months)];
 
   /* The leap years are 1972 and every 4. year until 2096,
    * but this algorithm will fail after year 2099 */
@@ -312,7 +312,7 @@ void mutt_date_normalize_time(struct tm *tm)
   if (!tm)
     return;
 
-  static const char DaysPerMonth[mutt_array_size(Months)] = {
+  static const char DaysPerMonth[countof(Months)] = {
     31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
   };
   int leap;
@@ -438,7 +438,7 @@ int mutt_date_check_month(const char *s)
   memcpy(buf, s, 3);
   uint32_t sv;
   memcpy(&sv, buf, sizeof(sv));
-  for (int i = 0; i < mutt_array_size(Months); i++)
+  for (int i = 0; i < countof(Months); i++)
   {
     uint32_t mv;
     memcpy(&mv, Months[i], sizeof(mv));

--- a/mutt/memory.h
+++ b/mutt/memory.h
@@ -23,6 +23,11 @@
 #ifndef MUTT_MUTT_MEMORY_H
 #define MUTT_MUTT_MEMORY_H
 
+#if defined __has_include
+# if __has_include(<stdcountof.h>)
+#  include <stdcountof.h>
+# endif
+#endif
 #include <stddef.h>
 
 #undef MAX
@@ -35,7 +40,9 @@
 #undef ROUND_UP
 #define ROUND_UP(NUM, STEP) ((((NUM) + (STEP) -1) / (STEP)) * (STEP))
 
-#define mutt_array_size(x) (sizeof(x) / sizeof((x)[0]))
+#if !defined(countof)
+# define countof(x)  (sizeof(x) / sizeof((x)[0]))
+#endif
 
 #define MUTT_MEM_CALLOC(n, type)  ((type *) mutt_mem_calloc(n, sizeof(type)))
 #define MUTT_MEM_MALLOC(n, type)  ((type *) mutt_mem_mallocarray(n, sizeof(type)))

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -169,7 +169,7 @@ static const struct SysExits SysExits[] = {
  */
 const char *mutt_str_sysexit(int err_num)
 {
-  for (size_t i = 0; i < mutt_array_size(SysExits); i++)
+  for (size_t i = 0; i < countof(SysExits); i++)
   {
     if (err_num == SysExits[i].err_num)
       return SysExits[i].err_str;

--- a/notmuch/query.c
+++ b/notmuch/query.c
@@ -76,7 +76,7 @@ enum NmQueryType nm_parse_type_from_query(char *buf, enum NmQueryType fallback)
   const char *variants[6] = { "&type=threads", "&type=messages",
                               "type=threads&", "type=messages&",
                               "type=threads",  "type=messages" };
-  int variants_size = mutt_array_size(variants);
+  int variants_size = countof(variants);
 
   for (int i = 0; i < variants_size; i++)
   {

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -472,7 +472,7 @@ static bool match_reference(struct Pattern *pat, struct ListHead *refs)
 static bool mutt_is_predicate_recipient(bool all_addr, struct Envelope *env, addr_predicate_t p)
 {
   struct AddressList *als[] = { &env->to, &env->cc };
-  for (size_t i = 0; i < mutt_array_size(als); i++)
+  for (size_t i = 0; i < countof(als); i++)
   {
     struct AddressList *al = als[i];
     struct Address *a = NULL;

--- a/pop/auth.c
+++ b/pop/auth.c
@@ -501,7 +501,7 @@ static const struct PopAuth PopAuthenticators[] = {
  */
 bool pop_auth_is_valid(const char *authenticator)
 {
-  for (size_t i = 0; i < mutt_array_size(PopAuthenticators); i++)
+  for (size_t i = 0; i < countof(PopAuthenticators); i++)
   {
     const struct PopAuth *auth = &PopAuthenticators[i];
     if (auth->method && mutt_istr_equal(auth->method, authenticator))

--- a/send/header.c
+++ b/send/header.c
@@ -68,7 +68,7 @@ enum UserHdrsOverrideIdx
 struct UserHdrsOverride
 {
   /// Which email headers have been overridden
-  bool is_overridden[mutt_array_size(UserhdrsOverrideHeaders)];
+  bool is_overridden[countof(UserhdrsOverrideHeaders)];
 };
 
 /**
@@ -384,7 +384,7 @@ static struct UserHdrsOverride write_userhdrs(FILE *fp, const struct ListHead *u
     /* check whether the current user-header is an override */
     size_t cur_override = ICONV_ILLEGAL_SEQ;
     const char *const *idx = bsearch(tmp->data, UserhdrsOverrideHeaders,
-                                     mutt_array_size(UserhdrsOverrideHeaders),
+                                     countof(UserhdrsOverrideHeaders),
                                      sizeof(char *), userhdrs_override_cmp);
     if (idx)
     {

--- a/send/send.c
+++ b/send/send.c
@@ -164,7 +164,7 @@ static void add_mailing_lists(struct AddressList *out, const struct AddressList 
 {
   const struct AddressList *const als[] = { t, c };
 
-  for (size_t i = 0; i < mutt_array_size(als); i++)
+  for (size_t i = 0; i < countof(als); i++)
   {
     const struct AddressList *al = als[i];
     struct Address *a = NULL;

--- a/send/smtp.c
+++ b/send/smtp.c
@@ -925,7 +925,7 @@ static const struct SmtpAuth SmtpAuthenticators[] = {
  */
 bool smtp_auth_is_valid(const char *authenticator)
 {
-  for (size_t i = 0; i < mutt_array_size(SmtpAuthenticators); i++)
+  for (size_t i = 0; i < countof(SmtpAuthenticators); i++)
   {
     const struct SmtpAuth *auth = &SmtpAuthenticators[i];
     if (auth->method && mutt_istr_equal(auth->method, authenticator))
@@ -956,7 +956,7 @@ static int smtp_authenticate(struct SmtpAccountData *adata)
     {
       mutt_debug(LL_DEBUG2, "Trying method %s\n", np->data);
 
-      for (size_t i = 0; i < mutt_array_size(SmtpAuthenticators); i++)
+      for (size_t i = 0; i < countof(SmtpAuthenticators); i++)
       {
         const struct SmtpAuth *auth = &SmtpAuthenticators[i];
         if (!auth->method || mutt_istr_equal(auth->method, np->data))
@@ -980,7 +980,7 @@ static int smtp_authenticate(struct SmtpAccountData *adata)
 #else
     mutt_debug(LL_DEBUG2, "Falling back to using any authenticator available\n");
     /* Try all available authentication methods */
-    for (size_t i = 0; i < mutt_array_size(SmtpAuthenticators); i++)
+    for (size_t i = 0; i < countof(SmtpAuthenticators); i++)
     {
       const struct SmtpAuth *auth = &SmtpAuthenticators[i];
       mutt_debug(LL_DEBUG2, "Trying method %s\n", auth->method ? auth->method : "<variable>");

--- a/test/address/config_type.c
+++ b/test/address/config_type.c
@@ -173,7 +173,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   int rc;
   const struct Address *VarDamson = NULL;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, valid[i], err);
@@ -194,7 +194,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   name = "Elderberry";
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, valid[i], err);

--- a/test/address/mutt_addrlist_to_intl.c
+++ b/test/address/mutt_addrlist_to_intl.c
@@ -73,7 +73,7 @@ void test_mutt_addrlist_to_intl(void)
     cs_subset_str_native_set(NeoMutt->sub, "idn_decode", true, NULL);
 #endif
 
-    for (size_t i = 0; i < mutt_array_size(local2intl); ++i)
+    for (size_t i = 0; i < countof(local2intl); ++i)
     {
       struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
       mutt_addrlist_append(&al, mutt_addr_create(NULL, local2intl[i].local));

--- a/test/address/mutt_addrlist_write_wrap.c
+++ b/test/address/mutt_addrlist_write_wrap.c
@@ -66,7 +66,7 @@ void test_mutt_addrlist_write_wrap(void)
   };
 
   {
-    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    for (size_t i = 0; i < countof(tests); i++)
     {
       TEST_CASE(test_name(tests[i].address_list));
 

--- a/test/atoi/mutt_str_atoi.c
+++ b/test/atoi/mutt_str_atoi.c
@@ -100,7 +100,7 @@ void test_mutt_str_atoi(void)
   TEST_CHECK(mutt_str_atoi("42", NULL) != NULL);
 
   // Normal tests
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     TEST_CASE(tests[i].str);
 

--- a/test/atoi/mutt_str_atol.c
+++ b/test/atoi/mutt_str_atol.c
@@ -127,7 +127,7 @@ void test_mutt_str_atol(void)
   TEST_CHECK(mutt_str_atol("42", NULL) != NULL);
 
   // Normal tests
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     TEST_CASE(tests[i].str);
 

--- a/test/atoi/mutt_str_atos.c
+++ b/test/atoi/mutt_str_atos.c
@@ -100,7 +100,7 @@ void test_mutt_str_atos(void)
   TEST_CHECK(mutt_str_atos("42", NULL) != 0);
 
   // Normal tests
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     TEST_CASE(tests[i].str);
 

--- a/test/atoi/mutt_str_atoui.c
+++ b/test/atoi/mutt_str_atoui.c
@@ -97,7 +97,7 @@ void test_mutt_str_atoui(void)
   TEST_CHECK(mutt_str_atoui("42", NULL) != NULL);
 
   // Normal tests
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     TEST_CASE(tests[i].str);
 

--- a/test/atoi/mutt_str_atoul.c
+++ b/test/atoi/mutt_str_atoul.c
@@ -104,7 +104,7 @@ void test_mutt_str_atoul(void)
   TEST_CHECK(mutt_str_atoul("42", NULL) != NULL);
 
   // Normal tests
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     TEST_CASE(tests[i].str);
 

--- a/test/atoi/mutt_str_atoull.c
+++ b/test/atoi/mutt_str_atoull.c
@@ -85,7 +85,7 @@ void test_mutt_str_atoull(void)
   TEST_CHECK(mutt_str_atoull("42", NULL) != NULL);
 
   // Normal tests
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     TEST_CASE(tests[i].str);
 

--- a/test/atoi/mutt_str_atous.c
+++ b/test/atoi/mutt_str_atous.c
@@ -99,7 +99,7 @@ void test_mutt_str_atous(void)
   TEST_CHECK(mutt_str_atous("42", NULL) != 0);
 
   // Normal tests
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     TEST_CASE(tests[i].str);
 

--- a/test/buffer/buf_addstr_n.c
+++ b/test/buffer/buf_addstr_n.c
@@ -48,7 +48,7 @@ void test_buf_addstr_n(void)
     const size_t len = strlen(str);
     size_t sizes[] = { 0, 5, len };
 
-    for (size_t i = 0; i < mutt_array_size(sizes); i++)
+    for (size_t i = 0; i < countof(sizes); i++)
     {
       TEST_CASE_("%ld", sizes[i]);
       struct Buffer *buf = buf_pool_get();
@@ -69,7 +69,7 @@ void test_buf_addstr_n(void)
     const char *combined = "testa quick brown fox";
     size_t sizes[] = { 0, 5, len };
 
-    for (size_t i = 0; i < mutt_array_size(sizes); i++)
+    for (size_t i = 0; i < countof(sizes); i++)
     {
       TEST_CASE_("%ld", sizes[i]);
       struct Buffer *buf = buf_pool_get();

--- a/test/buffer/buf_alloc.c
+++ b/test/buffer/buf_alloc.c
@@ -52,7 +52,7 @@ void test_buf_alloc(void)
       { 129, 256 },
     };
 
-    for (size_t i = 0; i < mutt_array_size(sizes); i++)
+    for (size_t i = 0; i < countof(sizes); i++)
     {
       struct Buffer *buf = MUTT_MEM_CALLOC(1, struct Buffer);
       buf_alloc(buf, orig_size);

--- a/test/buffer/buf_concat_path.c
+++ b/test/buffer/buf_concat_path.c
@@ -57,7 +57,7 @@ void test_buf_concat_path(void)
   // clang-format on
 
   {
-    for (size_t i = 0; i < mutt_array_size(concat_test); i++)
+    for (size_t i = 0; i < countof(concat_test); i++)
     {
       TEST_CASE_("DIR: '%s'  FILE: '%s'", NONULL(concat_test[i][0]),
                  NONULL(concat_test[i][1]));

--- a/test/buffer/buf_inline_replace.c
+++ b/test/buffer/buf_inline_replace.c
@@ -91,7 +91,7 @@ void test_buf_inline_replace(void)
   // clang-format on
 
   {
-    for (size_t i = 0; i < mutt_array_size(replace_tests); i++)
+    for (size_t i = 0; i < countof(replace_tests); i++)
     {
       const struct InlineReplaceTest *t = &replace_tests[i];
 

--- a/test/buffer/buf_join_str.c
+++ b/test/buffer/buf_join_str.c
@@ -58,7 +58,7 @@ void test_buf_join_str(void)
   // clang-format on
 
   {
-    for (size_t i = 0; i < mutt_array_size(append_tests); i++)
+    for (size_t i = 0; i < countof(append_tests); i++)
     {
       const struct AppendTest *t = &append_tests[i];
       struct Buffer *buf = NULL;

--- a/test/buffer/buf_rfind.c
+++ b/test/buffer/buf_rfind.c
@@ -59,7 +59,7 @@ void test_buf_rfind(void)
   {
     const char *find = "apple";
 
-    for (size_t i = 0; i < mutt_array_size(rstrn_tests); i++)
+    for (size_t i = 0; i < countof(rstrn_tests); i++)
     {
       struct Buffer *buf = NULL;
 

--- a/test/buffer/buf_strcpy_n.c
+++ b/test/buffer/buf_strcpy_n.c
@@ -50,7 +50,7 @@ void test_buf_strcpy_n(void)
     const size_t len = strlen(str);
     size_t sizes[] = { 0, 5, len };
 
-    for (size_t i = 0; i < mutt_array_size(sizes); i++)
+    for (size_t i = 0; i < countof(sizes); i++)
     {
       TEST_CASE_("%ld", sizes[i]);
       struct Buffer *buf = buf_pool_get();
@@ -69,7 +69,7 @@ void test_buf_strcpy_n(void)
     const size_t len = strlen(str);
     size_t sizes[] = { 0, 5, len };
 
-    for (size_t i = 0; i < mutt_array_size(sizes); i++)
+    for (size_t i = 0; i < countof(sizes); i++)
     {
       TEST_CASE_("%ld", sizes[i]);
       struct Buffer *buf = buf_pool_get();

--- a/test/cli/cli_parse.c
+++ b/test/cli/cli_parse.c
@@ -335,7 +335,7 @@ void test_cli_parse(void)
 
     struct Buffer *res = buf_pool_get();
 
-    for (size_t i = 0; i < mutt_array_size(Tests); i++)
+    for (size_t i = 0; i < countof(Tests); i++)
     {
       struct CommandLine *cli = command_line_new();
       struct StringArray sa = ARRAY_HEAD_INITIALIZER;
@@ -368,7 +368,7 @@ void test_cli_parse(void)
 
     opterr = 0; // Disable stderr warnings
 
-    for (size_t i = 0; i < mutt_array_size(Tests); i++)
+    for (size_t i = 0; i < countof(Tests); i++)
     {
       struct CommandLine *cli = command_line_new();
       struct StringArray sa = ARRAY_HEAD_INITIALIZER;

--- a/test/color/ansi_color_parse_single.c
+++ b/test/color/ansi_color_parse_single.c
@@ -81,7 +81,7 @@ void test_ansi_color_parse_single(void)
     };
 
     int len;
-    for (int i = 0; i < mutt_array_size(tests); i++)
+    for (int i = 0; i < countof(tests); i++)
     {
       TEST_CASE_("Length %d", i);
 
@@ -136,7 +136,7 @@ void test_ansi_color_parse_single(void)
     };
 
     int len;
-    for (int i = 0; i < mutt_array_size(tests); i++)
+    for (int i = 0; i < countof(tests); i++)
     {
       TEST_CASE_("Cancel %d", i);
 
@@ -196,11 +196,11 @@ void test_ansi_color_parse_single(void)
     char str[32];
     for (int i = 38; i < 49; i += 10)
     {
-      for (int r = 0; r < mutt_array_size(red); r++)
+      for (int r = 0; r < countof(red); r++)
       {
-        for (int g = 0; g < mutt_array_size(green); g++)
+        for (int g = 0; g < countof(green); g++)
         {
-          for (int b = 0; b < mutt_array_size(blue); b++)
+          for (int b = 0; b < countof(blue); b++)
           {
             int val_r = red[r];
             int val_g = green[g];
@@ -269,7 +269,7 @@ void test_ansi_color_parse_single(void)
     };
 
     int len;
-    for (int i = 0; i < mutt_array_size(tests); i++)
+    for (int i = 0; i < countof(tests); i++)
     {
       TEST_CASE_("Bad %d", i);
 

--- a/test/color/attr.c
+++ b/test/color/attr.c
@@ -169,7 +169,7 @@ void test_attr_colors(void)
       // clang-format on
     };
 
-    for (int i = 0; i < mutt_array_size(Tests); i++)
+    for (int i = 0; i < countof(Tests); i++)
     {
       color_t col = Tests[i].col_before;
       int attrs = Tests[i].attrs_before;
@@ -197,7 +197,7 @@ void test_attr_colors(void)
       // clang-format on
     };
 
-    for (int i = 0; i < mutt_array_size(Tests); i++)
+    for (int i = 0; i < countof(Tests); i++)
     {
       color_t col = Tests[i].col_before;
       int attrs = Tests[i].attrs_before;
@@ -232,7 +232,7 @@ void test_attr_colors(void)
       // clang-format on
     };
 
-    for (int i = 0; i < mutt_array_size(Colors); i++)
+    for (int i = 0; i < countof(Colors); i++)
     {
       color_t col = color_xterm256_to_24bit(Colors[i][0]);
       TEST_CHECK(col == Colors[i][1]);

--- a/test/compress/common.c
+++ b/test/compress/common.c
@@ -151,7 +151,7 @@ void compress_data_tests(const struct ComprOps *compr_ops, short min_level, shor
       one_test(compr_ops, level, size);
     }
 
-    for (size_t i = 0; i < mutt_array_size(sizes); i++)
+    for (size_t i = 0; i < countof(sizes); i++)
     {
       snprintf(case_name, sizeof(case_name), "    size %zu", sizes[i]);
       TEST_CASE(case_name);

--- a/test/config/bool.c
+++ b/test/config/bool.c
@@ -167,7 +167,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   bool VarDamson;
 
   int rc;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     cs_str_native_set(cs, name, ((i + 1) % 2), NULL);
 
@@ -203,7 +203,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   short_line();
-  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  for (unsigned int i = 0; i < countof(invalid); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, invalid[i], err);
@@ -321,7 +321,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   int invalid[] = { -1, 2 };
-  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  for (unsigned int i = 0; i < countof(invalid); i++)
   {
     short_line();
     cs_str_native_set(cs, name, false, NULL);
@@ -705,7 +705,7 @@ static bool test_toggle(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     bool before = tests[i].before;
     bool after = tests[i].after;
@@ -743,7 +743,7 @@ static bool test_toggle(struct ConfigSubset *sub, struct Buffer *err)
     short_line();
   }
 
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     bool before = tests[i].before;
     bool after = tests[i].after;

--- a/test/config/enum.c
+++ b/test/config/enum.c
@@ -183,7 +183,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   int rc;
   unsigned char VarDamson;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     cs_str_native_set(cs, name, ANIMAL_CASSOWARY, NULL);
 
@@ -212,7 +212,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
     short_line();
   }
 
-  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  for (unsigned int i = 0; i < countof(invalid); i++)
   {
     TEST_MSG("Setting %s to %s", name, NONULL(invalid[i]));
     buf_reset(err);
@@ -350,7 +350,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   int invalid[] = { -1, 256 };
-  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  for (unsigned int i = 0; i < countof(invalid); i++)
   {
     short_line();
     cs_str_native_set(cs, name, ANIMAL_CASSOWARY, NULL);

--- a/test/config/long.c
+++ b/test/config/long.c
@@ -153,7 +153,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   int rc;
   long VarDamson;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     cs_str_native_set(cs, name, -42, NULL);
 
@@ -182,7 +182,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
     short_line();
   }
 
-  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  for (unsigned int i = 0; i < countof(invalid); i++)
   {
     TEST_MSG("Setting %s to %s", name, NONULL(invalid[i]));
     buf_reset(err);
@@ -273,7 +273,7 @@ static bool test_string_plus_equals(struct ConfigSubset *sub, struct Buffer *err
 
   int rc;
   long VarDamson;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     cs_str_native_set(cs, name, -42, NULL);
 
@@ -303,7 +303,7 @@ static bool test_string_plus_equals(struct ConfigSubset *sub, struct Buffer *err
     short_line();
   }
 
-  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  for (unsigned int i = 0; i < countof(invalid); i++)
   {
     VarDamson = cs_subset_long(sub, "Damson");
     TEST_MSG("Increasing %s with initial value %d by %s", name, VarDamson,
@@ -358,7 +358,7 @@ static bool test_string_minus_equals(struct ConfigSubset *sub, struct Buffer *er
 
   int rc;
   long VarDamson;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     cs_str_native_set(cs, name, -42, NULL);
 
@@ -388,7 +388,7 @@ static bool test_string_minus_equals(struct ConfigSubset *sub, struct Buffer *er
     short_line();
   }
 
-  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  for (unsigned int i = 0; i < countof(invalid); i++)
   {
     VarDamson = cs_subset_long(sub, "Damson");
     TEST_MSG("Decreasing %s with initial value %d by %s", name, VarDamson,

--- a/test/config/mbtable.c
+++ b/test/config/mbtable.c
@@ -167,7 +167,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   char *mb = NULL;
 
   int rc;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, valid[i], err);
@@ -194,7 +194,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   name = "Elderberry";
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, valid[i], err);

--- a/test/config/myvar.c
+++ b/test/config/myvar.c
@@ -184,7 +184,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   const char *name = "Damson";
 
   int rc;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, valid[i], err);
@@ -220,7 +220,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   name = "Elderberry";
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     short_line();
     buf_reset(err);
@@ -305,7 +305,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
   struct ConfigSet *cs = sub->cs;
 
   int rc;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     buf_reset(err);
     rc = cs_str_native_set(cs, name, (intptr_t) valid[i], err);
@@ -341,7 +341,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   name = "Kumquat";
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     short_line();
     buf_reset(err);
@@ -417,7 +417,7 @@ static bool test_string_plus_equals(struct ConfigSubset *sub, struct Buffer *err
   };
 
   int rc;
-  for (unsigned int i = 0; i < mutt_array_size(PlusTests); i++)
+  for (unsigned int i = 0; i < countof(PlusTests); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, PlusTests[i][0], err);

--- a/test/config/number.c
+++ b/test/config/number.c
@@ -155,7 +155,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   int rc;
   short VarDamson;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     cs_str_native_set(cs, name, -42, NULL);
 
@@ -184,7 +184,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
     short_line();
   }
 
-  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  for (unsigned int i = 0; i < countof(invalid); i++)
   {
     TEST_MSG("Setting %s to %s", name, NONULL(invalid[i]));
     buf_reset(err);
@@ -318,7 +318,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   int invalid[] = { -32769, 32768 };
-  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  for (unsigned int i = 0; i < countof(invalid); i++)
   {
     short_line();
     cs_str_native_set(cs, name, 123, NULL);
@@ -381,7 +381,7 @@ static bool test_string_plus_equals(struct ConfigSubset *sub, struct Buffer *err
 
   int rc;
   short VarDamson;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     cs_str_native_set(cs, name, -42, NULL);
 
@@ -411,7 +411,7 @@ static bool test_string_plus_equals(struct ConfigSubset *sub, struct Buffer *err
     short_line();
   }
 
-  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  for (unsigned int i = 0; i < countof(invalid); i++)
   {
     VarDamson = cs_subset_number(sub, "Damson");
     TEST_MSG("Increasing %s with initial value %d by %s", name, VarDamson,
@@ -466,7 +466,7 @@ static bool test_string_minus_equals(struct ConfigSubset *sub, struct Buffer *er
 
   int rc;
   short VarDamson;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     cs_str_native_set(cs, name, -42, NULL);
 
@@ -496,7 +496,7 @@ static bool test_string_minus_equals(struct ConfigSubset *sub, struct Buffer *er
     short_line();
   }
 
-  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  for (unsigned int i = 0; i < countof(invalid); i++)
   {
     VarDamson = cs_subset_number(sub, "Damson");
     TEST_MSG("Decreasing %s with initial value %d by %s", name, VarDamson,

--- a/test/config/path.c
+++ b/test/config/path.c
@@ -176,7 +176,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   const char *name = "Damson";
 
   int rc;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, valid[i], err);
@@ -216,7 +216,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   name = "Elderberry";
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     short_line();
     buf_reset(err);
@@ -311,7 +311,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
   const char *name = "Jackfruit";
 
   int rc;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     buf_reset(err);
     rc = cs_str_native_set(cs, name, (intptr_t) valid[i], err);
@@ -351,7 +351,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   name = "Kumquat";
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     short_line();
     buf_reset(err);

--- a/test/config/quad.c
+++ b/test/config/quad.c
@@ -157,7 +157,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   char VarDamson;
 
   int rc;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     cs_str_native_set(cs, name, ((i + 1) % 4), NULL);
 
@@ -197,7 +197,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
     short_line();
   }
 
-  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  for (unsigned int i = 0; i < countof(invalid); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, invalid[i], err);
@@ -239,7 +239,7 @@ static bool test_string_get(struct ConfigSubset *sub, struct Buffer *err)
   int valid[] = { MUTT_NO, MUTT_YES, MUTT_ASKNO, MUTT_ASKYES };
 
   int rc;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     cs_str_native_set(cs, name, valid[i], NULL);
     buf_reset(err);
@@ -310,7 +310,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   int invalid[] = { -1, 4 };
-  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  for (unsigned int i = 0; i < countof(invalid); i++)
   {
     short_line();
     cs_str_native_set(cs, name, MUTT_NO, NULL);
@@ -670,7 +670,7 @@ static bool test_toggle(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     char before = tests[i].before;
     char after = tests[i].after;

--- a/test/config/regex.c
+++ b/test/config/regex.c
@@ -171,7 +171,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
   int rc;
 
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, valid[i], err);
@@ -198,7 +198,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   name = "Elderberry";
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, valid[i], err);

--- a/test/config/slist.c
+++ b/test/config/slist.c
@@ -168,7 +168,7 @@ static bool test_slist_parse(struct Buffer *err)
   buf_reset(err);
 
   struct Slist *list = NULL;
-  for (size_t i = 0; i < mutt_array_size(init); i++)
+  for (size_t i = 0; i < countof(init); i++)
   {
     TEST_CASE_(">>%s<<", init[i] ? init[i] : "NULL");
     list = slist_parse(init[i], flags);
@@ -266,7 +266,7 @@ static bool test_slist_is_member(struct Buffer *err)
 
     static const char *values[] = { "apple", "", "damson", NULL };
 
-    for (size_t i = 0; i < mutt_array_size(values); i++)
+    for (size_t i = 0; i < countof(values); i++)
     {
       TEST_MSG("member '%s' : %s", values[i], slist_is_member(list, values[i]) ? "yes" : "no");
     }
@@ -655,7 +655,7 @@ static bool test_plus_equals(struct ConfigSubset *sub, struct Buffer *err)
   };
 
   int rc;
-  for (size_t i = 0; i < mutt_array_size(PlusTests); i++)
+  for (size_t i = 0; i < countof(PlusTests); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, PlusTests[i][0], err);
@@ -734,7 +734,7 @@ static bool test_minus_equals(struct ConfigSubset *sub, struct Buffer *err)
   };
 
   int rc;
-  for (size_t i = 0; i < mutt_array_size(MinusTests); i++)
+  for (size_t i = 0; i < countof(MinusTests); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, MinusTests[i][0], err);

--- a/test/config/sort.c
+++ b/test/config/sort.c
@@ -181,7 +181,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   struct ConfigSet *cs = sub->cs;
 
   const struct Mapping *map = SortTestMethods;
-  for (unsigned int i = 0; i < mutt_array_size(name_list); i++)
+  for (unsigned int i = 0; i < countof(name_list); i++)
   {
     cs_str_native_set(cs, name_list[i], -1, NULL);
 
@@ -218,7 +218,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
       NULL,
     };
 
-    for (unsigned int j = 0; j < mutt_array_size(invalid); j++)
+    for (unsigned int j = 0; j < countof(invalid); j++)
     {
       buf_reset(err);
       rc = cs_str_string_set(cs, name_list[i], invalid[j], err);
@@ -353,7 +353,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
 
   int rc;
   const struct Mapping *map = SortTestMethods;
-  for (unsigned int i = 0; i < mutt_array_size(name_list); i++)
+  for (unsigned int i = 0; i < countof(name_list); i++)
   {
     cs_str_native_set(cs, name_list[i], -1, NULL);
 
@@ -404,7 +404,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
   TEST_MSG("%s = %d, set to '%d'", name, VarKumquat, value);
 
   int invalid[] = { -1, 999 };
-  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  for (unsigned int i = 0; i < countof(invalid); i++)
   {
     cs_str_native_set(cs, name, -1, NULL);
     buf_reset(err);

--- a/test/config/string.c
+++ b/test/config/string.c
@@ -173,7 +173,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   const char *name = "Damson";
 
   int rc;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, valid[i], err);
@@ -213,7 +213,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   name = "Elderberry";
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     short_line();
     buf_reset(err);
@@ -308,7 +308,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
   struct ConfigSet *cs = sub->cs;
 
   int rc;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     buf_reset(err);
     rc = cs_str_native_set(cs, name, (intptr_t) valid[i], err);
@@ -348,7 +348,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   name = "Kumquat";
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     short_line();
     buf_reset(err);
@@ -431,7 +431,7 @@ static bool test_string_plus_equals(struct ConfigSubset *sub, struct Buffer *err
   };
 
   int rc;
-  for (unsigned int i = 0; i < mutt_array_size(PlusTests); i++)
+  for (unsigned int i = 0; i < countof(PlusTests); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, PlusTests[i][0], err);

--- a/test/date/mutt_date_make_time.c
+++ b/test/date/mutt_date_make_time.c
@@ -61,7 +61,7 @@ void test_mutt_date_make_time(void)
   // clang-format on
 
   {
-    for (size_t i = 0; i < mutt_array_size(time_tests); i++)
+    for (size_t i = 0; i < countof(time_tests); i++)
     {
       struct tm *tm = &time_tests[i].tm;
 

--- a/test/date/mutt_date_normalize_time.c
+++ b/test/date/mutt_date_normalize_time.c
@@ -67,7 +67,7 @@ void test_mutt_date_normalize_time(void)
   // clang-format on
 
   {
-    for (size_t i = 0; i < mutt_array_size(time_tests); i++)
+    for (size_t i = 0; i < countof(time_tests); i++)
     {
       struct tm *date = &time_tests[i].date;
       struct tm *expected = &time_tests[i].expected;

--- a/test/date/mutt_date_parse_date.c
+++ b/test/date/mutt_date_parse_date.c
@@ -135,7 +135,7 @@ void test_mutt_date_parse_date(void)
 
   {
     struct Tz tz;
-    for (size_t i = 0; i < mutt_array_size(parse_tests); i++)
+    for (size_t i = 0; i < countof(parse_tests); i++)
     {
       memset(&tz, 0, sizeof(tz));
       TEST_CASE(parse_tests[i].str);

--- a/test/date/mutt_date_parse_imap.c
+++ b/test/date/mutt_date_parse_imap.c
@@ -59,7 +59,7 @@ void test_mutt_date_parse_imap(void)
   // clang-format on
 
   {
-    for (size_t i = 0; i < mutt_array_size(imap_tests); i++)
+    for (size_t i = 0; i < countof(imap_tests); i++)
     {
       TEST_CASE(imap_tests[i].str);
       time_t result = mutt_date_parse_imap(imap_tests[i].str);

--- a/test/email/mutt_extract_message_id.c
+++ b/test/email/mutt_extract_message_id.c
@@ -50,7 +50,7 @@ struct TestData
 
 void test_mutt_extract_message_id(void)
 {
-  for (size_t i = 0; i < mutt_array_size(test); i++)
+  for (size_t i = 0; i < countof(test); i++)
   {
     size_t len = 0;
     char *out = mutt_extract_message_id(test[i].in, &len);
@@ -67,14 +67,14 @@ void test_mutt_extract_message_id(void)
     const char *tokens[] = { "foo bar ", "<foo@bar.baz>", " moo mar", "<moo@mar.maz>" };
     char buf[1024];
     size_t off = 0;
-    for (size_t i = 0; i < mutt_array_size(tokens); i++)
+    for (size_t i = 0; i < countof(tokens); i++)
     {
       off += mutt_str_copy(&buf[0] + off, tokens[i], sizeof(buf) - off);
     }
 
     char *tmp = NULL;
     off = 0;
-    size_t elems = mutt_array_size(tokens);
+    size_t elems = countof(tokens);
     for (const char *it = &buf[0]; (tmp = mutt_extract_message_id(it, &off)); it += off)
     {
       TEST_CHECK(tmp[0] == '<');

--- a/test/email/mutt_parse_mailto.c
+++ b/test/email/mutt_parse_mailto.c
@@ -93,8 +93,8 @@ void test_mutt_parse_mailto(void)
       TEST_MSG("Expected: parsed <%s>", mailto);
       TEST_MSG("Actual  : NULL");
     }
-    check_addrlist(&env->to, to, mutt_array_size(to));
-    check_addrlist(&env->cc, cc, mutt_array_size(cc));
+    check_addrlist(&env->to, to, countof(to));
+    check_addrlist(&env->cc, cc, countof(cc));
     TEST_CHECK_STR_EQ(parsed_body, body);
     FREE(&parsed_body);
     mutt_env_free(&env);

--- a/test/email/mutt_rfc822_read_line.c
+++ b/test/email/mutt_rfc822_read_line.c
@@ -137,7 +137,7 @@ void test_mutt_rfc822_read_line(void)
     fclose(fp);
   }
 
-  for (size_t i = 0; i < mutt_array_size(test_data); ++i)
+  for (size_t i = 0; i < countof(test_data); ++i)
   {
     FILE *fp = test_make_file_with_contents(test_data[i].input,
                                             strlen(test_data[i].input));

--- a/test/expando/config.c
+++ b/test/expando/config.c
@@ -193,7 +193,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   const char *name = "Damson";
 
   int rc;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, valid[i], err);
@@ -234,7 +234,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   name = "Elderberry";
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     short_line();
     buf_reset(err);
@@ -346,7 +346,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
   struct ConfigSet *cs = sub->cs;
 
   int rc;
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     buf_reset(err);
     struct Expando *exp = expando_parse(valid[i], TestFormatDef, NULL);
@@ -389,7 +389,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   name = "Kumquat";
-  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  for (unsigned int i = 0; i < countof(valid); i++)
   {
     short_line();
     buf_reset(err);
@@ -480,7 +480,7 @@ static bool test_string_plus_equals(struct ConfigSubset *sub, struct Buffer *err
   };
 
   int rc;
-  for (unsigned int i = 0; i < mutt_array_size(PlusTests); i++)
+  for (unsigned int i = 0; i < countof(PlusTests); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(cs, name, PlusTests[i][0], err);

--- a/test/expando/filter.c
+++ b/test/expando/filter.c
@@ -79,7 +79,7 @@ void test_expando_filter(void)
     last->text = "hello";
     TEST_CHECK(!check_for_pipe(root));
 
-    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    for (size_t i = 0; i < countof(tests); i++)
     {
       TEST_CASE(tests[i].name);
       last->text = tests[i].name;

--- a/test/expando/format.c
+++ b/test/expando/format.c
@@ -150,7 +150,7 @@ void test_expando_node_expando_format(void)
   {
     struct ExpandoParseError err = { 0 };
 
-    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    for (size_t i = 0; i < countof(tests); i++)
     {
       const char *str = tests[i].src;
       const char *parsed_until = NULL;
@@ -181,7 +181,7 @@ void test_expando_node_expando_format(void)
 
     struct ExpandoParseError err = { 0 };
 
-    for (size_t i = 0; i < mutt_array_size(no_fmt_tests); i++)
+    for (size_t i = 0; i < countof(no_fmt_tests); i++)
     {
       const char *str = no_fmt_tests[i].src;
       const char *parsed_until = NULL;

--- a/test/expando/helpers.c
+++ b/test/expando/helpers.c
@@ -118,7 +118,7 @@ void test_expando_helpers(void)
       // clang-format on
     };
 
-    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    for (size_t i = 0; i < countof(tests); i++)
     {
       TEST_CASE_("%lu", i);
       buf_reset(buf);

--- a/test/expando/justify.c
+++ b/test/expando/justify.c
@@ -88,7 +88,7 @@ void test_expando_justify(void)
   {
     struct Buffer *buf = buf_pool_get();
 
-    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    for (size_t i = 0; i < countof(tests); i++)
     {
       const struct TestCase *test = &tests[i];
       buf_reset(buf);

--- a/test/expando/node_conddate.c
+++ b/test/expando/node_conddate.c
@@ -143,7 +143,7 @@ void test_expando_node_conddate(void)
     const char *parsed_until = NULL;
     struct ExpandoParseError err = { 0 };
 
-    for (size_t i = 0; i < mutt_array_size(test_dates); i++)
+    for (size_t i = 0; i < countof(test_dates); i++)
     {
       TEST_CASE(test_dates[i].str);
       struct ExpandoNode *node = node_conddate_parse(test_dates[i].str + 2, 1, 2, &parsed_until, &err);
@@ -192,7 +192,7 @@ void test_expando_node_conddate(void)
     const char *parsed_until = NULL;
     struct ExpandoParseError err = { 0 };
 
-    for (size_t i = 0; i < mutt_array_size(test_dates); i++)
+    for (size_t i = 0; i < countof(test_dates); i++)
     {
       TEST_CASE(test_dates[i].str);
       struct ExpandoNode *node = node_conddate_parse(test_dates[i].str + 2, 1, 2, &parsed_until, &err);

--- a/test/expando/node_container.c
+++ b/test/expando/node_container.c
@@ -124,7 +124,7 @@ void test_expando_node_container(void)
     struct Buffer *buf = buf_pool_get();
     int rc;
 
-    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    for (size_t i = 0; i < countof(tests); i++)
     {
       TEST_CASE_("%d", tests[i].value);
       buf_reset(buf);

--- a/test/expando/node_padding.c
+++ b/test/expando/node_padding.c
@@ -201,7 +201,7 @@ void test_expando_node_padding(void)
     struct Buffer *err = buf_pool_get();
     struct Expando *exp = NULL;
 
-    for (int i = 0; i < mutt_array_size(TestStrings); i++)
+    for (int i = 0; i < countof(TestStrings); i++)
     {
       buf_reset(buf);
       buf_reset(err);
@@ -243,7 +243,7 @@ void test_expando_node_padding(void)
     struct Expando *exp = NULL;
     int rc;
 
-    for (int i = 0; i < mutt_array_size(EolTests); i++)
+    for (int i = 0; i < countof(EolTests); i++)
     {
       buf_reset(buf);
       buf_reset(err);
@@ -336,7 +336,7 @@ void test_expando_node_padding(void)
     struct Expando *exp = NULL;
     int rc;
 
-    for (int i = 0; i < mutt_array_size(HardTests); i++)
+    for (int i = 0; i < countof(HardTests); i++)
     {
       buf_reset(buf);
       buf_reset(err);
@@ -429,7 +429,7 @@ void test_expando_node_padding(void)
     struct Expando *exp = NULL;
     int rc;
 
-    for (int i = 0; i < mutt_array_size(SoftTests); i++)
+    for (int i = 0; i < countof(SoftTests); i++)
     {
       buf_reset(buf);
       buf_reset(err);

--- a/test/expando/parse.c
+++ b/test/expando/parse.c
@@ -113,7 +113,7 @@ void test_expando_parser(void)
     struct Buffer *err = buf_pool_get();
     struct Expando *exp = NULL;
 
-    for (int i = 0; i < mutt_array_size(TestStrings); i++)
+    for (int i = 0; i < countof(TestStrings); i++)
     {
       buf_reset(buf);
       buf_reset(err);
@@ -157,7 +157,7 @@ void test_expando_parser(void)
     struct Buffer *err = buf_pool_get();
     struct Expando *exp = NULL;
 
-    for (int i = 0; i < mutt_array_size(TestsBad); i++)
+    for (int i = 0; i < countof(TestsBad); i++)
     {
       buf_reset(buf);
       buf_reset(err);

--- a/test/file/buf_quote_filename.c
+++ b/test/file/buf_quote_filename.c
@@ -51,7 +51,7 @@ void test_buf_quote_filename(void)
   }
 
   struct Buffer *result = buf_pool_get();
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     TEST_CASE(tests[i].first);
     buf_quote_filename(result, tests[i].first, (i % 2));

--- a/test/file/mutt_file_check_empty.c
+++ b/test/file/mutt_file_check_empty.c
@@ -51,7 +51,7 @@ void test_mutt_file_check_empty(void)
   struct Buffer *first = buf_pool_get();
 
   int rc;
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     test_gen_path(first, tests[i].first);
 

--- a/test/file/mutt_file_chmod_add.c
+++ b/test/file/mutt_file_chmod_add.c
@@ -45,7 +45,7 @@ void test_mutt_file_chmod_add(void)
   struct Buffer *first = buf_pool_get();
   int rc;
 
-  for (size_t i = 0; i < mutt_array_size(tests_fail); i++)
+  for (size_t i = 0; i < countof(tests_fail); i++)
   {
     test_gen_path(first, tests_fail[i].first);
 
@@ -62,7 +62,7 @@ void test_mutt_file_chmod_add(void)
   // clang-format on
 
   struct stat st;
-  for (size_t i = 0; i < mutt_array_size(tests_succeed); i++)
+  for (size_t i = 0; i < countof(tests_succeed); i++)
   {
     test_gen_path(first, tests_succeed[i].first);
 

--- a/test/file/mutt_file_chmod_add_stat.c
+++ b/test/file/mutt_file_chmod_add_stat.c
@@ -53,7 +53,7 @@ void test_mutt_file_chmod_add_stat(void)
   // clang-format on
 
   struct stat st;
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     test_gen_path(first, tests[i].first);
 

--- a/test/file/mutt_file_chmod_rm_stat.c
+++ b/test/file/mutt_file_chmod_rm_stat.c
@@ -53,7 +53,7 @@ void test_mutt_file_chmod_rm_stat(void)
   // clang-format on
 
   struct stat st;
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     test_gen_path(first, tests[i].first);
 

--- a/test/file/mutt_file_get_size.c
+++ b/test/file/mutt_file_get_size.c
@@ -45,7 +45,7 @@ void test_mutt_file_get_size(void)
   struct Buffer *first = buf_pool_get();
 
   int rc;
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     test_gen_path(first, tests[i].first);
 

--- a/test/file/mutt_file_resolve_symlink.c
+++ b/test/file/mutt_file_resolve_symlink.c
@@ -48,7 +48,7 @@ void test_mutt_file_resolve_symlink(void)
   struct Buffer *second = buf_pool_get();
 
   struct Buffer *result = buf_pool_get();
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     test_gen_path(first, tests[i].first);
     test_gen_path(second, tests[i].second);

--- a/test/file/mutt_file_stat_compare.c
+++ b/test/file/mutt_file_stat_compare.c
@@ -58,7 +58,7 @@ void test_mutt_file_stat_compare(void)
   struct Buffer *first = buf_pool_get();
   struct Buffer *second = buf_pool_get();
 
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     memset(&st1, 0, sizeof(st1));
     memset(&st2, 0, sizeof(st2));

--- a/test/from/is_from.c
+++ b/test/from/is_from.c
@@ -116,7 +116,7 @@ void test_is_from(void)
   char path[128];
   time_t epoch;
 
-  for (size_t i = 0; i < mutt_array_size(test); i++)
+  for (size_t i = 0; i < countof(test); i++)
   {
     const struct IsFromTest *t = &test[i];
     TEST_CASE(t->source);

--- a/test/gui/mutt_str_expand_tabs.c
+++ b/test/gui/mutt_str_expand_tabs.c
@@ -67,7 +67,7 @@ void test_mutt_str_expand_tabs(void)
   };
 
   {
-    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    for (size_t i = 0; i < countof(tests); i++)
     {
       TEST_CASE(tests[i].in);
       char *str = mutt_str_dup(tests[i].in);

--- a/test/gui/swap.c
+++ b/test/gui/swap.c
@@ -42,7 +42,7 @@ static const char * initial_order[] = {
 };
 // clang-format on
 
-static const int num_children = mutt_array_size(initial_order);
+static const int num_children = countof(initial_order);
 
 static void wdata_free(struct MuttWindow *win, void **ptr)
 {

--- a/test/gui/visible.c
+++ b/test/gui/visible.c
@@ -134,7 +134,7 @@ void test_window_visible(void)
 
   notify_observer_add(parent->notify, NT_WINDOW, visible_observer, &results);
 
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     parent->old.visible = tests[i].parent_before;
     parent->state.visible = tests[i].parent_after;

--- a/test/imap/msg_set.c
+++ b/test/imap/msg_set.c
@@ -65,14 +65,14 @@ void test_sort(void)
     };
 
     struct UidArray uida = ARRAY_HEAD_INITIALIZER;
-    for (int i = 0; i < mutt_array_size(data); i++)
+    for (int i = 0; i < countof(data); i++)
     {
       ARRAY_ADD(&uida, data[i]);
     }
 
     ARRAY_SORT(&uida, imap_sort_uid, NULL);
 
-    for (int i = 0; i < mutt_array_size(data); i++)
+    for (int i = 0; i < countof(data); i++)
     {
       unsigned int u = *ARRAY_GET(&uida, i);
       TEST_CHECK(u == i);
@@ -163,7 +163,7 @@ void test_make_simple(void)
     // clang-format on
   };
 
-  for (int i = 0; i < mutt_array_size(tests); i++)
+  for (int i = 0; i < countof(tests); i++)
   {
     struct UidArray uida = ARRAY_HEAD_INITIALIZER;
     const struct TestCase *test = &tests[i];
@@ -393,7 +393,7 @@ void test_make_curated(void)
     // clang-format on
   };
 
-  for (int i = 0; i < mutt_array_size(tests); i++)
+  for (int i = 0; i < countof(tests); i++)
   {
     struct UidArray uida = ARRAY_HEAD_INITIALIZER;
     const struct TestCase *test = &tests[i];
@@ -461,7 +461,7 @@ void test_exec(void)
   ImapMaxCmdlen = 50;
   imap_exec_results = buf_pool_get();
 
-  for (int i = 0; i < mutt_array_size(tests); i++)
+  for (int i = 0; i < countof(tests); i++)
   {
     struct UidArray uida = ARRAY_HEAD_INITIALIZER;
     const struct TestCase *test = &tests[i];

--- a/test/mbyte/mutt_mb_width.c
+++ b/test/mbyte/mutt_mb_width.c
@@ -70,7 +70,7 @@ void test_mutt_mb_width(void)
       // clang-format on
     };
 
-    for (int i = 0; i < mutt_array_size(tests); i++)
+    for (int i = 0; i < countof(tests); i++)
     {
       TEST_CASE(test_name(tests[i].str));
       int len = mutt_mb_width(tests[i].str, tests[i].col, false);
@@ -96,7 +96,7 @@ void test_mutt_mb_width(void)
       // clang-format on
     };
 
-    for (int i = 0; i < mutt_array_size(tests); i++)
+    for (int i = 0; i < countof(tests); i++)
     {
       TEST_CASE(test_name(tests[i].str));
       int len = mutt_mb_width(tests[i].str, tests[i].col, false);
@@ -115,7 +115,7 @@ void test_mutt_mb_width(void)
       // clang-format on
     };
 
-    for (int i = 0; i < mutt_array_size(tests); i++)
+    for (int i = 0; i < countof(tests); i++)
     {
       TEST_CASE(test_name(tests[i].str));
       int len = mutt_mb_width(tests[i].str, tests[i].col, true);

--- a/test/notmuch/query_type.c
+++ b/test/notmuch/query_type.c
@@ -61,7 +61,7 @@ void test_nm_parse_type_from_query(void)
   TEST_CHECK(nm_parse_type_from_query(NULL, NM_QUERY_TYPE_THREADS) == NM_QUERY_TYPE_THREADS);
 
   char buf[1024];
-  for (int i = 0; i < mutt_array_size(tests); i++)
+  for (int i = 0; i < countof(tests); i++)
   {
     const struct NmParseTypeTest *t = &tests[i];
     memset(buf, 0, sizeof(buf));

--- a/test/notmuch/window_query.c
+++ b/test/notmuch/window_query.c
@@ -77,7 +77,7 @@ void test_nm_windowed_query_from_query(void)
       "(date:3month..3month or (tag:unread and tag:flagged)) and tag:inbox" },
   };
 
-  for (int i = 0; i < mutt_array_size(tests); i++)
+  for (int i = 0; i < countof(tests); i++)
   {
     const struct TestCase *t = &tests[i];
     char buf[1024] = "\0";

--- a/test/parse/parse_rc.c
+++ b/test/parse/parse_rc.c
@@ -104,12 +104,12 @@ static void test_parse_set(void)
   struct Buffer *err = buf_pool_get();
   char line[64];
 
-  for (size_t v = 0; v < mutt_array_size(vars); v++)
+  for (size_t v = 0; v < countof(vars); v++)
   {
-    for (size_t c = 0; c < mutt_array_size(commands); c++)
+    for (size_t c = 0; c < countof(commands); c++)
     {
       TEST_CASE_("%s %s", commands[c], vars[v]);
-      for (size_t t = 0; t < mutt_array_size(tests); t++)
+      for (size_t t = 0; t < countof(tests); t++)
       {
         buf_reset(err);
 

--- a/test/parse/parse_rc_line.c
+++ b/test/parse/parse_rc_line.c
@@ -571,7 +571,7 @@ static bool set_empty_values(void)
     "Fig",
     "Guava",
   };
-  for (int i = 0; i < mutt_array_size(stringlike); i++)
+  for (int i = 0; i < countof(stringlike); i++)
   {
     buf_reset(err);
     rc = cs_str_string_set(NeoMutt->sub->cs, stringlike[i], "", err);
@@ -607,7 +607,7 @@ static void test_set(void)
       "%s = yes",
       "%s",
     };
-    for (int t = 0; t < mutt_array_size(template); t++)
+    for (int t = 0; t < countof(template); t++)
     {
       if (!TEST_CHECK(set_empty_values()))
       {
@@ -619,7 +619,7 @@ static void test_set(void)
         "Apple",
         "Banana",
       };
-      for (int v = 0; v < mutt_array_size(boolish); v++)
+      for (int v = 0; v < countof(boolish); v++)
       {
         buf_reset(err);
         buf_printf(line, template[t], boolish[v]);
@@ -751,7 +751,7 @@ static void test_unset(void)
       { "no%s", MUTT_SET_SET   },
       // clang-format on
     };
-    for (int t = 0; t < mutt_array_size(template); t++)
+    for (int t = 0; t < countof(template); t++)
     {
       if (!TEST_CHECK(set_non_empty_values()))
       {
@@ -763,7 +763,7 @@ static void test_unset(void)
         "Apple",
         "Banana",
       };
-      for (int v = 0; v < mutt_array_size(boolish); v++)
+      for (int v = 0; v < countof(boolish); v++)
       {
         buf_reset(err);
         buf_strcpy(line, boolish[v]);
@@ -914,7 +914,7 @@ static void test_reset(void)
       { "&%s", MUTT_SET_SET   },
       // clang-format on
     };
-    for (int t = 0; t < mutt_array_size(template); t++)
+    for (int t = 0; t < countof(template); t++)
     {
       if (!TEST_CHECK(set_empty_values()))
       {
@@ -1104,7 +1104,7 @@ static void test_toggle(void)
       { "inv%s", MUTT_SET_SET },
       // clang-format on
     };
-    for (int t = 0; t < mutt_array_size(template); t++)
+    for (int t = 0; t < countof(template); t++)
     {
       if (!TEST_CHECK(set_non_empty_values()))
       {
@@ -1124,7 +1124,7 @@ static void test_toggle(void)
         "yes",
         "ask-yes",
       };
-      for (int v = 0; v < mutt_array_size(boolish); v++)
+      for (int v = 0; v < countof(boolish); v++)
       {
         // First toggle
         {
@@ -1212,7 +1212,7 @@ static void test_query(void)
       "%s?",
       "?%s",
     };
-    for (int t = 0; t < mutt_array_size(template); t++)
+    for (int t = 0; t < countof(template); t++)
     {
       if (!TEST_CHECK(set_non_empty_values()))
       {
@@ -1241,7 +1241,7 @@ static void test_query(void)
       const char *expected[] = {
         "yes", "ask-yes", "555", "damson", "foo",
       };
-      for (int v = 0; v < mutt_array_size(vars); v++)
+      for (int v = 0; v < countof(vars); v++)
       {
         buf_reset(err);
         buf_printf(line, template[t], vars[v]);
@@ -1290,7 +1290,7 @@ static void test_query(void)
       "damson",
       "foo",
     };
-    for (int v = 0; v < mutt_array_size(vars); v++)
+    for (int v = 0; v < countof(vars); v++)
     {
       buf_reset(err);
       buf_strcpy(line, vars[v]);
@@ -1362,7 +1362,7 @@ static void test_increment(void)
       "damsonsmell",
       "foobar",
     };
-    for (int v = 0; v < mutt_array_size(vars); v++)
+    for (int v = 0; v < countof(vars); v++)
     {
       buf_reset(err);
       buf_printf(line, "%s += %s", vars[v], increment[v]);
@@ -1427,7 +1427,7 @@ static void test_decrement(void)
     const char *expected[] = {
       "455",
     };
-    for (int v = 0; v < mutt_array_size(vars); v++)
+    for (int v = 0; v < countof(vars); v++)
     {
       buf_reset(err);
       buf_printf(line, "%s -= %s", vars[v], increment[v]);
@@ -1485,7 +1485,7 @@ static void test_invalid_syntax(void)
       // clang-format on
     };
 
-    for (int t = 0; t < mutt_array_size(template); t++)
+    for (int t = 0; t < countof(template); t++)
     {
       buf_reset(err);
       buf_strcpy(line, template[t]);
@@ -1536,7 +1536,7 @@ static void test_path_expanding(void)
       "expanded/~/bar",
       "expanded/=foo",
     };
-    for (int v = 0; v < mutt_array_size(pathlike); v++)
+    for (int v = 0; v < countof(pathlike); v++)
     {
       buf_reset(err);
       buf_printf(line, "%s = %s", pathlike[v], newvalue[v]);

--- a/test/path/mutt_path_basename.c
+++ b/test/path/mutt_path_basename.c
@@ -43,7 +43,7 @@ void test_mutt_path_basename(void)
   };
 
   {
-    for (int i = 0; i < mutt_array_size(tests); i++)
+    for (int i = 0; i < countof(tests); i++)
     {
       const char *source = tests[i][0];
       const char *expected = tests[i][1];

--- a/test/path/mutt_path_dirname.c
+++ b/test/path/mutt_path_dirname.c
@@ -47,7 +47,7 @@ void test_mutt_path_dirname(void)
   };
 
   {
-    for (int i = 0; i < mutt_array_size(tests); i++)
+    for (int i = 0; i < countof(tests); i++)
     {
       const char *source = tests[i][0];
       const char *expected = tests[i][1];

--- a/test/path/mutt_path_escape.c
+++ b/test/path/mutt_path_escape.c
@@ -47,7 +47,7 @@ void test_mutt_path_escape(void)
   }
 
   {
-    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    for (size_t i = 0; i < countof(tests); i++)
     {
       TEST_CASE(tests[i][0]);
 

--- a/test/path/mutt_path_tidy.c
+++ b/test/path/mutt_path_tidy.c
@@ -145,7 +145,7 @@ void test_mutt_path_tidy(void)
 
   {
     struct Buffer *path = buf_pool_get();
-    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    for (size_t i = 0; i < countof(tests); i++)
     {
       TEST_CASE(tests[i][0]);
 

--- a/test/path/mutt_path_tidy_dotdot.c
+++ b/test/path/mutt_path_tidy_dotdot.c
@@ -80,7 +80,7 @@ void test_mutt_path_tidy_dotdot(void)
 
   {
     char buf[64];
-    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    for (size_t i = 0; i < countof(tests); i++)
     {
       TEST_CASE(tests[i][0]);
 

--- a/test/path/mutt_path_tidy_slash.c
+++ b/test/path/mutt_path_tidy_slash.c
@@ -68,7 +68,7 @@ void test_mutt_path_tidy_slash(void)
 
   {
     char buf[64];
-    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    for (size_t i = 0; i < countof(tests); i++)
     {
       TEST_CASE(tests[i][0]);
 

--- a/test/string/mutt_istr_find.c
+++ b/test/string/mutt_istr_find.c
@@ -70,7 +70,7 @@ void test_mutt_istr_find(void)
   {
     const char *find = "apple";
 
-    for (size_t i = 0; i < mutt_array_size(stri_tests); i++)
+    for (size_t i = 0; i < countof(stri_tests); i++)
     {
       struct StriTest *t = &stri_tests[i];
       TEST_CASE_("'%s'", t->str);

--- a/test/string/mutt_istr_remall.c
+++ b/test/string/mutt_istr_remall.c
@@ -80,7 +80,7 @@ void test_mutt_istr_remall(void)
     const char *remove = "apple";
     char buf[64];
 
-    for (size_t i = 0; i < mutt_array_size(remall_tests); i++)
+    for (size_t i = 0; i < countof(remall_tests); i++)
     {
       struct RemallTest *t = &remall_tests[i];
       memset(buf, 0, sizeof(buf));

--- a/test/string/mutt_istrn_rfind.c
+++ b/test/string/mutt_istrn_rfind.c
@@ -62,7 +62,7 @@ void test_mutt_istrn_rfind(void)
   {
     const char *find = "apple";
 
-    for (size_t i = 0; i < mutt_array_size(ristrn_tests); i++)
+    for (size_t i = 0; i < countof(ristrn_tests); i++)
     {
       struct RistrnTest *t = &ristrn_tests[i];
       TEST_CASE_("'%s'", t->str);

--- a/test/string/mutt_str_find_word.c
+++ b/test/string/mutt_str_find_word.c
@@ -60,7 +60,7 @@ void test_mutt_str_find_word(void)
   // clang-format on
 
   {
-    for (size_t i = 0; i < mutt_array_size(find_tests); i++)
+    for (size_t i = 0; i < countof(find_tests); i++)
     {
       struct FindWordTest *t = &find_tests[i];
 

--- a/test/string/mutt_str_hyphenate.c
+++ b/test/string/mutt_str_hyphenate.c
@@ -70,7 +70,7 @@ void test_mutt_str_hyphenate(void)
   {
     char result[128];
 
-    for (size_t i = 0; i < mutt_array_size(tests); i++)
+    for (size_t i = 0; i < countof(tests); i++)
     {
       memset(result, 0, sizeof(result));
       TEST_CASE(tests[i].input);

--- a/test/string/mutt_str_inbox_cmp.c
+++ b/test/string/mutt_str_inbox_cmp.c
@@ -45,7 +45,7 @@ void test_mutt_str_inbox_cmp(void)
 {
   char *folders[] = { "+Inbox", "+Foo",    "+Inbox.Archive", "+",
                       "+Bar",   "+FooBar", "+FooBar.Baz" };
-  mutt_qsort_r(&folders, mutt_array_size(folders), sizeof(*folders), sort, NULL);
+  mutt_qsort_r(&folders, countof(folders), sizeof(*folders), sort, NULL);
   TEST_CHECK_STR_EQ(folders[0], "+Inbox");
   TEST_CHECK_STR_EQ(folders[1], "+Inbox.Archive");
   TEST_CHECK_STR_EQ(folders[2], "+");

--- a/test/string/mutt_str_is_ascii.c
+++ b/test/string/mutt_str_is_ascii.c
@@ -54,7 +54,7 @@ void test_mutt_str_is_ascii(void)
   // clang-format on
 
   {
-    for (size_t i = 0; i < mutt_array_size(ascii_tests); i++)
+    for (size_t i = 0; i < countof(ascii_tests); i++)
     {
       struct IsAsciiTest *t = &ascii_tests[i];
       TEST_CASE_("%s", NONULL(t->str));

--- a/test/string/mutt_str_lws_len.c
+++ b/test/string/mutt_str_lws_len.c
@@ -60,7 +60,7 @@ void test_mutt_str_lws_len(void)
   // clang-format on
 
   {
-    for (size_t i = 0; i < mutt_array_size(lws_tests); i++)
+    for (size_t i = 0; i < countof(lws_tests); i++)
     {
       struct LwsLenTest *t = &lws_tests[i];
       TEST_CASE_("%ld, '%s'", i, NONULL(t->str));

--- a/test/string/mutt_str_remove_trailing_ws.c
+++ b/test/string/mutt_str_remove_trailing_ws.c
@@ -69,7 +69,7 @@ void test_mutt_str_remove_trailing_ws(void)
   {
     char buf[64];
 
-    for (size_t i = 0; i < mutt_array_size(trail_tests); i++)
+    for (size_t i = 0; i < countof(trail_tests); i++)
     {
       struct TrailTest *t = &trail_tests[i];
       memset(buf, 0, sizeof(buf));

--- a/test/string/mutt_str_skip_email_wsp.c
+++ b/test/string/mutt_str_skip_email_wsp.c
@@ -56,7 +56,7 @@ void test_mutt_str_skip_email_wsp(void)
   // clang-format on
 
   {
-    for (size_t i = 0; i < mutt_array_size(skip_tests); i++)
+    for (size_t i = 0; i < countof(skip_tests); i++)
     {
       struct SkipTest *t = &skip_tests[i];
       TEST_CASE_("'%s'", t->str);

--- a/test/string/mutt_str_skip_whitespace.c
+++ b/test/string/mutt_str_skip_whitespace.c
@@ -56,7 +56,7 @@ void test_mutt_str_skip_whitespace(void)
   // clang-format on
 
   {
-    for (size_t i = 0; i < mutt_array_size(skip_tests); i++)
+    for (size_t i = 0; i < countof(skip_tests); i++)
     {
       struct SkipTest *t = &skip_tests[i];
       TEST_CASE_("'%s'", t->str);

--- a/test/string/mutt_str_sysexit.c
+++ b/test/string/mutt_str_sysexit.c
@@ -64,7 +64,7 @@ void test_mutt_str_sysexit(void)
 
   const char *result = NULL;
 
-  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  for (size_t i = 0; i < countof(tests); i++)
   {
     TEST_MSG("Testing %d, expecting '%s'", tests[i].err_num, NONULL(tests[i].result));
     result = mutt_str_sysexit(tests[i].err_num);

--- a/test/tags/driver_tags_get.c
+++ b/test/tags/driver_tags_get.c
@@ -54,7 +54,7 @@ void test_driver_tags_get(void)
 
     struct TagList tl = STAILQ_HEAD_INITIALIZER(tl);
 
-    for (size_t i = 0; i < mutt_array_size(tags); i++)
+    for (size_t i = 0; i < countof(tags); i++)
     {
       STAILQ_INSERT_TAIL(&tl, &tags[i], entries);
     }

--- a/test/tags/driver_tags_get_transformed.c
+++ b/test/tags/driver_tags_get_transformed.c
@@ -54,7 +54,7 @@ void test_driver_tags_get_transformed(void)
 
     struct TagList tl = STAILQ_HEAD_INITIALIZER(tl);
 
-    for (size_t i = 0; i < mutt_array_size(tags); i++)
+    for (size_t i = 0; i < countof(tags); i++)
     {
       STAILQ_INSERT_TAIL(&tl, &tags[i], entries);
     }

--- a/test/tags/driver_tags_get_transformed_for.c
+++ b/test/tags/driver_tags_get_transformed_for.c
@@ -54,7 +54,7 @@ void test_driver_tags_get_transformed_for(void)
 
     struct TagList tl = STAILQ_HEAD_INITIALIZER(tl);
 
-    for (size_t i = 0; i < mutt_array_size(tags); i++)
+    for (size_t i = 0; i < countof(tags); i++)
     {
       STAILQ_INSERT_TAIL(&tl, &tags[i], entries);
     }

--- a/test/tags/driver_tags_get_with_hidden.c
+++ b/test/tags/driver_tags_get_with_hidden.c
@@ -54,7 +54,7 @@ void test_driver_tags_get_with_hidden(void)
 
     struct TagList tl = STAILQ_HEAD_INITIALIZER(tl);
 
-    for (size_t i = 0; i < mutt_array_size(tags); i++)
+    for (size_t i = 0; i < countof(tags); i++)
     {
       STAILQ_INSERT_TAIL(&tl, &tags[i], entries);
     }

--- a/test/url/url_parse.c
+++ b/test/url/url_parse.c
@@ -244,7 +244,7 @@ void test_url_parse(void)
   }
 
   {
-    for (size_t i = 0; i < mutt_array_size(test); i++)
+    for (size_t i = 0; i < countof(test); i++)
     {
       TEST_CASE(test[i].source);
       struct Url *url = url_parse(test[i].source);
@@ -284,15 +284,15 @@ void test_url_parse(void)
     const char *const cl[] = { "host.com", "[12AB::EF89]", "127.0.0.1" };
     const char *const dl[] = { "", ":123" };
     const char *const el[] = { "", "/", "/path", "/path/one/two", "/path.one.two" };
-    for (size_t a = 0; a < mutt_array_size(al); a++)
+    for (size_t a = 0; a < countof(al); a++)
     {
-      for (size_t b = 0; b < mutt_array_size(bl); b++)
+      for (size_t b = 0; b < countof(bl); b++)
       {
-        for (size_t c = 0; c < mutt_array_size(cl); c++)
+        for (size_t c = 0; c < countof(cl); c++)
         {
-          for (size_t d = 0; d < mutt_array_size(dl); d++)
+          for (size_t d = 0; d < countof(dl); d++)
           {
-            for (size_t e = 0; e < mutt_array_size(el); e++)
+            for (size_t e = 0; e < countof(el); e++)
             {
               char s[1024];
               snprintf(s, sizeof(s), "%s://%s%s%s%s", al[a], bl[b], cl[c], dl[d], el[e]);


### PR DESCRIPTION
* **What does this PR do?**

   Replace an custom macro by a standard one.

* **What are the relevant issue numbers?**

    Link: <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3550.pdf#subsubsection.0.6.5.4.5>
    Link: <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3550.pdf#section.0.7.21>
    Link: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117025>
    Link: <https://github.com/llvm/llvm-project/issues/102836>

---

Revisions:

<details>
<summary>v2</summary>

-  Use `__has_include` only if it's supported.  [@gahr ]

```
$ git range-diff neomutt/main neomutt/alx/countof alx/countof 
1:  c1cd00643 ! 1:  747fd6cda Use the standard countof instead of our mutt_array_size()
    @@ mutt/memory.h
      #ifndef MUTT_MUTT_MEMORY_H
      #define MUTT_MUTT_MEMORY_H
      
    -+#if __has_include(<stdcountof.h>)
    -+# include <stdcountof.h>
    ++#if defined __has_include
    ++# if __has_include(<stdcountof.h>)
    ++#  include <stdcountof.h>
    ++# endif
     +#endif
      #include <stddef.h>
      
```
</details>

<details>
<summary>v2b</summary>

-  Reviewed-by: @gahr 

```
$ git range-diff neomutt/main neomutt/alx/countof alx/countof 
1:  747fd6cda ! 1:  85353b1ea Use the standard countof instead of our mutt_array_size()
    @@ Commit message
         Link: <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3550.pdf#section.0.7.21>
         Link: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117025>
         Link: <https://github.com/llvm/llvm-project/issues/102836>
    +    Reviewed-by: Pietro Cerutti <gahr@gahr.ch>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## config/quad.c ##
```
</details>