### PR TITLE
Rename type-safe versions of malloc(3)-related APIs

### DIFF
--- a/address/address.c
+++ b/address/address.c
@@ -400,7 +400,7 @@ static bool add_addrspec(struct AddressList *al, const char *phrase,
  */
 struct Address *mutt_addr_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct Address);
+  return mutt_mem_calloc_T(1, struct Address);
 }
 
 /**

--- a/address/config_type.c
+++ b/address/config_type.c
@@ -51,7 +51,7 @@
  */
 struct Address *address_new(const char *addr)
 {
-  struct Address *a = MUTT_MEM_CALLOC(1, struct Address);
+  struct Address *a = mutt_mem_calloc_T(1, struct Address);
   a->mailbox = buf_new(addr);
   return a;
 }
@@ -165,7 +165,7 @@ static struct Address *address_dup(struct Address *addr)
   if (!addr)
     return NULL; /* LCOV_EXCL_LINE */
 
-  struct Address *a = MUTT_MEM_CALLOC(1, struct Address);
+  struct Address *a = mutt_mem_calloc_T(1, struct Address);
   a->personal = buf_dup(addr->personal);
   a->mailbox = buf_dup(addr->mailbox);
   return a;

--- a/address/group.c
+++ b/address/group.c
@@ -62,7 +62,7 @@ static void group_free(struct Group **ptr)
  */
 static struct Group *group_new(const char *name)
 {
-  struct Group *g = MUTT_MEM_CALLOC(1, struct Group);
+  struct Group *g = mutt_mem_calloc_T(1, struct Group);
 
   g->name = mutt_str_dup(name);
   STAILQ_INIT(&g->rs);
@@ -192,7 +192,7 @@ void grouplist_add_group(struct GroupList *gl, struct Group *g)
     if (np->group == g)
       return;
   }
-  np = MUTT_MEM_CALLOC(1, struct GroupNode);
+  np = mutt_mem_calloc_T(1, struct GroupNode);
   np->group = g;
   STAILQ_INSERT_TAIL(gl, np, entries);
 }

--- a/address/module.c
+++ b/address/module.c
@@ -44,7 +44,7 @@ extern struct ConfigDef AddressVarsIdn[];
  */
 static bool address_init(struct NeoMutt *n)
 {
-  struct AddressModuleData *mod_data = MUTT_MEM_CALLOC(1, struct AddressModuleData);
+  struct AddressModuleData *mod_data = mutt_mem_calloc_T(1, struct AddressModuleData);
   neomutt_set_module_data(n, MODULE_ID_ADDRESS, mod_data);
 
   mod_data->notify = notify_new();

--- a/alias/alias.c
+++ b/alias/alias.c
@@ -661,7 +661,7 @@ bool mutt_addr_is_user(const struct Address *addr)
  */
 struct Alias *alias_new(void)
 {
-  struct Alias *a = MUTT_MEM_CALLOC(1, struct Alias);
+  struct Alias *a = mutt_mem_calloc_T(1, struct Alias);
   TAILQ_INIT(&a->addr);
   STAILQ_INIT(&a->tags);
   return a;

--- a/alias/module.c
+++ b/alias/module.c
@@ -46,7 +46,7 @@ extern const struct Command AliasCommands[];
  */
 static bool alias_init(struct NeoMutt *n)
 {
-  struct AliasModuleData *mod_data = MUTT_MEM_CALLOC(1, struct AliasModuleData);
+  struct AliasModuleData *mod_data = mutt_mem_calloc_T(1, struct AliasModuleData);
   neomutt_set_module_data(n, MODULE_ID_ALIAS, mod_data);
 
   mod_data->notify = notify_new();

--- a/attach/attach.c
+++ b/attach/attach.c
@@ -72,8 +72,8 @@ void mutt_actx_add_attach(struct AttachCtx *actx, struct AttachPtr *attach)
   if (actx->idxlen == actx->idxmax)
   {
     actx->idxmax += grow;
-    MUTT_MEM_REALLOC(&actx->idx, actx->idxmax, struct AttachPtr *);
-    MUTT_MEM_REALLOC(&actx->v2r, actx->idxmax, short);
+    mutt_mem_realloc_T(&actx->idx, actx->idxmax, struct AttachPtr *);
+    mutt_mem_realloc_T(&actx->v2r, actx->idxmax, short);
 
     memset(&actx->idx[actx->idxlen], 0, grow * sizeof(struct AttachPtr *));
     memset(&actx->v2r[actx->idxlen], 0, grow * sizeof(short));
@@ -99,8 +99,8 @@ void mutt_actx_ins_attach(struct AttachCtx *actx, struct AttachPtr *attach, int 
   if (actx->idxlen == actx->idxmax)
   {
     actx->idxmax += 5;
-    MUTT_MEM_REALLOC(&actx->idx, actx->idxmax, struct AttachPtr *);
-    MUTT_MEM_REALLOC(&actx->v2r, actx->idxmax, short);
+    mutt_mem_realloc_T(&actx->idx, actx->idxmax, struct AttachPtr *);
+    mutt_mem_realloc_T(&actx->v2r, actx->idxmax, short);
     for (int i = actx->idxlen; i < actx->idxmax; i++)
       actx->idx[i] = NULL;
   }
@@ -126,7 +126,7 @@ void mutt_actx_add_fp(struct AttachCtx *actx, FILE *fp_new)
   if (actx->fp_len == actx->fp_max)
   {
     actx->fp_max += 5;
-    MUTT_MEM_REALLOC(&actx->fp_idx, actx->fp_max, FILE *);
+    mutt_mem_realloc_T(&actx->fp_idx, actx->fp_max, FILE *);
     for (int i = actx->fp_len; i < actx->fp_max; i++)
       actx->fp_idx[i] = NULL;
   }
@@ -147,7 +147,7 @@ void mutt_actx_add_body(struct AttachCtx *actx, struct Body *b)
   if (actx->body_len == actx->body_max)
   {
     actx->body_max += 5;
-    MUTT_MEM_REALLOC(&actx->body_idx, actx->body_max, struct Body *);
+    mutt_mem_realloc_T(&actx->body_idx, actx->body_max, struct Body *);
     for (int i = actx->body_len; i < actx->body_max; i++)
       actx->body_idx[i] = NULL;
   }

--- a/attach/attach.c
+++ b/attach/attach.c
@@ -39,7 +39,7 @@
  */
 struct AttachPtr *mutt_aptr_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct AttachPtr);
+  return mutt_mem_calloc_T(1, struct AttachPtr);
 }
 
 /**
@@ -188,7 +188,7 @@ void mutt_actx_entries_free(struct AttachCtx *actx)
  */
 struct AttachCtx *mutt_actx_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct AttachCtx);
+  return mutt_mem_calloc_T(1, struct AttachCtx);
 }
 
 /**

--- a/attach/cid.c
+++ b/attach/cid.c
@@ -65,7 +65,7 @@ struct CidMap *cid_map_new(const char *cid, const char *filename)
   if (!cid || !filename)
     return NULL;
 
-  struct CidMap *cid_map = MUTT_MEM_CALLOC(1, struct CidMap);
+  struct CidMap *cid_map = mutt_mem_calloc_T(1, struct CidMap);
 
   cid_map->cid = mutt_str_dup(cid);
   cid_map->fname = mutt_str_dup(filename);

--- a/attach/commands.c
+++ b/attach/commands.c
@@ -332,7 +332,7 @@ static enum CommandResult parse_attach_list(const struct Command *cmd, struct Bu
     }
 
     len = strlen(a->minor);
-    tmpminor = MUTT_MEM_MALLOC(len + 3, char);
+    tmpminor = mutt_mem_malloc_T(len + 3, char);
     memcpy(&tmpminor[1], a->minor, len);
     tmpminor[0] = '^';
     tmpminor[len + 1] = '$';

--- a/attach/commands.c
+++ b/attach/commands.c
@@ -78,7 +78,7 @@ void attachmatch_free(void **ptr)
  */
 struct AttachMatch *attachmatch_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct AttachMatch);
+  return mutt_mem_calloc_T(1, struct AttachMatch);
 }
 
 /**

--- a/attach/module.c
+++ b/attach/module.c
@@ -45,7 +45,7 @@ extern const struct Command AttachCommands[];
  */
 static bool attach_init(struct NeoMutt *n)
 {
-  struct AttachModuleData *mod_data = MUTT_MEM_CALLOC(1, struct AttachModuleData);
+  struct AttachModuleData *mod_data = mutt_mem_calloc_T(1, struct AttachModuleData);
   neomutt_set_module_data(n, MODULE_ID_ATTACH, mod_data);
 
   mod_data->notify = notify_new();

--- a/attach/private_data.c
+++ b/attach/private_data.c
@@ -49,5 +49,5 @@ void attach_private_data_free(struct Menu *menu, void **ptr)
  */
 struct AttachPrivateData *attach_private_data_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct AttachPrivateData);
+  return mutt_mem_calloc_T(1, struct AttachPrivateData);
 }

--- a/autocrypt/autocrypt_data.c
+++ b/autocrypt/autocrypt_data.c
@@ -39,7 +39,7 @@
  */
 struct AutocryptData *autocrypt_data_new(void)
 {
-  struct AutocryptData *ad = MUTT_MEM_CALLOC(1, struct AutocryptData);
+  struct AutocryptData *ad = mutt_mem_calloc_T(1, struct AutocryptData);
 
   ARRAY_INIT(&ad->entries);
 

--- a/autocrypt/db.c
+++ b/autocrypt/db.c
@@ -230,7 +230,7 @@ static char *strdup_column_text(sqlite3_stmt *stmt, int index)
  */
 struct AutocryptAccount *mutt_autocrypt_db_account_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct AutocryptAccount);
+  return mutt_mem_calloc_T(1, struct AutocryptAccount);
 }
 
 /**
@@ -536,7 +536,7 @@ cleanup:
  */
 struct AutocryptPeer *mutt_autocrypt_db_peer_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct AutocryptPeer);
+  return mutt_mem_calloc_T(1, struct AutocryptPeer);
 }
 
 /**
@@ -770,7 +770,7 @@ cleanup:
  */
 struct AutocryptPeerHistory *mutt_autocrypt_db_peer_history_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct AutocryptPeerHistory);
+  return mutt_mem_calloc_T(1, struct AutocryptPeerHistory);
 }
 
 /**
@@ -853,7 +853,7 @@ cleanup:
  */
 struct AutocryptGossipHistory *mutt_autocrypt_db_gossip_history_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct AutocryptGossipHistory);
+  return mutt_mem_calloc_T(1, struct AutocryptGossipHistory);
 }
 
 /**

--- a/autocrypt/dlg_autocrypt.c
+++ b/autocrypt/dlg_autocrypt.c
@@ -160,7 +160,7 @@ bool populate_menu(struct Menu *menu)
   struct AutocryptAccount **pac = NULL;
   ARRAY_FOREACH(pac, &accounts)
   {
-    struct AccountEntry *entry = MUTT_MEM_CALLOC(1, struct AccountEntry);
+    struct AccountEntry *entry = mutt_mem_calloc_T(1, struct AccountEntry);
 
     entry->num = ARRAY_FOREACH_IDX_pac + 1;
     /* note: we are transferring the account pointer to the entries

--- a/autocrypt/module.c
+++ b/autocrypt/module.c
@@ -44,7 +44,7 @@ extern struct ConfigDef AutocryptVars[];
  */
 static bool autocrypt_init(struct NeoMutt *n)
 {
-  struct AutocryptModuleData *mod_data = MUTT_MEM_CALLOC(1, struct AutocryptModuleData);
+  struct AutocryptModuleData *mod_data = mutt_mem_calloc_T(1, struct AutocryptModuleData);
   neomutt_set_module_data(n, MODULE_ID_AUTOCRYPT, mod_data);
 
   mod_data->notify = notify_new();

--- a/bcache/bcache.c
+++ b/bcache/bcache.c
@@ -164,7 +164,7 @@ struct BodyCache *mutt_bcache_open(struct ConnAccount *account, const char *mail
   if (!account)
     return NULL;
 
-  struct BodyCache *bcache = MUTT_MEM_CALLOC(1, struct BodyCache);
+  struct BodyCache *bcache = mutt_mem_calloc_T(1, struct BodyCache);
   if (bcache_path(account, mailbox, bcache) < 0)
   {
     mutt_bcache_close(&bcache);

--- a/bcache/module.c
+++ b/bcache/module.c
@@ -38,7 +38,7 @@
  */
 static bool bcache_init(struct NeoMutt *n)
 {
-  struct BcacheModuleData *mod_data = MUTT_MEM_CALLOC(1, struct BcacheModuleData);
+  struct BcacheModuleData *mod_data = mutt_mem_calloc_T(1, struct BcacheModuleData);
   neomutt_set_module_data(n, MODULE_ID_BCACHE, mod_data);
 
   mod_data->notify = notify_new();

--- a/browser/complete.c
+++ b/browser/complete.c
@@ -94,7 +94,7 @@ enum FunctionRetval complete_file_mbox(struct EnterWindowData *wdata, int op)
   if (mutt_complete(wdata->cd, wdata->buffer) == 0)
   {
     wdata->templen = wdata->state->lastchar;
-    MUTT_MEM_REALLOC(&wdata->tempbuf, wdata->templen, wchar_t);
+    mutt_mem_realloc_T(&wdata->tempbuf, wdata->templen, wchar_t);
     if (wdata->tempbuf)
       wmemcpy(wdata->tempbuf, wdata->state->wbuf, wdata->templen);
   }
@@ -133,7 +133,7 @@ enum FunctionRetval complete_file_simple(struct EnterWindowData *wdata, int op)
   if (mutt_complete(wdata->cd, wdata->buffer) == 0)
   {
     wdata->templen = wdata->state->lastchar - i;
-    MUTT_MEM_REALLOC(&wdata->tempbuf, wdata->templen, wchar_t);
+    mutt_mem_realloc_T(&wdata->tempbuf, wdata->templen, wchar_t);
     if (wdata->tempbuf)
       wmemcpy(wdata->tempbuf, wdata->state->wbuf + i, wdata->templen);
   }

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -905,7 +905,7 @@ static int op_quit(struct BrowserPrivateData *priv, const struct KeyEvent *event
     if (priv->menu->tag_prefix && (priv->menu->num_tagged != 0))
     {
       *priv->numfiles = priv->menu->num_tagged;
-      tfiles = MUTT_MEM_CALLOC(*priv->numfiles, char *);
+      tfiles = mutt_mem_calloc_T(*priv->numfiles, char *);
       size_t j = 0;
       struct FolderFile *ff = NULL;
       ARRAY_FOREACH(ff, &priv->state.entry)
@@ -924,7 +924,7 @@ static int op_quit(struct BrowserPrivateData *priv, const struct KeyEvent *event
     else if (!buf_is_empty(priv->file)) /* no tagged entries. return selected entry */
     {
       *priv->numfiles = 1;
-      tfiles = MUTT_MEM_CALLOC(*priv->numfiles, char *);
+      tfiles = mutt_mem_calloc_T(*priv->numfiles, char *);
       expand_path(priv->file, false);
       tfiles[0] = buf_strdup(priv->file);
       *priv->files = tfiles;

--- a/browser/module.c
+++ b/browser/module.c
@@ -42,7 +42,7 @@ extern struct ConfigDef BrowserVars[];
  */
 static bool browser_init(struct NeoMutt *n)
 {
-  struct BrowserModuleData *mod_data = MUTT_MEM_CALLOC(1, struct BrowserModuleData);
+  struct BrowserModuleData *mod_data = mutt_mem_calloc_T(1, struct BrowserModuleData);
   neomutt_set_module_data(n, MODULE_ID_BROWSER, mod_data);
 
   mod_data->notify = notify_new();

--- a/browser/private_data.c
+++ b/browser/private_data.c
@@ -54,7 +54,7 @@ void browser_private_data_free(struct BrowserPrivateData **ptr)
  */
 struct BrowserPrivateData *browser_private_data_new(void)
 {
-  struct BrowserPrivateData *priv = MUTT_MEM_CALLOC(1, struct BrowserPrivateData);
+  struct BrowserPrivateData *priv = mutt_mem_calloc_T(1, struct BrowserPrivateData);
 
   priv->old_last_dir = buf_pool_get();
   priv->prefix = buf_pool_get();

--- a/cli/objects.c
+++ b/cli/objects.c
@@ -104,7 +104,7 @@ static void cli_tui_clear(struct CliTui *tui)
  */
 struct CommandLine *command_line_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct CommandLine);
+  return mutt_mem_calloc_T(1, struct CommandLine);
 }
 
 /**

--- a/color/attr.c
+++ b/color/attr.c
@@ -88,7 +88,7 @@ void attr_color_free(struct AttrColor **ptr)
  */
 struct AttrColor *attr_color_new(void)
 {
-  struct AttrColor *ac = MUTT_MEM_CALLOC(1, struct AttrColor);
+  struct AttrColor *ac = mutt_mem_calloc_T(1, struct AttrColor);
 
   ac->fg.color = COLOR_DEFAULT;
   ac->fg.type = CT_SIMPLE;

--- a/color/curses.c
+++ b/color/curses.c
@@ -175,7 +175,7 @@ struct CursesColor *curses_color_new(color_t fg, color_t bg)
     return NULL;
 
   struct ColorModuleData *mod_data = neomutt_get_module_data(NeoMutt, MODULE_ID_COLOR);
-  struct CursesColor *cc_new = MUTT_MEM_CALLOC(1, struct CursesColor);
+  struct CursesColor *cc_new = mutt_mem_calloc_T(1, struct CursesColor);
   mod_data->num_curses_colors++;
   color_debug(LL_DEBUG5, "CursesColor %p\n", (void *) cc_new);
   cc_new->fg = fg;

--- a/color/module.c
+++ b/color/module.c
@@ -43,7 +43,7 @@ extern struct ConfigDef ColorVars[];
  */
 static bool color_init(struct NeoMutt *n)
 {
-  struct ColorModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ColorModuleData);
+  struct ColorModuleData *mod_data = mutt_mem_calloc_T(1, struct ColorModuleData);
   neomutt_set_module_data(n, MODULE_ID_COLOR, mod_data);
 
   mod_data->notify = notify_new();

--- a/color/qstyle.c
+++ b/color/qstyle.c
@@ -75,7 +75,7 @@ void qstyle_free_tree(struct QuoteStyle **quote_list)
  */
 static struct QuoteStyle *qstyle_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct QuoteStyle);
+  return mutt_mem_calloc_T(1, struct QuoteStyle);
 }
 
 /**

--- a/color/regex.c
+++ b/color/regex.c
@@ -143,7 +143,7 @@ void regex_color_free(struct RegexColor **ptr)
  */
 struct RegexColor *regex_color_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct RegexColor);
+  return mutt_mem_calloc_T(1, struct RegexColor);
 }
 
 /**
@@ -152,7 +152,7 @@ struct RegexColor *regex_color_new(void)
  */
 struct RegexColorList *regex_color_list_new(void)
 {
-  struct RegexColorList *rcl = MUTT_MEM_CALLOC(1, struct RegexColorList);
+  struct RegexColorList *rcl = mutt_mem_calloc_T(1, struct RegexColorList);
 
   STAILQ_INIT(rcl);
 

--- a/commands/module.c
+++ b/commands/module.c
@@ -40,7 +40,7 @@ extern const struct Command CommandsCommands[];
  */
 static bool commands_init(struct NeoMutt *n)
 {
-  struct CommandsModuleData *mod_data = MUTT_MEM_CALLOC(1, struct CommandsModuleData);
+  struct CommandsModuleData *mod_data = mutt_mem_calloc_T(1, struct CommandsModuleData);
   STAILQ_INIT(&mod_data->muttrc_stack);
   neomutt_set_module_data(n, MODULE_ID_COMMANDS, mod_data);
 

--- a/complete/data.c
+++ b/complete/data.c
@@ -70,10 +70,10 @@ void completion_data_free(struct CompletionData **ptr)
  */
 struct CompletionData *completion_data_new(void)
 {
-  struct CompletionData *cd = MUTT_MEM_CALLOC(1, struct CompletionData);
+  struct CompletionData *cd = mutt_mem_calloc_T(1, struct CompletionData);
 
   cd->match_list_len = 512;
-  cd->match_list = MUTT_MEM_CALLOC(cd->match_list_len, const char *);
+  cd->match_list = mutt_mem_calloc_T(cd->match_list_len, const char *);
 
   return cd;
 }

--- a/complete/helpers.c
+++ b/complete/helpers.c
@@ -58,7 +58,7 @@ void matches_ensure_morespace(struct CompletionData *cd, int new_size)
 
   new_size = ROUND_UP(new_size + 2, 512);
 
-  MUTT_MEM_REALLOC(&cd->match_list, new_size, const char *);
+  mutt_mem_realloc_T(&cd->match_list, new_size, const char *);
   memset(&cd->match_list[cd->match_list_len], 0,
          (new_size - cd->match_list_len) * sizeof(const char *));
 

--- a/complete/module.c
+++ b/complete/module.c
@@ -38,7 +38,7 @@
  */
 static bool complete_init(struct NeoMutt *n)
 {
-  struct CompleteModuleData *mod_data = MUTT_MEM_CALLOC(1, struct CompleteModuleData);
+  struct CompleteModuleData *mod_data = mutt_mem_calloc_T(1, struct CompleteModuleData);
   neomutt_set_module_data(n, MODULE_ID_COMPLETE, mod_data);
 
   mod_data->notify = notify_new();

--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -233,7 +233,7 @@ static struct CompressInfo *set_compress_info(struct Mailbox *m)
   struct Hook *close_hook = mutt_find_hook(CMD_CLOSE_HOOK, mailbox_path(m));
   struct Hook *append_hook = mutt_find_hook(CMD_APPEND_HOOK, mailbox_path(m));
 
-  struct CompressInfo *ci = MUTT_MEM_CALLOC(1, struct CompressInfo);
+  struct CompressInfo *ci = mutt_mem_calloc_T(1, struct CompressInfo);
   m->compress_info = ci;
 
   ci->cmd_open = open_hook->expando;

--- a/compmbox/module.c
+++ b/compmbox/module.c
@@ -40,7 +40,7 @@ extern const struct Command CompCommands[];
  */
 static bool compmbox_init(struct NeoMutt *n)
 {
-  struct CompmboxModuleData *mod_data = MUTT_MEM_CALLOC(1, struct CompmboxModuleData);
+  struct CompmboxModuleData *mod_data = mutt_mem_calloc_T(1, struct CompmboxModuleData);
   neomutt_set_module_data(n, MODULE_ID_COMPMBOX, mod_data);
 
   mod_data->notify = notify_new();

--- a/compose/attach_data.c
+++ b/compose/attach_data.c
@@ -53,7 +53,7 @@ void attach_data_free(struct Menu *menu, void **ptr)
  */
 struct ComposeAttachData *attach_data_new(struct Email *e)
 {
-  struct ComposeAttachData *attach_data = MUTT_MEM_CALLOC(1, struct ComposeAttachData);
+  struct ComposeAttachData *attach_data = mutt_mem_calloc_T(1, struct ComposeAttachData);
 
   attach_data->actx = mutt_actx_new();
   attach_data->actx->email = e;

--- a/compose/cbar_data.c
+++ b/compose/cbar_data.c
@@ -51,5 +51,5 @@ void cbar_data_free(struct MuttWindow *win, void **ptr)
  */
 struct ComposeBarData *cbar_data_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct ComposeBarData);
+  return mutt_mem_calloc_T(1, struct ComposeBarData);
 }

--- a/compose/module.c
+++ b/compose/module.c
@@ -41,7 +41,7 @@ extern struct ConfigDef ComposeVars[];
  */
 static bool compose_init(struct NeoMutt *n)
 {
-  struct ComposeModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ComposeModuleData);
+  struct ComposeModuleData *mod_data = mutt_mem_calloc_T(1, struct ComposeModuleData);
   neomutt_set_module_data(n, MODULE_ID_COMPOSE, mod_data);
 
   mod_data->notify = notify_new();

--- a/compose/shared_data.c
+++ b/compose/shared_data.c
@@ -47,5 +47,5 @@ void compose_shared_data_free(struct MuttWindow *win, void **ptr)
  */
 struct ComposeSharedData *compose_shared_data_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct ComposeSharedData);
+  return mutt_mem_calloc_T(1, struct ComposeSharedData);
 }

--- a/compress/lz4.c
+++ b/compress/lz4.c
@@ -70,7 +70,7 @@ void lz4_cdata_free(struct Lz4ComprData **ptr)
  */
 static struct Lz4ComprData *lz4_cdata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct Lz4ComprData);
+  return mutt_mem_calloc_T(1, struct Lz4ComprData);
 }
 
 /**

--- a/compress/module.c
+++ b/compress/module.c
@@ -38,7 +38,7 @@
  */
 static bool compress_init(struct NeoMutt *n)
 {
-  struct CompressModuleData *mod_data = MUTT_MEM_CALLOC(1, struct CompressModuleData);
+  struct CompressModuleData *mod_data = mutt_mem_calloc_T(1, struct CompressModuleData);
   neomutt_set_module_data(n, MODULE_ID_COMPRESS, mod_data);
 
   mod_data->notify = notify_new();

--- a/compress/zlib.c
+++ b/compress/zlib.c
@@ -71,7 +71,7 @@ void zlib_cdata_free(struct ZlibComprData **ptr)
  */
 static struct ZlibComprData *zlib_cdata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct ZlibComprData);
+  return mutt_mem_calloc_T(1, struct ZlibComprData);
 }
 
 /**

--- a/compress/zstd.c
+++ b/compress/zstd.c
@@ -72,7 +72,7 @@ void zstd_cdata_free(struct ZstdComprData **ptr)
  */
 static struct ZstdComprData *zstd_cdata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct ZstdComprData);
+  return mutt_mem_calloc_T(1, struct ZstdComprData);
 }
 
 /**

--- a/config/mbtable.c
+++ b/config/mbtable.c
@@ -75,13 +75,13 @@ struct MbTable *mbtable_parse(const char *s)
   if (!slen)
     return NULL;
 
-  t = MUTT_MEM_CALLOC(1, struct MbTable);
+  t = mutt_mem_calloc_T(1, struct MbTable);
 
   t->orig_str = mutt_str_dup(s);
   /* This could be more space efficient.  However, being used on tiny
    * strings (`$to_chars` and `$status_chars`), the overhead is not great. */
-  t->chars = MUTT_MEM_CALLOC(slen, char *);
-  t->segmented_str = MUTT_MEM_CALLOC(slen * 2, char);
+  t->chars = mutt_mem_calloc_T(slen, char *);
+  t->segmented_str = mutt_mem_calloc_T(slen * 2, char);
   d = t->segmented_str;
 
   while (slen && (k = mbrtowc(NULL, s, slen, &mbstate)))
@@ -205,7 +205,7 @@ static struct MbTable *mbtable_dup(struct MbTable *table)
   if (!table)
     return NULL; /* LCOV_EXCL_LINE */
 
-  struct MbTable *m = MUTT_MEM_CALLOC(1, struct MbTable);
+  struct MbTable *m = mutt_mem_calloc_T(1, struct MbTable);
   m->orig_str = mutt_str_dup(table->orig_str);
   return m;
 }

--- a/config/module.c
+++ b/config/module.c
@@ -52,7 +52,7 @@ extern const struct ConfigSetType CstString;
  */
 static bool config_init(struct NeoMutt *n)
 {
-  struct ConfigModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ConfigModuleData);
+  struct ConfigModuleData *mod_data = mutt_mem_calloc_T(1, struct ConfigModuleData);
   neomutt_set_module_data(n, MODULE_ID_CONFIG, mod_data);
 
   mod_data->notify = notify_new();

--- a/config/regex.c
+++ b/config/regex.c
@@ -105,9 +105,9 @@ struct Regex *regex_new(const char *str, uint32_t flags, struct Buffer *err)
     return NULL;
 
   int rflags = 0;
-  struct Regex *reg = MUTT_MEM_CALLOC(1, struct Regex);
+  struct Regex *reg = mutt_mem_calloc_T(1, struct Regex);
 
-  reg->regex = MUTT_MEM_CALLOC(1, regex_t);
+  reg->regex = mutt_mem_calloc_T(1, regex_t);
   reg->pattern = mutt_str_dup(str);
 
   /* Should we use smart case matching? */

--- a/config/set.c
+++ b/config/set.c
@@ -127,7 +127,7 @@ static struct HashElem *create_synonym(const struct ConfigSet *cs,
  */
 struct ConfigSet *cs_new(size_t size)
 {
-  struct ConfigSet *cs = MUTT_MEM_CALLOC(1, struct ConfigSet);
+  struct ConfigSet *cs = mutt_mem_calloc_T(1, struct ConfigSet);
 
   cs->hash = mutt_hash_new(size, MUTT_HASH_NONE);
   mutt_hash_set_destructor(cs->hash, cs_hashelem_free, (intptr_t) cs);
@@ -327,7 +327,7 @@ bool cs_register_variables(const struct ConfigSet *cs, struct ConfigDef vars[])
 struct HashElem *cs_create_variable(const struct ConfigSet *cs,
                                     struct ConfigDef *cdef, struct Buffer *err)
 {
-  struct ConfigDef *cdef_copy = MUTT_MEM_CALLOC(1, struct ConfigDef);
+  struct ConfigDef *cdef_copy = mutt_mem_calloc_T(1, struct ConfigDef);
   cdef_copy->name = mutt_str_dup(cdef->name);
   cdef_copy->type = cdef->type | D_INTERNAL_FREE_CONFIGDEF;
   cdef_copy->initial = cdef->initial;
@@ -363,7 +363,7 @@ struct HashElem *cs_inherit_variable(const struct ConfigSet *cs,
   if (CONFIG_TYPE(he_parent->type) == DT_MYVAR)
     return NULL;
 
-  struct Inheritance *i = MUTT_MEM_CALLOC(1, struct Inheritance);
+  struct Inheritance *i = mutt_mem_calloc_T(1, struct Inheritance);
   i->parent = he_parent;
   i->name = mutt_str_dup(name);
 

--- a/config/subset.c
+++ b/config/subset.c
@@ -158,7 +158,7 @@ void cs_subset_free(struct ConfigSubset **ptr)
 struct ConfigSubset *cs_subset_new(const char *name, struct ConfigSubset *sub_parent,
                                    struct Notify *not_parent)
 {
-  struct ConfigSubset *sub = MUTT_MEM_CALLOC(1, struct ConfigSubset);
+  struct ConfigSubset *sub = mutt_mem_calloc_T(1, struct ConfigSubset);
 
   if (sub_parent)
   {

--- a/conn/connaccount.c
+++ b/conn/connaccount.c
@@ -267,7 +267,7 @@ char *mutt_account_getoauthbearer(struct ConnAccount *cac, bool xoauth2)
   size_t encoded_len = oalen * 4 / 3 + 10;
   ASSERT(encoded_len < 6010); // Assure LGTM that we won't overflow
 
-  char *encoded_token = MUTT_MEM_MALLOC(encoded_len, char);
+  char *encoded_token = mutt_mem_malloc_T(encoded_len, char);
   mutt_b64_encode(oauthbearer, oalen, encoded_token, encoded_len);
 
   return encoded_token;

--- a/conn/gnutls.c
+++ b/conn/gnutls.c
@@ -245,7 +245,7 @@ static bool tls_compare_certificates(const gnutls_datum_t *peercert)
     return false;
 
   b64_data.size = st.st_size;
-  b64_data_data = MUTT_MEM_CALLOC(b64_data.size + 1, unsigned char);
+  b64_data_data = mutt_mem_calloc_T(b64_data.size + 1, unsigned char);
   b64_data.data = b64_data_data;
 
   FILE *fp = mutt_file_fopen(c_certificate_file, "r");
@@ -740,7 +740,7 @@ static void tls_get_client_cert(struct Connection *conn)
                                      0, NULL, &cnlen);
   if (((rc >= 0) || (rc == GNUTLS_E_SHORT_MEMORY_BUFFER)) && (cnlen > 0))
   {
-    cn = MUTT_MEM_CALLOC(cnlen, char);
+    cn = mutt_mem_calloc_T(cnlen, char);
     if (gnutls_x509_crt_get_dn_by_oid(clientcrt, GNUTLS_OID_X520_COMMON_NAME, 0,
                                       0, cn, &cnlen) < 0)
     {
@@ -883,7 +883,7 @@ static bool tls_socket_poll_with_timeout(struct Connection *conn)
  */
 static int tls_negotiate(struct Connection *conn)
 {
-  struct TlsSockData *data = MUTT_MEM_CALLOC(1, struct TlsSockData);
+  struct TlsSockData *data = mutt_mem_calloc_T(1, struct TlsSockData);
   conn->sockdata = data;
   int err = gnutls_certificate_allocate_credentials(&data->xcred);
   if (err < 0)

--- a/conn/module.c
+++ b/conn/module.c
@@ -52,7 +52,7 @@ extern struct ConfigDef ConnVarsSsl[];
  */
 static bool conn_init(struct NeoMutt *n)
 {
-  struct ConnModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ConnModuleData);
+  struct ConnModuleData *mod_data = mutt_mem_calloc_T(1, struct ConnModuleData);
   neomutt_set_module_data(n, MODULE_ID_CONN, mod_data);
 
 #ifdef USE_SSL_OPENSSL

--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -318,7 +318,7 @@ static void ssl_dprint_err_stack(void)
   long buflen = BIO_get_mem_data(bio, &buf);
   if (buflen > 0)
   {
-    char *output = MUTT_MEM_MALLOC(buflen + 1, char);
+    char *output = mutt_mem_malloc_T(buflen + 1, char);
     memcpy(output, buf, buflen);
     output[buflen] = '\0';
     mutt_debug(LL_DEBUG1, "SSL error stack: %s\n", output);
@@ -787,7 +787,7 @@ static int check_host(X509 *x509cert, const char *hostname, char *err, size_t er
       goto out;
     }
     bufsize++; /* space for the terminal nul char */
-    buf = MUTT_MEM_MALLOC(bufsize, char);
+    buf = mutt_mem_malloc_T(bufsize, char);
     if (X509_NAME_get_text_by_NID(x509_subject, NID_commonName, buf, bufsize) == -1)
     {
       if (err && errlen)

--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -1223,7 +1223,7 @@ static int ssl_setup(struct Connection *conn)
 {
   int maxbits = 0;
 
-  conn->sockdata = MUTT_MEM_CALLOC(1, struct SslSockData);
+  conn->sockdata = mutt_mem_calloc_T(1, struct SslSockData);
 
   sockdata(conn)->sctx = SSL_CTX_new(SSLv23_client_method());
   if (!sockdata(conn)->sctx)

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -745,7 +745,7 @@ int mutt_sasl_interact(sasl_interact_t *interaction)
  */
 void mutt_sasl_setup_conn(struct Connection *conn, sasl_conn_t *saslconn)
 {
-  struct SaslSockData *sasldata = MUTT_MEM_MALLOC(1, struct SaslSockData);
+  struct SaslSockData *sasldata = mutt_mem_malloc_T(1, struct SaslSockData);
   /* work around sasl_getprop aliasing issues */
   const void *tmp = NULL;
 

--- a/conn/socket.c
+++ b/conn/socket.c
@@ -271,7 +271,7 @@ int mutt_socket_readln_d(char *buf, size_t buflen, struct Connection *conn, int 
  */
 struct Connection *mutt_socket_new(enum ConnectionType type)
 {
-  struct Connection *conn = MUTT_MEM_CALLOC(1, struct Connection);
+  struct Connection *conn = mutt_mem_calloc_T(1, struct Connection);
   conn->fd = -1;
 
   if (type == MUTT_CONNECTION_TUNNEL)

--- a/conn/tunnel.c
+++ b/conn/tunnel.c
@@ -60,7 +60,7 @@ static int tunnel_socket_open(struct Connection *conn)
   int pin[2] = { 0 };
   int pout[2] = { 0 };
 
-  struct TunnelSockData *tunnel = MUTT_MEM_MALLOC(1, struct TunnelSockData);
+  struct TunnelSockData *tunnel = mutt_mem_malloc_T(1, struct TunnelSockData);
   conn->sockdata = tunnel;
 
   const char *const c_tunnel = cs_subset_string(NeoMutt->sub, "tunnel");

--- a/conn/zstrm.c
+++ b/conn/zstrm.c
@@ -323,10 +323,10 @@ void mutt_zstrm_wrap_conn(struct Connection *conn)
 
   /* allocate/setup (de)compression buffers */
   zctx->read.len = 8192;
-  zctx->read.buf = MUTT_MEM_MALLOC(zctx->read.len, char);
+  zctx->read.buf = mutt_mem_malloc_T(zctx->read.len, char);
   zctx->read.pos = 0;
   zctx->write.len = 8192;
-  zctx->write.buf = MUTT_MEM_MALLOC(zctx->write.len, char);
+  zctx->write.buf = mutt_mem_malloc_T(zctx->write.len, char);
   zctx->write.pos = 0;
 
   /* initialise zlib for inflate and deflate for RFC4978 */

--- a/conn/zstrm.c
+++ b/conn/zstrm.c
@@ -302,7 +302,7 @@ static int zstrm_write(struct Connection *conn, const char *buf, size_t count)
  */
 void mutt_zstrm_wrap_conn(struct Connection *conn)
 {
-  struct ZstrmContext *zctx = MUTT_MEM_CALLOC(1, struct ZstrmContext);
+  struct ZstrmContext *zctx = mutt_mem_calloc_T(1, struct ZstrmContext);
 
   /* store wrapped stream as next stream */
   zctx->next_conn.fd = conn->fd;

--- a/convert/content_info.c
+++ b/convert/content_info.c
@@ -233,7 +233,7 @@ struct Content *mutt_get_content_info(const char *fname, struct Body *b,
     return NULL;
   }
 
-  info = MUTT_MEM_CALLOC(1, struct Content);
+  info = mutt_mem_calloc_T(1, struct Content);
 
   const char *const c_charset = cc_charset();
   if (b && (b->type == TYPE_TEXT) && (!b->noconv && !b->force_charset))

--- a/convert/convert.c
+++ b/convert/convert.c
@@ -74,10 +74,10 @@ size_t mutt_convert_file_to(FILE *fp, const char *fromcode, struct Slist const *
     return -1;
 
   int ncodes = tocodes->count;
-  iconv_t *cd = MUTT_MEM_CALLOC(ncodes, iconv_t);
-  size_t *score = MUTT_MEM_CALLOC(ncodes, size_t);
-  struct ContentState *states = MUTT_MEM_CALLOC(ncodes, struct ContentState);
-  struct Content *infos = MUTT_MEM_CALLOC(ncodes, struct Content);
+  iconv_t *cd = mutt_mem_calloc_T(ncodes, iconv_t);
+  size_t *score = mutt_mem_calloc_T(ncodes, size_t);
+  struct ContentState *states = mutt_mem_calloc_T(ncodes, struct ContentState);
+  struct Content *infos = mutt_mem_calloc_T(ncodes, struct Content);
 
   struct ListNode *np = NULL;
   int ni = 0;
@@ -223,7 +223,7 @@ size_t mutt_convert_file_from_to(FILE *fp, const struct Slist *fromcodes,
   struct ListNode *np = NULL;
 
   /* Copy them */
-  tcode = MUTT_MEM_CALLOC(tocodes->count, char *);
+  tcode = mutt_mem_calloc_T(tocodes->count, char *);
   np = NULL;
   STAILQ_FOREACH(np, &tocodes->head, entries)
   {

--- a/convert/module.c
+++ b/convert/module.c
@@ -38,7 +38,7 @@
  */
 static bool convert_init(struct NeoMutt *n)
 {
-  struct ConvertModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ConvertModuleData);
+  struct ConvertModuleData *mod_data = mutt_mem_calloc_T(1, struct ConvertModuleData);
   neomutt_set_module_data(n, MODULE_ID_CONVERT, mod_data);
 
   mod_data->notify = notify_new();

--- a/core/account.c
+++ b/core/account.c
@@ -46,7 +46,7 @@ struct Account *account_new(const char *name, struct ConfigSubset *sub)
   if (!sub)
     return NULL;
 
-  struct Account *a = MUTT_MEM_CALLOC(1, struct Account);
+  struct Account *a = mutt_mem_calloc_T(1, struct Account);
 
   ARRAY_INIT(&a->mailboxes);
   a->notify = notify_new();

--- a/core/mailbox.c
+++ b/core/mailbox.c
@@ -68,14 +68,14 @@ int mailbox_gen(void)
  */
 struct Mailbox *mailbox_new(void)
 {
-  struct Mailbox *m = MUTT_MEM_CALLOC(1, struct Mailbox);
+  struct Mailbox *m = mutt_mem_calloc_T(1, struct Mailbox);
 
   buf_init(&m->pathbuf);
   m->notify = notify_new();
 
   m->email_max = 25;
-  m->emails = MUTT_MEM_CALLOC(m->email_max, struct Email *);
-  m->v2r = MUTT_MEM_CALLOC(m->email_max, int);
+  m->emails = mutt_mem_calloc_T(m->email_max, struct Email *);
+  m->v2r = mutt_mem_calloc_T(m->email_max, int);
   m->gen = mailbox_gen();
   m->notify_user = true;
   m->poll_new_mail = true;

--- a/core/message.c
+++ b/core/message.c
@@ -52,5 +52,5 @@ void message_free(struct Message **ptr)
  */
 struct Message *message_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct Message);
+  return mutt_mem_calloc_T(1, struct Message);
 }

--- a/core/module.c
+++ b/core/module.c
@@ -39,7 +39,7 @@
  */
 static bool core_init(struct NeoMutt *n)
 {
-  struct CoreModuleData *mod_data = MUTT_MEM_CALLOC(1, struct CoreModuleData);
+  struct CoreModuleData *mod_data = mutt_mem_calloc_T(1, struct CoreModuleData);
   neomutt_set_module_data(n, MODULE_ID_CORE, mod_data);
 
   mod_data->notify = notify_new();

--- a/core/neomutt.c
+++ b/core/neomutt.c
@@ -337,7 +337,7 @@ static bool init_gui_modules(struct NeoMutt *n)
  */
 struct NeoMutt *neomutt_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct NeoMutt);
+  return mutt_mem_calloc_T(1, struct NeoMutt);
 }
 
 /**

--- a/editor/functions.c
+++ b/editor/functions.c
@@ -168,7 +168,7 @@ void replace_part(struct EnterState *es, size_t from, const char *buf)
     if (es->curpos + savelen > es->wbuflen)
     {
       es->wbuflen = es->curpos + savelen;
-      MUTT_MEM_REALLOC(&es->wbuf, es->wbuflen, wchar_t);
+      mutt_mem_realloc_T(&es->wbuf, es->wbuflen, wchar_t);
     }
 
     /* Restore suffix */

--- a/editor/functions.c
+++ b/editor/functions.c
@@ -155,7 +155,7 @@ void replace_part(struct EnterState *es, size_t from, const char *buf)
 
   if (savelen)
   {
-    savebuf = MUTT_MEM_CALLOC(savelen, wchar_t);
+    savebuf = mutt_mem_calloc_T(savelen, wchar_t);
     wmemcpy(savebuf, es->wbuf + es->curpos, savelen);
   }
 

--- a/editor/module.c
+++ b/editor/module.c
@@ -38,7 +38,7 @@
  */
 static bool editor_init(struct NeoMutt *n)
 {
-  struct EditorModuleData *mod_data = MUTT_MEM_CALLOC(1, struct EditorModuleData);
+  struct EditorModuleData *mod_data = mutt_mem_calloc_T(1, struct EditorModuleData);
   neomutt_set_module_data(n, MODULE_ID_EDITOR, mod_data);
 
   mod_data->notify = notify_new();

--- a/editor/state.c
+++ b/editor/state.c
@@ -73,7 +73,7 @@ void enter_state_resize(struct EnterState *es, size_t num)
  */
 struct EnterState *enter_state_new(void)
 {
-  struct EnterState *es = MUTT_MEM_CALLOC(1, struct EnterState);
+  struct EnterState *es = mutt_mem_calloc_T(1, struct EnterState);
 
   enter_state_resize(es, 1);
 

--- a/editor/state.c
+++ b/editor/state.c
@@ -60,7 +60,7 @@ void enter_state_resize(struct EnterState *es, size_t num)
     return;
 
   num = ROUND_UP(num + 4, 128);
-  MUTT_MEM_REALLOC(&es->wbuf, num, wchar_t);
+  mutt_mem_realloc_T(&es->wbuf, num, wchar_t);
 
   wmemset(es->wbuf + es->wbuflen, 0, num - es->wbuflen);
 

--- a/editor/window.c
+++ b/editor/window.c
@@ -136,7 +136,7 @@ bool self_insert(struct EnterWindowData *wdata, int ch)
       {
         char **tfiles = NULL;
         *cdata->numfiles = 1;
-        tfiles = MUTT_MEM_CALLOC(*cdata->numfiles, char *);
+        tfiles = mutt_mem_calloc_T(*cdata->numfiles, char *);
         expand_path(wdata->buffer, false);
         tfiles[0] = buf_strdup(wdata->buffer);
         *cdata->files = tfiles;

--- a/email/body.c
+++ b/email/body.c
@@ -43,7 +43,7 @@
  */
 struct Body *mutt_body_new(void)
 {
-  struct Body *p = MUTT_MEM_CALLOC(1, struct Body);
+  struct Body *p = mutt_mem_calloc_T(1, struct Body);
 
   p->disposition = DISP_ATTACH;
   p->use_disp = true;

--- a/email/copy_email.c
+++ b/email/copy_email.c
@@ -353,7 +353,7 @@ int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end,
       {
         size_t blen = mutt_str_len(buf);
 
-        MUTT_MEM_REALLOC(&this_one, this_one_len + blen + 1, char);
+        mutt_mem_realloc_T(&this_one, this_one_len + blen + 1, char);
         mutt_strn_copy(this_one + this_one_len, buf, blen, blen + 1);
         this_one_len += blen;
       }

--- a/email/email.c
+++ b/email/email.c
@@ -78,7 +78,7 @@ struct Email *email_new(void)
 {
   static size_t sequence = 0;
 
-  struct Email *e = MUTT_MEM_CALLOC(1, struct Email);
+  struct Email *e = mutt_mem_calloc_T(1, struct Email);
   STAILQ_INIT(&e->tags);
   e->visible = true;
   e->sequence = sequence++;

--- a/email/enriched.c
+++ b/email/enriched.c
@@ -259,7 +259,7 @@ static void enriched_flush(struct EnrichedState *enriched, bool wrap)
     if (enriched->line_used > enriched->line_max)
     {
       enriched->line_max = enriched->line_used;
-      MUTT_MEM_REALLOC(&enriched->line, enriched->line_max + 1, wchar_t);
+      mutt_mem_realloc_T(&enriched->line, enriched->line_max + 1, wchar_t);
     }
     wcscat(enriched->line, enriched->buffer);
     enriched->line_len += enriched->word_len;
@@ -288,7 +288,7 @@ static void enriched_putwc(wchar_t c, struct EnrichedState *enriched)
       if ((enriched->param_used + 1) >= enriched->param_len)
       {
         enriched->param_len += 256;
-        MUTT_MEM_REALLOC(&enriched->param, enriched->param_len, wchar_t);
+        mutt_mem_realloc_T(&enriched->param, enriched->param_len, wchar_t);
       }
 
       enriched->param[enriched->param_used++] = c;
@@ -300,7 +300,7 @@ static void enriched_putwc(wchar_t c, struct EnrichedState *enriched)
   if ((enriched->buf_len < (enriched->buf_used + 3)) || !enriched->buffer)
   {
     enriched->buf_len += 1024;
-    MUTT_MEM_REALLOC(&enriched->buffer, enriched->buf_len + 1, wchar_t);
+    mutt_mem_realloc_T(&enriched->buffer, enriched->buf_len + 1, wchar_t);
   }
 
   if ((!enriched->tag_level[RICH_NOFILL] && iswspace(c)) || (c == (wchar_t) '\0'))
@@ -363,7 +363,7 @@ static void enriched_puts(const char *s, struct EnrichedState *enriched)
   if ((enriched->buf_len < (enriched->buf_used + mutt_str_len(s))) || !enriched->buffer)
   {
     enriched->buf_len += 1024;
-    MUTT_MEM_REALLOC(&enriched->buffer, enriched->buf_len + 1, wchar_t);
+    mutt_mem_realloc_T(&enriched->buffer, enriched->buf_len + 1, wchar_t);
   }
   c = s;
   while (*c)

--- a/email/enriched.c
+++ b/email/enriched.c
@@ -496,8 +496,8 @@ int text_enriched_handler(struct Body *b_email, struct State *state)
                              state->wraplen - 4 :
                              72;
   enriched.line_max = enriched.wrap_margin * 4;
-  enriched.line = MUTT_MEM_CALLOC(enriched.line_max + 1, wchar_t);
-  enriched.param = MUTT_MEM_CALLOC(256, wchar_t);
+  enriched.line = mutt_mem_calloc_T(enriched.line_max + 1, wchar_t);
+  enriched.param = mutt_mem_calloc_T(256, wchar_t);
 
   enriched.param_len = 256;
   enriched.param_used = 0;

--- a/email/envelope.c
+++ b/email/envelope.c
@@ -44,7 +44,7 @@
  */
 struct Envelope *mutt_env_new(void)
 {
-  struct Envelope *env = MUTT_MEM_CALLOC(1, struct Envelope);
+  struct Envelope *env = mutt_mem_calloc_T(1, struct Envelope);
   TAILQ_INIT(&env->return_path);
   TAILQ_INIT(&env->from);
   TAILQ_INIT(&env->to);
@@ -93,7 +93,7 @@ void mutt_env_set_subject(struct Envelope *env, const char *subj)
  */
 struct AutocryptHeader *mutt_autocrypthdr_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct AutocryptHeader);
+  return mutt_mem_calloc_T(1, struct AutocryptHeader);
 }
 
 /**

--- a/email/mailcap.c
+++ b/email/mailcap.c
@@ -445,7 +445,7 @@ static bool rfc1524_mailcap_parse(struct Body *b, const char *filename, const ch
  */
 struct MailcapEntry *mailcap_entry_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct MailcapEntry);
+  return mutt_mem_calloc_T(1, struct MailcapEntry);
 }
 
 /**

--- a/email/module.c
+++ b/email/module.c
@@ -45,7 +45,7 @@ extern const struct Command EmailCommands[];
  */
 static bool email_init(struct NeoMutt *n)
 {
-  struct EmailModuleData *mod_data = MUTT_MEM_CALLOC(1, struct EmailModuleData);
+  struct EmailModuleData *mod_data = mutt_mem_calloc_T(1, struct EmailModuleData);
   neomutt_set_module_data(n, MODULE_ID_EMAIL, mod_data);
 
   mod_data->notify = notify_new();

--- a/email/parameter.c
+++ b/email/parameter.c
@@ -39,7 +39,7 @@
  */
 struct Parameter *mutt_param_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct Parameter);
+  return mutt_mem_calloc_T(1, struct Parameter);
 }
 
 /**

--- a/email/rfc2047.c
+++ b/email/rfc2047.c
@@ -408,7 +408,7 @@ static char *decode_word(const char *s, size_t len, enum ContentEncoding enc)
   else if (enc == ENC_BASE64)
   {
     const int olen = 3 * len / 4 + 1;
-    char *out = MUTT_MEM_MALLOC(olen, char);
+    char *out = mutt_mem_malloc_T(olen, char);
     int dlen = mutt_b64_decode(it, out, olen);
     if (dlen == -1)
     {
@@ -562,7 +562,7 @@ static int encode(const char *d, size_t dlen, int col, const char *fromcode,
 
   /* Initialise the output buffer with the us-ascii prefix. */
   buflen = 2 * ulen;
-  buf = MUTT_MEM_MALLOC(buflen, char);
+  buf = mutt_mem_malloc_T(buflen, char);
   bufpos = t0 - u;
   memcpy(buf, u, t0 - u);
 

--- a/email/rfc2047.c
+++ b/email/rfc2047.c
@@ -605,7 +605,7 @@ static int encode(const char *d, size_t dlen, int col, const char *fromcode,
     if ((bufpos + wlen + lb_len) > buflen)
     {
       buflen = bufpos + wlen + lb_len;
-      MUTT_MEM_REALLOC(&buf, buflen, char);
+      mutt_mem_realloc_T(&buf, buflen, char);
     }
     r = encode_block(buf + bufpos, t, n, icode, tocode, encoder);
     ASSERT(r == wlen);
@@ -620,7 +620,7 @@ static int encode(const char *d, size_t dlen, int col, const char *fromcode,
 
   /* Add last encoded word and us-ascii suffix to buffer. */
   buflen = bufpos + wlen + (u + ulen - t1);
-  MUTT_MEM_REALLOC(&buf, buflen + 1, char);
+  mutt_mem_realloc_T(&buf, buflen + 1, char);
   r = encode_block(buf + bufpos, t, t1 - t, icode, tocode, encoder);
   ASSERT(r == wlen);
   bufpos += wlen;

--- a/email/rfc2231.c
+++ b/email/rfc2231.c
@@ -133,7 +133,7 @@ static void decode_one(char *dest, char *src)
  */
 static struct Rfc2231Parameter *parameter_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct Rfc2231Parameter);
+  return mutt_mem_calloc_T(1, struct Rfc2231Parameter);
 }
 
 /**

--- a/email/rfc2231.c
+++ b/email/rfc2231.c
@@ -211,7 +211,7 @@ static void join_continuations(struct ParameterList *pl, struct Rfc2231Parameter
 
       const size_t vl = strlen(par->value);
 
-      MUTT_MEM_REALLOC(&value, l + vl + 1, char);
+      mutt_mem_realloc_T(&value, l + vl + 1, char);
       strcpy(value + l, par->value);
       l += vl;
 

--- a/email/score.c
+++ b/email/score.c
@@ -127,7 +127,7 @@ enum CommandResult parse_score(const struct Command *cmd, struct Buffer *line,
     {
       goto done;
     }
-    ptr = MUTT_MEM_CALLOC(1, struct Score);
+    ptr = mutt_mem_calloc_T(1, struct Score);
     if (last)
       last->next = ptr;
     else

--- a/email/tags.c
+++ b/email/tags.c
@@ -61,7 +61,7 @@ void tag_free(struct Tag **ptr)
  */
 struct Tag *tag_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct Tag);
+  return mutt_mem_calloc_T(1, struct Tag);
 }
 
 /**

--- a/email/url.c
+++ b/email/url.c
@@ -77,7 +77,7 @@ static bool parse_query_string(struct UrlQueryList *list, char *src)
     if ((url_pct_decode(key) < 0) || (url_pct_decode(val) < 0))
       return false;
 
-    struct UrlQuery *qs = MUTT_MEM_CALLOC(1, struct UrlQuery);
+    struct UrlQuery *qs = mutt_mem_calloc_T(1, struct UrlQuery);
     qs->name = key;
     qs->value = val;
     STAILQ_INSERT_TAIL(list, qs, entries);
@@ -112,7 +112,7 @@ static enum UrlScheme get_scheme(const char *src, const regmatch_t *match)
  */
 static struct Url *url_new(void)
 {
-  struct Url *url = MUTT_MEM_CALLOC(1, struct Url);
+  struct Url *url = mutt_mem_calloc_T(1, struct Url);
   STAILQ_INIT(&url->query_strings);
   return url;
 }

--- a/envelope/module.c
+++ b/envelope/module.c
@@ -38,7 +38,7 @@
  */
 static bool envelope_init(struct NeoMutt *n)
 {
-  struct EnvelopeModuleData *mod_data = MUTT_MEM_CALLOC(1, struct EnvelopeModuleData);
+  struct EnvelopeModuleData *mod_data = mutt_mem_calloc_T(1, struct EnvelopeModuleData);
   neomutt_set_module_data(n, MODULE_ID_ENVELOPE, mod_data);
 
   mod_data->notify = notify_new();

--- a/envelope/wdata.c
+++ b/envelope/wdata.c
@@ -50,7 +50,7 @@ void env_wdata_free(struct MuttWindow *win, void **ptr)
  */
 struct EnvelopeWindowData *env_wdata_new(void)
 {
-  struct EnvelopeWindowData *wdata = MUTT_MEM_CALLOC(1, struct EnvelopeWindowData);
+  struct EnvelopeWindowData *wdata = mutt_mem_calloc_T(1, struct EnvelopeWindowData);
 
 #ifdef USE_AUTOCRYPT
   wdata->autocrypt_rec = AUTOCRYPT_REC_OFF;

--- a/expando/expando.c
+++ b/expando/expando.c
@@ -48,7 +48,7 @@ struct ExpandoDefinition;
  */
 struct Expando *expando_new(const char *format)
 {
-  struct Expando *exp = MUTT_MEM_CALLOC(1, struct Expando);
+  struct Expando *exp = mutt_mem_calloc_T(1, struct Expando);
   exp->string = mutt_str_dup(format);
   exp->node = node_container_new();
   return exp;

--- a/expando/module.c
+++ b/expando/module.c
@@ -41,7 +41,7 @@ extern const struct ConfigSetType CstExpando;
  */
 static bool expando_init(struct NeoMutt *n)
 {
-  struct ExpandoModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ExpandoModuleData);
+  struct ExpandoModuleData *mod_data = mutt_mem_calloc_T(1, struct ExpandoModuleData);
   neomutt_set_module_data(n, MODULE_ID_EXPANDO, mod_data);
 
   mod_data->notify = notify_new();

--- a/expando/node.c
+++ b/expando/node.c
@@ -38,7 +38,7 @@
  */
 struct ExpandoNode *node_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct ExpandoNode);
+  return mutt_mem_calloc_T(1, struct ExpandoNode);
 }
 
 /**

--- a/expando/node_conddate.c
+++ b/expando/node_conddate.c
@@ -48,7 +48,7 @@
  */
 struct NodeCondDatePrivate *node_conddate_private_new(int count, char period)
 {
-  struct NodeCondDatePrivate *priv = MUTT_MEM_CALLOC(1, struct NodeCondDatePrivate);
+  struct NodeCondDatePrivate *priv = mutt_mem_calloc_T(1, struct NodeCondDatePrivate);
 
   priv->count = count;
   priv->period = period;

--- a/expando/node_expando.c
+++ b/expando/node_expando.c
@@ -49,7 +49,7 @@
  */
 struct NodeExpandoPrivate *node_expando_private_new(void)
 {
-  struct NodeExpandoPrivate *priv = MUTT_MEM_CALLOC(1, struct NodeExpandoPrivate);
+  struct NodeExpandoPrivate *priv = mutt_mem_calloc_T(1, struct NodeExpandoPrivate);
 
   // NOTE(g0mb4): Expando definition should contain this
   priv->color = -1;
@@ -142,7 +142,7 @@ struct ExpandoFormat *parse_format(const char *str, const char **parsed_until,
 
   const char *start = str;
 
-  struct ExpandoFormat *fmt = MUTT_MEM_CALLOC(1, struct ExpandoFormat);
+  struct ExpandoFormat *fmt = mutt_mem_calloc_T(1, struct ExpandoFormat);
 
   fmt->leader = ' ';
   fmt->justification = JUSTIFY_RIGHT;

--- a/expando/node_padding.c
+++ b/expando/node_padding.c
@@ -46,7 +46,7 @@
  */
 struct NodePaddingPrivate *node_padding_private_new(enum ExpandoPadType pad_type)
 {
-  struct NodePaddingPrivate *priv = MUTT_MEM_CALLOC(1, struct NodePaddingPrivate);
+  struct NodePaddingPrivate *priv = mutt_mem_calloc_T(1, struct NodePaddingPrivate);
 
   priv->pad_type = pad_type;
 

--- a/fuzz/address.c
+++ b/fuzz/address.c
@@ -67,7 +67,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   MuttLogger = log_disp_null;
 
   NeoMutt = neomutt_new();
-  char **tmp_env = MUTT_MEM_CALLOC(2, char *);
+  char **tmp_env = mutt_mem_calloc_T(2, char *);
   neomutt_init(NeoMutt, tmp_env, Modules);
   FREE(&tmp_env);
 

--- a/fuzz/body.c
+++ b/fuzz/body.c
@@ -67,7 +67,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
   MuttLogger = log_disp_null;
 
   NeoMutt = neomutt_new();
-  char **tmp_env = MUTT_MEM_CALLOC(2, char *);
+  char **tmp_env = mutt_mem_calloc_T(2, char *);
   neomutt_init(NeoMutt, tmp_env, Modules);
   FREE(&tmp_env);
 

--- a/fuzz/cli.c
+++ b/fuzz/cli.c
@@ -50,7 +50,7 @@ static bool parse_args(const uint8_t *data, size_t size, int *argc, char ***argv
     return false;
 
   // Create a null-terminated copy of the input
-  char *input = MUTT_MEM_MALLOC(size + 1, char);
+  char *input = mutt_mem_malloc_T(size + 1, char);
   memcpy(input, data, size);
   input[size] = '\0';
 
@@ -75,7 +75,7 @@ static bool parse_args(const uint8_t *data, size_t size, int *argc, char ***argv
   }
 
   // Allocate argv array
-  char **args = MUTT_MEM_MALLOC(count + 1, char *);
+  char **args = mutt_mem_malloc_T(count + 1, char *);
   args[0] = mutt_str_dup("neomutt");
 
   // Fill in arguments

--- a/fuzzy/module.c
+++ b/fuzzy/module.c
@@ -38,7 +38,7 @@
  */
 static bool fuzzy_init(struct NeoMutt *n)
 {
-  struct FuzzyModuleData *mod_data = MUTT_MEM_CALLOC(1, struct FuzzyModuleData);
+  struct FuzzyModuleData *mod_data = mutt_mem_calloc_T(1, struct FuzzyModuleData);
   neomutt_set_module_data(n, MODULE_ID_FUZZY, mod_data);
 
   return true;

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -640,7 +640,7 @@ void mutt_str_expand_tabs(char **str, size_t *len, int tabwidth)
   {
     *len = ROUND_UP(required_len, 256);
   }
-  char *out = MUTT_MEM_CALLOC(*len, char);
+  char *out = mutt_mem_calloc_T(*len, char);
 
   // expand tabs
   for (int i = 0, o = 0; in[i] != '\0'; i++)

--- a/gui/module.c
+++ b/gui/module.c
@@ -76,7 +76,7 @@ static void log_gui(void)
  */
 static bool gui_init(struct NeoMutt *n)
 {
-  struct GuiModuleData *mod_data = MUTT_MEM_CALLOC(1, struct GuiModuleData);
+  struct GuiModuleData *mod_data = mutt_mem_calloc_T(1, struct GuiModuleData);
   neomutt_set_module_data(n, MODULE_ID_GUI, mod_data);
 
   mod_data->notify = notify_new();

--- a/gui/msgwin_wdata.c
+++ b/gui/msgwin_wdata.c
@@ -59,7 +59,7 @@ void msgwin_wdata_free(struct MuttWindow *win, void **ptr)
  */
 struct MsgWinWindowData *msgwin_wdata_new(void)
 {
-  struct MsgWinWindowData *wdata = MUTT_MEM_CALLOC(1, struct MsgWinWindowData);
+  struct MsgWinWindowData *wdata = mutt_mem_calloc_T(1, struct MsgWinWindowData);
 
   wdata->text = buf_new(NULL);
 

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -194,7 +194,7 @@ void window_set_visible(struct MuttWindow *win, bool visible)
 struct MuttWindow *mutt_window_new(enum WindowType type, enum MuttWindowOrientation orient,
                                    enum MuttWindowSize size, int cols, int rows)
 {
-  struct MuttWindow *win = MUTT_MEM_CALLOC(1, struct MuttWindow);
+  struct MuttWindow *win = mutt_mem_calloc_T(1, struct MuttWindow);
 
   win->type = type;
   win->orient = orient;

--- a/gui/mview.c
+++ b/gui/mview.c
@@ -90,7 +90,7 @@ struct MailboxView *mview_new(struct Mailbox *m, struct Notify *parent)
   if (!m)
     return NULL;
 
-  struct MailboxView *mv = MUTT_MEM_CALLOC(1, struct MailboxView);
+  struct MailboxView *mv = mutt_mem_calloc_T(1, struct MailboxView);
 
   mv->notify = notify_new();
   notify_set_parent(mv->notify, parent);

--- a/gui/sbar.c
+++ b/gui/sbar.c
@@ -193,7 +193,7 @@ static void sbar_wdata_free(struct MuttWindow *win, void **ptr)
  */
 static struct SBarPrivateData *sbar_data_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct SBarPrivateData);
+  return mutt_mem_calloc_T(1, struct SBarPrivateData);
 }
 
 /**

--- a/gui/thread.c
+++ b/gui/thread.c
@@ -953,7 +953,7 @@ static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
           if (i >= array_size)
           {
             array_size *= 2;
-            MUTT_MEM_REALLOC(&array, array_size, struct MuttThread *);
+            mutt_mem_realloc_T(&array, array_size, struct MuttThread *);
           }
 
           array[i] = thread;

--- a/gui/thread.c
+++ b/gui/thread.c
@@ -369,7 +369,7 @@ static void calculate_visibility(struct MuttThread *tree, int *max_depth)
  */
 struct ThreadsContext *mutt_thread_ctx_init(struct MailboxView *mv)
 {
-  struct ThreadsContext *tctx = MUTT_MEM_CALLOC(1, struct ThreadsContext);
+  struct ThreadsContext *tctx = mutt_mem_calloc_T(1, struct ThreadsContext);
   tctx->mailbox_view = mv;
   return tctx;
 }
@@ -908,7 +908,7 @@ static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
   top = thread;
 
   array_size = 256;
-  array = MUTT_MEM_CALLOC(array_size, struct MuttThread *);
+  array = mutt_mem_calloc_T(array_size, struct MuttThread *);
   while (true)
   {
     if (init || !thread->sort_thread_key || !thread->sort_aux_key)
@@ -1242,7 +1242,7 @@ void mutt_sort_threads(struct ThreadsContext *tctx, bool init)
       {
         tnew = (c_duplicate_threads ? thread : NULL);
 
-        thread = MUTT_MEM_CALLOC(1, struct MuttThread);
+        thread = mutt_mem_calloc_T(1, struct MuttThread);
         thread->message = e;
         thread->check_subject = true;
         e->thread = thread;
@@ -1334,7 +1334,7 @@ void mutt_sort_threads(struct ThreadsContext *tctx, bool init)
       }
       else
       {
-        tnew = MUTT_MEM_CALLOC(1, struct MuttThread);
+        tnew = mutt_mem_calloc_T(1, struct MuttThread);
         mutt_hash_insert(tctx->hash, ref->data, tnew);
       }
 

--- a/gui/thread.c
+++ b/gui/thread.c
@@ -492,8 +492,8 @@ void mutt_draw_tree(struct ThreadsContext *tctx)
   /* Do the visibility calculations and free the old thread chars.
    * From now on we can simply ignore invisible subtrees */
   calculate_visibility(tree, &max_depth);
-  pfx = MUTT_MEM_MALLOC((width * max_depth) + 2, char);
-  arrow = MUTT_MEM_MALLOC((width * max_depth) + 2, char);
+  pfx = mutt_mem_malloc_T((width * max_depth) + 2, char);
+  arrow = mutt_mem_malloc_T((width * max_depth) + 2, char);
   const bool c_hide_limited = cs_subset_bool(NeoMutt->sub, "hide_limited");
   const bool c_hide_missing = cs_subset_bool(NeoMutt->sub, "hide_missing");
   while (tree)
@@ -518,7 +518,7 @@ void mutt_draw_tree(struct ThreadsContext *tctx)
       {
         myarrow[width] = MUTT_TREE_RARROW;
         myarrow[width + 1] = 0;
-        new_tree = MUTT_MEM_MALLOC(((size_t) depth * width) + 2, char);
+        new_tree = mutt_mem_malloc_T(((size_t) depth * width) + 2, char);
         if (start_depth > 1)
         {
           strncpy(new_tree, pfx, (size_t) width * (start_depth - 1));

--- a/gui/utilwin.c
+++ b/gui/utilwin.c
@@ -217,7 +217,7 @@ struct MuttWindow *utilwin_new(void)
   struct MuttWindow *win = mutt_window_new(WT_CUSTOM, MUTT_WIN_ORIENT_VERTICAL,
                                            MUTT_WIN_SIZE_FIXED, UTILWIN_COLS, 1);
 
-  struct UtilWinData *priv = MUTT_MEM_CALLOC(1, struct UtilWinData);
+  struct UtilWinData *priv = mutt_mem_calloc_T(1, struct UtilWinData);
 
   win->wdata = priv;
   win->wdata_free = utilwin_wdata_free;

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -232,7 +232,7 @@ static void *dump_email(struct HeaderCache *hc, const struct Email *e, int *off,
   bool convert = !CharsetIsUtf8;
 
   *off = 0;
-  unsigned char *d = MUTT_MEM_MALLOC(4096, unsigned char);
+  unsigned char *d = mutt_mem_malloc_T(4096, unsigned char);
 
   d = serial_dump_uint32_t((uidvalidity != 0) ? uidvalidity : mutt_date_now(), d, off);
   d = serial_dump_int(hc->crc, d, off);
@@ -428,7 +428,7 @@ static char *get_foldername(const char *folder)
 {
   /* if the folder is local, canonify the path to ensure equivalent paths share
    * the hcache */
-  char *p = MUTT_MEM_MALLOC(PATH_MAX + 1, char);
+  char *p = mutt_mem_malloc_T(PATH_MAX + 1, char);
   if (!realpath(folder, p))
     mutt_str_replace(&p, folder);
 
@@ -725,7 +725,7 @@ int hcache_store_email(struct HeaderCache *hc, const char *key, size_t keylen,
       return -1;
     }
 
-    char *whole = MUTT_MEM_MALLOC(hlen + clen, char);
+    char *whole = mutt_mem_malloc_T(hlen + clen, char);
     memcpy(whole, data, hlen);
     memcpy(whole + hlen, cdata, clen);
 

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -120,7 +120,7 @@ static void hcache_free(struct HeaderCache **ptr)
  */
 static struct HeaderCache *hcache_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct HeaderCache);
+  return mutt_mem_calloc_T(1, struct HeaderCache);
 }
 
 /**

--- a/hcache/module.c
+++ b/hcache/module.c
@@ -42,7 +42,7 @@ extern struct ConfigDef HcacheVarsComp[];
  */
 static bool hcache_init(struct NeoMutt *n)
 {
-  struct HcacheModuleData *mod_data = MUTT_MEM_CALLOC(1, struct HcacheModuleData);
+  struct HcacheModuleData *mod_data = mutt_mem_calloc_T(1, struct HcacheModuleData);
   neomutt_set_module_data(n, MODULE_ID_HCACHE, mod_data);
 
   mod_data->notify = notify_new();

--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -260,7 +260,7 @@ bool serial_restore_char(char **c, const unsigned char *d, int *off, size_t dlen
   if ((size > SERIAL_MAX_CHAR_SIZE) || !serial_in_bounds(*off, size, dlen))
     return false;
 
-  *c = MUTT_MEM_MALLOC(size, char);
+  *c = mutt_mem_malloc_T(size, char);
   memcpy(*c, d + *off, size);
   if (convert && !mutt_str_is_ascii(*c, size))
   {

--- a/helpbar/module.c
+++ b/helpbar/module.c
@@ -41,7 +41,7 @@ extern struct ConfigDef HelpbarVars[];
  */
 static bool helpbar_init(struct NeoMutt *n)
 {
-  struct HelpbarModuleData *mod_data = MUTT_MEM_CALLOC(1, struct HelpbarModuleData);
+  struct HelpbarModuleData *mod_data = mutt_mem_calloc_T(1, struct HelpbarModuleData);
   neomutt_set_module_data(n, MODULE_ID_HELPBAR, mod_data);
 
   mod_data->notify = notify_new();

--- a/helpbar/wdata.c
+++ b/helpbar/wdata.c
@@ -38,7 +38,7 @@
  */
 struct HelpbarWindowData *helpbar_wdata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct HelpbarWindowData);
+  return mutt_mem_calloc_T(1, struct HelpbarWindowData);
 }
 
 /**

--- a/history/history.c
+++ b/history/history.c
@@ -120,7 +120,7 @@ static void init_history(struct History *h, int old_size)
 
   const short c_history = cs_subset_number(NeoMutt->sub, "history");
   if (c_history != 0)
-    h->hist = MUTT_MEM_CALLOC(c_history + 1, char *);
+    h->hist = mutt_mem_calloc_T(c_history + 1, char *);
 
   h->cur = 0;
   h->last = 0;

--- a/history/module.c
+++ b/history/module.c
@@ -42,7 +42,7 @@ extern struct ConfigDef HistoryVars[];
  */
 static bool history_init(struct NeoMutt *n)
 {
-  struct HistoryModuleData *mod_data = MUTT_MEM_CALLOC(1, struct HistoryModuleData);
+  struct HistoryModuleData *mod_data = mutt_mem_calloc_T(1, struct HistoryModuleData);
   neomutt_set_module_data(n, MODULE_ID_HISTORY, mod_data);
 
   mod_data->notify = notify_new();

--- a/hooks/hook.c
+++ b/hooks/hook.c
@@ -70,5 +70,5 @@ void hook_free(struct Hook **ptr)
  */
 struct Hook *hook_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct Hook);
+  return mutt_mem_calloc_T(1, struct Hook);
 }

--- a/hooks/module.c
+++ b/hooks/module.c
@@ -44,7 +44,7 @@ extern const struct Command HooksCommands[];
  */
 static bool hooks_init(struct NeoMutt *n)
 {
-  struct HooksModuleData *mod_data = MUTT_MEM_CALLOC(1, struct HooksModuleData);
+  struct HooksModuleData *mod_data = mutt_mem_calloc_T(1, struct HooksModuleData);
   TAILQ_INIT(&mod_data->hooks);
   neomutt_set_module_data(n, MODULE_ID_HOOKS, mod_data);
 

--- a/hooks/parse.c
+++ b/hooks/parse.c
@@ -487,7 +487,7 @@ enum CommandResult parse_regex_hook(const struct Command *cmd, struct Buffer *li
   }
 
   /* Hooks not allowing full patterns: Check syntax of regex */
-  rx = MUTT_MEM_CALLOC(1, regex_t);
+  rx = mutt_mem_calloc_T(1, regex_t);
   int rc2 = REG_COMP(rx, buf_string(regex), 0);
   if (rc2 != 0)
   {
@@ -627,7 +627,7 @@ enum CommandResult parse_folder_hook(const struct Command *cmd, struct Buffer *l
   }
 
   /* Hooks not allowing full patterns: Check syntax of regex */
-  rx = MUTT_MEM_CALLOC(1, regex_t);
+  rx = mutt_mem_calloc_T(1, regex_t);
   int rc2 = REG_COMP(rx, buf_string(regex), 0);
   if (rc2 != 0)
   {
@@ -725,7 +725,7 @@ enum CommandResult parse_crypt_hook(const struct Command *cmd, struct Buffer *li
   }
 
   /* Hooks not allowing full patterns: Check syntax of regex */
-  rx = MUTT_MEM_CALLOC(1, regex_t);
+  rx = mutt_mem_calloc_T(1, regex_t);
   int rc2 = REG_COMP(rx, buf_string(regex), REG_ICASE);
   if (rc2 != 0)
   {
@@ -872,7 +872,7 @@ enum CommandResult parse_mbox_hook(const struct Command *cmd, struct Buffer *lin
   }
 
   /* Hooks not allowing full patterns: Check syntax of regex */
-  rx = MUTT_MEM_CALLOC(1, regex_t);
+  rx = mutt_mem_calloc_T(1, regex_t);
   int rc2 = REG_COMP(rx, buf_string(regex), 0);
   if (rc2 != 0)
   {
@@ -991,7 +991,7 @@ enum CommandResult parse_compress_hook(const struct Command *cmd, struct Buffer 
   }
 
   /* Hooks not allowing full patterns: Check syntax of regex */
-  rx = MUTT_MEM_CALLOC(1, regex_t);
+  rx = mutt_mem_calloc_T(1, regex_t);
   int rc2 = REG_COMP(rx, buf_string(regex), 0);
   if (rc2 != 0)
   {
@@ -1178,7 +1178,7 @@ enum CommandResult parse_index_hook(const struct Command *cmd, struct Buffer *li
 
   if (!hl)
   {
-    hl = MUTT_MEM_CALLOC(1, struct HookList);
+    hl = mutt_mem_calloc_T(1, struct HookList);
     TAILQ_INIT(hl);
     mutt_hash_insert(mod_data->idx_fmt_hooks, buf_string(name), hl);
   }

--- a/imap/adata.c
+++ b/imap/adata.c
@@ -135,7 +135,7 @@ void imap_adata_free(void **ptr)
  */
 struct ImapAccountData *imap_adata_new(struct Account *a)
 {
-  struct ImapAccountData *adata = MUTT_MEM_CALLOC(1, struct ImapAccountData);
+  struct ImapAccountData *adata = mutt_mem_calloc_T(1, struct ImapAccountData);
   adata->account = a;
 
   static unsigned char new_seqid = 'a';
@@ -143,7 +143,7 @@ struct ImapAccountData *imap_adata_new(struct Account *a)
   adata->seqid = new_seqid;
   const short c_imap_pipeline_depth = cs_subset_number(NeoMutt->sub, "imap_pipeline_depth");
   adata->cmdslots = c_imap_pipeline_depth + 2;
-  adata->cmds = MUTT_MEM_CALLOC(adata->cmdslots, struct ImapCommand);
+  adata->cmds = mutt_mem_calloc_T(adata->cmdslots, struct ImapCommand);
 
   if (++new_seqid > 'z')
     new_seqid = 'a';

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -125,7 +125,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
   mutt_message(_("Authenticating (%s)..."), mech);
 
   bufsize = MAX((olen * 2), 1024);
-  buf = MUTT_MEM_MALLOC(bufsize, char);
+  buf = mutt_mem_malloc_T(bufsize, char);
 
   snprintf(buf, bufsize, "AUTHENTICATE %s", mech);
   if ((adata->capabilities & IMAP_CAP_SASL_IR) && client_start)

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -168,7 +168,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
         if (len > bufsize)
         {
           bufsize = len;
-          MUTT_MEM_REALLOC(&buf, bufsize, char);
+          mutt_mem_realloc_T(&buf, bufsize, char);
         }
         /* For sasl_decode64, the fourth parameter, outmax, doesn't
          * include space for the trailing null */
@@ -203,7 +203,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
       if ((olen * 2) > bufsize)
       {
         bufsize = olen * 2;
-        MUTT_MEM_REALLOC(&buf, bufsize, char);
+        mutt_mem_realloc_T(&buf, bufsize, char);
       }
       if (sasl_encode64(pc, olen, buf, bufsize, &olen) != SASL_OK)
       {

--- a/imap/command.c
+++ b/imap/command.c
@@ -1250,7 +1250,7 @@ int imap_cmd_step(struct ImapAccountData *adata)
   {
     if (len == adata->blen)
     {
-      MUTT_MEM_REALLOC(&adata->buf, adata->blen + IMAP_CMD_BUFSIZE, char);
+      mutt_mem_realloc_T(&adata->buf, adata->blen + IMAP_CMD_BUFSIZE, char);
       adata->blen = adata->blen + IMAP_CMD_BUFSIZE;
       mutt_debug(LL_DEBUG3, "grew buffer to %zu bytes\n", adata->blen);
     }
@@ -1291,7 +1291,7 @@ int imap_cmd_step(struct ImapAccountData *adata)
   /* don't let one large string make cmd->buf hog memory forever */
   if ((adata->blen > IMAP_CMD_BUFSIZE) && (len <= IMAP_CMD_BUFSIZE))
   {
-    MUTT_MEM_REALLOC(&adata->buf, IMAP_CMD_BUFSIZE, char);
+    mutt_mem_realloc_T(&adata->buf, IMAP_CMD_BUFSIZE, char);
     adata->blen = IMAP_CMD_BUFSIZE;
     mutt_debug(LL_DEBUG3, "shrank buffer to %zu bytes\n", adata->blen);
   }

--- a/imap/edata.c
+++ b/imap/edata.c
@@ -55,7 +55,7 @@ void imap_edata_free(void **ptr)
  */
 struct ImapEmailData *imap_edata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct ImapEmailData);
+  return mutt_mem_calloc_T(1, struct ImapEmailData);
 }
 
 /**

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1807,7 +1807,7 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
 #endif
 
   /* presort here to avoid doing 10 resorts in imap_exec_msg_set */
-  emails = MUTT_MEM_MALLOC(m->msg_count, struct Email *);
+  emails = mutt_mem_malloc_T(m->msg_count, struct Email *);
   memcpy(emails, m->emails, m->msg_count * sizeof(struct Email *));
   mutt_qsort_r(emails, m->msg_count, sizeof(struct Email *), imap_sort_email_uid, NULL);
 

--- a/imap/mdata.c
+++ b/imap/mdata.c
@@ -74,7 +74,7 @@ struct ImapMboxData *imap_mdata_get(struct Mailbox *m)
 struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char *name)
 {
   char buf[1024] = { 0 };
-  struct ImapMboxData *mdata = MUTT_MEM_CALLOC(1, struct ImapMboxData);
+  struct ImapMboxData *mdata = mutt_mem_calloc_T(1, struct ImapMboxData);
 
   imap_fix_path_with_delim(adata->delim, name, buf, sizeof(buf));
   if (buf[0] == '\0')

--- a/imap/module.c
+++ b/imap/module.c
@@ -44,7 +44,7 @@ extern const struct Command ImapCommands[];
  */
 static bool imap_init(struct NeoMutt *n)
 {
-  struct ImapModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ImapModuleData);
+  struct ImapModuleData *mod_data = mutt_mem_calloc_T(1, struct ImapModuleData);
   neomutt_set_module_data(n, MODULE_ID_IMAP, mod_data);
 
   mod_data->notify = notify_new();

--- a/imap/utf7.c
+++ b/imap/utf7.c
@@ -109,7 +109,7 @@ static char *utf7_to_utf8(const char *u7, size_t u7len, char **u8, size_t *u8len
   int ch;
   int k;
 
-  char *buf = MUTT_MEM_MALLOC(u7len + u7len / 8 + 1, char);
+  char *buf = mutt_mem_malloc_T(u7len + u7len / 8 + 1, char);
   char *p = buf;
   int pair1 = 0;
 
@@ -261,7 +261,7 @@ static char *utf8_to_utf7(const char *u8, size_t u8len, char **u7, size_t *u7len
 
   /* In the worst case we convert 2 chars to 7 chars. For example:
    * "\x10&\x10&..." -> "&ABA-&-&ABA-&-...".  */
-  char *buf = MUTT_MEM_MALLOC((u8len / 2) * 7 + 6, char);
+  char *buf = mutt_mem_malloc_T((u8len / 2) * 7 + 6, char);
   char *p = buf;
 
   while (u8len)

--- a/imap/utf7.c
+++ b/imap/utf7.c
@@ -227,7 +227,7 @@ static char *utf7_to_utf8(const char *u7, size_t u7len, char **u8, size_t *u8len
   if (u8len)
     *u8len = p - buf;
 
-  MUTT_MEM_REALLOC(&buf, p - buf, char);
+  mutt_mem_realloc_T(&buf, p - buf, char);
   if (u8)
     *u8 = buf;
   return buf;
@@ -383,7 +383,7 @@ static char *utf8_to_utf7(const char *u8, size_t u8len, char **u7, size_t *u7len
   *p++ = '\0';
   if (u7len)
     *u7len = p - buf;
-  MUTT_MEM_REALLOC(&buf, p - buf, char);
+  mutt_mem_realloc_T(&buf, p - buf, char);
   if (u7)
     *u7 = buf;
   return buf;

--- a/imap/util.c
+++ b/imap/util.c
@@ -1142,7 +1142,7 @@ struct SeqsetIterator *mutt_seqset_iterator_new(const char *seqset)
   if (!seqset || (*seqset == '\0'))
     return NULL;
 
-  struct SeqsetIterator *iter = MUTT_MEM_CALLOC(1, struct SeqsetIterator);
+  struct SeqsetIterator *iter = mutt_mem_calloc_T(1, struct SeqsetIterator);
   iter->full_seqset = mutt_str_dup(seqset);
   iter->eostr = strchr(iter->full_seqset, '\0');
   iter->substr_cur = iter->substr_end = iter->full_seqset;

--- a/imap/util.c
+++ b/imap/util.c
@@ -568,8 +568,8 @@ int imap_mxcmp(const char *mx1, const char *mx2)
     return 0;
   }
 
-  b1 = MUTT_MEM_MALLOC(strlen(mx1) + 1, char);
-  b2 = MUTT_MEM_MALLOC(strlen(mx2) + 1, char);
+  b1 = mutt_mem_malloc_T(strlen(mx1) + 1, char);
+  b2 = mutt_mem_malloc_T(strlen(mx2) + 1, char);
 
   imap_fix_path(mx1, b1, strlen(mx1) + 1);
   imap_fix_path(mx2, b2, strlen(mx2) + 1);

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -439,7 +439,7 @@ static void update_index_threaded(struct MailboxView *mv, enum MxStatus check, i
   if ((check != MX_STATUS_REOPENED) && (oldcount > 0) &&
       (lmt || c_uncollapse_new) && (num_new > 0))
   {
-    save_new = MUTT_MEM_MALLOC(num_new, struct Email *);
+    save_new = mutt_mem_malloc_T(num_new, struct Email *);
     for (int i = oldcount; i < m->msg_count; i++)
       save_new[i - oldcount] = m->emails[i];
   }

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -1026,7 +1026,7 @@ void mutt_draw_statusline(struct MuttWindow *win, int max_cols, const char *buf,
       if (!found)
       {
         chunks++;
-        MUTT_MEM_REALLOC(&syntax, chunks, struct StatusSyntax);
+        mutt_mem_realloc_T(&syntax, chunks, struct StatusSyntax);
       }
 
       i = chunks - 1;

--- a/index/ibar.c
+++ b/index/ibar.c
@@ -324,7 +324,7 @@ static void ibar_data_free(struct MuttWindow *win, void **ptr)
 static struct IBarPrivateData *ibar_data_new(struct IndexSharedData *shared,
                                              struct IndexPrivateData *priv)
 {
-  struct IBarPrivateData *ibar_data = MUTT_MEM_CALLOC(1, struct IBarPrivateData);
+  struct IBarPrivateData *ibar_data = mutt_mem_calloc_T(1, struct IBarPrivateData);
 
   ibar_data->shared = shared;
   ibar_data->priv = priv;

--- a/index/module.c
+++ b/index/module.c
@@ -44,7 +44,7 @@ extern const struct Command IndexCommands[];
  */
 static bool index_init(struct NeoMutt *n)
 {
-  struct IndexModuleData *mod_data = MUTT_MEM_CALLOC(1, struct IndexModuleData);
+  struct IndexModuleData *mod_data = mutt_mem_calloc_T(1, struct IndexModuleData);
   neomutt_set_module_data(n, MODULE_ID_INDEX, mod_data);
 
   mod_data->notify = notify_new();

--- a/index/private_data.c
+++ b/index/private_data.c
@@ -48,7 +48,7 @@ void index_private_data_free(struct MuttWindow *win, void **ptr)
  */
 struct IndexPrivateData *index_private_data_new(struct IndexSharedData *shared)
 {
-  struct IndexPrivateData *priv = MUTT_MEM_CALLOC(1, struct IndexPrivateData);
+  struct IndexPrivateData *priv = mutt_mem_calloc_T(1, struct IndexPrivateData);
 
   priv->shared = shared;
   priv->oldcount = -1;

--- a/index/shared_data.c
+++ b/index/shared_data.c
@@ -306,7 +306,7 @@ void index_shared_data_free(struct MuttWindow *win, void **ptr)
  */
 struct IndexSharedData *index_shared_data_new(void)
 {
-  struct IndexSharedData *shared = MUTT_MEM_CALLOC(1, struct IndexSharedData);
+  struct IndexSharedData *shared = mutt_mem_calloc_T(1, struct IndexSharedData);
 
   shared->notify = notify_new();
   shared->sub = NeoMutt->sub;

--- a/key/keymap.c
+++ b/key/keymap.c
@@ -129,10 +129,10 @@ struct Mapping *keymap_get_key_names(void)
  */
 struct Keymap *keymap_alloc(size_t len, keycode_t *keys)
 {
-  struct Keymap *km = MUTT_MEM_CALLOC(1, struct Keymap);
+  struct Keymap *km = mutt_mem_calloc_T(1, struct Keymap);
 
   km->len = len;
-  km->keys = MUTT_MEM_CALLOC(len, keycode_t);
+  km->keys = mutt_mem_calloc_T(len, keycode_t);
   memcpy(km->keys, keys, len * sizeof(keycode_t));
 
   return km;

--- a/key/menudef.c
+++ b/key/menudef.c
@@ -52,7 +52,7 @@ void submenu_free(struct SubMenu **pptr)
  */
 struct SubMenu *submenu_new(void)
 {
-  struct SubMenu *sm = MUTT_MEM_CALLOC(1, struct SubMenu);
+  struct SubMenu *sm = mutt_mem_calloc_T(1, struct SubMenu);
 
   ARRAY_INIT(&sm->keymaps);
 
@@ -83,7 +83,7 @@ void menudef_free(struct MenuDefinition **pptr)
  */
 struct MenuDefinition *menudef_new(void)
 {
-  struct MenuDefinition *md = MUTT_MEM_CALLOC(1, struct MenuDefinition);
+  struct MenuDefinition *md = mutt_mem_calloc_T(1, struct MenuDefinition);
 
   ARRAY_INIT(&md->submenus);
 

--- a/key/module.c
+++ b/key/module.c
@@ -41,7 +41,7 @@ extern const struct Command KeyCommands[];
  */
 static bool key_init(struct NeoMutt *n)
 {
-  struct KeyModuleData *mod_data = MUTT_MEM_CALLOC(1, struct KeyModuleData);
+  struct KeyModuleData *mod_data = mutt_mem_calloc_T(1, struct KeyModuleData);
   neomutt_set_module_data(n, MODULE_ID_KEY, mod_data);
 
   mod_data->notify = notify_new();

--- a/lua/module.c
+++ b/lua/module.c
@@ -41,7 +41,7 @@ extern const struct Command LuaCommands[];
  */
 static bool lua_init(struct NeoMutt *n)
 {
-  struct LuaModuleData *mod_data = MUTT_MEM_CALLOC(1, struct LuaModuleData);
+  struct LuaModuleData *mod_data = mutt_mem_calloc_T(1, struct LuaModuleData);
   neomutt_set_module_data(n, MODULE_ID_LUA, mod_data);
 
   mod_data->notify = notify_new();

--- a/maildir/edata.c
+++ b/maildir/edata.c
@@ -52,7 +52,7 @@ void maildir_edata_free(void **ptr)
  */
 struct MaildirEmailData *maildir_edata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct MaildirEmailData);
+  return mutt_mem_calloc_T(1, struct MaildirEmailData);
 }
 
 /**

--- a/maildir/mdata.c
+++ b/maildir/mdata.c
@@ -48,7 +48,7 @@ void maildir_mdata_free(void **ptr)
  */
 struct MaildirMboxData *maildir_mdata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct MaildirMboxData);
+  return mutt_mem_calloc_T(1, struct MaildirMboxData);
 }
 
 /**

--- a/maildir/mdemail.c
+++ b/maildir/mdemail.c
@@ -38,7 +38,7 @@
  */
 struct MdEmail *maildir_entry_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct MdEmail);
+  return mutt_mem_calloc_T(1, struct MdEmail);
 }
 
 /**

--- a/maildir/module.c
+++ b/maildir/module.c
@@ -42,7 +42,7 @@ extern struct ConfigDef MaildirVarsHcache[];
  */
 static bool maildir_init(struct NeoMutt *n)
 {
-  struct MaildirModuleData *mod_data = MUTT_MEM_CALLOC(1, struct MaildirModuleData);
+  struct MaildirModuleData *mod_data = mutt_mem_calloc_T(1, struct MaildirModuleData);
   neomutt_set_module_data(n, MODULE_ID_MAILDIR, mod_data);
 
   mod_data->notify = notify_new();

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -90,7 +90,7 @@ static void mbox_adata_free(void **ptr)
  */
 static struct MboxAccountData *mbox_adata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct MboxAccountData);
+  return mutt_mem_calloc_T(1, struct MboxAccountData);
 }
 
 /**
@@ -1194,8 +1194,8 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
     offset -= (sizeof(MMDF_SEP) - 1);
 
   /* allocate space for the new offsets */
-  new_offset = MUTT_MEM_CALLOC(m->msg_count - first, struct MUpdate);
-  old_offset = MUTT_MEM_CALLOC(m->msg_count - first, struct MUpdate);
+  new_offset = mutt_mem_calloc_T(m->msg_count - first, struct MUpdate);
+  old_offset = mutt_mem_calloc_T(m->msg_count - first, struct MUpdate);
 
   if (m->verbose)
   {

--- a/mbox/module.c
+++ b/mbox/module.c
@@ -41,7 +41,7 @@ extern struct ConfigDef MboxVars[];
  */
 static bool mbox_init(struct NeoMutt *n)
 {
-  struct MboxModuleData *mod_data = MUTT_MEM_CALLOC(1, struct MboxModuleData);
+  struct MboxModuleData *mod_data = mutt_mem_calloc_T(1, struct MboxModuleData);
   neomutt_set_module_data(n, MODULE_ID_MBOX, mod_data);
 
   mod_data->notify = notify_new();

--- a/menu/menu.c
+++ b/menu/menu.c
@@ -127,7 +127,7 @@ void menu_free(struct Menu **ptr)
 struct Menu *menu_new(const struct MenuDefinition *md, struct MuttWindow *win,
                       struct ConfigSubset *sub)
 {
-  struct Menu *menu = MUTT_MEM_CALLOC(1, struct Menu);
+  struct Menu *menu = mutt_mem_calloc_T(1, struct Menu);
 
   menu->md = md;
   menu->redraw = MENU_REDRAW_FULL;

--- a/menu/module.c
+++ b/menu/module.c
@@ -43,7 +43,7 @@ extern struct ConfigDef MenuVars[];
  */
 static bool menu_init(struct NeoMutt *n)
 {
-  struct MenuModuleData *mod_data = MUTT_MEM_CALLOC(1, struct MenuModuleData);
+  struct MenuModuleData *mod_data = mutt_mem_calloc_T(1, struct MenuModuleData);
   neomutt_set_module_data(n, MODULE_ID_MENU, mod_data);
 
   mod_data->notify = notify_new();

--- a/mh/mdata.c
+++ b/mh/mdata.c
@@ -48,7 +48,7 @@ void mh_mdata_free(void **ptr)
  */
 struct MhMboxData *mh_mdata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct MhMboxData);
+  return mutt_mem_calloc_T(1, struct MhMboxData);
 }
 
 /**

--- a/mh/mhemail.c
+++ b/mh/mhemail.c
@@ -38,7 +38,7 @@
  */
 struct MhEmail *mh_entry_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct MhEmail);
+  return mutt_mem_calloc_T(1, struct MhEmail);
 }
 
 /**

--- a/mh/module.c
+++ b/mh/module.c
@@ -41,7 +41,7 @@ extern struct ConfigDef MhVars[];
  */
 static bool mh_init(struct NeoMutt *n)
 {
-  struct MhModuleData *mod_data = MUTT_MEM_CALLOC(1, struct MhModuleData);
+  struct MhModuleData *mod_data = mutt_mem_calloc_T(1, struct MhModuleData);
   neomutt_set_module_data(n, MODULE_ID_MH, mod_data);
 
   mod_data->notify = notify_new();

--- a/mh/sequence.c
+++ b/mh/sequence.c
@@ -54,7 +54,7 @@ static void mh_seq_alloc(struct MhSequences *mhs, int i)
 
   const int newmax = i + 128;
   int j = mhs->flags ? mhs->max + 1 : 0;
-  MUTT_MEM_REALLOC(&mhs->flags, newmax + 1, MhSeqFlags);
+  mutt_mem_realloc_T(&mhs->flags, newmax + 1, MhSeqFlags);
   while (j <= newmax)
     mhs->flags[j++] = 0;
 

--- a/mlist/dlg_mlist.c
+++ b/mlist/dlg_mlist.c
@@ -123,7 +123,7 @@ void dlg_mlist(struct Mailbox *m, struct Email *e)
   struct MenuDefinition *md_list = menu_find(MENU_LIST);
   ASSERT(md_list);
 
-  struct ListData *ld = MUTT_MEM_CALLOC(1, struct ListData);
+  struct ListData *ld = mutt_mem_calloc_T(1, struct ListData);
   ld->mailbox = m;
 
   struct Message *msg = mx_msg_open(m, e);

--- a/mlist/module.c
+++ b/mlist/module.c
@@ -41,7 +41,7 @@ extern struct ConfigDef MlistVars[];
  */
 static bool mlist_init(struct NeoMutt *n)
 {
-  struct MlistModuleData *mod_data = MUTT_MEM_CALLOC(1, struct MlistModuleData);
+  struct MlistModuleData *mod_data = mutt_mem_calloc_T(1, struct MlistModuleData);
   neomutt_set_module_data(n, MODULE_ID_MLIST, mod_data);
 
   return true;

--- a/monitor.c
+++ b/monitor.c
@@ -216,7 +216,7 @@ static void monitor_check_cleanup(void)
  */
 static struct Monitor *monitor_new(struct MonitorInfo *info, int descriptor)
 {
-  struct Monitor *monitor = MUTT_MEM_CALLOC(1, struct Monitor);
+  struct Monitor *monitor = mutt_mem_calloc_T(1, struct Monitor);
   monitor->type = info->type;
   monitor->st_dev = info->st_dev;
   monitor->st_ino = info->st_ino;

--- a/monitor.c
+++ b/monitor.c
@@ -127,7 +127,7 @@ static void mutt_poll_fd_add(int fd, short events)
     if (PollFdsCount == PollFdsLen)
     {
       PollFdsLen += 2;
-      MUTT_MEM_REALLOC(&PollFds, PollFdsLen, struct pollfd);
+      mutt_mem_realloc_T(&PollFds, PollFdsLen, struct pollfd);
     }
     PollFdsCount++;
     PollFds[i].fd = fd;

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -366,7 +366,7 @@ void buf_alloc(struct Buffer *buf, size_t new_size)
 
   buf->dsize = dsize;
 
-  MUTT_MEM_REALLOC(&buf->data, buf->dsize, char);
+  mutt_mem_realloc_T(&buf->data, buf->dsize, char);
   buf->dptr = buf->data + offset;
 
   // Ensures that initially NULL buf->data is properly terminated

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -310,7 +310,7 @@ bool buf_is_empty(const struct Buffer *buf)
  */
 struct Buffer *buf_new(const char *str)
 {
-  struct Buffer *buf = MUTT_MEM_CALLOC(1, struct Buffer);
+  struct Buffer *buf = mutt_mem_calloc_T(1, struct Buffer);
 
   if (str)
     buf_addstr(buf, str);

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -331,7 +331,7 @@ int mutt_ch_convert_nonmime_string(const struct Slist *const assumed_charset,
   {
     char const *c = np->data;
     size_t n = mutt_str_len(c);
-    char *fromcode = MUTT_MEM_MALLOC(n + 1, char);
+    char *fromcode = mutt_mem_malloc_T(n + 1, char);
     mutt_str_copy(fromcode, c, n + 1);
     char *s = mutt_strn_dup(u, ulen);
     int m = mutt_ch_convert_string(&s, fromcode, charset, MUTT_ICONV_NONE);
@@ -792,7 +792,7 @@ int mutt_ch_check(const char *s, size_t slen, const char *from, const char *to)
     return -1;
 
   size_t outlen = MB_LEN_MAX * slen;
-  char *out = MUTT_MEM_MALLOC(outlen + 1, char);
+  char *out = mutt_mem_malloc_T(outlen + 1, char);
   char *saved_out = out;
 
   const size_t convlen = iconv(cd, (ICONV_CONST char **) &s, &slen, &out, &outlen);
@@ -853,7 +853,7 @@ int mutt_ch_convert_string(char **ps, const char *from, const char *to, uint8_t 
     return -1;
   }
   size_t obl = MB_LEN_MAX * ibl;
-  char *buf = MUTT_MEM_MALLOC(obl + 1, char);
+  char *buf = mutt_mem_malloc_T(obl + 1, char);
   char *ob = buf;
 
   mutt_ch_iconv(cd, &ib, &ibl, &ob, &obl, inrepls, outrepl, &rc);

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -255,7 +255,7 @@ static const struct MimeNames PreferredMimeNames[] = {
  */
 static struct Lookup *lookup_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct Lookup);
+  return mutt_mem_calloc_T(1, struct Lookup);
 }
 
 /**
@@ -499,7 +499,7 @@ bool mutt_ch_lookup_add(enum LookupType type, const char *pat,
   if (!pat || !replace)
     return false;
 
-  regex_t *rx = MUTT_MEM_CALLOC(1, regex_t);
+  regex_t *rx = mutt_mem_calloc_T(1, regex_t);
   int rc = REG_COMP(rx, pat, REG_ICASE);
   if (rc != 0)
   {
@@ -925,7 +925,7 @@ struct FgetConv *mutt_ch_fgetconv_open(FILE *fp, const char *from, const char *t
   if (from && to)
     cd = mutt_ch_iconv_open(to, from, flags);
 
-  struct FgetConv *fc = MUTT_MEM_CALLOC(1, struct FgetConv);
+  struct FgetConv *fc = mutt_mem_calloc_T(1, struct FgetConv);
   fc->fp = fp;
   fc->cd = cd;
 

--- a/mutt/envlist.c
+++ b/mutt/envlist.c
@@ -66,7 +66,7 @@ char **envlist_init(char **envp)
   for (src = envp; src && *src; src++)
     count++;
 
-  char **env_copy = MUTT_MEM_CALLOC(count + 1, char *);
+  char **env_copy = mutt_mem_calloc_T(count + 1, char *);
   for (src = envp, dst = env_copy; src && *src; src++, dst++)
     *dst = mutt_str_dup(*src);
 

--- a/mutt/envlist.c
+++ b/mutt/envlist.c
@@ -122,7 +122,7 @@ bool envlist_set(char ***envp, const char *name, const char *value, bool overwri
   else
   {
     // not found, add a new entry
-    MUTT_MEM_REALLOC(envp, count + 2, char *);
+    mutt_mem_realloc_T(envp, count + 2, char *);
     (*envp)[count] = work;
     (*envp)[count + 1] = NULL;
   }
@@ -156,7 +156,7 @@ bool envlist_unset(char ***envp, const char *name)
       // Move down the later entries
       memmove(&(*envp)[match], &(*envp)[match + 1], (count - match) * sizeof(char *));
       // Shrink the array
-      MUTT_MEM_REALLOC(envp, count, char *);
+      mutt_mem_realloc_T(envp, count, char *);
       return true;
     }
   }

--- a/mutt/envlist.c
+++ b/mutt/envlist.c
@@ -110,7 +110,7 @@ bool envlist_set(char ***envp, const char *name, const char *value, bool overwri
   const char *val = NONULL(value);
   size_t nlen = mutt_str_len(name);
   size_t vlen = mutt_str_len(val);
-  char *work = MUTT_MEM_MALLOC(nlen + 1 + vlen + 1, char);
+  char *work = mutt_mem_malloc_T(nlen + 1 + vlen + 1, char);
   snprintf(work, nlen + 1 + vlen + 1, "%s=%s", name, val);
 
   if (match >= 0)

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -731,7 +731,7 @@ char *mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, Rea
         /* There wasn't room for the line -- increase "line" */
         offset = *size - 1; /* overwrite the terminating 0 */
         *size += 256;
-        MUTT_MEM_REALLOC(&line, *size, char);
+        mutt_mem_realloc_T(&line, *size, char);
       }
     }
   }

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -686,7 +686,7 @@ char *mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, Rea
   if (!line)
   {
     *size = 256;
-    line = MUTT_MEM_MALLOC(*size, char);
+    line = mutt_mem_malloc_T(*size, char);
   }
 
   while (true)

--- a/mutt/hash.c
+++ b/mutt/hash.c
@@ -122,11 +122,11 @@ static int cmp_key_int(union HashKey a, union HashKey b)
  */
 static struct HashTable *hash_new(size_t num_elems)
 {
-  struct HashTable *table = MUTT_MEM_CALLOC(1, struct HashTable);
+  struct HashTable *table = mutt_mem_calloc_T(1, struct HashTable);
   if (num_elems == 0)
     num_elems = 2;
   table->num_elems = num_elems;
-  table->table = MUTT_MEM_CALLOC(num_elems, struct HashElem *);
+  table->table = mutt_mem_calloc_T(num_elems, struct HashElem *);
   return table;
 }
 
@@ -144,7 +144,7 @@ static struct HashElem *union_hash_insert(struct HashTable *table,
   if (!table)
     return NULL; // LCOV_EXCL_LINE
 
-  struct HashElem *he = MUTT_MEM_CALLOC(1, struct HashElem);
+  struct HashElem *he = mutt_mem_calloc_T(1, struct HashElem);
   size_t hash = table->gen_hash(key, table->num_elems);
   he->key = key;
   he->data = data;

--- a/mutt/list.c
+++ b/mutt/list.c
@@ -48,7 +48,7 @@ struct ListNode *mutt_list_insert_head(struct ListHead *h, char *s)
   if (!h)
     return NULL;
 
-  struct ListNode *np = MUTT_MEM_CALLOC(1, struct ListNode);
+  struct ListNode *np = mutt_mem_calloc_T(1, struct ListNode);
   np->data = s;
   STAILQ_INSERT_HEAD(h, np, entries);
   return np;
@@ -67,7 +67,7 @@ struct ListNode *mutt_list_insert_tail(struct ListHead *h, char *s)
   if (!h)
     return NULL;
 
-  struct ListNode *np = MUTT_MEM_CALLOC(1, struct ListNode);
+  struct ListNode *np = mutt_mem_calloc_T(1, struct ListNode);
   np->data = s;
   STAILQ_INSERT_TAIL(h, np, entries);
   return np;
@@ -87,7 +87,7 @@ struct ListNode *mutt_list_insert_after(struct ListHead *h, struct ListNode *n, 
   if (!h || !n)
     return NULL;
 
-  struct ListNode *np = MUTT_MEM_CALLOC(1, struct ListNode);
+  struct ListNode *np = mutt_mem_calloc_T(1, struct ListNode);
   np->data = s;
   STAILQ_INSERT_AFTER(h, n, np, entries);
   return np;

--- a/mutt/logging.c
+++ b/mutt/logging.c
@@ -399,7 +399,7 @@ int log_disp_queue(time_t stamp, const char *file, int line, const char *functio
     level = LL_ERROR;
   }
 
-  struct LogLine *ll = MUTT_MEM_CALLOC(1, struct LogLine);
+  struct LogLine *ll = mutt_mem_calloc_T(1, struct LogLine);
   ll->time = (stamp != 0) ? stamp : mutt_date_now();
   ll->file = file;
   ll->line = line;

--- a/mutt/mbyte.c
+++ b/mutt/mbyte.c
@@ -310,7 +310,7 @@ size_t mutt_mb_mbstowcs(wchar_t **pwbuf, size_t *pwbuflen, size_t i, const char 
       if (i >= wbuflen)
       {
         wbuflen = i + 20;
-        MUTT_MEM_REALLOC(&wbuf, wbuflen, wchar_t);
+        mutt_mem_realloc_T(&wbuf, wbuflen, wchar_t);
       }
       wbuf[i++] = wc;
     }
@@ -319,7 +319,7 @@ size_t mutt_mb_mbstowcs(wchar_t **pwbuf, size_t *pwbuflen, size_t i, const char 
       if (i >= wbuflen)
       {
         wbuflen = i + 20;
-        MUTT_MEM_REALLOC(&wbuf, wbuflen, wchar_t);
+        mutt_mem_realloc_T(&wbuf, wbuflen, wchar_t);
       }
       wbuf[i++] = ReplacementChar;
       buf++;

--- a/mutt/mbyte.c
+++ b/mutt/mbyte.c
@@ -458,7 +458,7 @@ int mutt_mb_filter_unprintable(char **s)
   FREE(s);
 
   if (buf_is_empty(buf))
-    *s = MUTT_MEM_CALLOC(1, char); // Fake empty string
+    *s = mutt_mem_calloc_T(1, char); // Fake empty string
   else
     *s = buf_strdup(buf);
 

--- a/mutt/memory.h
+++ b/mutt/memory.h
@@ -65,7 +65,8 @@
 
 #define RVALUE(lv)  ((void)0, (lv))
 
-#define MUTT_MEM_CALLOC(n, T)                                         \
+// mutt_mem_calloc_T - clear allocate type-safe
+#define mutt_mem_calloc_T(n, T)                                       \
 (                                                                     \
   RVALUE((typeas(T) *){mutt_mem_calloc(n, sizeof(T))})                \
 )

--- a/mutt/memory.h
+++ b/mutt/memory.h
@@ -71,7 +71,8 @@
   RVALUE((typeas(T) *){mutt_mem_calloc(n, sizeof(T))})                \
 )
 
-#define MUTT_MEM_MALLOC(n, T)                                         \
+// mutt_mem_malloc_T - memory allocate type-safe
+#define mutt_mem_malloc_T(n, T)                                       \
 (                                                                     \
   RVALUE((typeas(T) *){mutt_mem_mallocarray(n, sizeof(T))})           \
 )

--- a/mutt/memory.h
+++ b/mutt/memory.h
@@ -77,7 +77,8 @@
   RVALUE((typeas(T) *){mutt_mem_mallocarray(n, sizeof(T))})           \
 )
 
-#define MUTT_MEM_REALLOC(pptr, n, T)                                  \
+// mutt_mem_realloc_T - resize allocation type-safe
+#define mutt_mem_realloc_T(pptr, n, T)                                \
 (                                                                     \
   _Generic(*(pptr), typeas(T) *: (void)0),                            \
   mutt_mem_reallocarray(pptr, n, sizeof(T))                           \

--- a/mutt/module.c
+++ b/mutt/module.c
@@ -39,7 +39,7 @@
  */
 static bool mutt_init(struct NeoMutt *n)
 {
-  struct MuttModuleData *mod_data = MUTT_MEM_CALLOC(1, struct MuttModuleData);
+  struct MuttModuleData *mod_data = mutt_mem_calloc_T(1, struct MuttModuleData);
   neomutt_set_module_data(n, MODULE_ID_MUTT, mod_data);
 
   mod_data->notify = notify_new();

--- a/mutt/notify.c
+++ b/mutt/notify.c
@@ -61,7 +61,7 @@ struct Notify
  */
 struct Notify *notify_new(void)
 {
-  struct Notify *notify = MUTT_MEM_CALLOC(1, struct Notify);
+  struct Notify *notify = mutt_mem_calloc_T(1, struct Notify);
 
   STAILQ_INIT(&notify->observers);
 
@@ -204,12 +204,12 @@ bool notify_observer_add(struct Notify *notify, enum NotifyType type,
       return true;
   }
 
-  struct Observer *o = MUTT_MEM_CALLOC(1, struct Observer);
+  struct Observer *o = mutt_mem_calloc_T(1, struct Observer);
   o->type = type;
   o->callback = callback;
   o->global_data = global_data;
 
-  np = MUTT_MEM_CALLOC(1, struct ObserverNode);
+  np = mutt_mem_calloc_T(1, struct ObserverNode);
   np->observer = o;
   STAILQ_INSERT_HEAD(&notify->observers, np, entries);
 

--- a/mutt/pool.c
+++ b/mutt/pool.c
@@ -63,7 +63,7 @@ static void pool_increase_size(void)
   MUTT_MEM_REALLOC(&BufferPool, BufferPoolLen, struct Buffer *);
   while (BufferPoolCount < BufferPoolIncrement)
   {
-    struct Buffer *newbuf = MUTT_MEM_CALLOC(1, struct Buffer);
+    struct Buffer *newbuf = mutt_mem_calloc_T(1, struct Buffer);
     buf_alloc(newbuf, BufferPoolInitialBufferSize);
     BufferPool[BufferPoolCount++] = newbuf;
   }

--- a/mutt/pool.c
+++ b/mutt/pool.c
@@ -60,7 +60,7 @@ static void pool_increase_size(void)
   BufferPoolLen += BufferPoolIncrement;
   mutt_debug(LL_DEBUG1, "%zu\n", BufferPoolLen);
 
-  MUTT_MEM_REALLOC(&BufferPool, BufferPoolLen, struct Buffer *);
+  mutt_mem_realloc_T(&BufferPool, BufferPoolLen, struct Buffer *);
   while (BufferPoolCount < BufferPoolIncrement)
   {
     struct Buffer *newbuf = mutt_mem_calloc_T(1, struct Buffer);
@@ -131,7 +131,7 @@ void buf_pool_release(struct Buffer **ptr)
       (buf->dsize < BufferPoolInitialBufferSize))
   {
     buf->dsize = BufferPoolInitialBufferSize;
-    MUTT_MEM_REALLOC(&buf->data, buf->dsize, char);
+    mutt_mem_realloc_T(&buf->data, buf->dsize, char);
   }
   buf_reset(buf);
   BufferPool[BufferPoolCount++] = buf;

--- a/mutt/prex.c
+++ b/mutt/prex.c
@@ -280,12 +280,12 @@ static struct PrexStorage *prex(enum Prex which)
     uint32_t ccount = 0;
     pcre2_pattern_info(h->re, PCRE2_INFO_CAPTURECOUNT, &ccount);
     ASSERT(((ccount + 1) == h->nmatches) && "Number of matches do not match (...)");
-    h->matches = MUTT_MEM_CALLOC(h->nmatches, regmatch_t);
+    h->matches = mutt_mem_calloc_T(h->nmatches, regmatch_t);
 #else
-    h->re = MUTT_MEM_CALLOC(1, regex_t);
+    h->re = mutt_mem_calloc_T(1, regex_t);
     const int rc = regcomp(h->re, h->str, REG_EXTENDED);
     ASSERT(rc == 0 && "Fix your RE");
-    h->matches = MUTT_MEM_CALLOC(h->nmatches, regmatch_t);
+    h->matches = mutt_mem_calloc_T(h->nmatches, regmatch_t);
 #endif
   }
   return h;

--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -388,7 +388,7 @@ char *mutt_replacelist_apply(struct ReplaceList *rl, const char *str)
     /* If this pattern needs more matches, expand pmatch. */
     if (np->nmatch > nmatch)
     {
-      MUTT_MEM_REALLOC(&pmatch, np->nmatch, regmatch_t);
+      mutt_mem_realloc_T(&pmatch, np->nmatch, regmatch_t);
       nmatch = np->nmatch;
     }
 
@@ -494,7 +494,7 @@ bool mutt_replacelist_match(struct ReplaceList *rl, char *buf, size_t buflen, co
     /* If this pattern needs more matches, expand pmatch. */
     if (np->nmatch > nmatch)
     {
-      MUTT_MEM_REALLOC(&pmatch, np->nmatch, regmatch_t);
+      mutt_mem_realloc_T(&pmatch, np->nmatch, regmatch_t);
       nmatch = np->nmatch;
     }
 

--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -60,9 +60,9 @@ struct Regex *mutt_regex_compile(const char *str, uint16_t flags)
 {
   if (!str || (*str == '\0'))
     return NULL;
-  struct Regex *rx = MUTT_MEM_CALLOC(1, struct Regex);
+  struct Regex *rx = mutt_mem_calloc_T(1, struct Regex);
   rx->pattern = mutt_str_dup(str);
-  rx->regex = MUTT_MEM_CALLOC(1, regex_t);
+  rx->regex = mutt_mem_calloc_T(1, regex_t);
   if (REG_COMP(rx->regex, str, flags) != 0)
     mutt_regex_free(&rx);
 
@@ -83,9 +83,9 @@ struct Regex *mutt_regex_new(const char *str, uint32_t flags, struct Buffer *err
     return NULL;
 
   uint16_t rflags = 0;
-  struct Regex *reg = MUTT_MEM_CALLOC(1, struct Regex);
+  struct Regex *reg = mutt_mem_calloc_T(1, struct Regex);
 
-  reg->regex = MUTT_MEM_CALLOC(1, regex_t);
+  reg->regex = mutt_mem_calloc_T(1, regex_t);
   reg->pattern = mutt_str_dup(str);
 
   /* Should we use smart case matching? */
@@ -221,7 +221,7 @@ bool mutt_regexlist_match(struct RegexList *rl, const char *str)
  */
 struct RegexNode *mutt_regexlist_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct RegexNode);
+  return mutt_mem_calloc_T(1, struct RegexNode);
 }
 
 /**
@@ -560,7 +560,7 @@ bool mutt_replacelist_match(struct ReplaceList *rl, char *buf, size_t buflen, co
  */
 struct Replace *mutt_replacelist_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct Replace);
+  return mutt_mem_calloc_T(1, struct Replace);
 }
 
 /**

--- a/mutt/slist.c
+++ b/mutt/slist.c
@@ -50,7 +50,7 @@
  */
 struct Slist *slist_new(uint32_t flags)
 {
-  struct Slist *list = MUTT_MEM_CALLOC(1, struct Slist);
+  struct Slist *list = mutt_mem_calloc_T(1, struct Slist);
   list->flags = flags;
   STAILQ_INIT(&list->head);
 
@@ -186,7 +186,7 @@ struct Slist *slist_parse(const char *str, uint32_t flags)
   else if ((flags & D_SLIST_SEP_MASK) == D_SLIST_SEP_COLON)
     sep = ':';
 
-  struct Slist *list = MUTT_MEM_CALLOC(1, struct Slist);
+  struct Slist *list = mutt_mem_calloc_T(1, struct Slist);
   list->flags = flags;
   STAILQ_INIT(&list->head);
 

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -304,7 +304,7 @@ void mutt_str_adjust(char **ptr)
 {
   if (!ptr || !*ptr)
     return;
-  MUTT_MEM_REALLOC(ptr, strlen(*ptr) + 1, char);
+  mutt_mem_realloc_T(ptr, strlen(*ptr) + 1, char);
 }
 
 /**
@@ -833,12 +833,12 @@ int mutt_str_asprintf(char **strp, const char *fmt, ...)
       if (n == 0) /* convention is to use NULL for zero-length strings. */
         FREE(strp);
       else if (n != rlen - 1)
-        MUTT_MEM_REALLOC(strp, n + 1, char);
+        mutt_mem_realloc_T(strp, n + 1, char);
       return n;
     }
     /* increase size and try again */
     rlen = n + 1;
-    MUTT_MEM_REALLOC(strp, rlen, char);
+    mutt_mem_realloc_T(strp, rlen, char);
   }
   /* not reached */
 }

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -386,7 +386,7 @@ char *mutt_strn_dup(const char *begin, size_t len)
   if (!begin)
     return NULL;
 
-  char *p = MUTT_MEM_MALLOC(len + 1, char);
+  char *p = mutt_mem_malloc_T(len + 1, char);
   memcpy(p, begin, len);
   p[len] = '\0';
   return p;
@@ -813,7 +813,7 @@ int mutt_str_asprintf(char **strp, const char *fmt, ...)
 
   int rlen = 256;
 
-  *strp = MUTT_MEM_MALLOC(rlen, char);
+  *strp = mutt_mem_malloc_T(rlen, char);
   while (true)
   {
     va_list ap;

--- a/mx.c
+++ b/mx.c
@@ -1229,8 +1229,8 @@ void mx_alloc_memory(struct Mailbox *m, int req_size)
 
   if (m->emails)
   {
-    MUTT_MEM_REALLOC(&m->emails, req_size, struct Email *);
-    MUTT_MEM_REALLOC(&m->v2r, req_size, int);
+    mutt_mem_realloc_T(&m->emails, req_size, struct Email *);
+    mutt_mem_realloc_T(&m->v2r, req_size, int);
   }
   else
   {

--- a/mx.c
+++ b/mx.c
@@ -1234,8 +1234,8 @@ void mx_alloc_memory(struct Mailbox *m, int req_size)
   }
   else
   {
-    m->emails = MUTT_MEM_CALLOC(req_size, struct Email *);
-    m->v2r = MUTT_MEM_CALLOC(req_size, int);
+    m->emails = mutt_mem_calloc_T(req_size, struct Email *);
+    m->v2r = mutt_mem_calloc_T(req_size, int);
   }
 
   for (int i = m->email_max; i < req_size; i++)

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1033,7 +1033,7 @@ int crypt_get_keys(struct Email *e, char **keylist, bool oppenc_mode)
   if (!oppenc_mode && self_encrypt)
   {
     const size_t keylist_size = mutt_str_len(*keylist);
-    MUTT_MEM_REALLOC(keylist, keylist_size + mutt_str_len(self_encrypt) + 2, char);
+    mutt_mem_realloc_T(keylist, keylist_size + mutt_str_len(self_encrypt) + 2, char);
     sprintf(*keylist + keylist_size, " %s", self_encrypt);
   }
 
@@ -1092,7 +1092,7 @@ static void crypt_fetch_signatures(struct Body ***b_sigs, struct Body *b, int *n
     else
     {
       if ((*n % 5) == 0)
-        MUTT_MEM_REALLOC(b_sigs, *n + 6, struct Body *);
+        mutt_mem_realloc_T(b_sigs, *n + 6, struct Body *);
 
       (*b_sigs)[(*n)++] = b;
     }

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3677,7 +3677,7 @@ static char *find_keys(const struct AddressList *addrlist, unsigned int app, boo
     bypass_selection:
       /* Append the selected key ID to the space-separated keylist string */
       keylist_size += mutt_str_len(keyid) + 4 + 1;
-      MUTT_MEM_REALLOC(&keylist, keylist_size, char);
+      mutt_mem_realloc_T(&keylist, keylist_size, char);
       sprintf(keylist + keylist_used, "%s0x%s%s", keylist_used ? " " : "",
               keyid, forced_valid ? "!" : "");
       keylist_used = mutt_str_len(keylist);

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -229,7 +229,7 @@ struct CryptKeyInfo *crypt_copy_key(struct CryptKeyInfo *key)
 {
   struct CryptKeyInfo *k = NULL;
 
-  k = MUTT_MEM_CALLOC(1, struct CryptKeyInfo);
+  k = mutt_mem_calloc_T(1, struct CryptKeyInfo);
   k->kobj = key->kobj;
   gpgme_key_ref(key->kobj);
   k->idx = key->idx;
@@ -3048,7 +3048,7 @@ static char *list_to_pattern(struct ListHead *list)
     n++; /* delimiter or end of string */
   }
   n++; /* make sure to allocate at least one byte */
-  p = MUTT_MEM_CALLOC(n, char);
+  p = mutt_mem_calloc_T(n, char);
   pattern = p;
   STAILQ_FOREACH(np, list, entries)
   {
@@ -3130,7 +3130,7 @@ static struct CryptKeyInfo *get_candidates(struct ListHead *hints, SecurityFlags
     if (n == 0)
       goto no_pgphints;
 
-    char **patarr = MUTT_MEM_CALLOC(n + 1, char *);
+    char **patarr = mutt_mem_calloc_T(n + 1, char *);
     n = 0;
     STAILQ_FOREACH(np, hints, entries)
     {
@@ -3168,7 +3168,7 @@ static struct CryptKeyInfo *get_candidates(struct ListHead *hints, SecurityFlags
 
       for (idx = 0, uid = key->uids; uid; idx++, uid = uid->next)
       {
-        k = MUTT_MEM_CALLOC(1, struct CryptKeyInfo);
+        k = mutt_mem_calloc_T(1, struct CryptKeyInfo);
         k->kobj = key;
         gpgme_key_ref(k->kobj);
         k->idx = idx;
@@ -3219,7 +3219,7 @@ static struct CryptKeyInfo *get_candidates(struct ListHead *hints, SecurityFlags
 
       for (idx = 0, uid = key->uids; uid; idx++, uid = uid->next)
       {
-        k = MUTT_MEM_CALLOC(1, struct CryptKeyInfo);
+        k = mutt_mem_calloc_T(1, struct CryptKeyInfo);
         k->kobj = key;
         gpgme_key_ref(k->kobj);
         k->idx = idx;
@@ -3764,7 +3764,7 @@ int mutt_gpgme_select_secret_key(struct Buffer *keyid)
     int idx;
     for (idx = 0, uid = key->uids; uid; idx++, uid = uid->next)
     {
-      k = MUTT_MEM_CALLOC(1, struct CryptKeyInfo);
+      k = mutt_mem_calloc_T(1, struct CryptKeyInfo);
       k->kobj = key;
       gpgme_key_ref(k->kobj);
       k->idx = idx;

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -1278,7 +1278,7 @@ static void show_fingerprint(gpgme_key_t key, struct State *state)
     return;
   bool is_pgp = (key->protocol == GPGME_PROTOCOL_OpenPGP);
 
-  char *buf = MUTT_MEM_MALLOC(strlen(prefix) + strlen(s) * 4 + 2, char);
+  char *buf = mutt_mem_malloc_T(strlen(prefix) + strlen(s) * 4 + 2, char);
   strcpy(buf, prefix);
   char *p = buf + strlen(buf);
   if (is_pgp && (strlen(s) == 40))
@@ -3537,7 +3537,7 @@ static struct CryptKeyInfo *crypt_ask_for_key(const char *tag, const char *whatf
       }
       else
       {
-        l = MUTT_MEM_MALLOC(1, struct CryptCache);
+        l = mutt_mem_malloc_T(1, struct CryptCache);
         l->next = (struct CryptCache *) mod_data->gpgme_id_defaults;
         mod_data->gpgme_id_defaults = l;
         l->what = mutt_str_dup(whatfor);

--- a/ncrypt/crypt_mod.c
+++ b/ncrypt/crypt_mod.c
@@ -41,7 +41,7 @@
 void crypto_module_register(const struct CryptModuleSpecs *specs)
 {
   struct NcryptModuleData *mod_data = neomutt_get_module_data(NeoMutt, MODULE_ID_NCRYPT);
-  struct CryptModule *module = MUTT_MEM_CALLOC(1, struct CryptModule);
+  struct CryptModule *module = mutt_mem_calloc_T(1, struct CryptModule);
   module->specs = specs;
   STAILQ_INSERT_HEAD(&mod_data->crypt_modules, module, entries);
 }

--- a/ncrypt/functions_gpgme.c
+++ b/ncrypt/functions_gpgme.c
@@ -83,7 +83,7 @@ struct DnArray
  */
 static void print_utf8(FILE *fp, const char *buf, size_t len)
 {
-  char *tstr = MUTT_MEM_MALLOC(len + 1, char);
+  char *tstr = mutt_mem_malloc_T(len + 1, char);
   memcpy(tstr, buf, len);
   tstr[len] = 0;
 
@@ -186,7 +186,7 @@ static const char *parse_dn_part(struct DnArray *array, const char *str)
   n = s - str;
   if (n == 0)
     return NULL; /* empty key */
-  array->key = MUTT_MEM_MALLOC(n + 1, char);
+  array->key = mutt_mem_malloc_T(n + 1, char);
   p = array->key;
   memcpy(p, str, n); /* fixme: trim trailing spaces */
   p[n] = 0;
@@ -201,7 +201,7 @@ static const char *parse_dn_part(struct DnArray *array, const char *str)
     if ((n == 0) || (n & 1))
       return NULL; /* empty or odd number of digits */
     n /= 2;
-    p = MUTT_MEM_MALLOC(n + 1, char);
+    p = mutt_mem_malloc_T(n + 1, char);
     array->value = (char *) p;
     for (s1 = str; n > 0; s1 += 2, n--)
       sscanf(s1, "%2hhx", (unsigned char *) p++);
@@ -244,7 +244,7 @@ static const char *parse_dn_part(struct DnArray *array, const char *str)
       }
     }
 
-    p = MUTT_MEM_MALLOC(n + 1, char);
+    p = mutt_mem_malloc_T(n + 1, char);
     array->value = (char *) p;
     for (s = str; n > 0; s++, n--)
     {
@@ -285,7 +285,7 @@ static struct DnArray *parse_dn(const char *str)
   size_t arrayidx, arraysize;
 
   arraysize = 7; /* C,ST,L,O,OU,CN,email */
-  array = MUTT_MEM_MALLOC(arraysize + 1, struct DnArray);
+  array = mutt_mem_malloc_T(arraysize + 1, struct DnArray);
   arrayidx = 0;
   while (*str)
   {
@@ -297,7 +297,7 @@ static struct DnArray *parse_dn(const char *str)
     {
       /* neomutt lacks a real mutt_mem_realloc - so we need to copy */
       arraysize += 5;
-      struct DnArray *a2 = MUTT_MEM_MALLOC(arraysize + 1, struct DnArray);
+      struct DnArray *a2 = mutt_mem_malloc_T(arraysize + 1, struct DnArray);
       for (int i = 0; i < arrayidx; i++)
       {
         a2[i].key = array[i].key;

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -338,7 +338,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
 
         mutt_debug(LL_DEBUG2, "user ID: %s\n", NONULL(p));
 
-        uid = MUTT_MEM_CALLOC(1, struct PgpUid);
+        uid = mutt_mem_calloc_T(1, struct PgpUid);
         fix_uid(p);
         uid->addr = mutt_str_dup(p);
         uid->trust = trust;

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -102,7 +102,7 @@ static void fix_uid(char *uid)
   {
     int n = s - uid + 1; /* chars available in original buffer */
 
-    char *buf = MUTT_MEM_MALLOC(n + 1, char);
+    char *buf = mutt_mem_malloc_T(n + 1, char);
     const char *ib = uid;
     size_t ibl = d - uid + 1;
     char *ob = buf;
@@ -395,7 +395,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
 
   /* merge temp key back into real key */
   if (!(is_uid || is_fpr || (*is_subkey && c_pgp_ignore_subkeys)))
-    k = MUTT_MEM_MALLOC(1, struct PgpKeyInfo);
+    k = mutt_mem_malloc_T(1, struct PgpKeyInfo);
   if (!k)
     return NULL;
   memcpy(k, &tmp, sizeof(*k));

--- a/ncrypt/module.c
+++ b/ncrypt/module.c
@@ -45,7 +45,7 @@ extern struct ConfigDef NcryptVarsSmime[];
  */
 static bool ncrypt_init(struct NeoMutt *n)
 {
-  struct NcryptModuleData *mod_data = MUTT_MEM_CALLOC(1, struct NcryptModuleData);
+  struct NcryptModuleData *mod_data = mutt_mem_calloc_T(1, struct NcryptModuleData);
   STAILQ_INIT(&mod_data->crypt_modules);
   neomutt_set_module_data(n, MODULE_ID_NCRYPT, mod_data);
 

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1588,7 +1588,7 @@ char *pgp_class_find_keys(const struct AddressList *addrlist, bool oppenc_mode)
     bypass_selection:
       /* Append the selected key ID to the space-separated keylist string */
       keylist_size += mutt_str_len(keyid) + 4;
-      MUTT_MEM_REALLOC(&keylist, keylist_size, char);
+      mutt_mem_realloc_T(&keylist, keylist_size, char);
       sprintf(keylist + keylist_used, "%s0x%s", keylist_used ? " " : "", keyid);
       keylist_used = mutt_str_len(keylist);
 

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -240,7 +240,7 @@ struct PgpKeyInfo *pgp_ask_for_key(char *tag, const char *whatfor,
       }
       else
       {
-        l = MUTT_MEM_MALLOC(1, struct PgpCache);
+        l = mutt_mem_malloc_T(1, struct PgpCache);
         l->next = (struct PgpCache *) mod_data->pgp_id_defaults;
         mod_data->pgp_id_defaults = l;
         l->what = mutt_str_dup(whatfor);

--- a/ncrypt/pgplib.c
+++ b/ncrypt/pgplib.c
@@ -132,7 +132,7 @@ struct PgpUid *pgp_copy_uids(struct PgpUid *up, struct PgpKeyInfo *parent)
 
   for (; up; up = up->next)
   {
-    *lp = MUTT_MEM_CALLOC(1, struct PgpUid);
+    *lp = mutt_mem_calloc_T(1, struct PgpUid);
     (*lp)->trust = up->trust;
     (*lp)->flags = up->flags;
     (*lp)->addr = mutt_str_dup(up->addr);

--- a/ncrypt/pgppacket.c
+++ b/ncrypt/pgppacket.c
@@ -91,7 +91,7 @@ unsigned char *pgp_read_packet(FILE *fp, size_t *len)
   if (mod_data->packet_buf_len == 0)
   {
     mod_data->packet_buf_len = CHUNK_SIZE;
-    mod_data->packet_buf = MUTT_MEM_MALLOC(mod_data->packet_buf_len, unsigned char);
+    mod_data->packet_buf = mutt_mem_malloc_T(mod_data->packet_buf_len, unsigned char);
   }
 
   if (fread(&ctb, 1, 1, fp) < 1)

--- a/ncrypt/pgppacket.c
+++ b/ncrypt/pgppacket.c
@@ -54,7 +54,7 @@ static int read_material(size_t material, size_t *used, FILE *fp)
   {
     mod_data->packet_buf_len = *used + material + CHUNK_SIZE;
 
-    MUTT_MEM_REALLOC(&mod_data->packet_buf, mod_data->packet_buf_len, unsigned char);
+    mutt_mem_realloc_T(&mod_data->packet_buf, mod_data->packet_buf_len, unsigned char);
   }
 
   if (fread(mod_data->packet_buf + *used, 1, material, fp) < material)

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -120,7 +120,7 @@ static struct SmimeKey *smime_copy_key(struct SmimeKey *key)
 
   struct SmimeKey *copy = NULL;
 
-  copy = MUTT_MEM_CALLOC(1, struct SmimeKey);
+  copy = mutt_mem_calloc_T(1, struct SmimeKey);
   copy->email = mutt_str_dup(key->email);
   copy->hash = mutt_str_dup(key->hash);
   copy->label = mutt_str_dup(key->label);
@@ -252,7 +252,7 @@ static struct SmimeKey *smime_parse_key(char *buf)
   char *p = NULL;
   int field = 0;
 
-  struct SmimeKey *key = MUTT_MEM_CALLOC(1, struct SmimeKey);
+  struct SmimeKey *key = mutt_mem_calloc_T(1, struct SmimeKey);
 
   for (p = buf; p; p = pend)
   {
@@ -783,7 +783,7 @@ static int smime_handle_cert_email(const char *certificate, const char *mailbox,
   if (copy && buffer && num)
   {
     (*num) = count;
-    *buffer = MUTT_MEM_CALLOC(count, char *);
+    *buffer = mutt_mem_calloc_T(count, char *);
     count = 0;
 
     fseek(fp_out, 0, SEEK_SET);
@@ -793,7 +793,7 @@ static int smime_handle_cert_email(const char *certificate, const char *mailbox,
       size_t len = mutt_str_len(email);
       if (len && (email[len - 1] == '\n'))
         email[len - 1] = '\0';
-      (*buffer)[count] = MUTT_MEM_CALLOC(mutt_str_len(email) + 1, char);
+      (*buffer)[count] = mutt_mem_calloc_T(mutt_str_len(email) + 1, char);
       strncpy((*buffer)[count], email, mutt_str_len(email));
       count++;
     }

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -688,7 +688,7 @@ char *smime_class_find_keys(const struct AddressList *al, bool oppenc_mode)
 
     keyid = key->hash;
     keylist_size += mutt_str_len(keyid) + 2;
-    MUTT_MEM_REALLOC(&keylist, keylist_size, char);
+    mutt_mem_realloc_T(&keylist, keylist_size, char);
     sprintf(keylist + keylist_used, "%s%s", keylist_used ? " " : "", keyid);
     keylist_used = mutt_str_len(keylist);
 

--- a/nntp/adata.c
+++ b/nntp/adata.c
@@ -69,6 +69,6 @@ struct NntpAccountData *nntp_adata_new(struct Connection *conn)
   adata->groups_hash = mutt_hash_new(1009, MUTT_HASH_NONE);
   mutt_hash_set_destructor(adata->groups_hash, nntp_hashelem_free, 0);
   adata->groups_max = 16;
-  adata->groups_list = MUTT_MEM_MALLOC(adata->groups_max, struct NntpMboxData *);
+  adata->groups_list = mutt_mem_malloc_T(adata->groups_max, struct NntpMboxData *);
   return adata;
 }

--- a/nntp/adata.c
+++ b/nntp/adata.c
@@ -64,7 +64,7 @@ void nntp_adata_free(void **ptr)
  */
 struct NntpAccountData *nntp_adata_new(struct Connection *conn)
 {
-  struct NntpAccountData *adata = MUTT_MEM_CALLOC(1, struct NntpAccountData);
+  struct NntpAccountData *adata = mutt_mem_calloc_T(1, struct NntpAccountData);
   adata->conn = conn;
   adata->groups_hash = mutt_hash_new(1009, MUTT_HASH_NONE);
   mutt_hash_set_destructor(adata->groups_hash, nntp_hashelem_free, 0);

--- a/nntp/edata.c
+++ b/nntp/edata.c
@@ -49,7 +49,7 @@ void nntp_edata_free(void **ptr)
  */
 struct NntpEmailData *nntp_edata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct NntpEmailData);
+  return mutt_mem_calloc_T(1, struct NntpEmailData);
 }
 
 /**

--- a/nntp/module.c
+++ b/nntp/module.c
@@ -41,7 +41,7 @@ extern struct ConfigDef NntpVars[];
  */
 static bool nntp_init(struct NeoMutt *n)
 {
-  struct NntpModuleData *mod_data = MUTT_MEM_CALLOC(1, struct NntpModuleData);
+  struct NntpModuleData *mod_data = mutt_mem_calloc_T(1, struct NntpModuleData);
   neomutt_set_module_data(n, MODULE_ID_NNTP, mod_data);
 
   mod_data->notify = notify_new();

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -225,7 +225,7 @@ int nntp_newsrc_parse(struct NntpAccountData *adata)
     FREE(&mdata->newsrc_ent);
   }
 
-  line = MUTT_MEM_MALLOC(st.st_size + 1, char);
+  line = mutt_mem_malloc_T(st.st_size + 1, char);
   while (st.st_size && fgets(line, st.st_size + 1, adata->fp_newsrc))
   {
     char *b = NULL;

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -252,7 +252,7 @@ int nntp_newsrc_parse(struct NntpAccountData *adata)
     while (*b)
       if (*b++ == ',')
         j++;
-    mdata->newsrc_ent = MUTT_MEM_CALLOC(j, struct NewsrcEntry);
+    mdata->newsrc_ent = mutt_mem_calloc_T(j, struct NewsrcEntry);
     mdata->subscribed = subs;
 
     /* parse entries */
@@ -322,7 +322,7 @@ void nntp_newsrc_gen_entries(struct Mailbox *m)
   if (!entries)
   {
     entries = 5;
-    mdata->newsrc_ent = MUTT_MEM_CALLOC(entries, struct NewsrcEntry);
+    mdata->newsrc_ent = mutt_mem_calloc_T(entries, struct NewsrcEntry);
   }
 
   /* Set up to fake initial sequence from 1 to the article before the
@@ -451,7 +451,7 @@ int nntp_newsrc_update(struct NntpAccountData *adata)
   int rc = -1;
 
   size_t buflen = 10240;
-  char *buf = MUTT_MEM_CALLOC(buflen, char);
+  char *buf = mutt_mem_calloc_T(buflen, char);
   size_t off = 0;
 
   /* we will generate full newsrc here */
@@ -654,7 +654,7 @@ int nntp_active_save_cache(struct NntpAccountData *adata)
     return 0;
 
   size_t buflen = 10240;
-  char *buf = MUTT_MEM_CALLOC(buflen, char);
+  char *buf = mutt_mem_calloc_T(buflen, char);
   snprintf(buf, buflen, "%lu\n", (unsigned long) adata->newgroups_time);
   size_t off = strlen(buf);
 
@@ -1194,7 +1194,7 @@ struct NntpMboxData *mutt_newsgroup_subscribe(struct NntpAccountData *adata, cha
   mdata->subscribed = true;
   if (!mdata->newsrc_ent)
   {
-    mdata->newsrc_ent = MUTT_MEM_CALLOC(1, struct NewsrcEntry);
+    mdata->newsrc_ent = mutt_mem_calloc_T(1, struct NewsrcEntry);
     mdata->newsrc_len = 1;
     mdata->newsrc_ent[0].first = 1;
     mdata->newsrc_ent[0].last = 0;

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -91,7 +91,7 @@ static struct NntpMboxData *mdata_find(struct NntpAccountData *adata, const char
   if (adata->groups_num >= adata->groups_max)
   {
     adata->groups_max *= 2;
-    MUTT_MEM_REALLOC(&adata->groups_list, adata->groups_max, struct NntpMboxData *);
+    mutt_mem_realloc_T(&adata->groups_list, adata->groups_max, struct NntpMboxData *);
   }
   adata->groups_list[adata->groups_num++] = mdata;
 
@@ -288,7 +288,7 @@ int nntp_newsrc_parse(struct NntpAccountData *adata)
     if (mdata->last_message == 0)
       mdata->last_message = mdata->newsrc_ent[j - 1].last;
     mdata->newsrc_len = j;
-    MUTT_MEM_REALLOC(&mdata->newsrc_ent, j, struct NewsrcEntry);
+    mutt_mem_realloc_T(&mdata->newsrc_ent, j, struct NewsrcEntry);
     nntp_group_unread_stat(mdata);
     mutt_debug(LL_DEBUG2, "%s\n", mdata->group);
   }
@@ -346,7 +346,7 @@ void nntp_newsrc_gen_entries(struct Mailbox *m)
         if (mdata->newsrc_len >= entries)
         {
           entries *= 2;
-          MUTT_MEM_REALLOC(&mdata->newsrc_ent, entries, struct NewsrcEntry);
+          mutt_mem_realloc_T(&mdata->newsrc_ent, entries, struct NewsrcEntry);
         }
         mdata->newsrc_ent[mdata->newsrc_len].first = first;
         mdata->newsrc_ent[mdata->newsrc_len].last = last - 1;
@@ -371,13 +371,13 @@ void nntp_newsrc_gen_entries(struct Mailbox *m)
     if (mdata->newsrc_len >= entries)
     {
       entries++;
-      MUTT_MEM_REALLOC(&mdata->newsrc_ent, entries, struct NewsrcEntry);
+      mutt_mem_realloc_T(&mdata->newsrc_ent, entries, struct NewsrcEntry);
     }
     mdata->newsrc_ent[mdata->newsrc_len].first = first;
     mdata->newsrc_ent[mdata->newsrc_len].last = mdata->last_loaded;
     mdata->newsrc_len++;
   }
-  MUTT_MEM_REALLOC(&mdata->newsrc_ent, mdata->newsrc_len, struct NewsrcEntry);
+  mutt_mem_realloc_T(&mdata->newsrc_ent, mdata->newsrc_len, struct NewsrcEntry);
 
   if (c_sort != EMAIL_SORT_UNSORTED)
   {
@@ -466,7 +466,7 @@ int nntp_newsrc_update(struct NntpAccountData *adata)
     if ((off + strlen(mdata->group) + 3) > buflen)
     {
       buflen *= 2;
-      MUTT_MEM_REALLOC(&buf, buflen, char);
+      mutt_mem_realloc_T(&buf, buflen, char);
     }
     snprintf(buf + off, buflen - off, "%s%c ", mdata->group, mdata->subscribed ? ':' : '!');
     off += strlen(buf + off);
@@ -477,7 +477,7 @@ int nntp_newsrc_update(struct NntpAccountData *adata)
       if ((off + 1024) > buflen)
       {
         buflen *= 2;
-        MUTT_MEM_REALLOC(&buf, buflen, char);
+        mutt_mem_realloc_T(&buf, buflen, char);
       }
       if (j)
         buf[off++] = ',';
@@ -668,7 +668,7 @@ int nntp_active_save_cache(struct NntpAccountData *adata)
     if ((off + strlen(mdata->group) + (mdata->desc ? strlen(mdata->desc) : 0) + 50) > buflen)
     {
       buflen *= 2;
-      MUTT_MEM_REALLOC(&buf, buflen, char);
+      mutt_mem_realloc_T(&buf, buflen, char);
     }
     snprintf(buf + off, buflen - off, "%s " ANUM_FMT " " ANUM_FMT " %c%s%s\n",
              mdata->group, mdata->last_message, mdata->first_message,
@@ -1248,7 +1248,7 @@ struct NntpMboxData *mutt_newsgroup_catchup(struct Mailbox *m,
 
   if (mdata->newsrc_ent)
   {
-    MUTT_MEM_REALLOC(&mdata->newsrc_ent, 1, struct NewsrcEntry);
+    mutt_mem_realloc_T(&mdata->newsrc_ent, 1, struct NewsrcEntry);
     mdata->newsrc_len = 1;
     mdata->newsrc_ent[0].first = 1;
     mdata->newsrc_ent[0].last = mdata->last_message;
@@ -1287,7 +1287,7 @@ struct NntpMboxData *mutt_newsgroup_uncatchup(struct Mailbox *m,
 
   if (mdata->newsrc_ent)
   {
-    MUTT_MEM_REALLOC(&mdata->newsrc_ent, 1, struct NewsrcEntry);
+    mutt_mem_realloc_T(&mdata->newsrc_ent, 1, struct NewsrcEntry);
     mdata->newsrc_len = 1;
     mdata->newsrc_ent[0].first = 1;
     mdata->newsrc_ent[0].last = mdata->first_message - 1;

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -345,7 +345,7 @@ static int nntp_attempt_features(struct NntpAccountData *adata)
         if ((buflen - off) < 1024)
         {
           buflen *= 2;
-          MUTT_MEM_REALLOC(&adata->overview_fmt, buflen, char);
+          mutt_mem_realloc_T(&adata->overview_fmt, buflen, char);
         }
 
         const int chunk = mutt_socket_readln_d(adata->overview_fmt + off,
@@ -384,7 +384,7 @@ static int nntp_attempt_features(struct NntpAccountData *adata)
         }
       }
       adata->overview_fmt[off++] = '\0';
-      MUTT_MEM_REALLOC(&adata->overview_fmt, off, char);
+      mutt_mem_realloc_T(&adata->overview_fmt, off, char);
     }
   }
   rc = 0; // Success
@@ -883,7 +883,7 @@ static int nntp_fetch_lines(struct NntpMboxData *mdata, char *query, size_t qlen
         off = 0;
       }
 
-      MUTT_MEM_REALLOC(&line, off + sizeof(buf), char);
+      mutt_mem_realloc_T(&line, off + sizeof(buf), char);
     }
     FREE(&line);
     func(NULL, data);
@@ -1467,7 +1467,7 @@ static int nntp_group_poll(struct NntpMboxData *mdata, bool update_stat)
     mdata->last_cached = 0;
     if (mdata->newsrc_len)
     {
-      MUTT_MEM_REALLOC(&mdata->newsrc_ent, 1, struct NewsrcEntry);
+      mutt_mem_realloc_T(&mdata->newsrc_ent, 1, struct NewsrcEntry);
       mdata->newsrc_len = 1;
       mdata->newsrc_ent[0].first = 1;
       mdata->newsrc_ent[0].last = 0;
@@ -1761,7 +1761,7 @@ static int fetch_children(char *line, void *data)
   if (cc->num >= cc->max)
   {
     cc->max *= 2;
-    MUTT_MEM_REALLOC(&cc->child, cc->max, anum_t);
+    mutt_mem_realloc_T(&cc->child, cc->max, anum_t);
   }
   cc->child[cc->num++] = anum;
   return 0;

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1231,7 +1231,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
   fc.first = first;
   fc.last = last;
   fc.restore = restore;
-  fc.messages = MUTT_MEM_CALLOC(last - first + 1, unsigned char);
+  fc.messages = mutt_mem_calloc_T(last - first + 1, unsigned char);
   if (!fc.messages)
     return -1;
   fc.hc = hc;
@@ -1555,7 +1555,7 @@ static enum MxStatus check_mailbox(struct Mailbox *m)
     const long c_nntp_context = cs_subset_long(NeoMutt->sub, "nntp_context");
     if (c_nntp_context && ((mdata->last_message - first + 1) > c_nntp_context))
       first = mdata->last_message - c_nntp_context + 1;
-    messages = MUTT_MEM_CALLOC(mdata->last_loaded - first + 1, unsigned char);
+    messages = mutt_mem_calloc_T(mdata->last_loaded - first + 1, unsigned char);
     hc = nntp_hcache_open(mdata);
     nntp_hcache_update(mdata, hc);
 #endif

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -338,7 +338,7 @@ static int nntp_attempt_features(struct NntpAccountData *adata)
       size_t b = 0;
 
       FREE(&adata->overview_fmt);
-      adata->overview_fmt = MUTT_MEM_MALLOC(buflen, char);
+      adata->overview_fmt = mutt_mem_malloc_T(buflen, char);
 
       while (true)
       {
@@ -837,7 +837,7 @@ static int nntp_fetch_lines(struct NntpMboxData *mdata, char *query, size_t qlen
       return 1;
     }
 
-    line = MUTT_MEM_MALLOC(sizeof(buf), char);
+    line = mutt_mem_malloc_T(sizeof(buf), char);
     rc = 0;
 
     if (msg)
@@ -2315,7 +2315,7 @@ int nntp_check_children(struct Mailbox *m, const char *msgid)
   cc.mailbox = m;
   cc.num = 0;
   cc.max = 10;
-  cc.child = MUTT_MEM_MALLOC(cc.max, anum_t);
+  cc.child = mutt_mem_malloc_T(cc.max, anum_t);
 
   /* fetch numbers of child messages */
   snprintf(buf, sizeof(buf), "XPAT References " ANUM_FMT "-" ANUM_FMT " *%s*\r\n",

--- a/notmuch/adata.c
+++ b/notmuch/adata.c
@@ -57,7 +57,7 @@ void nm_adata_free(void **ptr)
  */
 struct NmAccountData *nm_adata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct NmAccountData);
+  return mutt_mem_calloc_T(1, struct NmAccountData);
 }
 
 /**

--- a/notmuch/edata.c
+++ b/notmuch/edata.c
@@ -60,7 +60,7 @@ void nm_edata_free(void **ptr)
  */
 struct NmEmailData *nm_edata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct NmEmailData);
+  return mutt_mem_calloc_T(1, struct NmEmailData);
 }
 
 /**

--- a/notmuch/mdata.c
+++ b/notmuch/mdata.c
@@ -70,7 +70,7 @@ struct NmMboxData *nm_mdata_new(const char *url)
   if (!url)
     return NULL;
 
-  struct NmMboxData *mdata = MUTT_MEM_CALLOC(1, struct NmMboxData);
+  struct NmMboxData *mdata = mutt_mem_calloc_T(1, struct NmMboxData);
   mutt_debug(LL_DEBUG1, "nm: initialize mailbox mdata %p\n", (void *) mdata);
 
   const short c_nm_db_limit = cs_subset_number(NeoMutt->sub, "nm_db_limit");

--- a/notmuch/module.c
+++ b/notmuch/module.c
@@ -43,7 +43,7 @@ extern const struct Command NmCommands[];
  */
 static bool notmuch_init(struct NeoMutt *n)
 {
-  struct NotmuchModuleData *mod_data = MUTT_MEM_CALLOC(1, struct NotmuchModuleData);
+  struct NotmuchModuleData *mod_data = mutt_mem_calloc_T(1, struct NotmuchModuleData);
   neomutt_set_module_data(n, MODULE_ID_NOTMUCH, mod_data);
 
   mod_data->notify = notify_new();

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -138,7 +138,7 @@ static char *nm_get_default_url(void)
 {
   // path to DB + query + url "decoration"
   size_t len = PATH_MAX + 1024 + 32;
-  char *url = MUTT_MEM_MALLOC(len, char);
+  char *url = mutt_mem_malloc_T(len, char);
 
   // Try to use `$nm_default_url` or `$folder`.
   // If neither are set, it is impossible to create a Notmuch URL.

--- a/pager/display.c
+++ b/pager/display.c
@@ -437,8 +437,8 @@ static void match_body_patterns(char *pat, struct Line *lines, int line_num)
         }
         if (++(lines[line_num].syntax_arr_size) > 1)
         {
-          MUTT_MEM_REALLOC(&(lines[line_num].syntax),
-                           lines[line_num].syntax_arr_size, struct TextSyntax);
+          mutt_mem_realloc_T(&(lines[line_num].syntax),
+                             lines[line_num].syntax_arr_size, struct TextSyntax);
           // Zero the new entry
           const int index = lines[line_num].syntax_arr_size - 1;
           struct TextSyntax *ts = &lines[line_num].syntax[index];
@@ -600,7 +600,7 @@ static void resolve_types(struct MuttWindow *win, char *buf, char *raw,
       if (lines[i].syntax_arr_size)
       {
         lines[i].syntax_arr_size = 0;
-        MUTT_MEM_REALLOC(&(lines[i].syntax), 1, struct TextSyntax);
+        mutt_mem_realloc_T(&(lines[i].syntax), 1, struct TextSyntax);
         lines[i].syntax[0].attr_color = NULL;
         lines[i].syntax[0].first = -1;
         lines[i].syntax[0].last = -1;
@@ -671,8 +671,8 @@ static void resolve_types(struct MuttWindow *win, char *buf, char *raw,
           {
             if (++(lines[line_num].syntax_arr_size) > 1)
             {
-              MUTT_MEM_REALLOC(&(lines[line_num].syntax),
-                               lines[line_num].syntax_arr_size, struct TextSyntax);
+              mutt_mem_realloc_T(&(lines[line_num].syntax),
+                                 lines[line_num].syntax_arr_size, struct TextSyntax);
               // Zero the new entry
               const int index = lines[line_num].syntax_arr_size - 1;
               struct TextSyntax *ts = &lines[line_num].syntax[index];
@@ -1097,7 +1097,7 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
   if (*lines_used == *lines_max)
   {
     *lines_max += LINES;
-    MUTT_MEM_REALLOC(lines, *lines_max, struct Line);
+    mutt_mem_realloc_T(lines, *lines_max, struct Line);
     for (ch = *lines_used; ch < *lines_max; ch++)
     {
       memset(&((*lines)[ch]), 0, sizeof(struct Line));
@@ -1226,7 +1226,7 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
     {
       if (++(cur_line->search_arr_size) > 1)
       {
-        MUTT_MEM_REALLOC(&(cur_line->search), cur_line->search_arr_size, struct TextSyntax);
+        mutt_mem_realloc_T(&(cur_line->search), cur_line->search_arr_size, struct TextSyntax);
         // Zero the new entry
         const int index = cur_line->search_arr_size - 1;
         struct TextSyntax *ts = &cur_line->search[index];

--- a/pager/display.c
+++ b/pager/display.c
@@ -1103,7 +1103,7 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
       memset(&((*lines)[ch]), 0, sizeof(struct Line));
       (*lines)[ch].cid = -1;
       (*lines)[ch].search_arr_size = -1;
-      (*lines)[ch].syntax = MUTT_MEM_CALLOC(1, struct TextSyntax);
+      (*lines)[ch].syntax = mutt_mem_calloc_T(1, struct TextSyntax);
       ((*lines)[ch].syntax)[0].first = -1;
       ((*lines)[ch].syntax)[0].last = -1;
     }
@@ -1234,7 +1234,7 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
       }
       else
       {
-        cur_line->search = MUTT_MEM_CALLOC(1, struct TextSyntax);
+        cur_line->search = mutt_mem_calloc_T(1, struct TextSyntax);
       }
       pmatch[0].rm_so += offset;
       pmatch[0].rm_eo += offset;

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -317,7 +317,7 @@ int dlg_pager(struct PagerView *pview)
   //---------- initialize redraw pdata  -----------------------------------------
   pview->win_pager->size = MUTT_WIN_SIZE_MAXIMISE;
   priv->lines_max = LINES; // number of lines on screen, from curses
-  priv->lines = MUTT_MEM_CALLOC(priv->lines_max, struct Line);
+  priv->lines = mutt_mem_calloc_T(priv->lines_max, struct Line);
   priv->fp = mutt_file_fopen(pview->pdata->fname, "r");
   priv->has_types = ((pview->mode == PAGER_MODE_EMAIL) || (pview->flags & MUTT_SHOWCOLOR)) ?
                         MUTT_TYPES :
@@ -327,7 +327,7 @@ int dlg_pager(struct PagerView *pview)
   {
     priv->lines[i].cid = -1;
     priv->lines[i].search_arr_size = -1;
-    priv->lines[i].syntax = MUTT_MEM_CALLOC(1, struct TextSyntax);
+    priv->lines[i].syntax = mutt_mem_calloc_T(1, struct TextSyntax);
     (priv->lines[i].syntax)[0].first = -1;
     (priv->lines[i].syntax)[0].last = -1;
   }

--- a/pager/module.c
+++ b/pager/module.c
@@ -41,7 +41,7 @@ extern struct ConfigDef PagerVars[];
  */
 static bool pager_init(struct NeoMutt *n)
 {
-  struct PagerModuleData *mod_data = MUTT_MEM_CALLOC(1, struct PagerModuleData);
+  struct PagerModuleData *mod_data = mutt_mem_calloc_T(1, struct PagerModuleData);
   neomutt_set_module_data(n, MODULE_ID_PAGER, mod_data);
 
   mod_data->notify = notify_new();

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -158,7 +158,7 @@ static int pager_repaint(struct MuttWindow *win)
       priv->lines[i].search_arr_size = -1;
       priv->lines[i].quote = NULL;
 
-      MUTT_MEM_REALLOC(&(priv->lines[i].syntax), 1, struct TextSyntax);
+      mutt_mem_realloc_T(&(priv->lines[i].syntax), 1, struct TextSyntax);
       priv->lines[i].syntax[0].attr_color = NULL;
       priv->lines[i].syntax[0].first = -1;
       priv->lines[i].syntax[0].last = -1;

--- a/pager/pbar.c
+++ b/pager/pbar.c
@@ -312,7 +312,7 @@ static void pbar_data_free(struct MuttWindow *win, void **ptr)
 static struct PBarPrivateData *pbar_data_new(struct IndexSharedData *shared,
                                              struct PagerPrivateData *priv)
 {
-  struct PBarPrivateData *pbar_data = MUTT_MEM_CALLOC(1, struct PBarPrivateData);
+  struct PBarPrivateData *pbar_data = mutt_mem_calloc_T(1, struct PBarPrivateData);
 
   pbar_data->shared = shared;
   pbar_data->priv = priv;

--- a/pager/private_data.c
+++ b/pager/private_data.c
@@ -58,7 +58,7 @@ void pager_private_data_free(struct MuttWindow *win, void **ptr)
  */
 struct PagerPrivateData *pager_private_data_new(void)
 {
-  struct PagerPrivateData *priv = MUTT_MEM_CALLOC(1, struct PagerPrivateData);
+  struct PagerPrivateData *priv = mutt_mem_calloc_T(1, struct PagerPrivateData);
 
   priv->notify = notify_new();
 

--- a/parse/module.c
+++ b/parse/module.c
@@ -38,7 +38,7 @@
  */
 static bool parse_init(struct NeoMutt *n)
 {
-  struct ParseModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ParseModuleData);
+  struct ParseModuleData *mod_data = mutt_mem_calloc_T(1, struct ParseModuleData);
   neomutt_set_module_data(n, MODULE_ID_PARSE, mod_data);
 
   mod_data->notify = notify_new();

--- a/parse/pcontext.c
+++ b/parse/pcontext.c
@@ -36,7 +36,7 @@
  */
 struct ParseContext *parse_context_new(void)
 {
-  struct ParseContext *pc = MUTT_MEM_CALLOC(1, struct ParseContext);
+  struct ParseContext *pc = mutt_mem_calloc_T(1, struct ParseContext);
 
   return pc;
 }

--- a/parse/perror.c
+++ b/parse/perror.c
@@ -36,7 +36,7 @@
  */
 struct ParseError *parse_error_new(void)
 {
-  struct ParseError *pc = MUTT_MEM_CALLOC(1, struct ParseError);
+  struct ParseError *pc = mutt_mem_calloc_T(1, struct ParseError);
 
   pc->message = buf_pool_get();
 

--- a/pattern/compile.c
+++ b/pattern/compile.c
@@ -87,7 +87,7 @@ static bool eat_regex(struct Pattern *pat, PatternCompFlags flags,
     goto out;
   }
 
-  pat->p.regex = MUTT_MEM_CALLOC(1, regex_t);
+  pat->p.regex = mutt_mem_calloc_T(1, regex_t);
 #ifdef USE_DEBUG_GRAPHVIZ
   pat->raw_pattern = buf_strdup(token);
 #endif
@@ -881,7 +881,7 @@ void mutt_pattern_free(struct PatternList **pat)
  */
 static struct Pattern *mutt_pattern_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct Pattern);
+  return mutt_mem_calloc_T(1, struct Pattern);
 }
 
 /**
@@ -890,7 +890,7 @@ static struct Pattern *mutt_pattern_new(void)
  */
 static struct PatternList *mutt_pattern_list_new(void)
 {
-  struct PatternList *h = MUTT_MEM_CALLOC(1, struct PatternList);
+  struct PatternList *h = mutt_mem_calloc_T(1, struct PatternList);
   SLIST_INIT(h);
   struct Pattern *p = mutt_pattern_new();
   SLIST_INSERT_HEAD(h, p, entries);

--- a/pattern/module.c
+++ b/pattern/module.c
@@ -42,7 +42,7 @@ extern struct ConfigDef PatternVars[];
  */
 static bool pattern_init(struct NeoMutt *n)
 {
-  struct PatternModuleData *mod_data = MUTT_MEM_CALLOC(1, struct PatternModuleData);
+  struct PatternModuleData *mod_data = mutt_mem_calloc_T(1, struct PatternModuleData);
 
   // clang-format off
   mod_data->range_regexes[RANGE_K_REL]  = (struct RangeRegex){ RANGE_REL_RX,  1, 3, 0, { 0 } };

--- a/pattern/search_state.c
+++ b/pattern/search_state.c
@@ -38,7 +38,7 @@
  */
 struct SearchState *search_state_new(void)
 {
-  struct SearchState *s = MUTT_MEM_CALLOC(1, struct SearchState);
+  struct SearchState *s = mutt_mem_calloc_T(1, struct SearchState);
   s->string = buf_pool_get();
   s->string_expn = buf_pool_get();
   return s;

--- a/pop/adata.c
+++ b/pop/adata.c
@@ -62,7 +62,7 @@ void pop_adata_free(void **ptr)
  */
 struct PopAccountData *pop_adata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct PopAccountData);
+  return mutt_mem_calloc_T(1, struct PopAccountData);
 }
 
 /**

--- a/pop/auth.c
+++ b/pop/auth.c
@@ -205,7 +205,7 @@ static enum PopAuthRes pop_auth_sasl(struct PopAccountData *adata, const char *m
   mutt_message(_("Authenticating (%s)..."), "SASL");
 
   size_t bufsize = MAX((olen * 2), 1024);
-  char *buf = MUTT_MEM_MALLOC(bufsize, char);
+  char *buf = mutt_mem_malloc_T(bufsize, char);
 
   snprintf(buf, bufsize, "AUTH %s", mech);
   olen = strlen(buf);

--- a/pop/auth.c
+++ b/pop/auth.c
@@ -276,7 +276,7 @@ static enum PopAuthRes pop_auth_sasl(struct PopAccountData *adata, const char *m
       if ((olen * 2) > bufsize)
       {
         bufsize = olen * 2;
-        MUTT_MEM_REALLOC(&buf, bufsize, char);
+        mutt_mem_realloc_T(&buf, bufsize, char);
       }
       if (sasl_encode64(pc, olen, buf, bufsize, &olen) != SASL_OK)
       {

--- a/pop/edata.c
+++ b/pop/edata.c
@@ -55,7 +55,7 @@ void pop_edata_free(void **ptr)
  */
 struct PopEmailData *pop_edata_new(const char *uid)
 {
-  struct PopEmailData *edata = MUTT_MEM_CALLOC(1, struct PopEmailData);
+  struct PopEmailData *edata = mutt_mem_calloc_T(1, struct PopEmailData);
   edata->uid = mutt_str_dup(uid);
   return edata;
 }

--- a/pop/lib.c
+++ b/pop/lib.c
@@ -521,7 +521,7 @@ int pop_fetch_data(struct PopAccountData *adata, const char *query,
   if (rc < 0)
     return rc;
 
-  char *inbuf = MUTT_MEM_MALLOC(sizeof(buf), char);
+  char *inbuf = mutt_mem_malloc_T(sizeof(buf), char);
 
   while (true)
   {

--- a/pop/lib.c
+++ b/pop/lib.c
@@ -557,7 +557,7 @@ int pop_fetch_data(struct PopAccountData *adata, const char *query,
       lenbuf = 0;
     }
 
-    MUTT_MEM_REALLOC(&inbuf, lenbuf + sizeof(buf), char);
+    mutt_mem_realloc_T(&inbuf, lenbuf + sizeof(buf), char);
   }
 
   FREE(&inbuf);

--- a/pop/module.c
+++ b/pop/module.c
@@ -41,7 +41,7 @@ extern struct ConfigDef PopVars[];
  */
 static bool pop_init(struct NeoMutt *n)
 {
-  struct PopModuleData *mod_data = MUTT_MEM_CALLOC(1, struct PopModuleData);
+  struct PopModuleData *mod_data = mutt_mem_calloc_T(1, struct PopModuleData);
   neomutt_set_module_data(n, MODULE_ID_POP, mod_data);
 
   mod_data->notify = notify_new();

--- a/postpone/module.c
+++ b/postpone/module.c
@@ -38,7 +38,7 @@
  */
 static bool postpone_init(struct NeoMutt *n)
 {
-  struct PostponeModuleData *mod_data = MUTT_MEM_CALLOC(1, struct PostponeModuleData);
+  struct PostponeModuleData *mod_data = mutt_mem_calloc_T(1, struct PostponeModuleData);
   neomutt_set_module_data(n, MODULE_ID_POSTPONE, mod_data);
 
   mod_data->notify = notify_new();

--- a/progress/module.c
+++ b/progress/module.c
@@ -41,7 +41,7 @@ extern struct ConfigDef ProgressVars[];
  */
 static bool progress_init(struct NeoMutt *n)
 {
-  struct ProgressModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ProgressModuleData);
+  struct ProgressModuleData *mod_data = mutt_mem_calloc_T(1, struct ProgressModuleData);
   neomutt_set_module_data(n, MODULE_ID_PROGRESS, mod_data);
 
   mod_data->notify = notify_new();

--- a/progress/wdata.c
+++ b/progress/wdata.c
@@ -36,7 +36,7 @@
  */
 struct ProgressWindowData *progress_wdata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct ProgressWindowData);
+  return mutt_mem_calloc_T(1, struct ProgressWindowData);
 }
 
 /**

--- a/question/module.c
+++ b/question/module.c
@@ -38,7 +38,7 @@
  */
 static bool question_init(struct NeoMutt *n)
 {
-  struct QuestionModuleData *mod_data = MUTT_MEM_CALLOC(1, struct QuestionModuleData);
+  struct QuestionModuleData *mod_data = mutt_mem_calloc_T(1, struct QuestionModuleData);
   neomutt_set_module_data(n, MODULE_ID_QUESTION, mod_data);
 
   mod_data->notify = notify_new();

--- a/send/header.c
+++ b/send/header.c
@@ -534,7 +534,7 @@ void mutt_write_references(const struct ListHead *r, FILE *fp, size_t trim)
       break;
   }
 
-  struct ListNode **ref = MUTT_MEM_CALLOC(length, struct ListNode *);
+  struct ListNode **ref = mutt_mem_calloc_T(length, struct ListNode *);
 
   // store in reverse order
   size_t tmp = length;

--- a/send/module.c
+++ b/send/module.c
@@ -43,7 +43,7 @@ extern const struct Command SendCommands[];
  */
 static bool send_init(struct NeoMutt *n)
 {
-  struct SendModuleData *mod_data = MUTT_MEM_CALLOC(1, struct SendModuleData);
+  struct SendModuleData *mod_data = mutt_mem_calloc_T(1, struct SendModuleData);
   neomutt_set_module_data(n, MODULE_ID_SEND, mod_data);
 
   mod_data->notify = notify_new();

--- a/send/send.c
+++ b/send/send.c
@@ -1642,7 +1642,7 @@ static bool search_attach_keyword(char *filename, struct ConfigSubset *sub)
   if (!fp_att)
     return false;
 
-  char *inputline = MUTT_MEM_MALLOC(1024, char);
+  char *inputline = mutt_mem_malloc_T(1024, char);
   bool found = false;
   while (!feof(fp_att) && fgets(inputline, 1024, fp_att))
   {

--- a/send/send.c
+++ b/send/send.c
@@ -587,7 +587,7 @@ static int inline_forward_attachments(struct Mailbox *m, struct Email *e,
   mutt_parse_mime_message(e, msg->fp);
   exec_message_hook(m, e, CMD_MESSAGE_HOOK);
 
-  actx = MUTT_MEM_CALLOC(1, struct AttachCtx);
+  actx = mutt_mem_calloc_T(1, struct AttachCtx);
   actx->email = e;
   actx->fp_root = msg->fp;
 

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -698,7 +698,7 @@ static void encode_headers(struct ListHead *h, struct ConfigSubset *sub)
       continue;
 
     rfc2047_encode(&tmp, NULL, i + 2, c_send_charset);
-    MUTT_MEM_REALLOC(&np->data, i + 2 + mutt_str_len(tmp) + 1, char);
+    mutt_mem_realloc_T(&np->data, i + 2 + mutt_str_len(tmp) + 1, char);
 
     sprintf(np->data + i + 2, "%s", tmp);
 

--- a/sidebar/module.c
+++ b/sidebar/module.c
@@ -45,7 +45,7 @@ extern const struct Command SbCommands[];
  */
 static bool sidebar_init(struct NeoMutt *n)
 {
-  struct SidebarModuleData *mod_data = MUTT_MEM_CALLOC(1, struct SidebarModuleData);
+  struct SidebarModuleData *mod_data = mutt_mem_calloc_T(1, struct SidebarModuleData);
   STAILQ_INIT(&mod_data->sidebar_pinned);
   neomutt_set_module_data(n, MODULE_ID_SIDEBAR, mod_data);
 

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -111,7 +111,7 @@ void sb_add_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
    * they're valid, our pointers will be updated in prepare_sidebar() */
 
   struct IndexSharedData *shared = wdata->shared;
-  struct SbEntry *entry = MUTT_MEM_CALLOC(1, struct SbEntry);
+  struct SbEntry *entry = mutt_mem_calloc_T(1, struct SbEntry);
   entry->mailbox = m;
   entry->score = -1;
 

--- a/sidebar/wdata.c
+++ b/sidebar/wdata.c
@@ -43,7 +43,7 @@ struct IndexSharedData;
  */
 struct SidebarWindowData *sb_wdata_new(struct MuttWindow *win, struct IndexSharedData *shared)
 {
-  struct SidebarWindowData *wdata = MUTT_MEM_CALLOC(1, struct SidebarWindowData);
+  struct SidebarWindowData *wdata = mutt_mem_calloc_T(1, struct SidebarWindowData);
   wdata->win = win;
   wdata->shared = shared;
   ARRAY_INIT(&wdata->entries);

--- a/store/lmdb.c
+++ b/store/lmdb.c
@@ -86,7 +86,7 @@ static void lmdb_sdata_free(struct LmdbStoreData **ptr)
  */
 static struct LmdbStoreData *lmdb_sdata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct LmdbStoreData);
+  return mutt_mem_calloc_T(1, struct LmdbStoreData);
 }
 
 /**

--- a/store/module.c
+++ b/store/module.c
@@ -38,7 +38,7 @@
  */
 static bool store_init(struct NeoMutt *n)
 {
-  struct StoreModuleData *mod_data = MUTT_MEM_CALLOC(1, struct StoreModuleData);
+  struct StoreModuleData *mod_data = mutt_mem_calloc_T(1, struct StoreModuleData);
   neomutt_set_module_data(n, MODULE_ID_STORE, mod_data);
 
   mod_data->notify = notify_new();

--- a/store/rocksdb.c
+++ b/store/rocksdb.c
@@ -68,7 +68,7 @@ static void rocksdb_sdata_free(struct RocksDbStoreData **ptr)
  */
 static struct RocksDbStoreData *rocksdb_sdata_new(void)
 {
-  return MUTT_MEM_CALLOC(1, struct RocksDbStoreData);
+  return mutt_mem_calloc_T(1, struct RocksDbStoreData);
 }
 
 /**

--- a/test/account/account_free.c
+++ b/test/account/account_free.c
@@ -48,13 +48,13 @@ void test_account_free(void)
   }
 
   {
-    struct Account *a = MUTT_MEM_CALLOC(1, struct Account);
+    struct Account *a = mutt_mem_calloc_T(1, struct Account);
     account_free(&a);
     TEST_CHECK_(1, "account_free(&a)");
   }
 
   {
-    struct Account *a = MUTT_MEM_CALLOC(1, struct Account);
+    struct Account *a = mutt_mem_calloc_T(1, struct Account);
     a->adata = mutt_mem_calloc(32, 1);
     a->adata_free = adata_free;
 

--- a/test/buffer/buf_alloc.c
+++ b/test/buffer/buf_alloc.c
@@ -37,7 +37,7 @@ void test_buf_alloc(void)
   }
 
   {
-    struct Buffer *buf = MUTT_MEM_CALLOC(1, struct Buffer);
+    struct Buffer *buf = mutt_mem_calloc_T(1, struct Buffer);
     buf_alloc(buf, 10);
     TEST_CHECK_(1, "buf_alloc(buf, 10)");
     buf_free(&buf);
@@ -54,7 +54,7 @@ void test_buf_alloc(void)
 
     for (size_t i = 0; i < countof(sizes); i++)
     {
-      struct Buffer *buf = MUTT_MEM_CALLOC(1, struct Buffer);
+      struct Buffer *buf = mutt_mem_calloc_T(1, struct Buffer);
       buf_alloc(buf, orig_size);
       TEST_CASE_("%d", sizes[i][0]);
       buf_alloc(buf, sizes[i][0]);

--- a/test/common.c
+++ b/test/common.c
@@ -163,7 +163,7 @@ bool test_neomutt_create(void)
   NeoMutt = neomutt_new();
   TEST_CHECK(NeoMutt != NULL);
 
-  char **tmp_env = MUTT_MEM_CALLOC(2, char *);
+  char **tmp_env = mutt_mem_calloc_T(2, char *);
   neomutt_init(NeoMutt, tmp_env, Modules);
   FREE(&tmp_env);
 

--- a/test/compress/common.c
+++ b/test/compress/common.c
@@ -119,7 +119,7 @@ static void one_test(const struct ComprOps *compr_ops, short level, size_t size)
   if (!TEST_CHECK(clen != 0))
     return;
 
-  void *copy = MUTT_MEM_MALLOC(clen, char);
+  void *copy = mutt_mem_malloc_T(clen, char);
   memcpy(copy, cdata, clen);
 
   size_t dlen = 0;

--- a/test/email/email_header_find.c
+++ b/test/email/email_header_find.c
@@ -33,7 +33,7 @@ void test_email_header_find(void)
   char *header = "X-TestHeader: 123";
 
   struct ListHead hdrlist = STAILQ_HEAD_INITIALIZER(hdrlist);
-  struct ListNode *n = MUTT_MEM_CALLOC(1, struct ListNode);
+  struct ListNode *n = mutt_mem_calloc_T(1, struct ListNode);
   n->data = mutt_str_dup(header);
   STAILQ_INSERT_TAIL(&hdrlist, n, entries);
 

--- a/test/email/email_header_update.c
+++ b/test/email/email_header_update.c
@@ -34,7 +34,7 @@ void test_email_header_update(void)
   const char *existing_header = "X-Found: foo";
   const char *new_value = "X-Found: 3.14";
 
-  struct ListNode *n = MUTT_MEM_CALLOC(1, struct ListNode);
+  struct ListNode *n = mutt_mem_calloc_T(1, struct ListNode);
   n->data = mutt_str_dup(existing_header);
 
   {

--- a/test/gui/mutt_str_expand_tabs.c
+++ b/test/gui/mutt_str_expand_tabs.c
@@ -42,7 +42,7 @@ void test_mutt_str_expand_tabs(void)
   /* Explicit test for null-termination */
   {
     size_t len = 8;
-    char *buf = MUTT_MEM_CALLOC(len, char);
+    char *buf = mutt_mem_calloc_T(len, char);
     buf[0] = '\t';
     mutt_str_expand_tabs(&buf, &len, 8);
     TEST_CHECK_STR_EQ(buf, "        ");

--- a/test/list/common.c
+++ b/test/list/common.c
@@ -34,7 +34,7 @@ struct ListHead test_list_create(const char *items[], bool copy)
 
   for (size_t i = 0; items[i]; i++)
   {
-    struct ListNode *np = MUTT_MEM_CALLOC(1, struct ListNode);
+    struct ListNode *np = mutt_mem_calloc_T(1, struct ListNode);
     if (copy)
       np->data = mutt_str_dup(items[i]);
     else

--- a/test/mailbox/mailbox_free.c
+++ b/test/mailbox/mailbox_free.c
@@ -48,13 +48,13 @@ void test_mailbox_free(void)
   }
 
   {
-    struct Mailbox *m = MUTT_MEM_CALLOC(1, struct Mailbox);
+    struct Mailbox *m = mutt_mem_calloc_T(1, struct Mailbox);
     mailbox_free(&m);
     TEST_CHECK_(1, "mailbox_free(&m)");
   }
 
   {
-    struct Mailbox *m = MUTT_MEM_CALLOC(1, struct Mailbox);
+    struct Mailbox *m = mutt_mem_calloc_T(1, struct Mailbox);
     m->mdata = mutt_mem_calloc(32, 1);
     m->mdata_free = mdata_free;
 

--- a/test/neo/neomutt_free.c
+++ b/test/neo/neomutt_free.c
@@ -43,7 +43,7 @@ void test_neomutt_free(void)
   }
 
   {
-    struct NeoMutt *n = MUTT_MEM_CALLOC(1, struct NeoMutt);
+    struct NeoMutt *n = mutt_mem_calloc_T(1, struct NeoMutt);
     neomutt_free(&n);
     TEST_CHECK_(1, "neomutt_free(&n)");
   }

--- a/test/sidebar/sb_remove_mailbox.c
+++ b/test/sidebar/sb_remove_mailbox.c
@@ -50,12 +50,12 @@ void test_sb_remove_mailbox(void)
 
   struct SidebarWindowData wdata = { 0 };
 
-  struct SbEntry *entry_a = MUTT_MEM_CALLOC(1, struct SbEntry);
+  struct SbEntry *entry_a = mutt_mem_calloc_T(1, struct SbEntry);
   entry_a->mailbox = &mailbox_a;
   entry_a->is_hidden = true; // No unhidden entry left for sb_prev() to backtrack to
   ARRAY_ADD(&wdata.entries, entry_a);
 
-  struct SbEntry *entry_b = MUTT_MEM_CALLOC(1, struct SbEntry);
+  struct SbEntry *entry_b = mutt_mem_calloc_T(1, struct SbEntry);
   entry_b->mailbox = &mailbox_b;
   entry_b->is_hidden = false;
   ARRAY_ADD(&wdata.entries, entry_b);

--- a/version.c
+++ b/version.c
@@ -466,7 +466,7 @@ static void kva_clear(struct KeyValueArray *kva)
  */
 struct NeoMuttVersion *version_get(void)
 {
-  struct NeoMuttVersion *ver = MUTT_MEM_CALLOC(1, struct NeoMuttVersion);
+  struct NeoMuttVersion *ver = mutt_mem_calloc_T(1, struct NeoMuttVersion);
 
   ver->version = mutt_str_dup(mutt_make_version());
 


### PR DESCRIPTION
*  */, mutt/memory.h: Rename MUTT_MEM_REALLOC() => mutt_mem_realloc_T()
*  */, mutt/memory.h: Rename MUTT_MEM_MALLOC() => mutt_mem_malloc_T()
*  */, mutt/memory.h: Rename MUTT_MEM_CALLOC() => mutt_mem_calloc_T()

---

Revisions:

<details>
<summary>v1b</summary>

-  Use `__typeof__` instead of `typeof`.  This should work even in strict ANSI mode.

```
$ git range-diff main neomutt/alx/typeas alx/typeas 
1:  0014f5204 = 1:  0014f5204 mutt/memory.h: MUTT_MEM_REALLOC(): Refactor for readability
2:  efd7238e2 ! 2:  86939984e mutt/memory.h: typeas(): Add macro
    @@ mutt/memory.h
      #endif
      
     +#if !defined(typeas)
    -+# define typeas(T)  typeof((T){0})
    ++# define typeas(T)  __typeof__((T){0})
     +#endif
     +
      #define MUTT_MEM_CALLOC(n, type)  ((type *) mutt_mem_calloc(n, sizeof(type)))
3:  a8062e502 ! 3:  fe7bda041 mutt/memory.h: Use typeas() to make these macros more robust
    @@ Commit message
     
      ## mutt/memory.h ##
     @@
    - # define typeas(T)  typeof((T){0})
    + # define typeas(T)  __typeof__((T){0})
      #endif
      
     -#define MUTT_MEM_CALLOC(n, type)  ((type *) mutt_mem_calloc(n, sizeof(type)))
4:  8d732141c ! 4:  3973e238b */, mutt/memory.h: Rename MUTT_MEM_CALLOC() => mutt_mem_calloc_T()
    @@ mutt/mbyte.c: int mutt_mb_filter_unprintable(char **s)
     
      ## mutt/memory.h ##
     @@
    - # define typeas(T)  typeof((T){0})
    + # define typeas(T)  __typeof__((T){0})
      #endif
      
     -#define MUTT_MEM_CALLOC(n, T)  ((typeas(T) *) mutt_mem_calloc(n, sizeof(T)))
5:  b1f482f57 = 5:  4afb0fd53 */, mutt/memory.h: Rename MUTT_MEM_MALLOC() => mutt_mem_malloc_T()
6:  bc4c4a727 = 6:  f34c0c260 */, mutt/memory.h: Rename MUTT_MEM_REALLOC() => mutt_mem_realloc_T()
```
</details>

<details>
<summary>v2</summary>

-  Use (C99) compound literals together with GNU statement expressions to avoid casts.

```
$ git range-diff main neomutt/alx/typeas alx/typeas 
1:  0014f5204 = 1:  0014f5204 mutt/memory.h: MUTT_MEM_REALLOC(): Refactor for readability
2:  86939984e = 2:  86939984e mutt/memory.h: typeas(): Add macro
3:  fe7bda041 = 3:  fe7bda041 mutt/memory.h: Use typeas() to make these macros more robust
4:  3973e238b = 4:  3973e238b */, mutt/memory.h: Rename MUTT_MEM_CALLOC() => mutt_mem_calloc_T()
5:  4afb0fd53 = 5:  4afb0fd53 */, mutt/memory.h: Rename MUTT_MEM_MALLOC() => mutt_mem_malloc_T()
6:  f34c0c260 = 6:  f34c0c260 */, mutt/memory.h: Rename MUTT_MEM_REALLOC() => mutt_mem_realloc_T()
-:  --------- > 7:  73b8b230f mutt/memory.h: Use compound literals instead of casts
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git range-diff neomutt/main neomutt/alx/typeas alx/typeas 
1:  0014f5204 = 1:  734523745 mutt/memory.h: MUTT_MEM_REALLOC(): Refactor for readability
2:  86939984e = 2:  b22bbfc9c mutt/memory.h: typeas(): Add macro
3:  fe7bda041 = 3:  f9873577f mutt/memory.h: Use typeas() to make these macros more robust
4:  3973e238b = 4:  d5861d511 */, mutt/memory.h: Rename MUTT_MEM_CALLOC() => mutt_mem_calloc_T()
5:  4afb0fd53 = 5:  7a460787a */, mutt/memory.h: Rename MUTT_MEM_MALLOC() => mutt_mem_malloc_T()
6:  f34c0c260 = 6:  2891df9c1 */, mutt/memory.h: Rename MUTT_MEM_REALLOC() => mutt_mem_realloc_T()
7:  73b8b230f = 7:  43d2bb6fb mutt/memory.h: Use compound literals instead of casts
```
</details>

<details>
<summary>v3</summary>

-  Rebase

```
$ git range-diff -U0 main neomutt/alx/typeas alx/typeas 
1:  734523745500 = 1:  d34b5828dbd9 mutt/memory.h: MUTT_MEM_REALLOC(): Refactor for readability
2:  b22bbfc9c4fd = 2:  da5e1a2cf793 mutt/memory.h: typeas(): Add macro
3:  f9873577f954 = 3:  08dc66088c29 mutt/memory.h: Use typeas() to make these macros more robust
4:  d5861d511f7d ! 4:  9deeb3116e8c */, mutt/memory.h: Rename MUTT_MEM_CALLOC() => mutt_mem_calloc_T()
    @@ address/group.c: void grouplist_add_group(struct GroupList *gl, struct Group *g)
    + ## address/module.c ##
    +@@ address/module.c: extern struct ConfigDef AddressVarsIdn[];
    +  */
    + static bool address_init(struct NeoMutt *n)
    + {
    +-  struct AddressModuleData *mod_data = MUTT_MEM_CALLOC(1, struct AddressModuleData);
    ++  struct AddressModuleData *mod_data = mutt_mem_calloc_T(1, struct AddressModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_ADDRESS, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ alias/alias.c: bool mutt_addr_is_user(const struct Address *addr)
    + ## alias/module.c ##
    +@@ alias/module.c: extern const struct Command AliasCommands[];
    +  */
    + static bool alias_init(struct NeoMutt *n)
    + {
    +-  struct AliasModuleData *mod_data = MUTT_MEM_CALLOC(1, struct AliasModuleData);
    ++  struct AliasModuleData *mod_data = mutt_mem_calloc_T(1, struct AliasModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_ALIAS, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ attach/commands.c
    -@@ attach/commands.c: static void attachmatch_free(struct AttachMatch **ptr)
    +@@ attach/commands.c: void attachmatch_free(void **ptr)
    @@ attach/commands.c: static void attachmatch_free(struct AttachMatch **ptr)
    - static struct AttachMatch *attachmatch_new(void)
    + struct AttachMatch *attachmatch_new(void)
    @@ attach/commands.c: static void attachmatch_free(struct AttachMatch **ptr)
    + ## attach/module.c ##
    +@@ attach/module.c: extern const struct Command AttachCommands[];
    +  */
    + static bool attach_init(struct NeoMutt *n)
    + {
    +-  struct AttachModuleData *mod_data = MUTT_MEM_CALLOC(1, struct AttachModuleData);
    ++  struct AttachModuleData *mod_data = mutt_mem_calloc_T(1, struct AttachModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_ATTACH, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ autocrypt/dlg_autocrypt.c: bool populate_menu(struct Menu *menu)
    + ## autocrypt/module.c ##
    +@@ autocrypt/module.c: extern struct ConfigDef AutocryptVars[];
    +  */
    + static bool autocrypt_init(struct NeoMutt *n)
    + {
    +-  struct AutocryptModuleData *mod_data = MUTT_MEM_CALLOC(1, struct AutocryptModuleData);
    ++  struct AutocryptModuleData *mod_data = mutt_mem_calloc_T(1, struct AutocryptModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_AUTOCRYPT, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ bcache/bcache.c: struct BodyCache *mutt_bcache_open(struct ConnAccount *account,
    + ## bcache/module.c ##
    +@@
    +  */
    + static bool bcache_init(struct NeoMutt *n)
    + {
    +-  struct BcacheModuleData *mod_data = MUTT_MEM_CALLOC(1, struct BcacheModuleData);
    ++  struct BcacheModuleData *mod_data = mutt_mem_calloc_T(1, struct BcacheModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_BCACHE, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ browser/functions.c
    -@@ browser/functions.c: static int op_exit(struct BrowserPrivateData *priv, int op)
    -     if (priv->menu->num_tagged)
    +@@ browser/functions.c: static int op_quit(struct BrowserPrivateData *priv, const struct KeyEvent *event
    +     if (priv->menu->tag_prefix && (priv->menu->num_tagged != 0))
    @@ browser/functions.c: static int op_exit(struct BrowserPrivateData *priv, int op)
    -@@ browser/functions.c: static int op_exit(struct BrowserPrivateData *priv, int op)
    +@@ browser/functions.c: static int op_quit(struct BrowserPrivateData *priv, const struct KeyEvent *event
    @@ browser/functions.c: static int op_exit(struct BrowserPrivateData *priv, int op)
    -       buf_expand_path(priv->file);
    +       expand_path(priv->file, false);
    @@ browser/functions.c: static int op_exit(struct BrowserPrivateData *priv, int op)
    + ## browser/module.c ##
    +@@ browser/module.c: extern struct ConfigDef BrowserVars[];
    +  */
    + static bool browser_init(struct NeoMutt *n)
    + {
    +-  struct BrowserModuleData *mod_data = MUTT_MEM_CALLOC(1, struct BrowserModuleData);
    ++  struct BrowserModuleData *mod_data = mutt_mem_calloc_T(1, struct BrowserModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_BROWSER, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ color/curses.c: struct CursesColor *curses_color_new(color_t fg, color_t bg)
    -   if (index == 0)
    @@ color/curses.c: struct CursesColor *curses_color_new(color_t fg, color_t bg)
    +   struct ColorModuleData *mod_data = neomutt_get_module_data(NeoMutt, MODULE_ID_COLOR);
    @@ color/curses.c: struct CursesColor *curses_color_new(color_t fg, color_t bg)
    -   NumCursesColors++;
    +   mod_data->num_curses_colors++;
    @@ color/curses.c: struct CursesColor *curses_color_new(color_t fg, color_t bg)
    + ## color/module.c ##
    +@@ color/module.c: extern struct ConfigDef ColorVars[];
    +  */
    + static bool color_init(struct NeoMutt *n)
    + {
    +-  struct ColorModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ColorModuleData);
    ++  struct ColorModuleData *mod_data = mutt_mem_calloc_T(1, struct ColorModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_COLOR, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ color/regex.c: struct RegexColor *regex_color_new(void)
    + ## commands/module.c ##
    +@@ commands/module.c: extern const struct Command CommandsCommands[];
    +  */
    + static bool commands_init(struct NeoMutt *n)
    + {
    +-  struct CommandsModuleData *mod_data = MUTT_MEM_CALLOC(1, struct CommandsModuleData);
    ++  struct CommandsModuleData *mod_data = mutt_mem_calloc_T(1, struct CommandsModuleData);
    +   STAILQ_INIT(&mod_data->muttrc_stack);
    +   neomutt_set_module_data(n, MODULE_ID_COMMANDS, mod_data);
    + 
    +
    @@ complete/data.c: void completion_data_free(struct CompletionData **ptr)
    + ## complete/module.c ##
    +@@
    +  */
    + static bool complete_init(struct NeoMutt *n)
    + {
    +-  struct CompleteModuleData *mod_data = MUTT_MEM_CALLOC(1, struct CompleteModuleData);
    ++  struct CompleteModuleData *mod_data = mutt_mem_calloc_T(1, struct CompleteModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_COMPLETE, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ compmbox/compress.c: static struct CompressInfo *set_compress_info(struct Mailbo
    -   const char *c = mutt_find_hook(CMD_CLOSE_HOOK, mailbox_path(m));
    -   const char *a = mutt_find_hook(CMD_APPEND_HOOK, mailbox_path(m));
    +   struct Hook *close_hook = mutt_find_hook(CMD_CLOSE_HOOK, mailbox_path(m));
    +   struct Hook *append_hook = mutt_find_hook(CMD_APPEND_HOOK, mailbox_path(m));
    @@ compmbox/compress.c: static struct CompressInfo *set_compress_info(struct Mailbo
    -   ci->cmd_open = validate_compress_expando(o);
    +   ci->cmd_open = open_hook->expando;
    +
    + ## compmbox/module.c ##
    +@@ compmbox/module.c: extern const struct Command CompCommands[];
    +  */
    + static bool compmbox_init(struct NeoMutt *n)
    + {
    +-  struct CompmboxModuleData *mod_data = MUTT_MEM_CALLOC(1, struct CompmboxModuleData);
    ++  struct CompmboxModuleData *mod_data = mutt_mem_calloc_T(1, struct CompmboxModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_COMPMBOX, mod_data);
    + 
    +   mod_data->notify = notify_new();
    @@ compose/cbar_data.c: void cbar_data_free(struct MuttWindow *win, void **ptr)
    + ## compose/module.c ##
    +@@ compose/module.c: extern struct ConfigDef ComposeVars[];
    +  */
    + static bool compose_init(struct NeoMutt *n)
    + {
    +-  struct ComposeModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ComposeModuleData);
    ++  struct ComposeModuleData *mod_data = mutt_mem_calloc_T(1, struct ComposeModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_COMPOSE, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ compress/lz4.c: void lz4_cdata_free(struct Lz4ComprData **ptr)
    + ## compress/module.c ##
    +@@
    +  */
    + static bool compress_init(struct NeoMutt *n)
    + {
    +-  struct CompressModuleData *mod_data = MUTT_MEM_CALLOC(1, struct CompressModuleData);
    ++  struct CompressModuleData *mod_data = mutt_mem_calloc_T(1, struct CompressModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_COMPRESS, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ config/mbtable.c: static struct MbTable *mbtable_dup(struct MbTable *table)
    + ## config/module.c ##
    +@@ config/module.c: extern const struct ConfigSetType CstString;
    +  */
    + static bool config_init(struct NeoMutt *n)
    + {
    +-  struct ConfigModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ConfigModuleData);
    ++  struct ConfigModuleData *mod_data = mutt_mem_calloc_T(1, struct ConfigModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_CONFIG, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ config/set.c: static struct HashElem *create_synonym(const struct ConfigSet *cs,
    -   cs->hash = mutt_hash_new(size, MUTT_HASH_NO_FLAGS);
    +   cs->hash = mutt_hash_new(size, MUTT_HASH_NONE);
    @@ conn/gnutls.c: static bool tls_socket_poll_with_timeout(struct Connection *conn)
    + ## conn/module.c ##
    +@@ conn/module.c: extern struct ConfigDef ConnVarsSsl[];
    +  */
    + static bool conn_init(struct NeoMutt *n)
    + {
    +-  struct ConnModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ConnModuleData);
    ++  struct ConnModuleData *mod_data = mutt_mem_calloc_T(1, struct ConnModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_CONN, mod_data);
    + 
    + #ifdef USE_SSL_OPENSSL
    +
    @@ convert/convert.c: size_t mutt_convert_file_from_to(FILE *fp, const struct Slist
    -   cn = 0;
    @@ convert/convert.c: size_t mutt_convert_file_from_to(FILE *fp, const struct Slist
    +   {
    +
    + ## convert/module.c ##
    +@@
    +  */
    + static bool convert_init(struct NeoMutt *n)
    + {
    +-  struct ConvertModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ConvertModuleData);
    ++  struct ConvertModuleData *mod_data = mutt_mem_calloc_T(1, struct ConvertModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_CONVERT, mod_data);
    + 
    +   mod_data->notify = notify_new();
    @@ core/message.c: void message_free(struct Message **ptr)
    + ## core/module.c ##
    +@@
    +  */
    + static bool core_init(struct NeoMutt *n)
    + {
    +-  struct CoreModuleData *mod_data = MUTT_MEM_CALLOC(1, struct CoreModuleData);
    ++  struct CoreModuleData *mod_data = mutt_mem_calloc_T(1, struct CoreModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_CORE, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ core/neomutt.c
    -@@ core/neomutt.c: struct NeoMutt *neomutt_new(struct ConfigSet *cs)
    -   if (!cs)
    -     return NULL;
    +@@ core/neomutt.c: static bool init_gui_modules(struct NeoMutt *n)
    +  */
    + struct NeoMutt *neomutt_new(void)
    + {
    +-  return MUTT_MEM_CALLOC(1, struct NeoMutt);
    ++  return mutt_mem_calloc_T(1, struct NeoMutt);
    + }
    @@ core/neomutt.c: struct NeoMutt *neomutt_new(struct ConfigSet *cs)
    --  struct NeoMutt *n = MUTT_MEM_CALLOC(1, struct NeoMutt);
    -+  struct NeoMutt *n = mutt_mem_calloc_T(1, struct NeoMutt);
    - 
    -   ARRAY_INIT(&n->accounts);
    -   n->notify = notify_new();
    + /**
    @@ editor/functions.c: void replace_part(struct EnterState *es, size_t from, const
    + ## editor/module.c ##
    +@@
    +  */
    + static bool editor_init(struct NeoMutt *n)
    + {
    +-  struct EditorModuleData *mod_data = MUTT_MEM_CALLOC(1, struct EditorModuleData);
    ++  struct EditorModuleData *mod_data = mutt_mem_calloc_T(1, struct EditorModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_EDITOR, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ editor/window.c: bool self_insert(struct EnterWindowData *wdata, int ch)
    -         buf_expand_path_regex(wdata->buffer, false);
    +         expand_path(wdata->buffer, false);
    @@ email/email.c: struct Email *email_new(void)
    + ## email/enriched.c ##
    +@@ email/enriched.c: int text_enriched_handler(struct Body *b_email, struct State *state)
    +                              state->wraplen - 4 :
    +                              72;
    +   enriched.line_max = enriched.wrap_margin * 4;
    +-  enriched.line = MUTT_MEM_CALLOC(enriched.line_max + 1, wchar_t);
    +-  enriched.param = MUTT_MEM_CALLOC(256, wchar_t);
    ++  enriched.line = mutt_mem_calloc_T(enriched.line_max + 1, wchar_t);
    ++  enriched.param = mutt_mem_calloc_T(256, wchar_t);
    + 
    +   enriched.param_len = 256;
    +   enriched.param_used = 0;
    +
    @@ email/envelope.c: void mutt_env_set_subject(struct Envelope *env, const char *su
    + ## email/mailcap.c ##
    +@@ email/mailcap.c: static bool rfc1524_mailcap_parse(struct Body *b, const char *filename, const ch
    +  */
    + struct MailcapEntry *mailcap_entry_new(void)
    + {
    +-  return MUTT_MEM_CALLOC(1, struct MailcapEntry);
    ++  return mutt_mem_calloc_T(1, struct MailcapEntry);
    + }
    + 
    + /**
    +
    + ## email/module.c ##
    +@@ email/module.c: extern const struct Command EmailCommands[];
    +  */
    + static bool email_init(struct NeoMutt *n)
    + {
    +-  struct EmailModuleData *mod_data = MUTT_MEM_CALLOC(1, struct EmailModuleData);
    ++  struct EmailModuleData *mod_data = mutt_mem_calloc_T(1, struct EmailModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_EMAIL, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ email/rfc2231.c: static void decode_one(char *dest, char *src)
    + ## email/score.c ##
    +@@ email/score.c: enum CommandResult parse_score(const struct Command *cmd, struct Buffer *line,
    +     {
    +       goto done;
    +     }
    +-    ptr = MUTT_MEM_CALLOC(1, struct Score);
    ++    ptr = mutt_mem_calloc_T(1, struct Score);
    +     if (last)
    +       last->next = ptr;
    +     else
    +
    @@ email/url.c: static enum UrlScheme get_scheme(const char *src, const regmatch_t
    - ## enriched.c ##
    -@@ enriched.c: int text_enriched_handler(struct Body *b_email, struct State *state)
    -                              state->wraplen - 4 :
    -                              72;
    -   enriched.line_max = enriched.wrap_margin * 4;
    --  enriched.line = MUTT_MEM_CALLOC(enriched.line_max + 1, wchar_t);
    --  enriched.param = MUTT_MEM_CALLOC(256, wchar_t);
    -+  enriched.line = mutt_mem_calloc_T(enriched.line_max + 1, wchar_t);
    -+  enriched.param = mutt_mem_calloc_T(256, wchar_t);
    + ## envelope/module.c ##
    +@@
    +  */
    + static bool envelope_init(struct NeoMutt *n)
    + {
    +-  struct EnvelopeModuleData *mod_data = MUTT_MEM_CALLOC(1, struct EnvelopeModuleData);
    ++  struct EnvelopeModuleData *mod_data = mutt_mem_calloc_T(1, struct EnvelopeModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_ENVELOPE, mod_data);
    @@ enriched.c: int text_enriched_handler(struct Body *b_email, struct State *state)
    -   enriched.param_len = 256;
    -   enriched.param_used = 0;
    +   mod_data->notify = notify_new();
    @@ expando/expando.c: struct ExpandoDefinition;
    + ## expando/module.c ##
    +@@ expando/module.c: extern const struct ConfigSetType CstExpando;
    +  */
    + static bool expando_init(struct NeoMutt *n)
    + {
    +-  struct ExpandoModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ExpandoModuleData);
    ++  struct ExpandoModuleData *mod_data = mutt_mem_calloc_T(1, struct ExpandoModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_EXPANDO, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ expando/node_padding.c
    + ## fuzz/address.c ##
    +@@ fuzz/address.c: int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
    +   MuttLogger = log_disp_null;
    + 
    +   NeoMutt = neomutt_new();
    +-  char **tmp_env = MUTT_MEM_CALLOC(2, char *);
    ++  char **tmp_env = mutt_mem_calloc_T(2, char *);
    +   neomutt_init(NeoMutt, tmp_env, Modules);
    +   FREE(&tmp_env);
    + 
    +
    + ## fuzz/body.c ##
    +@@ fuzz/body.c: int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
    +   MuttLogger = log_disp_null;
    + 
    +   NeoMutt = neomutt_new();
    +-  char **tmp_env = MUTT_MEM_CALLOC(2, char *);
    ++  char **tmp_env = mutt_mem_calloc_T(2, char *);
    +   neomutt_init(NeoMutt, tmp_env, Modules);
    +   FREE(&tmp_env);
    + 
    +
    + ## fuzzy/module.c ##
    +@@
    +  */
    + static bool fuzzy_init(struct NeoMutt *n)
    + {
    +-  struct FuzzyModuleData *mod_data = MUTT_MEM_CALLOC(1, struct FuzzyModuleData);
    ++  struct FuzzyModuleData *mod_data = mutt_mem_calloc_T(1, struct FuzzyModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_FUZZY, mod_data);
    + 
    +   return true;
    +
    + ## gui/curs_lib.c ##
    +@@ gui/curs_lib.c: void mutt_str_expand_tabs(char **str, size_t *len, int tabwidth)
    +   {
    +     *len = ROUND_UP(required_len, 256);
    +   }
    +-  char *out = MUTT_MEM_CALLOC(*len, char);
    ++  char *out = mutt_mem_calloc_T(*len, char);
    + 
    +   // expand tabs
    +   for (int i = 0, o = 0; in[i] != '\0'; i++)
    +
    + ## gui/module.c ##
    +@@ gui/module.c: static void log_gui(void)
    +  */
    + static bool gui_init(struct NeoMutt *n)
    + {
    +-  struct GuiModuleData *mod_data = MUTT_MEM_CALLOC(1, struct GuiModuleData);
    ++  struct GuiModuleData *mod_data = mutt_mem_calloc_T(1, struct GuiModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_GUI, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ gui/mutt_window.c: void window_set_visible(struct MuttWindow *win, bool visible)
    + ## gui/mview.c ##
    +@@ gui/mview.c: struct MailboxView *mview_new(struct Mailbox *m, struct Notify *parent)
    +   if (!m)
    +     return NULL;
    + 
    +-  struct MailboxView *mv = MUTT_MEM_CALLOC(1, struct MailboxView);
    ++  struct MailboxView *mv = mutt_mem_calloc_T(1, struct MailboxView);
    + 
    +   mv->notify = notify_new();
    +   notify_set_parent(mv->notify, parent);
    +
    @@ gui/sbar.c: static void sbar_wdata_free(struct MuttWindow *win, void **ptr)
    + ## gui/thread.c ##
    +@@ gui/thread.c: static void calculate_visibility(struct MuttThread *tree, int *max_depth)
    +  */
    + struct ThreadsContext *mutt_thread_ctx_init(struct MailboxView *mv)
    + {
    +-  struct ThreadsContext *tctx = MUTT_MEM_CALLOC(1, struct ThreadsContext);
    ++  struct ThreadsContext *tctx = mutt_mem_calloc_T(1, struct ThreadsContext);
    +   tctx->mailbox_view = mv;
    +   return tctx;
    + }
    +@@ gui/thread.c: static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
    +   top = thread;
    + 
    +   array_size = 256;
    +-  array = MUTT_MEM_CALLOC(array_size, struct MuttThread *);
    ++  array = mutt_mem_calloc_T(array_size, struct MuttThread *);
    +   while (true)
    +   {
    +     if (init || !thread->sort_thread_key || !thread->sort_aux_key)
    +@@ gui/thread.c: void mutt_sort_threads(struct ThreadsContext *tctx, bool init)
    +       {
    +         tnew = (c_duplicate_threads ? thread : NULL);
    + 
    +-        thread = MUTT_MEM_CALLOC(1, struct MuttThread);
    ++        thread = mutt_mem_calloc_T(1, struct MuttThread);
    +         thread->message = e;
    +         thread->check_subject = true;
    +         e->thread = thread;
    +@@ gui/thread.c: void mutt_sort_threads(struct ThreadsContext *tctx, bool init)
    +       }
    +       else
    +       {
    +-        tnew = MUTT_MEM_CALLOC(1, struct MuttThread);
    ++        tnew = mutt_mem_calloc_T(1, struct MuttThread);
    +         mutt_hash_insert(tctx->hash, ref->data, tnew);
    +       }
    + 
    +
    + ## gui/utilwin.c ##
    +@@ gui/utilwin.c: struct MuttWindow *utilwin_new(void)
    +   struct MuttWindow *win = mutt_window_new(WT_CUSTOM, MUTT_WIN_ORIENT_VERTICAL,
    +                                            MUTT_WIN_SIZE_FIXED, UTILWIN_COLS, 1);
    + 
    +-  struct UtilWinData *priv = MUTT_MEM_CALLOC(1, struct UtilWinData);
    ++  struct UtilWinData *priv = mutt_mem_calloc_T(1, struct UtilWinData);
    + 
    +   win->wdata = priv;
    +   win->wdata_free = utilwin_wdata_free;
    +
    @@ hcache/hcache.c: static void hcache_free(struct HeaderCache **ptr)
    + ## hcache/module.c ##
    +@@ hcache/module.c: extern struct ConfigDef HcacheVarsComp[];
    +  */
    + static bool hcache_init(struct NeoMutt *n)
    + {
    +-  struct HcacheModuleData *mod_data = MUTT_MEM_CALLOC(1, struct HcacheModuleData);
    ++  struct HcacheModuleData *mod_data = mutt_mem_calloc_T(1, struct HcacheModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_HCACHE, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    + ## helpbar/module.c ##
    +@@ helpbar/module.c: extern struct ConfigDef HelpbarVars[];
    +  */
    + static bool helpbar_init(struct NeoMutt *n)
    + {
    +-  struct HelpbarModuleData *mod_data = MUTT_MEM_CALLOC(1, struct HelpbarModuleData);
    ++  struct HelpbarModuleData *mod_data = mutt_mem_calloc_T(1, struct HelpbarModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_HELPBAR, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ history/history.c
    -@@ history/history.c: static void init_history(struct History *h)
    +@@ history/history.c: static void init_history(struct History *h, int old_size)
    @@ history/history.c: static void init_history(struct History *h)
    + ## history/module.c ##
    +@@ history/module.c: extern struct ConfigDef HistoryVars[];
    +  */
    + static bool history_init(struct NeoMutt *n)
    + {
    +-  struct HistoryModuleData *mod_data = MUTT_MEM_CALLOC(1, struct HistoryModuleData);
    ++  struct HistoryModuleData *mod_data = mutt_mem_calloc_T(1, struct HistoryModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_HISTORY, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ hooks/hook.c: void hook_free(struct Hook **ptr)
    + ## hooks/module.c ##
    +@@ hooks/module.c: extern const struct Command HooksCommands[];
    +  */
    + static bool hooks_init(struct NeoMutt *n)
    + {
    +-  struct HooksModuleData *mod_data = MUTT_MEM_CALLOC(1, struct HooksModuleData);
    ++  struct HooksModuleData *mod_data = mutt_mem_calloc_T(1, struct HooksModuleData);
    +   TAILQ_INIT(&mod_data->hooks);
    +   neomutt_set_module_data(n, MODULE_ID_HOOKS, mod_data);
    + 
    +
    @@ hooks/parse.c
    -@@ hooks/parse.c: enum CommandResult parse_hook_regex(const struct Command *cmd,
    +@@ hooks/parse.c: enum CommandResult parse_regex_hook(const struct Command *cmd, struct Buffer *li
    @@ hooks/parse.c: enum CommandResult parse_hook_regex(const struct Command *cmd,
    -@@ hooks/parse.c: enum CommandResult parse_hook_folder(const struct Command *cmd,
    +@@ hooks/parse.c: enum CommandResult parse_folder_hook(const struct Command *cmd, struct Buffer *l
    @@ hooks/parse.c: enum CommandResult parse_hook_folder(const struct Command *cmd,
    -@@ hooks/parse.c: enum CommandResult parse_hook_crypt(const struct Command *cmd,
    +@@ hooks/parse.c: enum CommandResult parse_crypt_hook(const struct Command *cmd, struct Buffer *li
    @@ hooks/parse.c: enum CommandResult parse_hook_crypt(const struct Command *cmd,
    -@@ hooks/parse.c: enum CommandResult parse_hook_mbox(const struct Command *cmd,
    +@@ hooks/parse.c: enum CommandResult parse_mbox_hook(const struct Command *cmd, struct Buffer *lin
    @@ hooks/parse.c: enum CommandResult parse_hook_mbox(const struct Command *cmd,
    -@@ hooks/parse.c: enum CommandResult parse_hook_compress(const struct Command *cmd,
    +@@ hooks/parse.c: enum CommandResult parse_compress_hook(const struct Command *cmd, struct Buffer
    @@ hooks/parse.c: enum CommandResult parse_hook_compress(const struct Command *cmd,
    -@@ hooks/parse.c: enum CommandResult parse_hook_index(const struct Command *cmd,
    +@@ hooks/parse.c: enum CommandResult parse_index_hook(const struct Command *cmd, struct Buffer *li
    @@ hooks/parse.c: enum CommandResult parse_hook_index(const struct Command *cmd,
    -     mutt_hash_insert(IdxFmtHooks, buf_string(name), hl);
    +     mutt_hash_insert(mod_data->idx_fmt_hooks, buf_string(name), hl);
    @@ imap/mdata.c: struct ImapMboxData *imap_mdata_get(struct Mailbox *m)
    + ## imap/module.c ##
    +@@ imap/module.c: extern const struct Command ImapCommands[];
    +  */
    + static bool imap_init(struct NeoMutt *n)
    + {
    +-  struct ImapModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ImapModuleData);
    ++  struct ImapModuleData *mod_data = mutt_mem_calloc_T(1, struct ImapModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_IMAP, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ index/ibar.c: static void ibar_data_free(struct MuttWindow *win, void **ptr)
    + ## index/module.c ##
    +@@ index/module.c: extern const struct Command IndexCommands[];
    +  */
    + static bool index_init(struct NeoMutt *n)
    + {
    +-  struct IndexModuleData *mod_data = MUTT_MEM_CALLOC(1, struct IndexModuleData);
    ++  struct IndexModuleData *mod_data = mutt_mem_calloc_T(1, struct IndexModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_INDEX, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ key/keymap.c
    -@@ key/keymap.c: struct Mapping KeyNames[] = {
    +@@ key/keymap.c: struct Mapping *keymap_get_key_names(void)
    @@ key/keymap.c: struct Mapping KeyNames[] = {
    - ## mailcap.c ##
    -@@ mailcap.c: static bool rfc1524_mailcap_parse(struct Body *b, const char *filename, const ch
    + ## key/menudef.c ##
    +@@ key/menudef.c: void submenu_free(struct SubMenu **pptr)
    @@ mailcap.c: static bool rfc1524_mailcap_parse(struct Body *b, const char *filenam
    - struct MailcapEntry *mailcap_entry_new(void)
    + struct SubMenu *submenu_new(void)
    @@ mailcap.c: static bool rfc1524_mailcap_parse(struct Body *b, const char *filenam
    --  return MUTT_MEM_CALLOC(1, struct MailcapEntry);
    -+  return mutt_mem_calloc_T(1, struct MailcapEntry);
    - }
    +-  struct SubMenu *sm = MUTT_MEM_CALLOC(1, struct SubMenu);
    ++  struct SubMenu *sm = mutt_mem_calloc_T(1, struct SubMenu);
    @@ mailcap.c: static bool rfc1524_mailcap_parse(struct Body *b, const char *filenam
    - /**
    +   ARRAY_INIT(&sm->keymaps);
    + 
    +@@ key/menudef.c: void menudef_free(struct MenuDefinition **pptr)
    +  */
    + struct MenuDefinition *menudef_new(void)
    + {
    +-  struct MenuDefinition *md = MUTT_MEM_CALLOC(1, struct MenuDefinition);
    ++  struct MenuDefinition *md = mutt_mem_calloc_T(1, struct MenuDefinition);
    + 
    +   ARRAY_INIT(&md->submenus);
    + 
    +
    + ## key/module.c ##
    +@@ key/module.c: extern const struct Command KeyCommands[];
    +  */
    + static bool key_init(struct NeoMutt *n)
    + {
    +-  struct KeyModuleData *mod_data = MUTT_MEM_CALLOC(1, struct KeyModuleData);
    ++  struct KeyModuleData *mod_data = mutt_mem_calloc_T(1, struct KeyModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_KEY, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    + ## lua/module.c ##
    +@@ lua/module.c: extern const struct Command LuaCommands[];
    +  */
    + static bool lua_init(struct NeoMutt *n)
    + {
    +-  struct LuaModuleData *mod_data = MUTT_MEM_CALLOC(1, struct LuaModuleData);
    ++  struct LuaModuleData *mod_data = mutt_mem_calloc_T(1, struct LuaModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_LUA, mod_data);
    + 
    +   mod_data->notify = notify_new();
    @@ maildir/mdemail.c
    + ## maildir/module.c ##
    +@@ maildir/module.c: extern struct ConfigDef MaildirVarsHcache[];
    +  */
    + static bool maildir_init(struct NeoMutt *n)
    + {
    +-  struct MaildirModuleData *mod_data = MUTT_MEM_CALLOC(1, struct MaildirModuleData);
    ++  struct MaildirModuleData *mod_data = mutt_mem_calloc_T(1, struct MaildirModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_MAILDIR, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ mbox/mbox.c: static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
    + ## mbox/module.c ##
    +@@ mbox/module.c: extern struct ConfigDef MboxVars[];
    +  */
    + static bool mbox_init(struct NeoMutt *n)
    + {
    +-  struct MboxModuleData *mod_data = MUTT_MEM_CALLOC(1, struct MboxModuleData);
    ++  struct MboxModuleData *mod_data = mutt_mem_calloc_T(1, struct MboxModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_MBOX, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ menu/menu.c: void menu_free(struct Menu **ptr)
    -  */
    - struct Menu *menu_new(enum MenuType type, struct MuttWindow *win, struct ConfigSubset *sub)
    + struct Menu *menu_new(const struct MenuDefinition *md, struct MuttWindow *win,
    +                       struct ConfigSubset *sub)
    @@ menu/menu.c: void menu_free(struct Menu **ptr)
    -   menu->type = type;
    +   menu->md = md;
    @@ menu/menu.c: void menu_free(struct Menu **ptr)
    + ## menu/module.c ##
    +@@ menu/module.c: extern struct ConfigDef MenuVars[];
    +  */
    + static bool menu_init(struct NeoMutt *n)
    + {
    +-  struct MenuModuleData *mod_data = MUTT_MEM_CALLOC(1, struct MenuModuleData);
    ++  struct MenuModuleData *mod_data = mutt_mem_calloc_T(1, struct MenuModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_MENU, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ mh/mhemail.c
    + ## mh/module.c ##
    +@@ mh/module.c: extern struct ConfigDef MhVars[];
    +  */
    + static bool mh_init(struct NeoMutt *n)
    + {
    +-  struct MhModuleData *mod_data = MUTT_MEM_CALLOC(1, struct MhModuleData);
    ++  struct MhModuleData *mod_data = mutt_mem_calloc_T(1, struct MhModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_MH, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    + ## mlist/dlg_mlist.c ##
    +@@ mlist/dlg_mlist.c: void dlg_mlist(struct Mailbox *m, struct Email *e)
    +   struct MenuDefinition *md_list = menu_find(MENU_LIST);
    +   ASSERT(md_list);
    + 
    +-  struct ListData *ld = MUTT_MEM_CALLOC(1, struct ListData);
    ++  struct ListData *ld = mutt_mem_calloc_T(1, struct ListData);
    +   ld->mailbox = m;
    + 
    +   struct Message *msg = mx_msg_open(m, e);
    +
    + ## mlist/module.c ##
    +@@ mlist/module.c: extern struct ConfigDef MlistVars[];
    +  */
    + static bool mlist_init(struct NeoMutt *n)
    + {
    +-  struct MlistModuleData *mod_data = MUTT_MEM_CALLOC(1, struct MlistModuleData);
    ++  struct MlistModuleData *mod_data = mutt_mem_calloc_T(1, struct MlistModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_MLIST, mod_data);
    + 
    +   return true;
    +
    @@ mutt/memory.h
    + ## mutt/module.c ##
    +@@
    +  */
    + static bool mutt_init(struct NeoMutt *n)
    + {
    +-  struct MuttModuleData *mod_data = MUTT_MEM_CALLOC(1, struct MuttModuleData);
    ++  struct MuttModuleData *mod_data = mutt_mem_calloc_T(1, struct MuttModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_MUTT, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ mutt/notify.c: bool notify_observer_add(struct Notify *notify, enum NotifyType t
    + ## mutt/pool.c ##
    +@@ mutt/pool.c: static void pool_increase_size(void)
    +   MUTT_MEM_REALLOC(&BufferPool, BufferPoolLen, struct Buffer *);
    +   while (BufferPoolCount < BufferPoolIncrement)
    +   {
    +-    struct Buffer *newbuf = MUTT_MEM_CALLOC(1, struct Buffer);
    ++    struct Buffer *newbuf = mutt_mem_calloc_T(1, struct Buffer);
    +     buf_alloc(newbuf, BufferPoolInitialBufferSize);
    +     BufferPool[BufferPoolCount++] = newbuf;
    +   }
    +
    @@ mutt/slist.c: struct Slist *slist_parse(const char *str, uint32_t flags)
    - ## mutt_thread.c ##
    -@@ mutt_thread.c: static void calculate_visibility(struct MuttThread *tree, int *max_depth)
    -  */
    - struct ThreadsContext *mutt_thread_ctx_init(struct MailboxView *mv)
    - {
    --  struct ThreadsContext *tctx = MUTT_MEM_CALLOC(1, struct ThreadsContext);
    -+  struct ThreadsContext *tctx = mutt_mem_calloc_T(1, struct ThreadsContext);
    -   tctx->mailbox_view = mv;
    -   return tctx;
    - }
    -@@ mutt_thread.c: static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
    -   top = thread;
    - 
    -   array_size = 256;
    --  array = MUTT_MEM_CALLOC(array_size, struct MuttThread *);
    -+  array = mutt_mem_calloc_T(array_size, struct MuttThread *);
    -   while (true)
    -   {
    -     if (init || !thread->sort_thread_key || !thread->sort_aux_key)
    -@@ mutt_thread.c: void mutt_sort_threads(struct ThreadsContext *tctx, bool init)
    -       {
    -         tnew = (c_duplicate_threads ? thread : NULL);
    - 
    --        thread = MUTT_MEM_CALLOC(1, struct MuttThread);
    -+        thread = mutt_mem_calloc_T(1, struct MuttThread);
    -         thread->message = e;
    -         thread->check_subject = true;
    -         e->thread = thread;
    -@@ mutt_thread.c: void mutt_sort_threads(struct ThreadsContext *tctx, bool init)
    -       }
    -       else
    -       {
    --        tnew = MUTT_MEM_CALLOC(1, struct MuttThread);
    -+        tnew = mutt_mem_calloc_T(1, struct MuttThread);
    -         mutt_hash_insert(tctx->hash, ref->data, tnew);
    -       }
    - 
    -
    - ## mview.c ##
    -@@ mview.c: struct MailboxView *mview_new(struct Mailbox *m, struct Notify *parent)
    -   if (!m)
    -     return NULL;
    - 
    --  struct MailboxView *mv = MUTT_MEM_CALLOC(1, struct MailboxView);
    -+  struct MailboxView *mv = mutt_mem_calloc_T(1, struct MailboxView);
    - 
    -   mv->notify = notify_new();
    -   notify_set_parent(mv->notify, parent);
    -
    @@ ncrypt/crypt_mod.c
    -@@ ncrypt/crypt_mod.c: static struct CryptModuleList CryptModules = STAILQ_HEAD_INITIALIZER(CryptModule
    -  */
    +@@
    @@ ncrypt/crypt_mod.c: static struct CryptModuleList CryptModules = STAILQ_HEAD_INI
    +   struct NcryptModuleData *mod_data = neomutt_get_module_data(NeoMutt, MODULE_ID_NCRYPT);
    @@ ncrypt/crypt_mod.c: static struct CryptModuleList CryptModules = STAILQ_HEAD_INI
    -   STAILQ_INSERT_HEAD(&CryptModules, module, entries);
    +   STAILQ_INSERT_HEAD(&mod_data->crypt_modules, module, entries);
    @@ ncrypt/gnupgparse.c: static struct PgpKeyInfo *parse_pub_line(char *buf, bool *i
    + ## ncrypt/module.c ##
    +@@ ncrypt/module.c: extern struct ConfigDef NcryptVarsSmime[];
    +  */
    + static bool ncrypt_init(struct NeoMutt *n)
    + {
    +-  struct NcryptModuleData *mod_data = MUTT_MEM_CALLOC(1, struct NcryptModuleData);
    ++  struct NcryptModuleData *mod_data = mutt_mem_calloc_T(1, struct NcryptModuleData);
    +   STAILQ_INIT(&mod_data->crypt_modules);
    +   neomutt_set_module_data(n, MODULE_ID_NCRYPT, mod_data);
    + 
    +
    @@ ncrypt/smime.c: static struct SmimeKey *smime_parse_key(char *buf)
    -   char *pend = NULL, *p = NULL;
    +   char *p = NULL;
    @@ ncrypt/smime.c: static int smime_handle_cert_email(const char *certificate, cons
    -     rewind(fp_out);
    +     fseek(fp_out, 0, SEEK_SET);
    @@ nntp/adata.c: void nntp_adata_free(void **ptr)
    -   adata->groups_hash = mutt_hash_new(1009, MUTT_HASH_NO_FLAGS);
    +   adata->groups_hash = mutt_hash_new(1009, MUTT_HASH_NONE);
    @@ nntp/edata.c: void nntp_edata_free(void **ptr)
    + ## nntp/module.c ##
    +@@ nntp/module.c: extern struct ConfigDef NntpVars[];
    +  */
    + static bool nntp_init(struct NeoMutt *n)
    + {
    +-  struct NntpModuleData *mod_data = MUTT_MEM_CALLOC(1, struct NntpModuleData);
    ++  struct NntpModuleData *mod_data = mutt_mem_calloc_T(1, struct NntpModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_NNTP, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ notmuch/adata.c: void nm_adata_free(void **ptr)
    - ## notmuch/complete.c ##
    -@@ notmuch/complete.c: int complete_all_nm_tags(struct CompletionData *cd, const char *pt)
    -     goto done;
    - 
    -   /* Get all the tags. */
    --  const char **nm_tags = MUTT_MEM_CALLOC(tag_count_1, const char *);
    -+  const char **nm_tags = mutt_mem_calloc_T(tag_count_1, const char *);
    -   if ((nm_get_all_tags(m_cur, nm_tags, &tag_count_2) != 0) || (tag_count_1 != tag_count_2))
    -   {
    -     completion_data_free_match_strings(cd);
    -
    @@ notmuch/mdata.c: struct NmMboxData *nm_mdata_new(const char *url)
    + ## notmuch/module.c ##
    +@@ notmuch/module.c: extern const struct Command NmCommands[];
    +  */
    + static bool notmuch_init(struct NeoMutt *n)
    + {
    +-  struct NotmuchModuleData *mod_data = MUTT_MEM_CALLOC(1, struct NotmuchModuleData);
    ++  struct NotmuchModuleData *mod_data = mutt_mem_calloc_T(1, struct NotmuchModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_NOTMUCH, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ pager/dlg_pager.c: int dlg_pager(struct PagerView *pview)
    + ## pager/module.c ##
    +@@ pager/module.c: extern struct ConfigDef PagerVars[];
    +  */
    + static bool pager_init(struct NeoMutt *n)
    + {
    +-  struct PagerModuleData *mod_data = MUTT_MEM_CALLOC(1, struct PagerModuleData);
    ++  struct PagerModuleData *mod_data = mutt_mem_calloc_T(1, struct PagerModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_PAGER, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ pager/private_data.c: void pager_private_data_free(struct MuttWindow *win, void
    + ## parse/module.c ##
    +@@
    +  */
    + static bool parse_init(struct NeoMutt *n)
    + {
    +-  struct ParseModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ParseModuleData);
    ++  struct ParseModuleData *mod_data = mutt_mem_calloc_T(1, struct ParseModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_PARSE, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    + ## parse/pcontext.c ##
    +@@
    +  */
    + struct ParseContext *parse_context_new(void)
    + {
    +-  struct ParseContext *pc = MUTT_MEM_CALLOC(1, struct ParseContext);
    ++  struct ParseContext *pc = mutt_mem_calloc_T(1, struct ParseContext);
    + 
    +   return pc;
    + }
    +
    + ## parse/perror.c ##
    +@@
    +  */
    + struct ParseError *parse_error_new(void)
    + {
    +-  struct ParseError *pc = MUTT_MEM_CALLOC(1, struct ParseError);
    ++  struct ParseError *pc = mutt_mem_calloc_T(1, struct ParseError);
    + 
    +   pc->message = buf_pool_get();
    + 
    +
    @@ pattern/compile.c: static bool eat_regex(struct Pattern *pat, PatternCompFlags f
    +     goto out;
    @@ pattern/compile.c: static bool eat_regex(struct Pattern *pat, PatternCompFlags f
    -   else
    -   {
    --    pat->p.regex = MUTT_MEM_CALLOC(1, regex_t);
    -+    pat->p.regex = mutt_mem_calloc_T(1, regex_t);
    + 
    +-  pat->p.regex = MUTT_MEM_CALLOC(1, regex_t);
    ++  pat->p.regex = mutt_mem_calloc_T(1, regex_t);
    @@ pattern/compile.c: static bool eat_regex(struct Pattern *pat, PatternCompFlags f
    -     pat->raw_pattern = buf_strdup(token);
    +   pat->raw_pattern = buf_strdup(token);
    @@ pattern/compile.c: static struct Pattern *mutt_pattern_new(void)
    + ## pattern/module.c ##
    +@@ pattern/module.c: extern struct ConfigDef PatternVars[];
    +  */
    + static bool pattern_init(struct NeoMutt *n)
    + {
    +-  struct PatternModuleData *mod_data = MUTT_MEM_CALLOC(1, struct PatternModuleData);
    ++  struct PatternModuleData *mod_data = mutt_mem_calloc_T(1, struct PatternModuleData);
    + 
    +   // clang-format off
    +   mod_data->range_regexes[RANGE_K_REL]  = (struct RangeRegex){ RANGE_REL_RX,  1, 3, 0, { 0 } };
    +
    @@ pop/edata.c: void pop_edata_free(void **ptr)
    - ## pop/pop.c ##
    -@@ pop/pop.c: void pop_fetch_mail(void)
    -   int last = 0, msgs = 0, bytes = 0, rset = 0, rc;
    -   struct ConnAccount cac = { { 0 } };
    + ## pop/module.c ##
    +@@ pop/module.c: extern struct ConfigDef PopVars[];
    +  */
    + static bool pop_init(struct NeoMutt *n)
    + {
    +-  struct PopModuleData *mod_data = MUTT_MEM_CALLOC(1, struct PopModuleData);
    ++  struct PopModuleData *mod_data = mutt_mem_calloc_T(1, struct PopModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_POP, mod_data);
    @@ pop/pop.c: void pop_fetch_mail(void)
    --  char *p = MUTT_MEM_CALLOC(strlen(c_pop_host) + 7, char);
    -+  char *p = mutt_mem_calloc_T(strlen(c_pop_host) + 7, char);
    -   char *url = p;
    -   if (url_check_scheme(c_pop_host) == U_UNKNOWN)
    -   {
    +   mod_data->notify = notify_new();
    +
    + ## postpone/module.c ##
    +@@
    +  */
    + static bool postpone_init(struct NeoMutt *n)
    + {
    +-  struct PostponeModuleData *mod_data = MUTT_MEM_CALLOC(1, struct PostponeModuleData);
    ++  struct PostponeModuleData *mod_data = mutt_mem_calloc_T(1, struct PostponeModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_POSTPONE, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    + ## progress/module.c ##
    +@@ progress/module.c: extern struct ConfigDef ProgressVars[];
    +  */
    + static bool progress_init(struct NeoMutt *n)
    + {
    +-  struct ProgressModuleData *mod_data = MUTT_MEM_CALLOC(1, struct ProgressModuleData);
    ++  struct ProgressModuleData *mod_data = mutt_mem_calloc_T(1, struct ProgressModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_PROGRESS, mod_data);
    + 
    +   mod_data->notify = notify_new();
    @@ progress/wdata.c
    - ## score.c ##
    -@@ score.c: enum CommandResult parse_score(const struct Command *cmd, struct Buffer *line,
    -     {
    -       goto done;
    -     }
    --    ptr = MUTT_MEM_CALLOC(1, struct Score);
    -+    ptr = mutt_mem_calloc_T(1, struct Score);
    -     if (last)
    -       last->next = ptr;
    -     else
    + ## question/module.c ##
    +@@
    +  */
    + static bool question_init(struct NeoMutt *n)
    + {
    +-  struct QuestionModuleData *mod_data = MUTT_MEM_CALLOC(1, struct QuestionModuleData);
    ++  struct QuestionModuleData *mod_data = mutt_mem_calloc_T(1, struct QuestionModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_QUESTION, mod_data);
    + 
    +   mod_data->notify = notify_new();
    @@ send/header.c: void mutt_write_references(const struct ListHead *r, FILE *fp, si
    + ## send/module.c ##
    +@@ send/module.c: extern const struct Command SendCommands[];
    +  */
    + static bool send_init(struct NeoMutt *n)
    + {
    +-  struct SendModuleData *mod_data = MUTT_MEM_CALLOC(1, struct SendModuleData);
    ++  struct SendModuleData *mod_data = mutt_mem_calloc_T(1, struct SendModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_SEND, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ send/send.c: static int inline_forward_attachments(struct Mailbox *m, struct Ema
    -   mutt_message_hook(m, e, CMD_MESSAGE_HOOK);
    +   exec_message_hook(m, e, CMD_MESSAGE_HOOK);
    @@ send/send.c: static int inline_forward_attachments(struct Mailbox *m, struct Ema
    + ## sidebar/module.c ##
    +@@ sidebar/module.c: extern const struct Command SbCommands[];
    +  */
    + static bool sidebar_init(struct NeoMutt *n)
    + {
    +-  struct SidebarModuleData *mod_data = MUTT_MEM_CALLOC(1, struct SidebarModuleData);
    ++  struct SidebarModuleData *mod_data = mutt_mem_calloc_T(1, struct SidebarModuleData);
    +   STAILQ_INIT(&mod_data->sidebar_pinned);
    +   neomutt_set_module_data(n, MODULE_ID_SIDEBAR, mod_data);
    + 
    +
    @@ sidebar/sidebar.c: void sb_add_mailbox(struct SidebarWindowData *wdata, struct M
    +   entry->score = -1;
    @@ sidebar/sidebar.c: void sb_add_mailbox(struct SidebarWindowData *wdata, struct M
    -   if (wdata->top_index < 0)
    @@ sidebar/wdata.c: struct IndexSharedData;
    - ## store/bdb.c ##
    -@@ store/bdb.c: static void bdb_sdata_free(struct BdbStoreData **ptr)
    -  */
    - static struct BdbStoreData *bdb_sdata_new(void)
    - {
    --  struct BdbStoreData *sdata = MUTT_MEM_CALLOC(1, struct BdbStoreData);
    -+  struct BdbStoreData *sdata = mutt_mem_calloc_T(1, struct BdbStoreData);
    - 
    -   buf_alloc(&sdata->lockfile, 128);
    - 
    -
    @@ store/lmdb.c: static void lmdb_sdata_free(struct LmdbStoreData **ptr)
    + ## store/module.c ##
    +@@
    +  */
    + static bool store_init(struct NeoMutt *n)
    + {
    +-  struct StoreModuleData *mod_data = MUTT_MEM_CALLOC(1, struct StoreModuleData);
    ++  struct StoreModuleData *mod_data = mutt_mem_calloc_T(1, struct StoreModuleData);
    +   neomutt_set_module_data(n, MODULE_ID_STORE, mod_data);
    + 
    +   mod_data->notify = notify_new();
    +
    @@ test/common.c: bool test_neomutt_create(void)
    - 
    -   NeoMutt = neomutt_new(cs);
    +   NeoMutt = neomutt_new();
    @@ test/common.c: bool test_neomutt_create(void)
    --  NeoMutt->env = MUTT_MEM_CALLOC(2, char *);
    -+  NeoMutt->env = mutt_mem_calloc_T(2, char *);
    @@ test/common.c: bool test_neomutt_create(void)
    -   TEST_CHECK(cs_register_variables(cs, Vars));
    +-  char **tmp_env = MUTT_MEM_CALLOC(2, char *);
    ++  char **tmp_env = mutt_mem_calloc_T(2, char *);
    +   neomutt_init(NeoMutt, tmp_env, Modules);
    +   FREE(&tmp_env);
    @@ test/email/email_header_update.c: void test_email_header_update(void)
    + ## test/gui/mutt_str_expand_tabs.c ##
    +@@ test/gui/mutt_str_expand_tabs.c: void test_mutt_str_expand_tabs(void)
    +   /* Explicit test for null-termination */
    +   {
    +     size_t len = 8;
    +-    char *buf = MUTT_MEM_CALLOC(len, char);
    ++    char *buf = mutt_mem_calloc_T(len, char);
    +     buf[0] = '\t';
    +     mutt_str_expand_tabs(&buf, &len, 8);
    +     TEST_CHECK_STR_EQ(buf, "        ");
    +
    @@ test/neo/neomutt_free.c: void test_neomutt_free(void)
    + ## test/sidebar/sb_remove_mailbox.c ##
    +@@ test/sidebar/sb_remove_mailbox.c: void test_sb_remove_mailbox(void)
    + 
    +   struct SidebarWindowData wdata = { 0 };
    + 
    +-  struct SbEntry *entry_a = MUTT_MEM_CALLOC(1, struct SbEntry);
    ++  struct SbEntry *entry_a = mutt_mem_calloc_T(1, struct SbEntry);
    +   entry_a->mailbox = &mailbox_a;
    +   entry_a->is_hidden = true; // No unhidden entry left for sb_prev() to backtrack to
    +   ARRAY_ADD(&wdata.entries, entry_a);
    + 
    +-  struct SbEntry *entry_b = MUTT_MEM_CALLOC(1, struct SbEntry);
    ++  struct SbEntry *entry_b = mutt_mem_calloc_T(1, struct SbEntry);
    +   entry_b->mailbox = &mailbox_b;
    +   entry_b->is_hidden = false;
    +   ARRAY_ADD(&wdata.entries, entry_b);
    +
5:  7a460787a3a5 ! 5:  3759a6c05e5e */, mutt/memory.h: Rename MUTT_MEM_MALLOC() => mutt_mem_malloc_T()
    @@ attach/commands.c: static enum CommandResult parse_attach_list(const struct Comm
    -     strcpy(&tmpminor[1], a->minor);
    +     memcpy(&tmpminor[1], a->minor, len);
    @@ conn/tunnel.c: static int tunnel_socket_open(struct Connection *conn)
    - {
    -   int pin[2], pout[2];
    +   int pin[2] = { 0 };
    +   int pout[2] = { 0 };
    @@ email/rfc2047.c: static int encode(const char *d, size_t dlen, int col, const ch
    + ## fuzz/cli.c ##
    +@@ fuzz/cli.c: static bool parse_args(const uint8_t *data, size_t size, int *argc, char ***argv
    +     return false;
    + 
    +   // Create a null-terminated copy of the input
    +-  char *input = MUTT_MEM_MALLOC(size + 1, char);
    ++  char *input = mutt_mem_malloc_T(size + 1, char);
    +   memcpy(input, data, size);
    +   input[size] = '\0';
    + 
    +@@ fuzz/cli.c: static bool parse_args(const uint8_t *data, size_t size, int *argc, char ***argv
    +   }
    + 
    +   // Allocate argv array
    +-  char **args = MUTT_MEM_MALLOC(count + 1, char *);
    ++  char **args = mutt_mem_malloc_T(count + 1, char *);
    +   args[0] = mutt_str_dup("neomutt");
    + 
    +   // Fill in arguments
    +
    + ## gui/thread.c ##
    +@@ gui/thread.c: void mutt_draw_tree(struct ThreadsContext *tctx)
    +   /* Do the visibility calculations and free the old thread chars.
    +    * From now on we can simply ignore invisible subtrees */
    +   calculate_visibility(tree, &max_depth);
    +-  pfx = MUTT_MEM_MALLOC((width * max_depth) + 2, char);
    +-  arrow = MUTT_MEM_MALLOC((width * max_depth) + 2, char);
    ++  pfx = mutt_mem_malloc_T((width * max_depth) + 2, char);
    ++  arrow = mutt_mem_malloc_T((width * max_depth) + 2, char);
    +   const bool c_hide_limited = cs_subset_bool(NeoMutt->sub, "hide_limited");
    +   const bool c_hide_missing = cs_subset_bool(NeoMutt->sub, "hide_missing");
    +   while (tree)
    +@@ gui/thread.c: void mutt_draw_tree(struct ThreadsContext *tctx)
    +       {
    +         myarrow[width] = MUTT_TREE_RARROW;
    +         myarrow[width + 1] = 0;
    +-        new_tree = MUTT_MEM_MALLOC(((size_t) depth * width) + 2, char);
    ++        new_tree = mutt_mem_malloc_T(((size_t) depth * width) + 2, char);
    +         if (start_depth > 1)
    +         {
    +           strncpy(new_tree, pfx, (size_t) width * (start_depth - 1));
    +
    @@ hcache/serialize.c
    -@@ hcache/serialize.c: void serial_restore_char(char **c, const unsigned char *d, int *off, bool conver
    -     return;
    -   }
    +@@ hcache/serialize.c: bool serial_restore_char(char **c, const unsigned char *d, int *off, size_t dlen
    +   if ((size > SERIAL_MAX_CHAR_SIZE) || !serial_in_bounds(*off, size, dlen))
    +     return false;
    @@ imap/utf7.c: static char *utf7_to_utf8(const char *u7, size_t u7len, char **u8,
    - {
    -   int b, ch, k;
    +   int ch;
    +   int k;
    @@ mutt/charset.c: int mutt_ch_convert_nonmime_string(const struct Slist *const ass
    -     int m = mutt_ch_convert_string(&s, fromcode, charset, MUTT_ICONV_NO_FLAGS);
    +     int m = mutt_ch_convert_string(&s, fromcode, charset, MUTT_ICONV_NONE);
    @@ mutt/charset.c: int mutt_ch_convert_string(char **ps, const char *from, const ch
    + ## mutt/envlist.c ##
    +@@ mutt/envlist.c: bool envlist_set(char ***envp, const char *name, const char *value, bool overwri
    +   const char *val = NONULL(value);
    +   size_t nlen = mutt_str_len(name);
    +   size_t vlen = mutt_str_len(val);
    +-  char *work = MUTT_MEM_MALLOC(nlen + 1 + vlen + 1, char);
    ++  char *work = mutt_mem_malloc_T(nlen + 1 + vlen + 1, char);
    +   snprintf(work, nlen + 1 + vlen + 1, "%s=%s", name, val);
    + 
    +   if (match >= 0)
    +
    @@ mutt/string.c: int mutt_str_asprintf(char **strp, const char *fmt, ...)
    - ## mutt_thread.c ##
    -@@ mutt_thread.c: void mutt_draw_tree(struct ThreadsContext *tctx)
    -   /* Do the visibility calculations and free the old thread chars.
    -    * From now on we can simply ignore invisible subtrees */
    -   calculate_visibility(tree, &max_depth);
    --  pfx = MUTT_MEM_MALLOC((width * max_depth) + 2, char);
    --  arrow = MUTT_MEM_MALLOC((width * max_depth) + 2, char);
    -+  pfx = mutt_mem_malloc_T((width * max_depth) + 2, char);
    -+  arrow = mutt_mem_malloc_T((width * max_depth) + 2, char);
    -   const bool c_hide_limited = cs_subset_bool(NeoMutt->sub, "hide_limited");
    -   const bool c_hide_missing = cs_subset_bool(NeoMutt->sub, "hide_missing");
    -   while (tree)
    -@@ mutt_thread.c: void mutt_draw_tree(struct ThreadsContext *tctx)
    -       {
    -         myarrow[width] = MUTT_TREE_RARROW;
    -         myarrow[width + 1] = 0;
    --        new_tree = MUTT_MEM_MALLOC(((size_t) depth * width) + 2, char);
    -+        new_tree = mutt_mem_malloc_T(((size_t) depth * width) + 2, char);
    -         if (start_depth > 1)
    -         {
    -           strncpy(new_tree, pfx, (size_t) width * (start_depth - 1));
    -
    @@ ncrypt/crypt_gpgme.c: static struct CryptKeyInfo *crypt_ask_for_key(const char *
    -         l->next = IdDefaults;
    -         IdDefaults = l;
    +         l->next = (struct CryptCache *) mod_data->gpgme_id_defaults;
    +         mod_data->gpgme_id_defaults = l;
    @@ ncrypt/crypt_gpgme.c: static struct CryptKeyInfo *crypt_ask_for_key(const char *
    + ## ncrypt/functions_gpgme.c ##
    +@@ ncrypt/functions_gpgme.c: struct DnArray
    +  */
    + static void print_utf8(FILE *fp, const char *buf, size_t len)
    + {
    +-  char *tstr = MUTT_MEM_MALLOC(len + 1, char);
    ++  char *tstr = mutt_mem_malloc_T(len + 1, char);
    +   memcpy(tstr, buf, len);
    +   tstr[len] = 0;
    + 
    +@@ ncrypt/functions_gpgme.c: static const char *parse_dn_part(struct DnArray *array, const char *str)
    +   n = s - str;
    +   if (n == 0)
    +     return NULL; /* empty key */
    +-  array->key = MUTT_MEM_MALLOC(n + 1, char);
    ++  array->key = mutt_mem_malloc_T(n + 1, char);
    +   p = array->key;
    +   memcpy(p, str, n); /* fixme: trim trailing spaces */
    +   p[n] = 0;
    +@@ ncrypt/functions_gpgme.c: static const char *parse_dn_part(struct DnArray *array, const char *str)
    +     if ((n == 0) || (n & 1))
    +       return NULL; /* empty or odd number of digits */
    +     n /= 2;
    +-    p = MUTT_MEM_MALLOC(n + 1, char);
    ++    p = mutt_mem_malloc_T(n + 1, char);
    +     array->value = (char *) p;
    +     for (s1 = str; n > 0; s1 += 2, n--)
    +       sscanf(s1, "%2hhx", (unsigned char *) p++);
    +@@ ncrypt/functions_gpgme.c: static const char *parse_dn_part(struct DnArray *array, const char *str)
    +       }
    +     }
    + 
    +-    p = MUTT_MEM_MALLOC(n + 1, char);
    ++    p = mutt_mem_malloc_T(n + 1, char);
    +     array->value = (char *) p;
    +     for (s = str; n > 0; s++, n--)
    +     {
    +@@ ncrypt/functions_gpgme.c: static struct DnArray *parse_dn(const char *str)
    +   size_t arrayidx, arraysize;
    + 
    +   arraysize = 7; /* C,ST,L,O,OU,CN,email */
    +-  array = MUTT_MEM_MALLOC(arraysize + 1, struct DnArray);
    ++  array = mutt_mem_malloc_T(arraysize + 1, struct DnArray);
    +   arrayidx = 0;
    +   while (*str)
    +   {
    +@@ ncrypt/functions_gpgme.c: static struct DnArray *parse_dn(const char *str)
    +     {
    +       /* neomutt lacks a real mutt_mem_realloc - so we need to copy */
    +       arraysize += 5;
    +-      struct DnArray *a2 = MUTT_MEM_MALLOC(arraysize + 1, struct DnArray);
    ++      struct DnArray *a2 = mutt_mem_malloc_T(arraysize + 1, struct DnArray);
    +       for (int i = 0; i < arrayidx; i++)
    +       {
    +         a2[i].key = array[i].key;
    +
    @@ ncrypt/gnupgparse.c: static struct PgpKeyInfo *parse_pub_line(char *buf, bool *i
    - ## ncrypt/gpgme_functions.c ##
    -@@ ncrypt/gpgme_functions.c: struct DnArray
    -  */
    - static void print_utf8(FILE *fp, const char *buf, size_t len)
    - {
    --  char *tstr = MUTT_MEM_MALLOC(len + 1, char);
    -+  char *tstr = mutt_mem_malloc_T(len + 1, char);
    -   memcpy(tstr, buf, len);
    -   tstr[len] = 0;
    - 
    -@@ ncrypt/gpgme_functions.c: static const char *parse_dn_part(struct DnArray *array, const char *str)
    -   n = s - str;
    -   if (n == 0)
    -     return NULL; /* empty key */
    --  array->key = MUTT_MEM_MALLOC(n + 1, char);
    -+  array->key = mutt_mem_malloc_T(n + 1, char);
    -   p = array->key;
    -   memcpy(p, str, n); /* fixme: trim trailing spaces */
    -   p[n] = 0;
    -@@ ncrypt/gpgme_functions.c: static const char *parse_dn_part(struct DnArray *array, const char *str)
    -     if ((n == 0) || (n & 1))
    -       return NULL; /* empty or odd number of digits */
    -     n /= 2;
    --    p = MUTT_MEM_MALLOC(n + 1, char);
    -+    p = mutt_mem_malloc_T(n + 1, char);
    -     array->value = (char *) p;
    -     for (s1 = str; n > 0; s1 += 2, n--)
    -       sscanf(s1, "%2hhx", (unsigned char *) p++);
    -@@ ncrypt/gpgme_functions.c: static const char *parse_dn_part(struct DnArray *array, const char *str)
    -       }
    -     }
    - 
    --    p = MUTT_MEM_MALLOC(n + 1, char);
    -+    p = mutt_mem_malloc_T(n + 1, char);
    -     array->value = (char *) p;
    -     for (s = str; n > 0; s++, n--)
    -     {
    -@@ ncrypt/gpgme_functions.c: static struct DnArray *parse_dn(const char *str)
    -   size_t arrayidx, arraysize;
    - 
    -   arraysize = 7; /* C,ST,L,O,OU,CN,email */
    --  array = MUTT_MEM_MALLOC(arraysize + 1, struct DnArray);
    -+  array = mutt_mem_malloc_T(arraysize + 1, struct DnArray);
    -   arrayidx = 0;
    -   while (*str)
    -   {
    -@@ ncrypt/gpgme_functions.c: static struct DnArray *parse_dn(const char *str)
    -     {
    -       /* neomutt lacks a real mutt_mem_realloc - so we need to copy */
    -       arraysize += 5;
    --      struct DnArray *a2 = MUTT_MEM_MALLOC(arraysize + 1, struct DnArray);
    -+      struct DnArray *a2 = mutt_mem_malloc_T(arraysize + 1, struct DnArray);
    -       for (int i = 0; i < arrayidx; i++)
    -       {
    -         a2[i].key = array[i].key;
    -
    @@ ncrypt/pgpkey.c: struct PgpKeyInfo *pgp_ask_for_key(char *tag, const char *whatf
    -         l->next = IdDefaults;
    -         IdDefaults = l;
    +         l->next = (struct PgpCache *) mod_data->pgp_id_defaults;
    +         mod_data->pgp_id_defaults = l;
    @@ ncrypt/pgppacket.c: unsigned char *pgp_read_packet(FILE *fp, size_t *len)
    -   if (PacketBufLen == 0)
    +   if (mod_data->packet_buf_len == 0)
    @@ ncrypt/pgppacket.c: unsigned char *pgp_read_packet(FILE *fp, size_t *len)
    -     PacketBufLen = CHUNK_SIZE;
    --    PacketBuf = MUTT_MEM_MALLOC(PacketBufLen, unsigned char);
    -+    PacketBuf = mutt_mem_malloc_T(PacketBufLen, unsigned char);
    +     mod_data->packet_buf_len = CHUNK_SIZE;
    +-    mod_data->packet_buf = MUTT_MEM_MALLOC(mod_data->packet_buf_len, unsigned char);
    ++    mod_data->packet_buf = mutt_mem_malloc_T(mod_data->packet_buf_len, unsigned char);
    @@ nntp/adata.c: struct NntpAccountData *nntp_adata_new(struct Connection *conn)
    -   adata->groups_hash = mutt_hash_new(1009, MUTT_HASH_NO_FLAGS);
    +   adata->groups_hash = mutt_hash_new(1009, MUTT_HASH_NONE);
    @@ nntp/newsrc.c: int nntp_newsrc_parse(struct NntpAccountData *adata)
    -     char *b = NULL, *h = NULL;
    +     char *b = NULL;
    @@ nntp/nntp.c: static int nntp_attempt_features(struct NntpAccountData *adata)
    -       size_t buflen = 2048, off = 0, b = 0;
    +       size_t b = 0;
    @@ test/compress/common.c: static void one_test(const struct ComprOps *compr_ops, s
    -   void *ddata = compr_ops->decompress(compr_handle, copy, clen);
    +   size_t dlen = 0;
6:  2891df9c17aa ! 6:  1805adf64b31 */, mutt/memory.h: Rename MUTT_MEM_REALLOC() => mutt_mem_realloc_T()
    @@ complete/helpers.c: void matches_ensure_morespace(struct CompletionData *cd, int
    -   memset(&cd->match_list[cd->match_list_len], 0, new_size - cd->match_list_len);
    +   memset(&cd->match_list[cd->match_list_len], 0,
    +          (new_size - cd->match_list_len) * sizeof(const char *));
    @@ complete/helpers.c: void matches_ensure_morespace(struct CompletionData *cd, int
    -   cd->match_list_len = new_size;
    -
    - ## copy.c ##
    -@@ copy.c: int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end,
    -       {
    -         size_t blen = mutt_str_len(buf);
    - 
    --        MUTT_MEM_REALLOC(&this_one, this_one_len + blen + 1, char);
    -+        mutt_mem_realloc_T(&this_one, this_one_len + blen + 1, char);
    -         mutt_strn_copy(this_one + this_one_len, buf, blen, blen + 1);
    -         this_one_len += blen;
    -       }
    @@ editor/state.c: void enter_state_resize(struct EnterState *es, size_t num)
    - ## editor/window.c ##
    -@@ editor/window.c: bool self_insert(struct EnterWindowData *wdata, int ch)
    -     if (wdata->state->lastchar >= wdata->state->wbuflen)
    + ## email/copy_email.c ##
    +@@ email/copy_email.c: int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end,
    +       {
    +         size_t blen = mutt_str_len(buf);
    + 
    +-        MUTT_MEM_REALLOC(&this_one, this_one_len + blen + 1, char);
    ++        mutt_mem_realloc_T(&this_one, this_one_len + blen + 1, char);
    +         mutt_strn_copy(this_one + this_one_len, buf, blen, blen + 1);
    +         this_one_len += blen;
    +       }
    +
    + ## email/enriched.c ##
    +@@ email/enriched.c: static void enriched_flush(struct EnrichedState *enriched, bool wrap)
    +     if (enriched->line_used > enriched->line_max)
    @@ editor/window.c: bool self_insert(struct EnterWindowData *wdata, int ch)
    -       wdata->state->wbuflen = wdata->state->lastchar + 20;
    --      MUTT_MEM_REALLOC(&wdata->state->wbuf, wdata->state->wbuflen, wchar_t);
    -+      mutt_mem_realloc_T(&wdata->state->wbuf, wdata->state->wbuflen, wchar_t);
    +       enriched->line_max = enriched->line_used;
    +-      MUTT_MEM_REALLOC(&enriched->line, enriched->line_max + 1, wchar_t);
    ++      mutt_mem_realloc_T(&enriched->line, enriched->line_max + 1, wchar_t);
    @@ editor/window.c: bool self_insert(struct EnterWindowData *wdata, int ch)
    -     memmove(wdata->state->wbuf + wdata->state->curpos + 1,
    -             wdata->state->wbuf + wdata->state->curpos,
    +     wcscat(enriched->line, enriched->buffer);
    +     enriched->line_len += enriched->word_len;
    +@@ email/enriched.c: static void enriched_putwc(wchar_t c, struct EnrichedState *enriched)
    +       if ((enriched->param_used + 1) >= enriched->param_len)
    +       {
    +         enriched->param_len += 256;
    +-        MUTT_MEM_REALLOC(&enriched->param, enriched->param_len, wchar_t);
    ++        mutt_mem_realloc_T(&enriched->param, enriched->param_len, wchar_t);
    +       }
    + 
    +       enriched->param[enriched->param_used++] = c;
    +@@ email/enriched.c: static void enriched_putwc(wchar_t c, struct EnrichedState *enriched)
    +   if ((enriched->buf_len < (enriched->buf_used + 3)) || !enriched->buffer)
    +   {
    +     enriched->buf_len += 1024;
    +-    MUTT_MEM_REALLOC(&enriched->buffer, enriched->buf_len + 1, wchar_t);
    ++    mutt_mem_realloc_T(&enriched->buffer, enriched->buf_len + 1, wchar_t);
    +   }
    + 
    +   if ((!enriched->tag_level[RICH_NOFILL] && iswspace(c)) || (c == (wchar_t) '\0'))
    +@@ email/enriched.c: static void enriched_puts(const char *s, struct EnrichedState *enriched)
    +   if ((enriched->buf_len < (enriched->buf_used + mutt_str_len(s))) || !enriched->buffer)
    +   {
    +     enriched->buf_len += 1024;
    +-    MUTT_MEM_REALLOC(&enriched->buffer, enriched->buf_len + 1, wchar_t);
    ++    mutt_mem_realloc_T(&enriched->buffer, enriched->buf_len + 1, wchar_t);
    +   }
    +   c = s;
    +   while (*c)
    @@ email/rfc2231.c: static void join_continuations(struct ParameterList *pl, struct
    - ## enriched.c ##
    -@@ enriched.c: static void enriched_flush(struct EnrichedState *enriched, bool wrap)
    -     if (enriched->line_used > enriched->line_max)
    -     {
    -       enriched->line_max = enriched->line_used;
    --      MUTT_MEM_REALLOC(&enriched->line, enriched->line_max + 1, wchar_t);
    -+      mutt_mem_realloc_T(&enriched->line, enriched->line_max + 1, wchar_t);
    -     }
    -     wcscat(enriched->line, enriched->buffer);
    -     enriched->line_len += enriched->word_len;
    -@@ enriched.c: static void enriched_putwc(wchar_t c, struct EnrichedState *enriched)
    -       if ((enriched->param_used + 1) >= enriched->param_len)
    -       {
    -         enriched->param_len += 256;
    --        MUTT_MEM_REALLOC(&enriched->param, enriched->param_len, wchar_t);
    -+        mutt_mem_realloc_T(&enriched->param, enriched->param_len, wchar_t);
    -       }
    + ## gui/thread.c ##
    +@@ gui/thread.c: static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
    +           if (i >= array_size)
    +           {
    +             array_size *= 2;
    +-            MUTT_MEM_REALLOC(&array, array_size, struct MuttThread *);
    ++            mutt_mem_realloc_T(&array, array_size, struct MuttThread *);
    +           }
    @@ enriched.c: static void enriched_putwc(wchar_t c, struct EnrichedState *enriched
    -       enriched->param[enriched->param_used++] = c;
    -@@ enriched.c: static void enriched_putwc(wchar_t c, struct EnrichedState *enriched)
    -   if ((enriched->buf_len < (enriched->buf_used + 3)) || !enriched->buffer)
    -   {
    -     enriched->buf_len += 1024;
    --    MUTT_MEM_REALLOC(&enriched->buffer, enriched->buf_len + 1, wchar_t);
    -+    mutt_mem_realloc_T(&enriched->buffer, enriched->buf_len + 1, wchar_t);
    -   }
    - 
    -   if ((!enriched->tag_level[RICH_NOFILL] && iswspace(c)) || (c == (wchar_t) '\0'))
    -@@ enriched.c: static void enriched_puts(const char *s, struct EnrichedState *enriched)
    -   if ((enriched->buf_len < (enriched->buf_used + mutt_str_len(s))) || !enriched->buffer)
    -   {
    -     enriched->buf_len += 1024;
    --    MUTT_MEM_REALLOC(&enriched->buffer, enriched->buf_len + 1, wchar_t);
    -+    mutt_mem_realloc_T(&enriched->buffer, enriched->buf_len + 1, wchar_t);
    -   }
    -   c = s;
    -   while (*c)
    -
    - ## gui/curs_lib.c ##
    -@@ gui/curs_lib.c: char *mutt_str_expand_tabs(char *str, size_t *len, int tabwidth)
    -   while (required_len > *len)
    -   {
    -     *len += 256;
    --    MUTT_MEM_REALLOC(&str, *len, char);
    -+    mutt_mem_realloc_T(&str, *len, char);
    -   }
    - 
    -   // expand tabs
    +           array[i] = thread;
    @@ mutt/buffer.c: void buf_alloc(struct Buffer *buf, size_t new_size)
    -   buf->dsize = ROUND_UP(new_size + 1, BufferStepSize);
    +   buf->dsize = dsize;
    @@ mutt/envlist.c: bool envlist_set(char ***envp, const char *name, const char *val
    -     (*envp)[count] = mutt_str_dup(work);
    +     (*envp)[count] = work;
    @@ mutt/pool.c: static void pool_increase_size(void)
    -     struct Buffer *newbuf = buf_new(NULL);
    +     struct Buffer *newbuf = mutt_mem_calloc_T(1, struct Buffer);
    @@ mutt/string.c: int mutt_str_asprintf(char **strp, const char *fmt, ...)
    - ## mutt_thread.c ##
    -@@ mutt_thread.c: static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
    -           if (i >= array_size)
    -           {
    -             array_size *= 2;
    --            MUTT_MEM_REALLOC(&array, array_size, struct MuttThread *);
    -+            mutt_mem_realloc_T(&array, array_size, struct MuttThread *);
    -           }
    - 
    -           array[i] = thread;
    -
    @@ ncrypt/crypt_gpgme.c: static char *find_keys(const struct AddressList *addrlist,
    - 
    @@ ncrypt/crypt_gpgme.c: static char *find_keys(const struct AddressList *addrlist,
    +       /* Append the selected key ID to the space-separated keylist string */
    @@ ncrypt/pgp.c: char *pgp_class_find_keys(const struct AddressList *addrlist, bool
    - 
    @@ ncrypt/pgp.c: char *pgp_class_find_keys(const struct AddressList *addrlist, bool
    +       /* Append the selected key ID to the space-separated keylist string */
    @@ ncrypt/pgppacket.c: static int read_material(size_t material, size_t *used, FILE
    -     PacketBufLen = *used + material + CHUNK_SIZE;
    +     mod_data->packet_buf_len = *used + material + CHUNK_SIZE;
    @@ ncrypt/pgppacket.c: static int read_material(size_t material, size_t *used, FILE
    --    MUTT_MEM_REALLOC(&PacketBuf, PacketBufLen, unsigned char);
    -+    mutt_mem_realloc_T(&PacketBuf, PacketBufLen, unsigned char);
    +-    MUTT_MEM_REALLOC(&mod_data->packet_buf, mod_data->packet_buf_len, unsigned char);
    ++    mutt_mem_realloc_T(&mod_data->packet_buf, mod_data->packet_buf_len, unsigned char);
    @@ ncrypt/pgppacket.c: static int read_material(size_t material, size_t *used, FILE
    -   if (fread(PacketBuf + *used, 1, material, fp) < material)
    +   if (fread(mod_data->packet_buf + *used, 1, material, fp) < material)
    @@ pager/display.c: static void resolve_types(struct MuttWindow *win, char *buf, ch
    --        MUTT_MEM_REALLOC(&(lines[line_num].syntax), 1, struct TextSyntax);
    -+        mutt_mem_realloc_T(&(lines[line_num].syntax), 1, struct TextSyntax);
    -       }
    -       lines[i++].cid = MT_COLOR_SIGNATURE;
    -     }
    +-        MUTT_MEM_REALLOC(&(lines[i].syntax), 1, struct TextSyntax);
    ++        mutt_mem_realloc_T(&(lines[i].syntax), 1, struct TextSyntax);
    +         lines[i].syntax[0].attr_color = NULL;
    +         lines[i].syntax[0].first = -1;
    +         lines[i].syntax[0].last = -1;
    @@ pager/pager.c: static int pager_repaint(struct MuttWindow *win)
    -       if (priv->search_compiled && priv->lines[i].search)
    -         FREE(&(priv->lines[i].search));
    -     }
    +       priv->lines[i].syntax[0].attr_color = NULL;
    +       priv->lines[i].syntax[0].first = -1;
    +       priv->lines[i].syntax[0].last = -1;
7:  43d2bb6fbb9c = 7:  6d69a67c8439 mutt/memory.h: Use compound literals instead of casts
```
</details>

<details>
<summary>v4</summary>

-  Improve typeas() to allow `void` and function types.

```
$ git range-diff -U0 main neomutt/alx/typeas alx/typeas 
1:  d34b5828dbd9 = 1:  d34b5828dbd9 mutt/memory.h: MUTT_MEM_REALLOC(): Refactor for readability
2:  da5e1a2cf793 ! 2:  c5ee24421e3b mutt/memory.h: typeas(): Add macro
    @@ mutt/memory.h
    -+# define typeas(T)  __typeof__((T){0})
    ++# define typeas(T)  __typeof__(*(__typeof__(T) *){_Generic(0, T: NULL, default: NULL)})
3:  08dc66088c29 ! 3:  d97b26fca6db mutt/memory.h: Use typeas() to make these macros more robust
    @@ mutt/memory.h
    - # define typeas(T)  __typeof__((T){0})
    + # define typeas(T)  __typeof__(*(__typeof__(T) *){_Generic(0, T: NULL, default: NULL)})
4:  9deeb3116e8c ! 4:  eabee97d48b7 */, mutt/memory.h: Rename MUTT_MEM_CALLOC() => mutt_mem_calloc_T()
    @@ mutt/memory.h
    - # define typeas(T)  __typeof__((T){0})
    + # define typeas(T)  __typeof__(*(__typeof__(T) *){_Generic(0, T: NULL, default: NULL)})
5:  3759a6c05e5e = 5:  9b0ded54c1a9 */, mutt/memory.h: Rename MUTT_MEM_MALLOC() => mutt_mem_malloc_T()
6:  1805adf64b31 = 6:  1767d0af9b1e */, mutt/memory.h: Rename MUTT_MEM_REALLOC() => mutt_mem_realloc_T()
7:  6d69a67c8439 = 7:  86aab2b56763 mutt/memory.h: Use compound literals instead of casts
```
</details>

<details>
<summary>v5</summary>

-  Add and use RVALUE(), which uses the standard comma operator, instead of statement expressions (a GNU extension, which BTW is more complex).

```
$ git range-diff --creation-factor=99 main neomutt/alx/typeas alx/typeas 
1:  d34b5828dbd9 = 1:  d34b5828dbd9 mutt/memory.h: MUTT_MEM_REALLOC(): Refactor for readability
2:  c5ee24421e3b = 2:  c5ee24421e3b mutt/memory.h: typeas(): Add macro
3:  d97b26fca6db = 3:  d97b26fca6db mutt/memory.h: Use typeas() to make these macros more robust
4:  eabee97d48b7 = 4:  eabee97d48b7 */, mutt/memory.h: Rename MUTT_MEM_CALLOC() => mutt_mem_calloc_T()
5:  9b0ded54c1a9 = 5:  9b0ded54c1a9 */, mutt/memory.h: Rename MUTT_MEM_MALLOC() => mutt_mem_malloc_T()
6:  1767d0af9b1e = 6:  1767d0af9b1e */, mutt/memory.h: Rename MUTT_MEM_REALLOC() => mutt_mem_realloc_T()
-:  ------------ > 7:  1da7e4569c9e mutt/memory.h: RVALUE(): Add macro for performing lvalue conversion
7:  86aab2b56763 ! 8:  c90601a8e857 mutt/memory.h: Use compound literals instead of casts
    @@ Commit message
         compound literals come with their own issues; they are lvalues, and as
         such, their address can be taken, and they can be assigned to.  To use
         a compound literal safely, we must perform "lvalue conversion", to turn
    -    it into a simple expression.  The way to do that is with a GNU statement
    -    expression.
    +    it into a simple expression.  The way to do that is the RVALUE() macro,
    +    which uses the comma operator.
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## mutt/memory.h ##
     @@
    - 
      // mutt_mem_calloc_T - clear allocate type-safe
      #define mutt_mem_calloc_T(n, T)                                       \
    --(                                                                     \
    + (                                                                     \
     -  (typeas(T) *) mutt_mem_calloc(n, sizeof(T))                         \
    --)
    -+({                                                                    \
    -+  (typeas(T) *){mutt_mem_calloc(n, sizeof(T))};                       \
    -+})
    ++  RVALUE((typeas(T) *){mutt_mem_calloc(n, sizeof(T))})                \
    + )
      
      // mutt_mem_malloc_T - memory allocate type-safe
      #define mutt_mem_malloc_T(n, T)                                       \
    --(                                                                     \
    + (                                                                     \
     -  (typeas(T) *) mutt_mem_mallocarray(n, sizeof(T))                    \
    --)
    -+({                                                                    \
    -+  (typeas(T) *){mutt_mem_mallocarray(n, sizeof(T))};                  \
    -+})
    ++  RVALUE((typeas(T) *){mutt_mem_mallocarray(n, sizeof(T))})           \
    + )
      
      // mutt_mem_realloc_T - resize allocation type-safe
    - #define mutt_mem_realloc_T(pptr, n, T)                                \
```
</details>

<details>
<summary>v5b</summary>

-  Fix alignment (clang-format).

```
$ git range-diff main neomutt/alx/typeas alx/typeas 
1:  d34b5828dbd9 = 1:  d34b5828dbd9 mutt/memory.h: MUTT_MEM_REALLOC(): Refactor for readability
2:  c5ee24421e3b = 2:  c5ee24421e3b mutt/memory.h: typeas(): Add macro
3:  d97b26fca6db = 3:  d97b26fca6db mutt/memory.h: Use typeas() to make these macros more robust
4:  eabee97d48b7 = 4:  eabee97d48b7 */, mutt/memory.h: Rename MUTT_MEM_CALLOC() => mutt_mem_calloc_T()
5:  9b0ded54c1a9 = 5:  9b0ded54c1a9 */, mutt/memory.h: Rename MUTT_MEM_MALLOC() => mutt_mem_malloc_T()
6:  1767d0af9b1e ! 6:  c3fee54676aa */, mutt/memory.h: Rename MUTT_MEM_REALLOC() => mutt_mem_realloc_T()
    @@ pager/display.c: static void match_body_patterns(char *pat, struct Line *lines,
              if (++(lines[line_num].syntax_arr_size) > 1)
              {
     -          MUTT_MEM_REALLOC(&(lines[line_num].syntax),
    +-                           lines[line_num].syntax_arr_size, struct TextSyntax);
     +          mutt_mem_realloc_T(&(lines[line_num].syntax),
    -                            lines[line_num].syntax_arr_size, struct TextSyntax);
    ++                             lines[line_num].syntax_arr_size, struct TextSyntax);
                // Zero the new entry
                const int index = lines[line_num].syntax_arr_size - 1;
    +           struct TextSyntax *ts = &lines[line_num].syntax[index];
     @@ pager/display.c: static void resolve_types(struct MuttWindow *win, char *buf, char *raw,
            if (lines[i].syntax_arr_size)
            {
    @@ pager/display.c: static void resolve_types(struct MuttWindow *win, char *buf, ch
                  if (++(lines[line_num].syntax_arr_size) > 1)
                  {
     -              MUTT_MEM_REALLOC(&(lines[line_num].syntax),
    +-                               lines[line_num].syntax_arr_size, struct TextSyntax);
     +              mutt_mem_realloc_T(&(lines[line_num].syntax),
    -                                lines[line_num].syntax_arr_size, struct TextSyntax);
    ++                                 lines[line_num].syntax_arr_size, struct TextSyntax);
                    // Zero the new entry
                    const int index = lines[line_num].syntax_arr_size - 1;
    +               struct TextSyntax *ts = &lines[line_num].syntax[index];
     @@ pager/display.c: int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
        if (*lines_used == *lines_max)
        {
7:  1da7e4569c9e = 7:  77ce59316ded mutt/memory.h: RVALUE(): Add macro for performing lvalue conversion
8:  c90601a8e857 = 8:  fd44a62e1b08 mutt/memory.h: Use compound literals instead of casts
```
</details>

<details>
<summary>v6</summary>

-  Rebase after #5032.

```
$ git range-diff main..neomutt/alx/typeas alx/t..alx/typeas 
1:  d34b5828dbd9 < -:  ------------ mutt/memory.h: MUTT_MEM_REALLOC(): Refactor for readability
2:  c5ee24421e3b < -:  ------------ mutt/memory.h: typeas(): Add macro
3:  d97b26fca6db < -:  ------------ mutt/memory.h: Use typeas() to make these macros more robust
4:  eabee97d48b7 ! 1:  5506394af650 */, mutt/memory.h: Rename MUTT_MEM_CALLOC() => mutt_mem_calloc_T()
    @@ Commit message
         The '_T' in the name notes that this API is a type-safe variant of the
         API it wraps.  This makes the name more explicative.
     
    -    Except for the added comment, and the readability improvement in the
    -    implementation (mutt/memory.h), this patch has been scripted:
    +    Except for the added comment in the implementation (mutt/memory.h),
    +    this patch has been scripted:
     
                 $ grep -rl MUTT_MEM_CALLOC \
                 | xargs sed -i 's/MUTT_MEM_CALLOC/mutt_mem_calloc_T/g';
    @@ mutt/mbyte.c: int mutt_mb_filter_unprintable(char **s)
     
      ## mutt/memory.h ##
     @@
    - # define typeas(T)  __typeof__(*(__typeof__(T) *){_Generic(0, T: NULL, default: NULL)})
    - #endif
      
    --#define MUTT_MEM_CALLOC(n, T)  ((typeas(T) *) mutt_mem_calloc(n, sizeof(T)))
    + #define RVALUE(lv)  ((void)0, (lv))
    + 
    +-#define MUTT_MEM_CALLOC(n, T)                                         \
     +// mutt_mem_calloc_T - clear allocate type-safe
     +#define mutt_mem_calloc_T(n, T)                                       \
    -+(                                                                     \
    -+  (typeas(T) *) mutt_mem_calloc(n, sizeof(T))                         \
    -+)
    -+
    - #define MUTT_MEM_MALLOC(n, T)  ((typeas(T) *) mutt_mem_mallocarray(n, sizeof(T)))
    - 
    - #define MUTT_MEM_REALLOC(pptr, n, T)                                  \
    + (                                                                     \
    +   RVALUE((typeas(T) *){mutt_mem_calloc(n, sizeof(T))})                \
    + )
     
      ## mutt/module.c ##
     @@
5:  9b0ded54c1a9 ! 2:  4a10b52d913c */, mutt/memory.h: Rename MUTT_MEM_MALLOC() => mutt_mem_malloc_T()
    @@ Commit message
         The '_T' in the name notes that this API is a type-safe variant of the
         API it wraps.  This makes the name more explicative.
     
    -    Except for the added comment, and the readability improvement in the
    -    implementation (mutt/memory.h), this patch has been scripted:
    +    Except for the added comment in the implementation (mutt/memory.h),
    +    this patch has been scripted:
     
                 $ grep -rl MUTT_MEM_MALLOC \
                 | xargs sed -i 's/MUTT_MEM_MALLOC/mutt_mem_malloc_T/g';
    @@ mutt/file.c: char *mutt_file_read_line(char *line, size_t *size, FILE *fp, int *
     
      ## mutt/memory.h ##
     @@
    -   (typeas(T) *) mutt_mem_calloc(n, sizeof(T))                         \
    +   RVALUE((typeas(T) *){mutt_mem_calloc(n, sizeof(T))})                \
      )
      
    --#define MUTT_MEM_MALLOC(n, T)  ((typeas(T) *) mutt_mem_mallocarray(n, sizeof(T)))
    +-#define MUTT_MEM_MALLOC(n, T)                                         \
     +// mutt_mem_malloc_T - memory allocate type-safe
     +#define mutt_mem_malloc_T(n, T)                                       \
    -+(                                                                     \
    -+  (typeas(T) *) mutt_mem_mallocarray(n, sizeof(T))                    \
    -+)
    - 
    - #define MUTT_MEM_REALLOC(pptr, n, T)                                  \
      (                                                                     \
    +   RVALUE((typeas(T) *){mutt_mem_mallocarray(n, sizeof(T))})           \
    + )
     
      ## mutt/string.c ##
     @@ mutt/string.c: char *mutt_strn_dup(const char *begin, size_t len)
6:  c3fee54676aa ! 3:  460703895ea0 */, mutt/memory.h: Rename MUTT_MEM_REALLOC() => mutt_mem_realloc_T()
    @@ mutt/mbyte.c: size_t mutt_mb_mbstowcs(wchar_t **pwbuf, size_t *pwbuflen, size_t
     
      ## mutt/memory.h ##
     @@
    -   (typeas(T) *) mutt_mem_mallocarray(n, sizeof(T))                    \
    +   RVALUE((typeas(T) *){mutt_mem_mallocarray(n, sizeof(T))})           \
      )
      
     -#define MUTT_MEM_REALLOC(pptr, n, T)                                  \
7:  77ce59316ded < -:  ------------ mutt/memory.h: RVALUE(): Add macro for performing lvalue conversion
8:  fd44a62e1b08 < -:  ------------ mutt/memory.h: Use compound literals instead of casts
```

```diff
$ git diff fd44a62e1b08..460703895ea0
$
```
</details>

<details>
<summary>v6b</summary>

-  Rebase

```
$ git range-diff 5506394af650^..460703895ea0 main..alx/typeas 
1:  5506394af650 = 1:  8fbdde454c6e */, mutt/memory.h: Rename MUTT_MEM_CALLOC() => mutt_mem_calloc_T()
2:  4a10b52d913c = 2:  9a1cf7124354 */, mutt/memory.h: Rename MUTT_MEM_MALLOC() => mutt_mem_malloc_T()
3:  460703895ea0 = 3:  d15fbc98fce3 */, mutt/memory.h: Rename MUTT_MEM_REALLOC() => mutt_mem_realloc_T()
```
</details>