### PR TITLE
Add ayu-dark-256 colorscheme

### DIFF
--- a/data/colorschemes/ayu-dark-256.neomuttrc
+++ b/data/colorschemes/ayu-dark-256.neomuttrc
@@ -1,0 +1,116 @@
+# Ayu Dark Scheme for NeoMutt
+# Source : https://github.com/gopi487krishna/neomutt-ayu
+# Based on : neovim-ayu
+# Source : https://github.com/Shatur/neovim-ayu
+# Adapted from :Neonwolf Color Scheme for Neomutt
+# Source: https://codeberg.org/h3xx/mutt-colors-neonwolf/raw/branch/main/mutt-colors-neonwolf-256.muttrc
+
+# custom body highlights -----------------------------------------------
+
+# custom index highlights ----------------------------------------------
+
+
+# for background in 16 color terminal, valid background colors include:
+# base03, bg, black, any of the non brights
+
+# style notes:
+# when bg=235, that's a highlighted message
+# normal bg=233
+
+# basic colors ---------------------------------------------------------
+color error               color204  color16                         # message line error text
+color tilde               color81   color16                         # vi-like tildes marking blank lines
+color message             color82   color16
+color markers       bold  color232  color222                        # wrapped-line /^\+/ markers
+color attachment    bold  color183  color16                         # attachment headers
+color search              color232  color149                        # search patterns in pager
+color status        bold  color215  color234
+color indicator     bold  color232  color24                         # selected email in index
+color tree          bold  color209  color16                         # arrow in threads (`-->')
+
+# basic monochrome screen
+mono bold           bold
+mono underline      underline
+mono indicator      reverse
+mono error          bold
+mono header         bold                            "^(From|Subject|Date|To|Cc|Bcc):"
+mono quoted         bold
+
+# index ----------------------------------------------------------------
+
+color index               color160  color16         "~A"           # all messages
+color index               color166  color16        "~E"            # expired messages
+color index         bold  color149  color16        "~N"            # new messages
+color index               color149  color16        "~O"            # old messages
+color index               color244  color16        "~R"            # read messages
+color index         bold  color39   color16        "~Q"            # messages that have been replied to
+color index         bold  color149  color16        "~U"            # unread messages
+color index         bold  color149  color16        "~U~$"          # unread, unreferenced messages
+color index               color222  color16        "~v"            # messages part of a collapsed thread
+color index               color222  color16        "~P"            # messages from me
+#color index               color39   color16        "~p!~F"         # messages to me
+#color index               color39   color16        "~N~p!~F"       # new messages to me
+#color index               color39   color16        "~U~p!~F"       # unread messages to me
+#color index               color244  color16        "~R~p!~F"       # messages to me
+color index         bold  color183  color16        "~F"            # flagged messages
+color index         bold  color183  color16        "~F~p"          # flagged messages to me
+color index         bold  color183  color16        "~N~F"          # new flagged messages
+color index         bold  color183  color16        "~N~F~p"        # new flagged messages to me
+color index         bold  color183  color16        "~U~F~p"        # new flagged messages to me
+color index               color232  color204        "!~N ~D"       # deleted messages
+color index               color232  color204        "~N ~D"        # deleted new messages
+color index               color244  color16         "~v~(!~N)"     # collapsed thread with no unread
+color index               color81   color16        "~v~(~N)"       # collapsed thread with some unread
+color index               color81   color16        "~N~v~(~N)"     # collapsed thread with unread parent
+# statusbg used to indicated flagged when foreground color shows other status
+# for collapsed thread
+color index               color160  color16        "~v~(~F)!~N"    # collapsed thread with flagged, no unread
+color index               color81   color16        "~v~(~F~N)"     # collapsed thread with some unread & flagged
+color index               color81   color16        "~N~v~(~F~N)"   # collapsed thread with unread parent & flagged
+color index               color81   color16        "~N~v~(~F)"     # collapsed thread with unread parent, no unread inside, but some flagged
+color index               color39   color16        "~v~(~p)"       # collapsed thread with unread parent, no unread inside, some to me directly
+color index               color81   color160        "~v~(~D)"      # thread with deleted (doesn't differentiate between all or partial)
+color index               color222  color16        "~T"            # tagged messages
+color index         bold  color222  color16        "~T~F"          # tagged, flagged messages
+color index         bold  color222  color16        "~T~N"          # tagged, new messages
+color index         bold  color222  color16        "~T~U"          # tagged, unread messages
+
+# message headers ------------------------------------------------------
+
+color hdrdefault    bold  color222  color16
+color header        bold  color39   color16        "^(From|To|Cc|Bcc)"
+color header        bold  color183  color16        "^(Subject|Date)"
+
+# body -----------------------------------------------------------------
+
+color quoted              color75   color16
+color quoted1             color215  color16
+color quoted2             color149   color16
+color quoted3             color222  color16
+color quoted4             color183  color16
+color signature           color81   color16                        # everything below /^--\s*$/
+
+color bold                color255  color16
+color underline           color16  color244
+color normal              color209  color16         #UI foreground background
+
+## pgp
+
+color body                color160  color16        "(BAD signature)"
+color body                color39   color16        "(Good signature)"
+color body                color16   color16        "^gpg: Good signature .*"
+color body                color241  color16        "^gpg: "
+color body                color241  color160        "^gpg: BAD signature from.*"
+mono  body          bold                            "^gpg: Good signature"
+mono  body          bold                            "^gpg: BAD signature from.*"
+
+# yes, an insane URL regex
+color body          bold  color39   color16        "([a-z][a-z0-9+-]*://(((([a-z0-9_.!~*'();:&=+$,-]|%[0-9a-f][0-9a-f])*@)?((([a-z0-9]([a-z0-9-]*[a-z0-9])?)\\.)*([a-z]([a-z0-9-]*[a-z0-9])?)\\.?|[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+)(:[0-9]+)?)|([a-z0-9_.!~*'()$,;:@&=+-]|%[0-9a-f][0-9a-f])+)(/([a-z0-9_.!~*'():@&=+$,-]|%[0-9a-f][0-9a-f])*(;([a-z0-9_.!~*'():@&=+$,-]|%[0-9a-f][0-9a-f])*)*(/([a-z0-9_.!~*'():@&=+$,-]|%[0-9a-f][0-9a-f])*(;([a-z0-9_.!~*'():@&=+$,-]|%[0-9a-f][0-9a-f])*)*)*)?(\\?([a-z0-9_.!~*'();/?:@&=+$,-]|%[0-9a-f][0-9a-f])*)?(#([a-z0-9_.!~*'();/?:@&=+$,-]|%[0-9a-f][0-9a-f])*)?|(www|ftp)\\.(([a-z0-9]([a-z0-9-]*[a-z0-9])?)\\.)*([a-z]([a-z0-9-]*[a-z0-9])?)\\.?(:[0-9]+)?(/([-a-z0-9_.!~*'():@&=+$,]|%[0-9a-f][0-9a-f])*(;([-a-z0-9_.!~*'():@&=+$,]|%[0-9a-f][0-9a-f])*)*(/([-a-z0-9_.!~*'():@&=+$,]|%[0-9a-f][0-9a-f])*(;([-a-z0-9_.!~*'():@&=+$,]|%[0-9a-f][0-9a-f])*)*)*)?(\\?([-a-z0-9_.!~*'();/?:@&=+$,]|%[0-9a-f][0-9a-f])*)?(#([-a-z0-9_.!~*'();/?:@&=+$,]|%[0-9a-f][0-9a-f])*)?)[^].,:;!)? \t\r\n<>\"]"
+# and a heavy handed email regex
+color body          bold  color39   color16        "((@(([0-9a-z-]+\\.)*[0-9a-z-]+\\.?|#[0-9]+|\\[[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\]),)*@(([0-9a-z-]+\\.)*[0-9a-z-]+\\.?|#[0-9]+|\\[[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\.[0-9]?[0-9]?[0-9]\\]):)?[0-9a-z_.+%$-]+@(([0-9a-z-]+\\.)*[0-9a-z-]+\\.?|#[0-9]+|\\[[0-2]?[0-9]?[0-9]\\.[0-2]?[0-9]?[0-9]\\.[0-2]?[0-9]?[0-9]\\.[0-2]?[0-9]?[0-9]\\])"
+
+# simplified regex for URL & email
+#color body             magenta         default "(ftp|https?|gopher|news|telnet|finger)://[^ \"\t\r\n]+"
+#color body             magenta         default "[-a-z_0-9.]+@[-a-z_0-9.]+"
+
+# vi: ft=muttrc ts=4 sw=4 sts=4 et


### PR DESCRIPTION
* **What does this PR do?**
Adds ayu-dark colorscheme

* **Screenshots (if relevant)**

<img width="1496" height="962" alt="dark1" src="https://github.com/user-attachments/assets/3d0c2ad1-fb84-410c-b9e8-fe0f30e7fa29" />
<img width="1496" height="962" alt="dark4" src="https://github.com/user-attachments/assets/0b3b4f21-98bf-4093-9ebc-5a88509ac2a3" />

<img width="1496" height="962" alt="dark2" src="https://github.com/user-attachments/assets/7412d61d-e4be-41e0-b02e-46fa216a9c1f" />
<img width="1496" height="962" alt="dark3" src="https://github.com/user-attachments/assets/08bfc295-fd51-4792-be9c-7618c5f42a91" />
