### PR TITLE
cli: support getopt long options

### DIFF
--- a/cli/objects.h
+++ b/cli/objects.h
@@ -76,8 +76,8 @@ struct CliHelp
 struct CliInfo
 {
   bool is_set;                      ///< This struct has been used
-  bool dump_config;                 ///< `-D`  Dump the config
-  bool dump_changed;                ///< `-DD` Dump the changed config
+  bool dump_config;                 ///< `-D`  Dump the config options
+  bool dump_changed;                ///< `-DD` Dump the changed config options
   bool show_help;                   ///< `-O`  Show one-liner help
   bool hide_sensitive;              ///< `-S`  Hide sensitive config
 

--- a/cli/parse.c
+++ b/cli/parse.c
@@ -27,11 +27,66 @@
  */
 
 #include "config.h"
+#include <getopt.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <sys/param.h> // IWYU pragma: keep
 #include <unistd.h>
 #include "mutt/lib.h"
 #include "objects.h"
+
+/**
+ * LongOptions - Long option definitions for getopt_long()
+ *
+ * All short options have corresponding long options for clarity.
+ * The syntax is backwards compatible - all original short options work.
+ */
+static const struct option LongOptions[] = {
+  // clang-format off
+  // Shared options
+  { "command",             required_argument, NULL, 'e' },
+  { "config",              required_argument, NULL, 'F' },
+  { "debug-file",          required_argument, NULL, 'l' },
+  { "debug-level",         required_argument, NULL, 'd' },
+  { "mbox-type",           required_argument, NULL, 'm' },
+  { "no-system-config",    no_argument,       NULL, 'n' },
+
+  // Help options
+  { "help",                no_argument,       NULL, 'h' },
+  { "license",             no_argument,       NULL, 'L' },
+  { "version",             no_argument,       NULL, 'v' },
+
+  // Info options
+  { "alias",               required_argument, NULL, 'A' },
+  { "dump-changed-config", no_argument,       NULL, 'X' },
+  { "dump-config",         no_argument,       NULL, 'D' },
+  { "hide-sensitive",      no_argument,       NULL, 'S' },
+  { "query",               required_argument, NULL, 'Q' },
+  { "with-docs",           no_argument,       NULL, 'O' },
+
+  // Send options
+  { "attach",              required_argument, NULL, 'a' },
+  { "bcc",                 required_argument, NULL, 'b' },
+  { "cc",                  required_argument, NULL, 'c' },
+  { "crypto",              no_argument,       NULL, 'C' },
+  { "draft",               required_argument, NULL, 'H' },
+  { "edit-message",        no_argument,       NULL, 'E' },
+  { "include",             required_argument, NULL, 'i' },
+  { "subject",             required_argument, NULL, 's' },
+
+  // TUI options
+  { "browser",             no_argument,       NULL, 'y' },
+  { "check-any-mail",      no_argument,       NULL, 'z' },
+  { "check-new-mail",      no_argument,       NULL, 'Z' },
+  { "folder",              required_argument, NULL, 'f' },
+  { "nntp-browser",        no_argument,       NULL, 'G' },
+  { "nntp-server",         required_argument, NULL, 'g' },
+  { "postponed",           no_argument,       NULL, 'p' },
+  { "read-only",           no_argument,       NULL, 'R' },
+
+  { NULL, 0, NULL, 0 },
+  // clang-format on
+};
 
 /**
  * check_help_mode - Check for help mode
@@ -117,7 +172,8 @@ bool cli_parse(int argc, char *const *argv, struct CommandLine *cli)
 
   while (rc && (argc > 1) && (optind < argc))
   {
-    int opt = getopt(argc, argv, "+:A:a:b:Cc:Dd:Ee:F:f:Gg:H:hi:l:m:nOpQ:RSs:TvyZz");
+    int opt = getopt_long(argc, argv, "+:A:a:b:Cc:Dd:Ee:F:f:Gg:H:hi:l:m:nOpQ:RSs:vyZz",
+                          LongOptions, NULL);
     switch (opt)
     {
       // ------------------------------------------------------------
@@ -173,6 +229,12 @@ bool cli_parse(int argc, char *const *argv, struct CommandLine *cli)
         cli->help.is_set = true;
         break;
       }
+      case 'L': // license
+      {
+        cli->help.license = true;
+        cli->help.is_set = true;
+        break;
+      }
       case 'v': // version, license
       {
         if (cli->help.version)
@@ -221,6 +283,13 @@ bool cli_parse(int argc, char *const *argv, struct CommandLine *cli)
       case 'S': // hide sensitive
       {
         cli->info.hide_sensitive = true;
+        cli->info.is_set = true;
+        break;
+      }
+      case 'X': // dump changed
+      {
+        cli->info.dump_config = true;
+        cli->info.dump_changed = true;
         cli->info.is_set = true;
         break;
       }

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -19628,14 +19628,14 @@ folder-hook ^pop 'set read_inc=1'
               </entry>
             </row>
             <row>
-              <entry>-A <literal>alias</literal></entry>
+              <entry>-A, --alias <literal>alias</literal></entry>
               <entry>
                 Print an expanded version of the given <literal>alias</literal>
                 to stdout and exit
               </entry>
             </row>
             <row>
-              <entry>-a <literal>file</literal></entry>
+              <entry>-a, --attach <literal>file</literal></entry>
               <entry>
                 Attach one or more <literal>file</literal>s to a message (must
                 be the last option). Add any addresses after the
@@ -19649,13 +19649,13 @@ neomutt -a image.jpg *.png -- address1 address2
               </entry>
             </row>
             <row>
-              <entry>-b <literal>address</literal></entry>
+              <entry>-b, --bcc <literal>address</literal></entry>
               <entry>
                 Specify a blind carbon copy (Bcc) recipient
               </entry>
             </row>
             <row>
-              <entry>-C</entry>
+              <entry>-C, --crypto</entry>
               <entry>
                 Enable cryptographic operations in the cases in which they're
                 disabled by default. Those include batch mode, sending a
@@ -19663,13 +19663,13 @@ neomutt -a image.jpg *.png -- address1 address2
               </entry>
             </row>
             <row>
-              <entry>-c <literal>address</literal></entry>
+              <entry>-c, --cc <literal>address</literal></entry>
               <entry>
                 Specify a carbon copy (Cc) recipient
               </entry>
             </row>
             <row>
-              <entry>-D</entry>
+              <entry>-D, --dump-config</entry>
               <entry>
                 Dump all config variables as
                 &apos;<emphasis role="bold">name=value</emphasis>&apos; pairs
@@ -19677,27 +19677,28 @@ neomutt -a image.jpg *.png -- address1 address2
               </entry>
             </row>
             <row>
-              <entry>-D -D (or -DD)</entry>
+              <entry>-DD, --dump-changed-config</entry>
               <entry>
-                Like <emphasis role="bold">-D</emphasis>, but only show the
-                config that has changed
+                Dump all changed config variables as
+                &apos;<emphasis role="bold">name=value</emphasis>&apos; pairs
+                to stdout
               </entry>
             </row>
             <row>
-              <entry>-D -O</entry>
+              <entry>-D -O, --with-docs</entry>
               <entry>
                 Like <emphasis role="bold">-D</emphasis>, but show one-liner documentation
               </entry>
             </row>
             <row>
-              <entry>-D -S</entry>
+              <entry>-D -S, --hide-sensitive</entry>
               <entry>
                 Like <emphasis role="bold">-D</emphasis>, but hide the value of
-                sensitive variables
+                sensitive config options
               </entry>
             </row>
             <row>
-              <entry>-d <literal>level</literal></entry>
+              <entry>-d, --debug-level <literal>level</literal></entry>
               <entry>
                 Log debugging output to a file (default is
                 &quot;<literal>~/.neomuttdebug0</literal>&quot;).
@@ -19711,7 +19712,7 @@ neomutt -a image.jpg *.png -- address1 address2
               </entry>
             </row>
             <row>
-              <entry>-E</entry>
+              <entry>-E, --edit-message</entry>
               <entry>
                 Edit
                 <literal>draft</literal> (<emphasis role="bold">-H</emphasis>) or
@@ -19720,14 +19721,14 @@ neomutt -a image.jpg *.png -- address1 address2
               </entry>
             </row>
             <row>
-              <entry>-e <literal>command</literal></entry>
+              <entry>-e, --command <literal>command</literal></entry>
               <entry>
                 Specify a <literal>command</literal> to be run after reading
                 the config files
               </entry>
             </row>
             <row>
-              <entry>-F <literal>config</literal></entry>
+              <entry>-F, --config <literal>config</literal></entry>
               <entry>
                 Specify an alternative initialization file to read, see section
                 <link linkend="configuration-files">Location of Initialization Files</link>
@@ -19735,7 +19736,7 @@ neomutt -a image.jpg *.png -- address1 address2
               </entry>
             </row>
             <row>
-              <entry>-f <literal>mailbox</literal></entry>
+              <entry>-f, --folder <literal>mailbox</literal></entry>
               <entry>
                 Specify a <literal>mailbox</literal> (as defined with
                 <link linkend="mailboxes"><command>mailboxes</command> command</link>)
@@ -19743,40 +19744,40 @@ neomutt -a image.jpg *.png -- address1 address2
               </entry>
             </row>
             <row>
-              <entry>-G</entry>
+              <entry>-G, --nntp-browser</entry>
               <entry>
                 Start NeoMutt with a listing of subscribed newsgroups
               </entry>
             </row>
             <row>
-              <entry>-g <literal>server</literal></entry>
+              <entry>-g, --nntp-server <literal>server</literal></entry>
               <entry>
                 Like <emphasis role="bold">-G</emphasis>, but start at
                 specified news <literal>server</literal>
               </entry>
             </row>
             <row>
-              <entry>-H <literal>draft</literal></entry>
+              <entry>-H, --draft <literal>draft</literal></entry>
               <entry>
                 Specify a <literal>draft</literal> file with header and body
                 for message composing
               </entry>
             </row>
             <row>
-              <entry>-h</entry>
+              <entry>-h, --help</entry>
               <entry>
                 Print this help message and exit
               </entry>
             </row>
             <row>
-              <entry>-i <literal>include</literal></entry>
+              <entry>-i, --include <literal>include</literal></entry>
               <entry>
                 Specify an <literal>include</literal> file to be embedded in
                 the body of a message
               </entry>
             </row>
             <row>
-              <entry>-l <literal>file</literal></entry>
+              <entry>-l, --debug-file <literal>file</literal></entry>
               <entry>
                 Specify a <literal>file</literal> for debugging output (default
                 &quot;<literal>~/.neomuttdebug0</literal>&quot;). This
@@ -19789,7 +19790,7 @@ neomutt -a image.jpg *.png -- address1 address2
               </entry>
             </row>
             <row>
-              <entry>-m <literal>type</literal></entry>
+              <entry>-m, --mbox-type <literal>type</literal></entry>
               <entry>
                 Specify a default mailbox format <literal>type</literal> for
                 newly created folders. The <literal>type</literal> is either
@@ -19797,19 +19798,19 @@ neomutt -a image.jpg *.png -- address1 address2
               </entry>
             </row>
             <row>
-              <entry>-n</entry>
+              <entry>-n, --no-system-config</entry>
               <entry>
                 Do not read the system-wide configuration file
               </entry>
             </row>
             <row>
-              <entry>-p</entry>
+              <entry>-p, --postponed</entry>
               <entry>
                 Resume a prior postponed message, if any
               </entry>
             </row>
             <row>
-              <entry>-Q <literal>variable</literal></entry>
+              <entry>-Q, --query <literal>variable</literal></entry>
               <entry>
                 Query a configuration <literal>variable</literal> and print its
                 value to stdout (after the config has been read and any
@@ -19818,45 +19819,45 @@ neomutt -a image.jpg *.png -- address1 address2
               </entry>
             </row>
             <row>
-              <entry>-R</entry>
+              <entry>-R, --read-only</entry>
               <entry>
                 Open mailbox in read-only mode
               </entry>
             </row>
             <row>
-              <entry>-s <literal>subject</literal></entry>
+              <entry>-s, --subject <literal>subject</literal></entry>
               <entry>
                 Specify a <literal>subject</literal> (must be enclosed in
                 quotes if it has spaces)
               </entry>
             </row>
             <row>
-              <entry>-v</entry>
+              <entry>-v, --version</entry>
               <entry>
                 Print the NeoMutt version and compile-time definitions and exit
               </entry>
             </row>
             <row>
-              <entry>-vv</entry>
+              <entry>-vv, --license</entry>
               <entry>
                 Print the NeoMutt license and copyright information and exit
               </entry>
             </row>
             <row>
-              <entry>-y</entry>
+              <entry>-y, --browser</entry>
               <entry>
                 Start NeoMutt with a listing of all defined mailboxes
               </entry>
             </row>
             <row>
-              <entry>-Z</entry>
+              <entry>-Z, --check-new-mail</entry>
               <entry>
                 Open the first mailbox with new message or exit immediately
                 with exit code 1 if none is found in all defined mailboxes
               </entry>
             </row>
             <row>
-              <entry>-z</entry>
+              <entry>-z, --check-any-mail</entry>
               <entry>
                 Open the first or specified
                 (<emphasis role="bold">-f</emphasis>) mailbox if it holds any

--- a/docs/neomutt.man
+++ b/docs/neomutt.man
@@ -30,40 +30,43 @@ The NeoMutt Mail User Agent (MUA)
 .SH SYNTAX
 .\" --------------------------------------------------------------------
 .SY neomutt
-.RB [ \-Enx ]
-.RB [ \-e\~\c
+.RB [ \-E | \-\-edit\-message ]
+.RB [ \-n | \-\-no\-system\-config ]
+.RB [ \-x ]
+.RB [ \-e | \-\-command \~\c
 .IR command ]
-.RB [ \-F\~\c
+.RB [ \-F | \-\-config \~\c
 .IR config ]
-.RB [ \-H\~\c
+.RB [ \-H | \-\-draft \~\c
 .IR draft ]
-.RB [ \-i\~\c
+.RB [ \-i | \-\-include \~\c
 .IR include ]
-.RB [ \-b\~\c
+.RB [ \-b | \-\-bcc \~\c
 .IR address ]
-.RB [ \-c\~\c
+.RB [ \-c | \-\-cc \~\c
 .IR address ]
-.RB [ \-s\~\c
+.RB [ \-s | \-\-subject \~\c
 .IR subject ]
-.RB [ \-a\~\c
+.RB [ \-a | \-\-attach \~\c
 .IR file ]\~.\|.\|.\&
 .RB [ \-\- ]
 .IR address \~.\|.\|.
 .YS
 .
 .SY neomutt
-.RB [ \-nx ]
-.RB [ \-e\~\c
+.RB [ \-n | \-\-no\-system\-config ]
+.RB [ \-x ]
+.RB [ \-e | \-\-command \~\c
 .IR command ]
-.RB [ \-F\~\c
+.RB [ \-F | \-\-config \~\c
 .IR config ]
-.RB [ \-b\~\c
+.RB [ \-b | \-\-bcc \~\c
 .IR address ]
-.RB [ \-c\~\c
+.RB [ \-c | \-\-cc \~\c
 .IR address ]
-.RB [ \-s\~\c
+.RB [ \-s | \-\-subject \~\c
 .IR subject ]
-.RB [ \-a\~\c
+.RB [ \-a | \-\-attach \~\c
 .IR file ]\~.\|.\|.\&
 .RB [ \-\- ]
 .IR address \~.\|.\|.\&
@@ -71,115 +74,126 @@ The NeoMutt Mail User Agent (MUA)
 .YS
 .
 .SY neomutt
-.RB [ \-nRy ]
-.RB [ \-e\~\c
+.RB [ \-n | \-\-no\-system\-config ]
+.RB [ \-R | \-\-read\-only ]
+.RB [ \-y | \-\-browser ]
+.RB [ \-e | \-\-command \~\c
 .IR command ]
-.RB [ \-F\~\c
+.RB [ \-F | \-\-config \~\c
 .IR config ]
-.RB [ \-f\~\c
+.RB [ \-f | \-\-folder \~\c
 .IR mailbox ]
-.RB [ \-m\~\c
+.RB [ \-m | \-\-mbox\-type \~\c
 .IR type ]
 .YS
 .
 .SY neomutt
-.RB [ \-n ]
-.RB [ \-e\~\c
+.RB [ \-n | \-\-no\-system\-config ]
+.RB [ \-e | \-\-command \~\c
 .IR command ]
-.RB [ \-F\~\c
+.RB [ \-F | \-\-config \~\c
 .IR config ]
-.BI \-A\~ alias
+.BR \-A | \-\-alias \~\c
+.IR alias
 .YS
 .
 .SY neomutt
-.RB [ \-n ]
-.RB [ \-e\~\c
+.RB [ \-n | \-\-no\-system\-config ]
+.RB [ \-e | \-\-command \~\c
 .IR command ]
-.RB [ \-F\~\c
+.RB [ \-F | \-\-config \~\c
 .IR config ]
 .B \-B
 .YS
 .
 .SY neomutt
-.RB [ \-n ]
-.RB [ \-e\~\c
+.RB [ \-n | \-\-no\-system\-config ]
+.RB [ \-e | \-\-command \~\c
 .IR command ]
-.RB [ \-F\~\c
+.RB [ \-F | \-\-config \~\c
 .IR config ]
-.B \-D
-.RB [ \-S ]
-.RB [ \-O ]
+.BR \-D | \-\-dump\-config | \-DD | \-\-dump-changed
+.RB [ \-S | \-\-hide\-sensitive ]
+.RB [ \-O | \-\-with\-docs ]
 .YS
 .
 .SY neomutt
-.RB [ \-n ]
-.RB [ \-e\~\c
+.RB [ \-n | \-\-no\-system\-config ]
+.RB [ \-e | \-\-command \~\c
 .IR command ]
-.RB [ \-F\~\c
+.RB [ \-F | \-\-config \~\c
 .IR config ]
-.BI \-d\~ level
-.BI \-l\~ file
+.BR \-d | \-\-debug\-level \~\c
+.IR level
+.BR \-l | \-\-debug\-file \~\c
+.IR file
 .YS
 .
 .SY neomutt
-.RB [ \-n ]
-.RB [ \-e\~\c
+.RB [ \-n | \-\-no\-system\-config ]
+.RB [ \-e | \-\-command \~\c
 .IR command ]
-.RB [ \-F\~\c
+.RB [ \-F | \-\-config \~\c
 .IR config ]
-.B \-G
+.BR \-G | \-\-nntp\-browser
 .YS
 .
 .SY neomutt
-.RB [ \-n ]
-.RB [ \-e\~\c
+.RB [ \-n | \-\-no\-system\-config ]
+.RB [ \-e | \-\-command \~\c
 .IR command ]
-.RB [ \-F\~\c
+.RB [ \-F | \-\-config \~\c
 .IR config ]
-.BI \-g\~ server
+.BR \-g | \-\-nntp\-server \~\c
+.IR server
 .YS
 .
 .SY neomutt
-.RB [ \-n ]
-.RB [ \-e\~\c
+.RB [ \-n | \-\-no\-system\-config ]
+.RB [ \-e | \-\-command \~\c
 .IR command ]
-.RB [ \-F\~\c
+.RB [ \-F | \-\-config \~\c
 .IR config ]
-.B \-p
+.BR \-p | \-\-postponed
 .YS
 .
 .SY neomutt
-.RB [ \-n ]
-.RB [ \-e\~\c
+.RB [ \-n | \-\-no\-system\-config ]
+.RB [ \-e | \-\-command \~\c
 .IR command ]
-.RB [ \-F\~\c
+.RB [ \-F | \-\-config \~\c
 .IR config ]
-.BI \-Q\~ variable
-.RB [ \-O ]
+.BR \-Q | \-\-query \~\c
+.IR variable
+.RB [ \-O | \-\-with\-docs ]
 .YS
 .
 .SY neomutt
-.RB [ \-n ]
-.RB [ \-e\~\c
+.RB [ \-n | \-\-no\-system\-config ]
+.RB [ \-e | \-\-command \~\c
 .IR command ]
-.RB [ \-F\~\c
+.RB [ \-F | \-\-config \~\c
 .IR config ]
-.B \-Z
+.BR \-Z | \-\-check\-new\-mail
 .YS
 .
 .SY neomutt
-.RB [ \-n ]
-.RB [ \-e\~\c
+.RB [ \-n | \-\-no\-system\-config ]
+.RB [ \-e | \-\-command \~\c
 .IR command ]
-.RB [ \-F\~\c
+.RB [ \-F | \-\-config \~\c
 .IR config ]
-.B \-z
-.RB [ \-f\~\c
+.BR \-z | \-\-check\-any\-mail
+.RB [ \-f | \-\-folder \~\c
 .IR mailbox ]
 .YS
 .
 .SY neomutt
-.BR \-v [ v ]
+.BR \-v | \-\-version | \-vv | \-\-license
+.YS
+.
+.SY neomutt
+.BR \-h | \-\-help
 .YS
 .
 .\" --------------------------------------------------------------------
@@ -211,11 +225,11 @@ Special argument forces NeoMutt to stop option parsing and
 treat remaining arguments as \fIaddress\fPes even if they start with a dash
 .
 .TP
-.BI \-A " alias"
+.BR \-A ", " \-\-alias " " \fIalias\fP
 Print an expanded version of the given \fIalias\fP to stdout and exit
 .
 .TP
-.BI \-a " file"
+.BR \-a ", " \-\-attach " " \fIfile\fP
 Attach one or more \fIfile\fPs to a message (must be the last option).
 Add any addresses after the \(aq\fB\-\-\fP\(aq argument, e.g.:
 .RS
@@ -227,11 +241,11 @@ Add any addresses after the \(aq\fB\-\-\fP\(aq argument, e.g.:
 .RE
 .
 .TP
-.BI \-b " address"
+.BR \-b ", " \-\-bcc " " \fIaddress\fP
 Specify a blind carbon copy (Bcc) recipient
 .
 .TP
-.B \-C
+.BR \-C ", " \-\-crypto
 Enable cryptographic operations
 in the cases in which they're disabled by default.
 Those include:
@@ -247,30 +261,29 @@ Resending a message.
 .RE
 .
 .TP
-.BI \-c " address"
+.BR \-c ", " \-\-cc " " \fIaddress\fP
 Specify a carbon copy (Cc) recipient
 .
 .TP
-.B \-D
+.BR \-D ", " \-\-dump\-config
 Dump all configuration variables as
 .RB \(aq name = value \(aq
 pairs to stdout
 .
 .TP
-.B \-D\ \-D
-.B \-DD
+.B \-DD ", " \-\-dump\-changed\-config
 Like \fB\-D\fP, but only show the config that has changed
 .
 .TP
-.B \-D\ \-O
+.BR "\-D \-O" ", " "\-\-dump\-config \-\-with\-docs"
 Like \fB\-D\fP, but show one-liner documentation
 .
 .TP
-.B \-D\ \-S
+.BR "\-D \-S" ", " "\-\-dump\-config \-\-hide\-sensitive"
 Like \fB\-D\fP, but hide the value of sensitive variables
 .
 .TP
-.BI \-d " level"
+.BR \-d ", " \-\-debug\-level " " \fIlevel\fP
 Log debugging output to a file (default is \(dq\fI~/.neomuttdebug0\fP\(dq).
 The \fIlevel\fP can range from 1\(en5 and affects verbosity
 (a value of 2 is recommended)
@@ -280,33 +293,33 @@ to log the early startup process
 (before reading any configuration and hence $debug_level and $debug_file)
 .
 .TP
-.B \-E
+.BR \-E ", " \-\-edit\-message
 Edit \fIdraft\fP (\fB\-H\fP) or \fIinclude\fP (\fB\-i\fP) file
 during message composition
 .
 .TP
-.BI \-e " command"
+.BR \-e ", " \-\-command " " \fIcommand\fP
 Specify a \fIcommand\fP to be run after reading the config files
 .
 .TP
-.BI \-F " config"
+.BR \-F ", " \-\-config " " \fIconfig\fP
 Specify an alternative initialization file to read,
 see \fIFILES\fP section below for a list of regular configuration files
 .
 .TP
-.BI \-f " mailbox"
+.BR \-f ", " \-\-folder " " \fImailbox\fP
 Specify a \fImailbox\fP (as defined with \fBmailboxes\fP command) to load
 .
 .TP
-.B \-G
+.BR \-G ", " \-\-nntp\-browser
 Start NeoMutt with a listing of subscribed newsgroups
 .
 .TP
-.BI \-g " server"
+.BR \-g ", " \-\-nntp\-server " " \fIserver\fP
 Like \fB\-G\fP, but start at specified news \fIserver\fP
 .
 .TP
-.BI \-H " draft"
+.BR \-H ", " \-\-draft " " \fIdraft\fP
 Specify a \fIdraft\fP file which contains header and body to use to
 send a message.  If \fIdraft\fP is \*(lq\fB\-\fP\*(rq, then data is
 read from stdin.  The draft file is expected to contain just an RFC822
@@ -317,15 +330,15 @@ are not passed through untouched.  For example, encrypted draft files
 will be decrypted.
 .
 .TP
-.B \-h
+.BR \-h ", " \-\-help
 Print this help message and exit
 .
 .TP
-.BI \-i " include"
+.BR \-i ", " \-\-include " " \fIinclude\fP
 Specify an \fIinclude\fP file to be embedded in the body of a message
 .
 .TP
-.BI \-l " file"
+.BR \-l ", " \-\-debug\-file " " \fIfile\fP
 Specify a \fIfile\fP for debugging output (default
 \(dq\fI~/.neomuttdebug0\fP\(dq)
 .IP
@@ -334,54 +347,62 @@ This overrules $debug_file setting and NeoMutt keeps up to five debug logs
 before override the oldest file
 .
 .TP
-.BI \-m " type"
+.BR \-m ", " \-\-mbox\-type " " \fItype\fP
 Specify a default mailbox format \fItype\fP for newly created folders
 .IP
 The \fItype\fP is either MH, MMDF, Maildir or mbox (case-insensitive)
 .
 .TP
-.B \-n
+.BR \-n ", " \-\-no\-system\-config
 Do not read the system-wide configuration file
 .
 .TP
-.B \-p
+.BR \-O ", " \-\-with\-docs
+Show one-liner documentation (used with \fB\-D\fP or \fB\-Q\fP)
+.
+.TP
+.BR \-p ", " \-\-postponed
 Resume a prior postponed message, if any
 .
 .TP
-.BI \-Q " variable"
+.BR \-Q ", " \-\-query " " \fIvariable\fP
 Query a configuration \fIvariable\fP and print its value to stdout
 (after the config has been read and any commands executed).
 Add \-O for one-liner documentation.
 .
 .TP
-.B \-R
+.BR \-R ", " \-\-read\-only
 Open mailbox in read-only mode
 .
 .TP
-.BI \-s " subject"
+.BR \-S ", " \-\-hide\-sensitive
+Hide the value of sensitive variables (used with \fB\-D\fP)
+.
+.TP
+.BR \-s ", " \-\-subject " " \fIsubject\fP
 Specify a \fIsubject\fP
 (must be enclosed in quotes if it has spaces)
 .
 .TP
-.B \-v
+.BR \-v ", " \-\-version
 Print the NeoMutt version and compile-time definitions and exit
 .
 .TP
-.B \-vv
+.B \-vv ", " \-\-license
 Print the NeoMutt license and copyright information and exit
 .
 .TP
-.B \-y
+.BR \-y ", " \-\-browser
 Start NeoMutt with a listing of all defined mailboxes
 .
 .TP
-.B \-Z
+.BR \-Z ", " \-\-check\-new\-mail
 Open the first mailbox with new message
 or exit immediately with exit code 1
 if none is found in all defined mailboxes
 .
 .TP
-.B \-z
+.BR \-z ", " \-\-check\-any\-mail
 Open the first or specified (\fB\-f\fP) mailbox
 if it holds any message
 or exit immediately with exit code 1 otherwise

--- a/usage.c
+++ b/usage.c
@@ -53,7 +53,7 @@ static void print_header(const char *section, const char *desc, bool use_color)
  */
 static void show_cli_overview(bool use_color)
 {
-  // L10N: Help Overview -- `neomutt -h`
+  // L10N: Help Overview -- `neomutt --help`
   //       The modes are: help, info, send, tui
   //       Plus two helper modes: shared, all
   //       These should not be translated.
@@ -68,53 +68,57 @@ static void show_cli_overview(bool use_color)
 
   // L10N: Parameters in <>s may be translated
   print_header("shared", _("Options that apply to all modes"), use_color);
-  puts(_("neomutt -n                           Don't read system config file"));
-  puts(_("        -F <config>                  Use this user config file"));
-  puts(_("        -e <command>                 Run extra commands"));
-  puts(_("        -m <type>                    Set default mailbox type"));
-  puts(_("        -d <level>                   Set logging level (1..5)"));
-  puts(_("        -l <file>                    Set logging file"));
+  puts(_("neomutt -n, --no-system-config       Don't read system config file"));
+  puts(_("        -F, --config <file>          Use this user config file"));
+  puts(_("        -e, --command <command>      Run extra commands"));
+  puts(_("        -m, --mbox-type <type>       Set default mailbox type"));
+  puts(_("        -d, --debug-level <level>    Set logging level (1..5)"));
+  puts(_("        -l, --debug-file <file>      Set logging file"));
   puts("");
 
   print_header("help", _("Get command line help for NeoMutt"), use_color);
-  puts(_("neomutt -h <mode>                    Detailed help for a mode"));
-  puts(_("        -v[v]                        Version or license"));
+  puts(_("neomutt -h, --help <mode>            Detailed help for a mode"));
+  puts(_("        -v, --version                Version"));
+  puts(_("        -vv, --license               License"));
   puts("");
 
   print_header("info", _("Ask NeoMutt for config information"), use_color);
-  puts(_("neomutt -A <alias> [...]             Lookup email aliases"));
-  puts(_("        -D [-D] [-O] [-S]            Dump the config"));
-  puts(_("        -Q <option> [...] [-O] [-S]  Query config options"));
+  puts(_("neomutt -A, --alias <alias> [...]             Lookup email aliases"));
+  puts(_("        -D, --dump-config [-O] [-S]           Dump the config"));
+  puts(_("        -DD, --dump-changed-config [-O] [-S]  Dump the changed config options"));
+  puts(_("        -Q, --query <option> [...] [-O] [-S]  Query config options"));
+  puts(_("        -O, --with-docs                       Add one-liner documentation"));
+  puts(_("        -S, --hide-sensitive                  Hide sensitive option values"));
   puts("");
 
   print_header("send", _("Send an email from the command line"), use_color);
-  puts(_("neomutt -a <file> [...]              Attach files"));
-  puts(_("        -b <address>                 Add Bcc: address"));
-  puts(_("        -C                           Use crypto (signing/encryption)"));
-  puts(_("        -c <address>                 Add Cc: address"));
-  puts(_("        -E                           Edit message"));
-  puts(_("        -H <draft>                   Use draft email"));
-  puts(_("        -i <include>                 Include body file"));
-  puts(_("        -s <subject>                 Set Subject:"));
+  puts(_("neomutt -a, --attach <file> [...]    Attach files"));
+  puts(_("        -b, --bcc <address>          Add Bcc: address"));
+  puts(_("        -C, --crypto                 Use crypto (signing/encryption)"));
+  puts(_("        -c, --cc <address>           Add Cc: address"));
+  puts(_("        -E, --edit-message           Edit message (draft/include)"));
+  puts(_("        -H, --draft <file>           Use draft email file"));
+  puts(_("        -i, --include <file>         Include body file"));
+  puts(_("        -s, --subject <subject>      Set Subject:"));
   puts(_("        -- <address> [...]           Add To: addresses"));
   puts("");
 
   print_header("tui", _("Start NeoMutt's TUI (Terminal User Interface)"), use_color);
   puts(_("neomutt                              Start NeoMutt's TUI"));
-  puts(_("        -f <mailbox>                 Open this mailbox"));
-  puts(_("        -G                           Open NNTP browser"));
-  puts(_("        -g <server>                  Use this NNTP server"));
-  puts(_("        -p                           Resume postponed email"));
-  puts(_("        -R                           Open mailbox read-only"));
-  puts(_("        -y                           Open mailbox browser"));
-  puts(_("        -Z                           Check for new mail"));
-  puts(_("        -z                           Check for any mail"));
+  puts(_("        -f, --folder <mailbox>       Open this mailbox"));
+  puts(_("        -G, --nntp-browser           Open NNTP browser"));
+  puts(_("        -g, --nntp-server <server>   Use this NNTP server"));
+  puts(_("        -p, --postponed              Resume postponed email"));
+  puts(_("        -R, --read-only              Open mailbox read-only"));
+  puts(_("        -y, --browser                Open mailbox browser"));
+  puts(_("        -Z, --check-new-mail         Check for new mail"));
+  puts(_("        -z, --check-any-mail         Check for any mail"));
   puts("");
 
   if (use_color)
-    printf("%s \033[1m%s\033[0m\n", _("For detailed help, run:"), "neomutt -h all");
+    printf("%s \033[1m%s\033[0m\n", _("For detailed help, run:"), "neomutt --help all");
   else
-    printf("%s %s\n", _("For detailed help, run:"), "neomutt -h all");
+    printf("%s %s\n", _("For detailed help, run:"), "neomutt --help all");
 }
 
 /**
@@ -123,7 +127,7 @@ static void show_cli_overview(bool use_color)
  */
 static void show_cli_shared(bool use_color)
 {
-  // L10N: Shared Help -- `neomutt -h shared`
+  // L10N: Shared Help -- `neomutt --help shared`
   print_header("shared", _("Options that apply to all modes"), use_color);
   puts("");
 
@@ -131,23 +135,23 @@ static void show_cli_shared(bool use_color)
   puts(_("e.g. /etc/neomuttrc and ~/.neomuttrc"));
 
   // L10N: Parameters in <>s may be translated
-  puts(_("  -n            Don't read system config file"));
-  puts(_("  -F <config>   Use this user config file"));
-  puts(_("                May be used multiple times"));
+  puts(_("  -n, --no-system-config      Don't read system config file"));
+  puts(_("  -F, --config <file>         Use this user config file"));
+  puts(_("                              May be used multiple times"));
   puts("");
 
   puts(_("These options override the config:"));
-  puts(_("  -m <type>     Set default mailbox type"));
-  puts(_("                May be: maildir, mbox, mh, mmdf"));
-  puts(_("  -e <command>  Run extra commands"));
-  puts(_("                May be used multiple times"));
+  puts(_("  -m, --mbox-type <type>      Set default mailbox type"));
+  puts(_("                              May be: maildir, mbox, mh, mmdf"));
+  puts(_("  -e, --command <command>     Run extra commands"));
+  puts(_("                              May be used multiple times"));
   puts("");
 
   puts(_("These logging options override the config:"));
-  puts(_("  -d <level>    Set logging level"));
-  puts(_("                0 (off), 1 (low) .. 5 (high)"));
-  puts(_("  -l <file>     Set logging file"));
-  puts(_("                Default file '~/.neomuttdebug0'"));
+  puts(_("  -d, --debug-level <level>   Set logging level"));
+  puts(_("                              0 (off), 1 (low) .. 5 (high)"));
+  puts(_("  -l, --debug-file <file>     Set logging file"));
+  puts(_("                              Default file '~/.neomuttdebug0'"));
   puts("");
 
   if (use_color)
@@ -156,17 +160,17 @@ static void show_cli_shared(bool use_color)
     printf("%s\n", _("Examples:"));
 
   // L10N: Examples: Filenames may be translated
-  puts(_("  neomutt -n"));
-  puts(_("  neomutt -F work.rc"));
-  puts(_("  neomutt -F work.rc -F colours.rc"));
+  puts(_("  neomutt --no-system-config"));
+  puts(_("  neomutt --config work.rc"));
+  puts(_("  neomutt --config work.rc --config colours.rc"));
   puts("");
 
-  puts(_("  neomutt -m maildir"));
-  puts(_("  neomutt -e 'set ask_cc = yes'"));
+  puts(_("  neomutt --mbox-type maildir"));
+  puts(_("  neomutt --command 'set ask_cc = yes'"));
   puts("");
 
-  puts(_("  neomutt -d 2"));
-  puts(_("  neomutt -d 5 -l neolog"));
+  puts(_("  neomutt --debug-level 2"));
+  puts(_("  neomutt --debug-level 5 --debug-file neolog"));
   puts("");
 
   puts(_("See also:"));
@@ -179,15 +183,15 @@ static void show_cli_shared(bool use_color)
  */
 static void show_cli_help(bool use_color)
 {
-  // L10N: Help Help -- `neomutt -h help`
+  // L10N: Help Help -- `neomutt --help help`
   print_header("help", _("Get command line help for NeoMutt"), use_color);
   puts("");
 
   // L10N: Parameters in <>s may be translated
-  puts(_("  -h         Overview of command line options"));
-  puts(_("  -h <mode>  Detailed help for: shared, help, info, send, tui, all"));
-  puts(_("  -v         NeoMutt version and build parameters"));
-  puts(_("  -vv        NeoMutt Copyright and license"));
+  puts(_("  -h, --help           Overview of command line options"));
+  puts(_("  -h, --help <mode>    Detailed help for: shared, help, info, send, tui, all"));
+  puts(_("  -v, --version        NeoMutt version and build parameters"));
+  puts(_("  -vv, --license       NeoMutt Copyright and license"));
   puts("");
 
   if (use_color)
@@ -196,8 +200,8 @@ static void show_cli_help(bool use_color)
     printf("%s\n", _("Examples:"));
 
   // L10N: Examples
-  puts(_("  neomutt -h info"));
-  puts(_("  neomutt -vv"));
+  puts(_("  neomutt --help info"));
+  puts(_("  neomutt --license"));
 }
 
 /**
@@ -206,25 +210,25 @@ static void show_cli_help(bool use_color)
  */
 static void show_cli_info(bool use_color)
 {
-  // L10N: Info Help -- `neomutt -h info`
+  // L10N: Info Help -- `neomutt --help info`
   print_header("info", _("Ask NeoMutt for config information"), use_color);
   puts("");
 
   // L10N: Parameters in <>s may be translated
-  puts(_("  -A <alias> [...]  Lookup email aliases"));
-  puts(_("                    Multiple aliases can be looked up (space-separated)"));
+  puts(_("  -A, --alias <alias> [...]   Lookup email aliases"));
+  puts(_("                              Multiple aliases can be looked up (space-separated)"));
   puts("");
 
-  puts(_("  -D                Dump all the config options"));
-  puts(_("  -D -D             (or -DD) Like -D, but only show changed config"));
+  puts(_("  -D, --dump-config           Dump all the config options"));
+  puts(_("  -DD, --dump-changed-config  Dump the changed config options"));
   puts("");
 
-  puts(_("  -Q <option> [...] Query config options"));
-  puts(_("                    Multiple options can be looked up (space-separated)"));
+  puts(_("  -Q, --query <option> [...]  Query config options"));
+  puts(_("                              Multiple options can be looked up (space-separated)"));
 
   puts(_("Modify the -D and -Q options:"));
-  puts(_("  -O                Add one-liner documentation"));
-  puts(_("  -S                Hide the value of sensitive options"));
+  puts(_("  -O, --with-docs             Add one-liner documentation"));
+  puts(_("  -S, --hide-sensitive        Hide the value of sensitive options"));
   puts("");
 
   if (use_color)
@@ -233,10 +237,10 @@ static void show_cli_info(bool use_color)
     printf("%s\n", _("Examples:"));
 
   // L10N: Examples
-  puts(_("  neomutt -A flatcap gahr"));
-  puts(_("  neomutt -D -O"));
-  puts(_("  neomutt -DD -S"));
-  puts(_("  neomutt -O -Q alias_format index_format"));
+  puts(_("  neomutt --alias flatcap gahr"));
+  puts(_("  neomutt --dump-config --with-docs"));
+  puts(_("  neomutt --dump-changed-config --hide-sensitive"));
+  puts(_("  neomutt --with-docs --query alias_format index_format"));
 }
 
 /**
@@ -245,7 +249,7 @@ static void show_cli_info(bool use_color)
  */
 static void show_cli_send(bool use_color)
 {
-  // L10N: Sending Help -- `neomutt -h send`
+  // L10N: Sending Help -- `neomutt --help send`
   print_header("send", _("Send an email from the command line"), use_color);
   puts("");
 
@@ -256,19 +260,19 @@ static void show_cli_send(bool use_color)
   puts("");
 
   // L10N: Parameters in <>s may be translated
-  puts(_("  -a <file> [...]     Attach files"));
-  puts(_("                      Terminated by -- or another option"));
-  puts(_("  -b <address>        Add Bcc: address"));
-  puts(_("  -C                  Use crypto (signing/encryption)"));
-  puts(_("                      Must be set up in the config file"));
-  puts(_("  -c <address>        Add Cc: address"));
-  puts(_("  -E                  Edit message"));
-  puts(_("                      (supplied by -H or -i)"));
-  puts(_("  -H <draft>          Use draft email"));
-  puts(_("                      Full email with headers and body"));
-  puts(_("  -i <include>        Include body file"));
-  puts(_("  -s <subject>        Set Subject:"));
-  puts(_("  -- <address> [...]  Add To: addresses"));
+  puts(_("  -a, --attach <file> [...]   Attach files"));
+  puts(_("                              Terminated by -- or another option"));
+  puts(_("  -b, --bcc <address>         Add Bcc: address"));
+  puts(_("  -C, --crypto                Use crypto (signing/encryption)"));
+  puts(_("                              Must be set up in the config file"));
+  puts(_("  -c, --cc <address>          Add Cc: address"));
+  puts(_("  -E, --edit-message          Edit message (draft/include)"));
+  puts(_("                              (supplied by -H or -i)"));
+  puts(_("  -H, --draft <file>          Use draft email file"));
+  puts(_("                              Full email with headers and body"));
+  puts(_("  -i, --include <file>        Include body file"));
+  puts(_("  -s, --subject <subject>     Set Subject:"));
+  puts(_("  -- <address> [...]          Add To: addresses"));
   puts("");
 
   if (use_color)
@@ -277,10 +281,10 @@ static void show_cli_send(bool use_color)
     printf("%s\n", _("Examples:"));
 
   // L10N: Examples: Filenames and email subjects may be translated
-  puts(_("  neomutt flatcap -s 'Meeting' < meeting.txt"));
-  puts(_("  neomutt jim@example.com -c bob@example.com -s 'Party' -i party.txt"));
-  puts(_("  neomutt -s 'Receipts' -a receipt1.pdf receipt2.pdf -- rocco"));
-  puts(_("  cat secret.txt | neomutt gahr -s 'Secret' -C"));
+  puts(_("  neomutt flatcap --subject 'Meeting' < meeting.txt"));
+  puts(_("  neomutt jim@example.com --cc bob@example.com --subject 'Party' --include party.txt"));
+  puts(_("  neomutt --subject 'Receipts' --attach receipt1.pdf receipt2.pdf -- rocco"));
+  puts(_("  cat secret.txt | neomutt gahr --subject 'Secret' --crypto"));
 }
 
 /**
@@ -289,7 +293,7 @@ static void show_cli_send(bool use_color)
  */
 static void show_cli_tui(bool use_color)
 {
-  // L10N: TUI Help -- `neomutt -h tui`
+  // L10N: TUI Help -- `neomutt --help tui`
   print_header("tui", _("Start NeoMutt's TUI (Terminal User Interface)"), use_color);
   puts("");
 
@@ -299,18 +303,18 @@ static void show_cli_tui(bool use_color)
 
   puts(_("These options cause NeoMutt to check a mailbox for mail."));
   puts(_("If the condition isn't matched, NeoMutt exits."));
-  puts(_("  -p            Resume postponed email"));
-  puts(_("  -Z            Check for new mail"));
-  puts(_("  -z            Check for any mail"));
+  puts(_("  -p, --postponed       Resume postponed email"));
+  puts(_("  -Z, --check-new-mail  Check for new mail"));
+  puts(_("  -z, --check-any-mail  Check for any mail"));
   puts("");
 
   // L10N: Parameters in <>s may be translated
   puts(_("These options change the starting behavior:"));
-  puts(_("  -f <mailbox>  Open this mailbox"));
-  puts(_("  -G            Open NNTP browser"));
-  puts(_("  -g <server>   Use this NNTP server"));
-  puts(_("  -R            Open mailbox read-only"));
-  puts(_("  -y            Open mailbox browser"));
+  puts(_("  -f, --folder <mailbox>      Open this mailbox"));
+  puts(_("  -G, --nntp-browser          Open NNTP browser"));
+  puts(_("  -g, --nntp-server <server>  Use this NNTP server"));
+  puts(_("  -R, --read-only             Open mailbox read-only"));
+  puts(_("  -y, --browser               Open mailbox browser"));
   puts("");
 
   if (use_color)
@@ -319,9 +323,9 @@ static void show_cli_tui(bool use_color)
     printf("%s\n", _("Examples:"));
 
   // L10N: Examples: Path may be translated
-  puts(_("  neomutt -f ~/mail -Z"));
-  puts(_("  neomutt -p"));
-  puts(_("  neomutt -y"));
+  puts(_("  neomutt --folder ~/mail --check-new-mail"));
+  puts(_("  neomutt --postponed"));
+  puts(_("  neomutt --browser"));
 }
 
 /**


### PR DESCRIPTION
A simple change to support CLI long-options.
Completely backwards-compatible.

The long-option names are open to debate.

If people like the changes, I'll perform some magic to update the translations.

|            | Short | Long                    | Args             | Description                          |
| :-------   | :---- | :---------------------- | :--------------- | :----------------------------------- |
| **Shared** | `-d`  | `--debug-level`         | `<level>`        | Set logging level (1..5)             |
|            | `-e`  | `--command`             | `<command>`      | Run extra commands                   |
|            | `-F`  | `--config`              | `<file>`         | Use this user config file            |
|            | `-l`  | `--debug-file`          | `<file>`         | Set logging file                     |
|            | `-m`  | `--mbox-type`           | `<type>`         | Set default mailbox type             |
|            | `-n`  | `--no-system-config`    |                  | Don't read system config file        |
|            |       |                         |                  |                                      |
| **Help**   | `-h`  | `--help`                |                  | Overview of command line options     |
|            | `-v`  | `--version`             |                  | NeoMutt version and build parameters |
|            | `-vv` | `--license`             |                  | NeoMutt Copyright and license        |
|            |       |                         |                  |                                      |
| **Info**   | `-A`  | `--alias`               | `<alias> [...]`  | Lookup email aliases                 |
|            | `-D`  | `--dump-config`         |                  | Dump all the config options          |
|            | `-DD` | `--dump-changed-config` |                  | Dump the changed config options      |
|            | `-O`  | `--show-docs`           |                  | Add one-liner documentation          |
|            | `-Q`  | `--query`               | `<option> [...]` | Query config options                 |
|            | `-S`  | `--hide-sensitive`      |                  | Hide the value of sensitive options  |
|            |       |                         |                  |                                      |
| **Send**   | `-a`  | `--attach`              | `<file> [...]`   | Attach files                         |
|            | `-b`  | `--bcc`                 | `<address>`      | Add Bcc: address                     |
|            | `-c`  | `--cc`                  | `<address>`      | Add Cc: address                      |
|            | `-C`  | `--crypto`              |                  | Use crypto (signing/encryption)      |
|            | `-E`  | `--edit-message`        |                  | Edit message (draft/include)         |
|            | `-H`  | `--draft`               | `<file>`         | Use draft email file                 |
|            | `-i`  | `--include`             | `<file>`         | Include body file                    |
|            | `-s`  | `--subject`             | `<subject>`      | Set Subject:                         |
|            |       |                         |                  |                                      |
| **TUI**    | `-f`  | `--folder`              | `<mailbox>`      | Open this mailbox                    |
|            | `-G`  | `--nntp-browser`        |                  | Open NNTP browser                    |
|            | `-g`  | `--nntp-server`         | `<server>`       | Use this NNTP server                 |
|            | `-p`  | `--postponed`           |                  | Resume postponed email               |
|            | `-R`  | `--read-only`           |                  | Open mailbox read-only               |
|            | `-y`  | `--browser`             |                  | Open mailbox browser                 |
|            | `-z`  | `--check-any-mail`      |                  | Check for any mail                   |
|            | `-Z`  | `--check-new-mail`      |                  | Check for new mail                   |

<details>
<summary>Updates(1)</summary>

```diff
< | `-d`  | `--debug-level`         | `<level>`        | Set logging level                    |
> | `-d`  | `--debug-level`         | `<level>`        | Set logging level (1..5)             |
< | `-DD` | `--dump-changed`        |                  | Dump the changed config              |
> | `-DD` | `--dump-changed-config` |                  | Dump the changed config options      |
< | `-E`  | `--edit-infile`         |                  | Edit message                         |
> | `-E`  | `--edit-message`        |                  | Edit message (draft/include)         |
< | `-G`  | `--newsgroups`          |                  | Open NNTP browser                    |
> | `-G`  | `--nntp-browser`        |                  | Open NNTP browser                    |
< | `-g`  | `--news-server`         | `<server>`       | Use this NNTP server                 |
> | `-g`  | `--nntp-server`         | `<server>`       | Use this NNTP server                 |
< | `-H`  | `--draft`               | `<file>`         | Use draft email                      |
> | `-H`  | `--draft`               | `<file>`         | Use draft email file                 |
< | `-n`  | `--no-system`           |                  | Don't read system config file        |
> | `-n`  | `--no-system-config`    |                  | Don't read system config file        |
< | `-O`  | `--one-liner`           |                  | Add one-liner documentation          |
> | `-O`  | `--show-docs`           |                  | Add one-liner documentation          |
< | `-z`  | `--any-mail`            |                  | Check for any mail                   |
> | `-z`  | `--check-any-mail`      |                  | Check for any mail                   |
< | `-Z`  | `--new-mail`            |                  | Check for new mail                   |
> | `-Z`  | `--check-new-mail`      |                  | Check for new mail                   |
```

</details>
<details>
<summary>Update(2)</summary>

Sort by category

</details>
