### PR TITLE
Flush S/MIME passkey on failure to sign

### DIFF
--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1448,7 +1448,10 @@ struct Body *smime_class_sign_message(struct Body *b, const struct AddressList *
   mutt_file_unlink(buf_string(filetosign));
 
   if (err)
+  {
+    smime_class_void_passphrase();
     mutt_any_key_to_continue(NULL);
+  }
 
   if (empty)
   {


### PR DESCRIPTION
When using classic S/MIME (i.e., via OpenSSL commands instead of using GPGMe), NeoMutt caches the private key passphrase. However, it fails to flush the cache on a failure to sign, which presumably comes from the user entering a wrong passphrase.

So, upon entering a wrong passphrase, the user currently has to wait for the cache to expire (`smime_timeout`) before trying again.

This PR fixes it, by immediately flusing the cached passphrase upon failure to sign.