### PR TITLE
deprecate old ssl and tls options

### DIFF
--- a/conn/config.c
+++ b/conn/config.c
@@ -80,15 +80,6 @@ static struct ConfigDef ConnVarsSsl[] = {
   { "ssl_starttls", DT_QUAD, MUTT_YES, 0, NULL,
     "(ssl) Use STARTTLS on servers advertising the capability"
   },
-  { "ssl_use_sslv3", DT_BOOL, false, 0, NULL,
-    "(ssl) INSECURE: Use SSLv3 for authentication"
-  },
-  { "ssl_use_tlsv1", DT_BOOL, false, 0, NULL,
-    "(ssl) Use TLSv1 for authentication"
-  },
-  { "ssl_use_tlsv1_1", DT_BOOL, false, 0, NULL,
-    "(ssl) Use TLSv1.1 for authentication"
-  },
   { "ssl_use_tlsv1_2", DT_BOOL, true, 0, NULL,
     "(ssl) Use TLSv1.2 for authentication"
   },
@@ -101,6 +92,10 @@ static struct ConfigDef ConnVarsSsl[] = {
   { "ssl_verify_host", DT_BOOL, true, 0, NULL,
     "(ssl) Verify the server's hostname against the certificate"
   },
+
+  { "ssl_use_sslv3",   D_INTERNAL_DEPRECATED|DT_BOOL, 0, IP "2025-12-07" },
+  { "ssl_use_tlsv1",   D_INTERNAL_DEPRECATED|DT_BOOL, 0, IP "2025-12-07" },
+  { "ssl_use_tlsv1_1", D_INTERNAL_DEPRECATED|DT_BOOL, 0, IP "2025-12-07" },
   { NULL },
   // clang-format on
 };
@@ -132,13 +127,12 @@ static struct ConfigDef ConnVarsOpenssl[] = {
   { "entropy_file", DT_PATH|D_PATH_FILE, 0, 0, NULL,
     "(ssl) File/device containing random data to initialise SSL"
   },
-  { "ssl_use_sslv2", DT_BOOL, false, 0, NULL,
-    "(ssl) INSECURE: Use SSLv2 for authentication"
-  },
   { "ssl_use_system_certs", DT_BOOL, true, 0, NULL,
     "(ssl) Use CA certificates in the system-wide store"
   },
   { "ssl_usesystemcerts", DT_SYNONYM, IP "ssl_use_system_certs", IP "2021-02-11" },
+
+  { "ssl_use_sslv2", D_INTERNAL_DEPRECATED|DT_BOOL, 0, IP "2025-12-07" },
   { NULL },
   // clang-format on
 };

--- a/conn/gnutls.c
+++ b/conn/gnutls.c
@@ -760,7 +760,7 @@ err:
  */
 static int tls_set_priority(struct TlsSockData *data)
 {
-  size_t nproto = 5;
+  size_t nproto = 2;
   int rv = -1;
 
   struct Buffer *priority = buf_pool_get();
@@ -783,24 +783,11 @@ static int tls_set_priority(struct TlsSockData *data)
     nproto--;
     buf_addstr(priority, ":-VERS-TLS1.2");
   }
-  const bool c_ssl_use_tlsv1_1 = cs_subset_bool(NeoMutt->sub, "ssl_use_tlsv1_1");
-  if (!c_ssl_use_tlsv1_1)
-  {
-    nproto--;
-    buf_addstr(priority, ":-VERS-TLS1.1");
-  }
-  const bool c_ssl_use_tlsv1 = cs_subset_bool(NeoMutt->sub, "ssl_use_tlsv1");
-  if (!c_ssl_use_tlsv1)
-  {
-    nproto--;
-    buf_addstr(priority, ":-VERS-TLS1.0");
-  }
-  const bool c_ssl_use_sslv3 = cs_subset_bool(NeoMutt->sub, "ssl_use_sslv3");
-  if (!c_ssl_use_sslv3)
-  {
-    nproto--;
-    buf_addstr(priority, ":-VERS-SSL3.0");
-  }
+
+  // Deprecated protocols
+  buf_addstr(priority, ":-VERS-TLS1.1");
+  buf_addstr(priority, ":-VERS-TLS1.0");
+  buf_addstr(priority, ":-VERS-SSL3.0");
 
   if (nproto == 0)
   {
@@ -837,15 +824,6 @@ static int tls_set_priority(struct TlsSockData *data)
   const bool c_ssl_use_tlsv1_2 = cs_subset_bool(NeoMutt->sub, "ssl_use_tlsv1_2");
   if (c_ssl_use_tlsv1_2)
     ProtocolPriority[nproto++] = GNUTLS_TLS1_2;
-  const bool c_ssl_use_tlsv1_1 = cs_subset_bool(NeoMutt->sub, "ssl_use_tlsv1_1");
-  if (c_ssl_use_tlsv1_1)
-    ProtocolPriority[nproto++] = GNUTLS_TLS1_1;
-  const bool c_ssl_use_tlsv1 = cs_subset_bool(NeoMutt->sub, "ssl_use_tlsv1");
-  if (c_ssl_use_tlsv1)
-    ProtocolPriority[nproto++] = GNUTLS_TLS1;
-  const bool c_ssl_use_sslv3 = cs_subset_bool(NeoMutt->sub, "ssl_use_sslv3");
-  if (c_ssl_use_sslv3)
-    ProtocolPriority[nproto++] = GNUTLS_SSL3;
   ProtocolPriority[nproto] = 0;
 
   if (nproto == 0)

--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -1234,25 +1234,15 @@ static int ssl_setup(struct Connection *conn)
     SSL_CTX_set_options(sockdata(conn)->sctx, SSL_OP_NO_TLSv1_2);
 #endif
 
+  // Deprecated protocols
 #ifdef SSL_OP_NO_TLSv1_1
-  const bool c_ssl_use_tlsv1_1 = cs_subset_bool(NeoMutt->sub, "ssl_use_tlsv1_1");
-  if (!c_ssl_use_tlsv1_1)
-    SSL_CTX_set_options(sockdata(conn)->sctx, SSL_OP_NO_TLSv1_1);
+  SSL_CTX_set_options(sockdata(conn)->sctx, SSL_OP_NO_TLSv1_1);
 #endif
-
 #ifdef SSL_OP_NO_TLSv1
-  const bool c_ssl_use_tlsv1 = cs_subset_bool(NeoMutt->sub, "ssl_use_tlsv1");
-  if (!c_ssl_use_tlsv1)
-    SSL_CTX_set_options(sockdata(conn)->sctx, SSL_OP_NO_TLSv1);
+  SSL_CTX_set_options(sockdata(conn)->sctx, SSL_OP_NO_TLSv1);
 #endif
-
-  const bool c_ssl_use_sslv3 = cs_subset_bool(NeoMutt->sub, "ssl_use_sslv3");
-  if (!c_ssl_use_sslv3)
-    SSL_CTX_set_options(sockdata(conn)->sctx, SSL_OP_NO_SSLv3);
-
-  const bool c_ssl_use_sslv2 = cs_subset_bool(NeoMutt->sub, "ssl_use_sslv2");
-  if (!c_ssl_use_sslv2)
-    SSL_CTX_set_options(sockdata(conn)->sctx, SSL_OP_NO_SSLv2);
+  SSL_CTX_set_options(sockdata(conn)->sctx, SSL_OP_NO_SSLv3);
+  SSL_CTX_set_options(sockdata(conn)->sctx, SSL_OP_NO_SSLv2);
 
   const bool c_ssl_use_system_certs = cs_subset_bool(NeoMutt->sub, "ssl_use_system_certs");
   if (c_ssl_use_system_certs)

--- a/docs/config.c
+++ b/docs/config.c
@@ -5158,27 +5158,6 @@
 #endif
 
 #ifdef USE_SSL_OPENSSL
-{ "ssl_use_sslv2", DT_BOOL, false },
-/*
-** .pp
-** If \fIset\fP , NeoMutt will use SSLv2 when communicating with servers that
-** request it. \fBN.B. As of 2011, SSLv2 is considered insecure, and using
-** is inadvisable\fP. See https://tools.ietf.org/html/rfc6176
-** (OpenSSL only)
-*/
-#endif
-
-#ifdef USE_SSL
-{ "ssl_use_sslv3", DT_BOOL, false },
-/*
-** .pp
-** If \fIset\fP , NeoMutt will use SSLv3 when communicating with servers that
-** request it. \fBN.B. As of 2015, SSLv3 is considered insecure, and using
-** it is inadvisable\fP. See https://tools.ietf.org/html/rfc7525
-*/
-#endif
-
-#ifdef USE_SSL_OPENSSL
 { "ssl_use_system_certs", DT_BOOL, true },
 /*
 ** .pp
@@ -5189,22 +5168,6 @@
 #endif
 
 #ifdef USE_SSL
-{ "ssl_use_tlsv1", DT_BOOL, false },
-/*
-** .pp
-** If \fIset\fP , NeoMutt will use TLSv1.0 when communicating with servers that
-** request it. \fBN.B. As of 2015, TLSv1.0 is considered insecure, and using
-** it is inadvisable\fP. See https://tools.ietf.org/html/rfc7525
-*/
-
-{ "ssl_use_tlsv1_1", DT_BOOL, false },
-/*
-** .pp
-** If \fIset\fP , NeoMutt will use TLSv1.1 when communicating with servers that
-** request it. \fBN.B. As of 2015, TLSv1.1 is considered insecure, and using
-** it is inadvisable\fP. See https://tools.ietf.org/html/rfc7525
-*/
-
 { "ssl_use_tlsv1_2", DT_BOOL, true },
 /*
 ** .pp


### PR DESCRIPTION
The use of **SSL** has been deprecated.
The use of **v1** and **v1.1** of **TLS** has been deprecated.

Deprecate the Config Options and the backing code.
- `$ssl_use_sslv2`
- `$ssl_use_sslv3`
- `$ssl_use_tlsv1`
- `$ssl_use_tlsv1_1`

**Note:** Users with old config may see warnings on startup:

> Option ssl_use_sslv2 is deprecated
> Option ssl_use_sslv3 is deprecated
> Option ssl_use_tlsv1 is deprecated
> Option ssl_use_tlsv1_1 is deprecated
