### PR TITLE
test: fix build for re-entrant ncurses

### DIFF
--- a/test/color/ansi.c
+++ b/test/color/ansi.c
@@ -47,7 +47,6 @@ void test_ansi_color(void)
   TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars));
 
   curses_colors_init();
-  COLOR_PAIRS = 256;
 
   const char *str = NULL;
   int rc;

--- a/test/color/attr.c
+++ b/test/color/attr.c
@@ -56,7 +56,12 @@ struct ModifyTest
 
 void test_attr_colors(void)
 {
+#if NCURSES_REENTRANT == 1
+  return;
+#else
   COLOR_PAIRS = 32;
+#endif
+
   curses_colors_init();
   TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars));
 
@@ -155,7 +160,9 @@ void test_attr_colors(void)
   }
 
   {
+#if NCURSES_REENTRANT == 0
     COLORS = 256;
+#endif
 
     struct ModifyTest Tests[] = {
       // clang-format off
@@ -185,7 +192,9 @@ void test_attr_colors(void)
   }
 
   {
+#if NCURSES_REENTRANT == 0
     COLORS = 8;
+#endif
 
     struct ModifyTest Tests[] = {
       // clang-format off

--- a/test/color/curses.c
+++ b/test/color/curses.c
@@ -34,9 +34,14 @@ ARRAY_HEAD(CursesColorArray, struct CursesColor *);
 
 void test_curses_colors(void)
 {
+#if NCURSES_REENTRANT == 1
+  return;
+#else
+  COLOR_PAIRS = 32;
+#endif
+
   MuttLogger = log_disp_null;
 
-  COLOR_PAIRS = 32;
   curses_colors_init();
 
   {


### PR DESCRIPTION
In the some of the tests, we set COLOR_PAIRS to artificially limit the number of colours available.

If ncurses has been built with NCURSES_REENTRANT set, altering the variable isn't possible, so skip the tests.

This affects two tests:
- test_ansi_color
- test_attr_colors

Fixes: #4667

---

This is a bit of a hack.
To fix the tests properly, we'd have to introduce a wrapper around `COLOR_PAIRS` in our code.