### PR TITLE
fix: `:exec` auto-completion

### DIFF
--- a/alias/alias.c
+++ b/alias/alias.c
@@ -513,7 +513,7 @@ retry_name:
   const char *const c_alias_file = cs_subset_path(sub, "alias_file");
   buf_strcpy(buf, c_alias_file);
 
-  struct FileCompletionData cdata = { false, NULL, NULL, NULL };
+  struct FileCompletionData cdata = { false, NULL, NULL, NULL, NULL };
   if (mw_get_field(_("Save to file: "), buf, MUTT_COMP_CLEAR, HC_FILE,
                    &CompleteFileOps, &cdata) != 0)
   {

--- a/attach/recvattach.c
+++ b/attach/recvattach.c
@@ -304,7 +304,7 @@ static int query_save_attachment(FILE *fp, struct Body *b, struct Email *e, char
   prompt = _("Save to file: ");
   while (prompt)
   {
-    struct FileCompletionData cdata = { false, NULL, NULL, NULL };
+    struct FileCompletionData cdata = { false, NULL, NULL, NULL, NULL };
     if ((mw_get_field(prompt, buf, MUTT_COMP_CLEAR, HC_FILE, &CompleteFileOps, &cdata) != 0) ||
         buf_is_empty(buf))
     {
@@ -485,7 +485,7 @@ void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
           buf_strcpy(buf, mutt_path_basename(NONULL(b->filename)));
           prepend_savedir(buf);
 
-          struct FileCompletionData cdata = { false, NULL, NULL, NULL };
+          struct FileCompletionData cdata = { false, NULL, NULL, NULL, NULL };
           if ((mw_get_field(_("Save to file: "), buf, MUTT_COMP_CLEAR, HC_FILE,
                             &CompleteFileOps, &cdata) != 0) ||
               buf_is_empty(buf))

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -154,7 +154,7 @@ static int op_browser_new_file(struct BrowserPrivateData *priv, int op)
   struct Buffer *buf = buf_pool_get();
   buf_printf(buf, "%s/", buf_string(&LastDir));
 
-  struct FileCompletionData cdata = { false, priv->mailbox, NULL, NULL };
+  struct FileCompletionData cdata = { false, priv->mailbox, NULL, NULL, NULL };
   const int rc = mw_get_field(_("New file name: "), buf, MUTT_COMP_NO_FLAGS,
                               HC_FILE, &CompleteMailboxOps, &cdata);
   if (rc != 0)
@@ -355,7 +355,7 @@ static int op_change_directory(struct BrowserPrivateData *priv, int op)
 
   if (op == OP_CHANGE_DIRECTORY)
   {
-    struct FileCompletionData cdata = { false, priv->mailbox, NULL, NULL };
+    struct FileCompletionData cdata = { false, priv->mailbox, NULL, NULL, NULL };
     int rc = mw_get_field(_("Chdir to: "), buf, MUTT_COMP_NO_FLAGS, HC_FILE,
                           &CompleteMailboxOps, &cdata);
     if ((rc != 0) && buf_is_empty(buf))

--- a/complete/lib.h
+++ b/complete/lib.h
@@ -48,7 +48,7 @@ struct Buffer;
 extern const struct CompleteOps CompleteCommandOps;
 extern const struct CompleteOps CompleteLabelOps;
 
-int  mutt_command_complete  (struct CompletionData *cd, struct Buffer *buf, int pos, int numtabs);
+int  mutt_command_complete  (struct CompletionData *cd, struct Buffer *buf, int pos, int numtabs, void *cdata);
 int  mutt_complete          (struct CompletionData *cd, struct Buffer *buf);
 int  mutt_label_complete    (struct CompletionData *cd, struct Buffer *buf, int numtabs);
 bool mutt_nm_query_complete (struct CompletionData *cd, struct Buffer *buf, int numtabs);

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1445,7 +1445,7 @@ static int op_attachment_new_mime(struct ComposeSharedData *shared, int op)
   struct Buffer *type = NULL;
   struct AttachPtr *ap = NULL;
 
-  struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
+  struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL, NULL };
   if ((mw_get_field(_("New file: "), fname, MUTT_COMP_NO_FLAGS, HC_FILE,
                     &CompleteFileOps, &cdata) != 0) ||
       buf_is_empty(fname))
@@ -1555,7 +1555,7 @@ static int op_attachment_rename_attachment(struct ComposeSharedData *shared, int
     src = cur_att->body->filename;
   struct Buffer *fname = buf_pool_get();
   buf_strcpy(fname, mutt_path_basename(NONULL(src)));
-  struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
+  struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL, NULL };
   int rc = mw_get_field(_("Send attachment with name: "), fname,
                         MUTT_COMP_NO_FLAGS, HC_FILE, &CompleteFileOps, &cdata);
   if (rc == 0)
@@ -1889,7 +1889,7 @@ static int op_compose_rename_file(struct ComposeSharedData *shared, int op)
   struct Buffer *fname = buf_pool_get();
   buf_strcpy(fname, cur_att->body->filename);
   buf_pretty_mailbox(fname);
-  struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL };
+  struct FileCompletionData cdata = { false, shared->mailbox, NULL, NULL, NULL };
   if ((mw_get_field(_("Rename to: "), fname, MUTT_COMP_NO_FLAGS, HC_FILE,
                     &CompleteFileOps, &cdata) == 0) &&
       !buf_is_empty(fname))

--- a/envelope/functions.c
+++ b/envelope/functions.c
@@ -226,7 +226,7 @@ static int op_envelope_edit_fcc(struct EnvelopeWindowData *wdata, int op)
   struct Buffer *fname = buf_pool_get();
   buf_copy(fname, wdata->fcc);
 
-  struct FileCompletionData cdata = { false, NULL, NULL, NULL };
+  struct FileCompletionData cdata = { false, NULL, NULL, NULL, NULL };
   if (mw_get_field(Prompts[HDR_FCC], fname, MUTT_COMP_CLEAR, HC_MAILBOX,
                    &CompleteMailboxOps, &cdata) != 0)
   {

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -294,7 +294,7 @@ int mw_enter_fname(const char *prompt, struct Buffer *fname, bool mailbox,
       mutt_unget_op(event.op);
 
     buf_alloc(fname, 1024);
-    struct FileCompletionData cdata = { multiple, m, files, numfiles };
+    struct FileCompletionData cdata = { multiple, m, files, numfiles, NULL };
     enum HistoryClass hclass = mailbox ? HC_MAILBOX : HC_FILE;
     if (mw_get_field(pc, fname, MUTT_COMP_CLEAR, hclass, &CompleteMailboxOps, &cdata) != 0)
     {

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -411,7 +411,7 @@ int imap_mailbox_create(const char *path)
     buf_addch(name, adata->delim);
   }
 
-  struct FileCompletionData cdata = { false, NULL, NULL, NULL };
+  struct FileCompletionData cdata = { false, NULL, NULL, NULL, NULL };
   if (mw_get_field(_("Create mailbox: "), name, MUTT_COMP_NO_FLAGS, HC_MAILBOX,
                    &CompleteMailboxOps, &cdata) != 0)
   {
@@ -472,7 +472,7 @@ int imap_mailbox_rename(const char *path)
   buf_printf(buf, _("Rename mailbox %s to: "), mdata->name);
   buf_strcpy(newname, mdata->name);
 
-  struct FileCompletionData cdata = { false, NULL, NULL, NULL };
+  struct FileCompletionData cdata = { false, NULL, NULL, NULL, NULL };
   if (mw_get_field(buf_string(buf), newname, MUTT_COMP_NO_FLAGS, HC_MAILBOX,
                    &CompleteMailboxOps, &cdata) != 0)
   {

--- a/muttlib.c
+++ b/muttlib.c
@@ -579,7 +579,7 @@ int mutt_check_overwrite(const char *attname, const char *path, struct Buffer *f
 
     struct Buffer *tmp = buf_pool_get();
     buf_strcpy(tmp, mutt_path_basename(NONULL(attname)));
-    struct FileCompletionData cdata = { false, NULL, NULL, NULL };
+    struct FileCompletionData cdata = { false, NULL, NULL, NULL, NULL };
     if ((mw_get_field(_("File under directory: "), tmp, MUTT_COMP_CLEAR,
                       HC_FILE, &CompleteFileOps, &cdata) != 0) ||
         buf_is_empty(tmp))

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -1019,7 +1019,7 @@ static int op_save(struct IndexSharedData *shared, struct PagerPrivateData *priv
   long pos = ftell(priv->fp);
   rewind(priv->fp);
 
-  struct FileCompletionData cdata = { false, NULL, NULL, NULL };
+  struct FileCompletionData cdata = { false, NULL, NULL, NULL, NULL };
   if ((mw_get_field(_("Save to file: "), buf, MUTT_COMP_CLEAR, HC_FILE,
                     &CompleteFileOps, &cdata) != 0) ||
       buf_is_empty(buf))


### PR DESCRIPTION
Auto-completion on the `:exec` command has been broken for quite a while.

**Steps**:
- In the Index, type: `:exec a<Tab><Tab>`

**Expected Result**:
- `alias-dialog`
- `autocrypt-acct-menu`
- ...

This fix isn't brilliant, but it works.

---

The `exec` command takes a NeoMutt function as its argument.
To know which functions are possible, the auto-completion needs to know which Dialog is active.

Historically, this info was obtained by dark magic.

`alldialogs_get_current()` looked for the top-most dialog and tried to determine its type.
This was replaced by function that used the current focus.

Unfortunately, the moment the user hits `:` (`<enter-command>`), the focus moves to the Editor Window.

Extend `struct FileCompletionData` to take a `MuttWindow` that `exec` can use.