### PR TITLE
fix command documentation discrepancies

### DIFF
--- a/commands/commands.c
+++ b/commands/commands.c
@@ -167,7 +167,7 @@ const struct Command CommandsCommands[] = {
         "configuration.html#source" },
   { "spam", CMD_SPAM, parse_spam, CMD_NO_DATA,
         N_("Define rules to parse spam detection headers"),
-        N_("spam <regex> <format>"),
+        N_("spam <regex> [ <format> ]"),
         "configuration.html#spam" },
   { "subject-regex", CMD_SUBJECT_REGEX, parse_subjectrx_list, CMD_NO_DATA,
         N_("Apply regex-based rewriting to message subjects"),

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -849,7 +849,7 @@ configuration file the hook is defined in.
 .
 .PP
 .nf
-\fBspam\fP \fIregex\fP \fIformat\fP
+\fBspam\fP \fIregex\fP [ \fIformat\fP ]
 \fBnospam\fP { \fB*\fP | \fIregex\fP }
 .fi
 .IP


### PR DESCRIPTION
## Summary

Corrects inconsistencies between NeoMutt's command implementations and their documentation, ensuring syntax matches actual behavior.

## Changes

* `setenv`: Added no-args listing and clarified query syntax (`?<var>` and `var?`)
* `unalternates`: Removed unsupported `-group` flag
* `unlists/unsubscribe`: Removed unsupported `-group` flag
* `source`: Allow multiple filenames (`<filename> [ <filename> ... ]`)
* `spam`: Made `<format>` optional (`<regex> [ <format> ]`)

AI disclaimer: I tasked [Amp](https://ampcode.com/) with checking for discrepancies between the implementation and documentation of all commands. This is what it came up with. I've sanity checked the changes and they look good.