### PR TITLE
convert the ctype wrappers to use bool

### DIFF
--- a/mutt/ctype.c
+++ b/mutt/ctype.c
@@ -29,89 +29,90 @@
  */
 
 #include <ctype.h>
+#include <stdbool.h>
 
 /**
  * mutt_isalnum - Wrapper for isalnum(3)
  * @param arg Character to test
- * @retval 1 Character is alphanumeric
+ * @retval true Character is alphanumeric
  */
-int mutt_isalnum(int arg)
+bool mutt_isalnum(int arg)
 {
   if (isascii(arg))
     return isalnum(arg);
 
-  return 0;
+  return false;
 }
 
 /**
  * mutt_isalpha - Wrapper for isalpha(3)
  * @param arg Character to test
- * @retval 1 Character is alphabetic
+ * @retval true Character is alphabetic
  */
-int mutt_isalpha(int arg)
+bool mutt_isalpha(int arg)
 {
   if (isascii(arg))
     return isalpha(arg);
 
-  return 0;
+  return false;
 }
 
 /**
  * mutt_isdigit - Wrapper for isdigit(3)
  * @param arg Character to test
- * @retval 1 Character is a digit (0 through 9)
+ * @retval true Character is a digit (0 through 9)
  */
-int mutt_isdigit(int arg)
+bool mutt_isdigit(int arg)
 {
   if (isascii(arg))
     return isdigit(arg);
 
-  return 0;
+  return false;
 }
 
 /**
  * mutt_ispunct - Wrapper for ispunct(3)
  * @param arg Character to test
- * @retval 1 Character is printable but is not a space or alphanumeric
+ * @retval true Character is printable but is not a space or alphanumeric
  */
-int mutt_ispunct(int arg)
+bool mutt_ispunct(int arg)
 {
   if (isascii(arg))
     return ispunct(arg);
 
-  return 0;
+  return false;
 }
 
 /**
  * mutt_isspace - Wrapper for isspace(3)
  * @param arg Character to test
- * @retval 1 Character is white-space
+ * @retval true Character is white-space
  *
  * In the "C" and "POSIX" locales, these are: space, form-feed ('\\f'),
  * newline ('\\n'), carriage return ('\\r'), horizontal tab ('\\t'),
  * and vertical tab ('\\v').
  */
-int mutt_isspace(int arg)
+bool mutt_isspace(int arg)
 {
   if (isascii(arg))
     return isspace(arg);
 
-  return 0;
+  return false;
 }
 
 /**
  * mutt_isxdigit - Wrapper for isxdigit(3)
  * @param arg Character to test
- * @retval 1 Character is a hexadecimal digits
+ * @retval true Character is a hexadecimal digits
  *
  * That is, one of 0 1 2 3 4 5 6 7 8 9 a b c d e f A B C D E F.
  */
-int mutt_isxdigit(int arg)
+bool mutt_isxdigit(int arg)
 {
   if (isascii(arg))
     return isxdigit(arg);
 
-  return 0;
+  return false;
 }
 
 /**

--- a/mutt/ctype2.h
+++ b/mutt/ctype2.h
@@ -23,13 +23,15 @@
 #ifndef MUTT_MUTT_CTYPE_H
 #define MUTT_MUTT_CTYPE_H
 
-int mutt_isalnum(int arg);
-int mutt_isalpha(int arg);
-int mutt_isdigit(int arg);
-int mutt_ispunct(int arg);
-int mutt_isspace(int arg);
-int mutt_isxdigit(int arg);
-int mutt_tolower(int arg);
-int mutt_toupper(int arg);
+#include <stdbool.h>
+
+bool mutt_isalnum (int arg);
+bool mutt_isalpha (int arg);
+bool mutt_isdigit (int arg);
+bool mutt_ispunct (int arg);
+bool mutt_isspace (int arg);
+bool mutt_isxdigit(int arg);
+int  mutt_tolower (int arg);
+int  mutt_toupper (int arg);
 
 #endif /* MUTT_MUTT_CTYPE_H */


### PR DESCRIPTION
Change the return type of the ctype wrappers, to `bool`.

- `bool mutt_isalnum (int arg);`
- `bool mutt_isalpha (int arg);`
- `bool mutt_isdigit (int arg);`
- `bool mutt_ispunct (int arg);`
- `bool mutt_isspace (int arg);`
- `bool mutt_isxdigit(int arg);`

All the callers were using the functions in a `bool`-y way, so they didn't need to be changed.