### PR TITLE
limit: force refresh of index bar

### DIFF
--- a/index/functions.c
+++ b/index/functions.c
@@ -1272,6 +1272,7 @@ static int op_main_limit(struct IndexSharedData *shared, struct IndexPrivateData
         collapse_all(shared->mailbox_view, priv->menu, 0);
       mutt_draw_tree(shared->mailbox_view->threads);
     }
+    notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, NULL);
     menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
   }
   if (lmt)


### PR DESCRIPTION
After `<limit>`, send a notification so that the Index Bar (status) gets updated.

Fixes: #4664, #3662

**Test Steps**:
- Run NeoMutt with zero config:
  `neomutt -n -F /dev/null -f /dev/null -e "set status_format=%V"`
- Apply a limit that matches zero emails: <kbd>l</kbd> <kbd>foo</kbd> <kbd>\<enter\></kbd>

**Expected Result**
- Index Bar shows the limit string 'foo'

----

Applying a limit normally causes an Index notification.

This isn't the case in two situations:
- The Index is empty
- One zero-matches limit is followed by another zero-matches limit

The fix is pretty simple: send a notification to simulate a change to the Index.

The fix isn't perfect for a couple of reasons:

- The Index Bar is independent of the Index.
  We send a notification, but the Pattern code shows the "no matches" error first.

- The Pattern code has some horrible dependencies.
  **It** asks for the limit pattern and displays error messages.
  (Sending the notification from the Pattern code would mean even more dependencies.)
