### PR TITLE
mutt/array.h: ARRAY_RESERVE(): Fix benign off-by-one bug

### DIFF
--- a/mutt/array.h
+++ b/mutt/array.h
@@ -187,7 +187,7 @@
  * @retval num New capacity of the array
  */
 #define ARRAY_RESERVE(head, num)                                               \
-  (((head)->capacity > (num)) ?                                                \
+  (((head)->capacity >= (num)) ?                                               \
        (head)->capacity :                                                      \
        ((mutt_mem_reallocarray(                                                \
          &(head)->entries, (num) + ARRAY_HEADROOM, ARRAY_ELEM_SIZE(head))),    \


### PR DESCRIPTION
    mutt/array.h: ARRAY_RESERVE(): Fix benign off-by-one bug
    
    If (head)->capacity == (num), we have enough storage, and no allocation
    is needed.  While this didn't misbehave, it was unnecessarily
    calling allocation APIs, and was confusing the reader (at least me).
    
Fixes: f4fd43e406ce (2020-08-22; "Implement ARRAY API")
Closes: <https://github.com/neomutt/neomutt/issues/4754>

---

Revisions:

<details>
<summary>v2</summary>

-  Fix parentheses and semicolon.  [@flatcap ]
-  Rename num => n.

```
$ git range-diff --creation-factor=99 HEAD^ neomutt/alx/offby1 alx/offby1 
1:  7ef8ccd1e ! 1:  d81b583c3 mutt/array.h: ARRAY_RESERVE(): Rewrite using GNU statement expression
    @@ Commit message
     
                 0e7c2c38957b (2025-01-13; "Update mutt/queue.h")
     
    +    Also, rename num => n.  It's just simpler, and more idiomatic.
    +
         Link: <https://github.com/neomutt/neomutt/issues/4753>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## mutt/array.h ##
     @@
    -  * @retval num New capacity of the array
    + /**
    +  * ARRAY_RESERVE - Reserve memory for the array
    +  * @param head Pointer to a struct defined using ARRAY_HEAD()
    +- * @param num Number of elements to make room for
    +- * @retval num New capacity of the array
    ++ * @param n    Number of elements to make room for
    ++ * @retval n   New capacity of the array
       */
    - #define ARRAY_RESERVE(head, num)                                               \
    +-#define ARRAY_RESERVE(head, num)                                               \
     -  (((head)->capacity >= (num)) ?                                               \
     -       (head)->capacity :                                                      \
     -       ((mutt_mem_reallocarray(                                                \
    @@ mutt/array.h
     -                ((num) + ARRAY_HEADROOM - (head)->capacity) *                  \
     -                ARRAY_ELEM_SIZE(head))),                                       \
     -        ((head)->capacity = (num) + ARRAY_HEADROOM)))
    -+({                                                                             \
    -+  if ((head)->capacity < (num))                                                \
    -+  {                                                                            \
    -+    mutt_mem_reallocarray(&(head)->entries,                                    \
    -+                          (num) + ARRAY_HEADROOM, ARRAY_ELEM_SIZE(head)));     \
    -+    memset((head)->entries + (head)->capacity, 0,                              \
    -+           ((num) + ARRAY_HEADROOM - (head)->capacity) * ARRAY_ELEM_SIZE(head)),\
    -+    (head)->capacity = (num) + ARRAY_HEADROOM;                                 \
    -+  }                                                                            \
    -+  (head)->capacity;                                                            \
    ++#define ARRAY_RESERVE(head, n)                                        \
    ++({                                                                    \
    ++  if ((head)->capacity < (n))                                         \
    ++  {                                                                   \
    ++    mutt_mem_reallocarray(&(head)->entries,                           \
    ++                          (n) + ARRAY_HEADROOM,                       \
    ++                          ARRAY_ELEM_SIZE(head));                     \
    ++    memset((head)->entries + (head)->capacity, 0,                     \
    ++           ((n) + ARRAY_HEADROOM - (head)->capacity) * ARRAY_ELEM_SIZE(head));\
    ++    (head)->capacity = (n) + ARRAY_HEADROOM;                          \
    ++  }                                                                   \
    ++  (head)->capacity;                                                   \
     +})
      
      /**
```
</details>