### PR TITLE
Handle a non-existing message_cache_dir

### DIFF
--- a/bcache/bcache.c
+++ b/bcache/bcache.c
@@ -65,7 +65,7 @@ static int bcache_path(struct ConnAccount *account, const char *mailbox, struct 
     return -1;
 
   struct stat st = { 0 };
-  if (!((stat(c_message_cache_dir, &st) == 0) && S_ISDIR(st.st_mode)))
+  if ((stat(c_message_cache_dir, &st) == 0) && !S_ISDIR(st.st_mode))
   {
     mutt_error(_("Cache disabled, $message_cache_dir isn't a directory: %s"), c_message_cache_dir);
     return -1;


### PR DESCRIPTION
The code was previously requiring `message_cache_dir` to exist *and* be a directory. We now only require that it is a directory *if* it exists. If it doesn't exist, we already take care of creating it at `mutt_bcache_put` time.

The check was introduced in #2661. @louis77, do you have an issue with the fix I propose?

Fixes #4583