### PR TITLE
Fix freeze in IMAP w/ OpenSSL

### DIFF
--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -1344,7 +1344,10 @@ retry:
   else if (BIO_should_retry(SSL_get_rbio(data->ssl)))
   {
     // Temporary failure, e.g. signal received
-    goto retry;
+    if (raw_socket_poll(conn, 0) >= 0)
+    {
+      goto retry;
+    }
   }
 
   data->isopen = 0;


### PR DESCRIPTION
We might get back a retriable error from SSL_read, e.g., if there's no data anymore byt the connection is still open. Unless we select or something, no additional data might become available, hence the freeze.