### PR TITLE
Consistently convert headers to LF EOL convention

### DIFF
--- a/copy.c
+++ b/copy.c
@@ -136,6 +136,14 @@ int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end,
       if (!fgets(buf, sizeof(buf), fp_in))
         break;
 
+      /* Convert CRLF line endings to LF */
+      const size_t line_len = strlen(buf);
+      if ((line_len > 2) && (buf[line_len - 2] == '\r') && (buf[line_len - 1] == '\n'))
+      {
+        buf[line_len - 2] = '\n';
+        buf[line_len - 1] = '\0';
+      }
+
       /* Is it the beginning of a header? */
       if (nl && (buf[0] != ' ') && (buf[0] != '\t'))
       {
@@ -230,14 +238,6 @@ int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end,
           if (address_header_decode(&this_one) == 0)
             rfc2047_decode(&this_one);
           this_one_len = mutt_str_len(this_one);
-
-          /* Convert CRLF line endings to LF */
-          if ((this_one_len > 2) && (this_one[this_one_len - 2] == '\r') &&
-              (this_one[this_one_len - 1] == '\n'))
-          {
-            this_one[this_one_len - 2] = '\n';
-            this_one[this_one_len - 1] = '\0';
-          }
         }
 
         add_one_header(&headers, x, this_one);


### PR DESCRIPTION
When NeoMutt copies a message between folders, it might add additional headers, e.g., Content-Length. In doing so, it terminates lines with a LF character, no matter whether the existing header lines used LF or CRLF.

There was code in place to convert CRLF to LF, but it was triggered only for address headers.

This PR makes it more consistent by converting all header lines to LF convention.

Fixes #4685 