### PR TITLE
build: make openssl/gnutls mutually exclusive

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -714,7 +714,11 @@ if {[opt-val with-domain] ne {}} {
 
 ###############################################################################
 # TLS support
-if {[get-define want-ssl] && ![get-define want-gnutls]} {
+if {[get-define want-gnutls] && [get-define want-ssl]} {
+  user-error "Configuration error: options '--ssl' (OpenSSL) and '--gnutls' (GnuTLS) are mutually exclusive"
+}
+
+if {[get-define want-ssl]} {
   # OpenSSL
   if {[pkgconf false openssl]} {
     # cool - we do not make pkg-config mandatory for OpenSSL because BSDs still


### PR DESCRIPTION
Allow `configure` to take `--ssl` or `--gnutls`, but not both.

In the code, OpenSSL and GnuTLS are mutually exclusive.
If `configure` is run with both options, GnuTLS is used.

If both options are given, fail with an error message:
```
$ ./configure --quiet --gnutls --ssl
Error: Configuration error: options '--ssl' (OpenSSL) and '--gnutls' (GnuTLS) are mutually exclusive
Try: 'configure --help' for options
```
