### PR TITLE
document magic config value for builtin pager

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -2983,9 +2983,9 @@
 /*
 ** .pp
 ** This variable specifies which pager you would like to use to view
-** messages. When empty, NeoMutt will use the built-in pager, otherwise this
-** variable should specify the pathname of the external pager you would
-** like to use.
+** messages. When empty or set to the magic value \fbuiltin\fP, NeoMutt will use
+** the built-in pager, otherwise this variable should specify the pathname of
+** the external pager you would like to use.
 ** .pp
 ** Using an external pager may have some disadvantages: Additional
 ** keystrokes are necessary because you can't call NeoMutt functions


### PR DESCRIPTION
* **What does this PR do?**

The default builtin pager is used when the pager variable is either empty or set to the magic value "builtin". Update the documentation to mention the magic value.

* **What are the relevant issue numbers?**

While discussing the a bug report in https://github.com/neomutt/neomutt/issues/4682, it was suggested that we also update the pager config variable docs to clarify that there is a magic value that can also be used.