### PR TITLE
execute message-hook sooner

### DIFF
--- a/index/functions.c
+++ b/index/functions.c
@@ -607,6 +607,9 @@ static int op_display_message(struct IndexSharedData *shared,
 {
   if (!shared->email)
     return FR_NO_ACTION;
+
+  mutt_message_hook(shared->mailbox, shared->email, MUTT_MESSAGE_HOOK);
+
   /* toggle the weeding of headers so that a user can press the key
    * again while reading the message.  */
   if (op == OP_DISPLAY_HEADERS)

--- a/pager/message.c
+++ b/pager/message.c
@@ -169,7 +169,6 @@ static int email_to_file(struct Message *msg, struct Buffer *tempfile,
   pid_t filterpid = -1;
 
   mutt_parse_mime_message(e, msg->fp);
-  mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
 
   char columns[16] = { 0 };
   // win_pager might not be visible and have a size yet, so use win_index


### PR DESCRIPTION
In the docs, the example `message-hook` sets the value of $pager.

A refactoring 4 years ago, e3a3b9983, meant that we checked the value of $pager *before* the hook fired.

Execute the hook before we use any config.

Fixes: #4682 
