### PR TITLE
Ensure that read mails are synced when expunging deleted mails

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1504,7 +1504,10 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
     struct UidArray uida = ARRAY_HEAD_INITIALIZER;
     select_email_uids(m->emails, m->msg_count, MUTT_DELETED, true, false, &uida);
     ARRAY_SORT(&uida, imap_sort_uid, NULL);
-    rc = imap_exec_msg_set(adata, "UID STORE", "+FLAGS.SILENT (\\Deleted)", &uida);
+    if (m->rights & MUTT_ACL_SEEN)
+      rc = imap_exec_msg_set(adata, "UID STORE", "+FLAGS.SILENT (\\Deleted) (\\Seen)", &uida);
+    else
+      rc = imap_exec_msg_set(adata, "UID STORE", "+FLAGS.SILENT (\\Deleted)", &uida);
     ARRAY_FREE(&uida);
     if (rc < 0)
     {


### PR DESCRIPTION
This issue has been plaguing me for years and I can't take it anymore. When marking mails as read and deleting mails and syncing the deleted mails to the server the mails marked as read will not be synced to the servers. So next time the the mailbox is opened again they appear as unread. It's really terrible especially when having gone through thousands of mail. Sync seen mails as well.

Fixes: #3519

* **What does this PR do?**

Ensure that mails that are seen are synced when syncing deleted mails.

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/code)

* **What are the relevant issue numbers?**
* 
#3519
