### PR TITLE
Update FreeBSD CI and workaround `pkg` bug

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,6 +8,7 @@ task:
     CIRRUS_CLONE_DEPTH: 3
     PKG_UPDATE: pkg update -f
     PKG_INSTALL: pkg install -y
+    PKG_PRE: xmlcatmgr
     PKG_COMMON:
       cyrus-sasl db5 docbook-xsl gdbm gettext-tools git gpgme iconv jimtcl
       kyotocabinet libgpg-error libidn2 liblz4 libxslt lmdb lua53 lynx notmuch
@@ -23,6 +24,7 @@ task:
         NEOMUTT_TEST_DIR: ${CIRRUS_WORKING_DIR}/test-files
       install_script:
         - ${PKG_UPDATE}
+        - ${PKG_INSTALL} ${PKG_PRE}
         - ${PKG_INSTALL} ${PKG_COMMON}
         - git clone --depth 1 https://github.com/neomutt/neomutt-test-files.git ${NEOMUTT_TEST_DIR}
         - (cd ${NEOMUTT_TEST_DIR} && ./setup.sh)
@@ -38,6 +40,7 @@ task:
     - name: FreeBSD / OpenSSL
       install_script:
         - ${PKG_UPDATE}
+        - ${PKG_INSTALL} ${PKG_PRE}
         - ${PKG_INSTALL} ${PKG_COMMON} openssl
       configure_script: ./configure ${CONFIGURE_COMMON} --ssl
       build_script: make
@@ -48,6 +51,7 @@ task:
     - name: FreeBSD / LibreSSL
       install_script:
         - ${PKG_UPDATE}
+        - ${PKG_INSTALL} ${PKG_PRE}
         - ${PKG_INSTALL} ${PKG_COMMON} libressl
       configure_script: ./configure ${CONFIGURE_COMMON} --ssl
       build_script: make
@@ -58,6 +62,7 @@ task:
     - name: FreeBSD / GnuTLS
       install_script:
         - ${PKG_UPDATE}
+        - ${PKG_INSTALL} ${PKG_PRE}
         - ${PKG_INSTALL} ${PKG_COMMON} gnutls
       configure_script: ./configure ${CONFIGURE_COMMON} --gnutls
       build_script: make

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-14-2
+  image_family: freebsd-14-3
 
 task:
   only_if: $CIRRUS_BRANCH == "main" || $CIRRUS_PR != ""

--- a/.github/workflows/build-and-test-freebsd.yml
+++ b/.github/workflows/build-and-test-freebsd.yml
@@ -36,6 +36,7 @@ jobs:
       with:
         usesh: true
         prepare: |
+          pkg install -y xmlcatmgr
           pkg install -y perl5 pkgconf gettext libxslt docbook-xsl db5 gdbm gpgme gnutls kyotocabinet tokyocabinet lmdb lua54 pcre2 notmuch qdbm rocksdb cyrus-sasl tdb zstd
         run: |
           cd test-files


### PR DESCRIPTION
The FreeBSD Cirrus jobs are currently failing due to a bug in the pkg manager which fails to correctly install xmlcatmgr before docbook-xsl. See https://github.com/freebsd/pkg/issues/2464. As a workaround, I'm explicitly installing xmlcatmgr before installing anything else.