### PR TITLE
alias: complete when only one match

### DIFF
--- a/alias/dlg_alias.c
+++ b/alias/dlg_alias.c
@@ -336,6 +336,8 @@ int alias_complete(struct Buffer *buf, struct ConfigSubset *sub)
 {
   struct Alias *np = NULL;
   char bestname[8192] = { 0 };
+  struct Alias *a_best = NULL;
+  int count = 0;
 
   struct AliasMenuData mdata = { ARRAY_HEAD_INITIALIZER, NULL, sub };
   mdata.limit = buf_strdup(buf);
@@ -347,6 +349,9 @@ int alias_complete(struct Buffer *buf, struct ConfigSubset *sub)
     {
       if (np->name && mutt_strn_equal(np->name, buf_string(buf), buf_len(buf)))
       {
+        a_best = np;
+        count++;
+
         if (bestname[0] == '\0') /* init */
         {
           mutt_str_copy(bestname, np->name,
@@ -361,6 +366,15 @@ int alias_complete(struct Buffer *buf, struct ConfigSubset *sub)
           bestname[i] = '\0';
         }
       }
+    }
+
+    // Exactly one match, so expand the Alias and return
+    if (count == 1)
+    {
+      buf_reset(buf);
+      mutt_addrlist_write(&a_best->addr, buf, true);
+      buf_addstr(buf, ", ");
+      return 1;
     }
 
     if (bestname[0] == '\0')


### PR DESCRIPTION
Don't display the Alias Dialog (Address Book) unless necessary.

### Scenario

- `<mail>` - Start composing an Email
- `fre<tab>` - Type an Alias and try auto-completion

### Current Behaviour

If there's exactly one match, then the Alias will be completed.
e.g. `fre` becomes `fred`

If you hit `<tab>` again, then the Alias Dialog is shown, with **one entry**.
Hitting `<enter>` selects that Alias and the prompt now shows: `Fred Johnson <fred@tycho.com>, `

### New Behaviour

- `<mail>` - Start composing an Email
- `fre<tab>` - Type an Alias and try auto-completion

The `fre` is immediately replaced by `Fred Johnson <fred@tycho.com>, `

This allows the user to keep typing.