### PR TITLE
Fix: adding a default socket timeout in mutt_oauth2.py to prevent cli…

### DIFF
--- a/contrib/oauth2/mutt_oauth2.py
+++ b/contrib/oauth2/mutt_oauth2.py
@@ -40,6 +40,10 @@ import socket
 import http.server
 import subprocess
 
+# Sometime the communication will hang, freezing Mutt.
+# this timeout prevents this from happening
+socket.setdefaulttimeout(15)
+
 # The token file must be encrypted because it contains multi-use bearer tokens
 # whose usage does not require additional verification. Specify whichever
 # encryption and decryption pipes you prefer. They should read from standard


### PR DESCRIPTION
Fix: adding a default socket timeout in mutt_oauth2.py to prevent client from hanging forever/freezing 

* **What does this PR do?**

It adds a default timeout to all socket operations in the mutt_oauth2.py client.

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/code)

* **What are the relevant issue numbers?**
