### PR TITLE
browser: fix select/descend folder/mailbox

### DIFF
--- a/browser/functions.c
+++ b/browser/functions.c
@@ -667,13 +667,18 @@ static int op_generic_select_entry(struct BrowserPrivateData *priv, int op)
     enum MailboxType type = mx_path_probe(buf_string(buf));
     buf_pool_release(&buf);
 
-    if ((op == OP_DESCEND_DIRECTORY) || (type == MUTT_MAILBOX_ERROR) ||
-        (type == MUTT_UNKNOWN) || ff->inferiors)
+    const bool dot_dot = mutt_str_equal(ff->name, "..");
+
+    // Descend into a directory, if:
+    // 1) User selected '..'
+    // 2) User pressed <descend-directory>
+    // 3) User is looking for a Mailbox and this directory isn't one
+    if (dot_dot || (op == OP_DESCEND_DIRECTORY) || (priv->folder && (type <= MUTT_UNKNOWN)))
     {
       /* save the old directory */
       buf_copy(priv->old_last_dir, &LastDir);
 
-      if (mutt_str_equal(ff->name, ".."))
+      if (dot_dot)
       {
         size_t lastdirlen = buf_len(&LastDir);
         if ((lastdirlen > 1) && mutt_str_equal("..", buf_string(&LastDir) + lastdirlen - 2))


### PR DESCRIPTION
The Browser wouldn't allow you to select a directory when saving a file.
(Reported by madduck,mgedmin on IRC)

This bad behaviour probably dates back to the introduction of `<descend-directory>`.

Fix the Browser behaviour, for:
1. `OP_GENERIC_SELECT_ENTRY` (`<select-entry>`)
2. `OP_DESCEND_DIRECTORY` (`<descend-directory>`)

Descend into a directory, if:
- User selected `..`
- User pressed `<descend-directory>`
- User is looking for a Mailbox and this directory isn't one

---

### File / Directory Operations

- File + `<select-entry>` -- File selected
- File + `<descend-directory>` -- Error, not a directory
- Directory + `<select-entry>` -- Directory selected
- Directory + `<descend-directory>` -- Change directory

### Mailbox Operations

When changing folders, with `<change-folder>` the behaviour slightly different.
It's optimised to finding a Mailbox.

- Mailbox Directory + `<select-entry>` -- Mailbox selected
- Non-mailbox Directory + `<select-entry>` -- Change directory
- Directory + `<descend-directory>` -- Change directory

This allows the user to quickly navigate to a Mailbox.