### PR TITLE
mutt/array.h: Readability improvements

### DIFF
--- a/mutt/array.h
+++ b/mutt/array.h
@@ -332,9 +332,12 @@
 #define ARRAY_REMOVE(head, elem)                                               \
   do                                                                           \
   {                                                                            \
-    memmove(elem, (elem) + 1,                                                  \
-            ARRAY_ELEM_SIZE(head) *                                            \
-                MAX(0, (ARRAY_SIZE(head) - ARRAY_IDX(head, elem) - 1)));       \
+    if (ARRAY_SIZE(head) > ARRAY_IDX(head, elem) + 1)                          \
+    {                                                                          \
+      memmove(elem, (elem) + 1,                                                \
+              ARRAY_ELEM_SIZE(head) *                                          \
+              (ARRAY_SIZE(head) - ARRAY_IDX(head, elem) - 1));                 \
+    }                                                                          \
     ARRAY_SHRINK(head, 1);                                                     \
   } while (0)
 


### PR DESCRIPTION
* mutt/array.h: ARRAY_REMOVE(): Use conditional to avoid complex logic
* mutt/array.h: Use do{}while(0) to implement macros that don't return anything
* mutt/array.h: Rewrite using GNU statement expressions
* mutt/array.h: Rename macro parameter num => n
* mutt/array.h: Remove redunant parentheses
* mutt/array.h: Put macro newline escapes in column 71

This is queued after the bugfix <https://github.com/neomutt/neomutt/pull/4755>.

Since I had a look at that file, I stopped to improve its readability.