### PR TITLE
expunge: guard against segfault

### DIFF
--- a/imap/command.c
+++ b/imap/command.c
@@ -273,14 +273,12 @@ static void cmd_parse_expunge(struct ImapAccountData *adata, const char *s)
   e = imap_msn_get(&mdata->msn, exp_msn - 1);
   if (e)
   {
-    struct ImapEmailData *edata = NULL;
-
     /* imap_expunge_mailbox() will rewrite e->index.
      * It needs to resort using EMAIL_SORT_UNSORTED anyway, so setting to INT_MAX
      * makes the code simpler and possibly more efficient. */
     e->index = INT_MAX;
 
-    edata = imap_edata_get(e);
+    struct ImapEmailData *edata = imap_edata_get(e);
     if (edata)
       edata->msn = 0;
   }


### PR DESCRIPTION
* **What does this PR do?**

In some cases, calling imap_edata_get() can return NULL, if the corresponding edata field is NULL.

Don't segfault in this case.

What I cannot determine here, is why the call to `imap_edata_get()` has `edata == NULL` and I can't track that down.  That would be the preferred fix here, but since this issue comes up once in a blue moon, I thought I'd post this here to indicate the issue...