### PR TITLE
shrink history file on every new entry (fixes #3623, #4662)

### DIFF
--- a/history/history.c
+++ b/history/history.c
@@ -317,8 +317,6 @@ cleanup:
  */
 static void save_history(enum HistoryClass hclass, const char *str)
 {
-  static int n = 0;
-
   if (!str || (*str == '\0')) // This shouldn't happen, but it's safer
     return;
 
@@ -342,12 +340,7 @@ static void save_history(enum HistoryClass hclass, const char *str)
   mutt_file_fclose(&fp);
   FREE(&tmp);
 
-  if (--n < 0)
-  {
-    const short c_save_history = cs_subset_number(NeoMutt->sub, "save_history");
-    n = c_save_history;
-    shrink_histfile();
-  }
+  shrink_histfile();
 }
 
 /**


### PR DESCRIPTION
The problem was that we only checked every `$save_history` times if the history file needed compacting. That only works for the first batch of entries. But once we reach `$save_history` number of entries we need to compact on every new entry.

I'm not particularly convinced that this is a good fix. Because compacting the history file is a quite expensive operation that we do now on every command. However I also don't have a better idea right yet.

Side-note: the behavior is actually like that since the beginning of the feature: https://github.com/neomutt/neomutt/commit/fe054524f870b89acec9d041bf77138e54e50b90