### PR TITLE
build: make docs on demand

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -20,7 +20,7 @@ define PACKAGE_VERSION  "20251211"
 define BUGS_ADDRESS     "neomutt-devel@neomutt.org"
 
 # Subdirectories that contain additional Makefile.autosetup files
-set subdirs {po data docs contrib test smime}
+set subdirs {po data contrib test smime}
 ###############################################################################
 
 ###############################################################################
@@ -30,7 +30,6 @@ set valid_options {
   with-ncurses:path         => "Location of ncurses"
 # Features w/o 3rd party dependencies
   doc=1                     => "Disable building the documentation"
-  full-doc=0                => "Build the full documentation set"
   docdir:path               => "Documentation root"
   with-lock:=fcntl          => "Select fcntl() or flock() to lock files"
   fmemopen=0                => "Use fmemopen() for temporary in-memory files"
@@ -123,6 +122,7 @@ set valid_options {
 }
 
 set deprecated_options  {
+  full-doc:=
   idn:
   include-path-in-cflags:=
   mixmaster:=
@@ -175,7 +175,7 @@ if {1} {
   foreach opt {
     asan autocrypt bdb compile-commands coverage debug-backtrace debug-color
     debug-email debug-graphviz debug-keymap debug-logging debug-names
-    debug-notify debug-queue debug-window doc everything fmemopen full-doc
+    debug-notify debug-queue debug-window doc everything fmemopen
     fuzzing gdbm gnutls gpgme gsasl gss homespool idn2 inotify kyotocabinet
     lmdb locales-fix lua lz4 nls notmuch paths-in-cflags pcre2 pgp
     qdbm rocksdb sasl smime sqlite ssl tdb
@@ -510,8 +510,6 @@ if {[get-define want-doc]} {
     user-error "Install dependencies or './configure --disable-doc'"
   }
 }
-if {[get-define want-full-doc]} {define MAKEDOC_FULL}
-
 ###############################################################################
 # AutoCrypt
 if {[get-define want-autocrypt]} {
@@ -1247,6 +1245,11 @@ foreach dir $subdirs {
   define-append INSTALL_TARGETS install-$dir
   define-append UNINSTALL_TARGETS uninstall-$dir
 }
+
+# Docs are not built by default, but clean/install/uninstall targets are included
+define-append CLEAN_TARGETS clean-docs
+define-append INSTALL_TARGETS install-docs
+define-append UNINSTALL_TARGETS uninstall-docs
 
 ###############################################################################
 # Define package timestamp (UTC) based on PACKAGE_VERSION for:

--- a/docs/Makefile.autosetup
+++ b/docs/Makefile.autosetup
@@ -22,8 +22,6 @@ docs/neomuttrc: docs docs/makedoc$(EXEEXT) $(SRCDIR)/docs/neomuttrc.head \
 docs:
 	$(MKDIR_P) docs
 
-@if BUILD_DOC
-
 CHUNKED_DOCFILES = docs/advancedusage.html docs/configuration.html \
 			docs/gettingstarted.html docs/intro.html docs/mimesupport.html \
 			docs/miscellany.html docs/optionalfeatures.html docs/reference.html \
@@ -36,8 +34,18 @@ srcdir_DOCFILES = $(SRCDIR)/ChangeLog.md \
 		  $(SRCDIR)/docs/CONTRIBUTING.md $(SRCDIR)/SECURITY.md \
 		  $(SRCDIR)/INSTALL.md $(SRCDIR)/LICENSE.md $(SRCDIR)/README.md
 
-all-docs:	docs $(CHUNKED_DOCFILES) docs/index.html docs/manual.txt \
+.PHONY: docs-full docs-light
+
+@if BUILD_DOC
+
+docs-full: MAKEDOC_CPP = $(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) -D_MAKEDOC -DMAKEDOC_FULL -E -C -I. -I$(SRCDIR)
+docs-full: docs $(CHUNKED_DOCFILES) docs/index.html docs/manual.txt \
 		docs/manual.html docs/neomuttrc docs/neomutt.1 docs/neomuttrc.5
+
+docs-light: docs $(CHUNKED_DOCFILES) docs/index.html docs/manual.txt \
+		docs/manual.html docs/neomuttrc docs/neomutt.1 docs/neomuttrc.5
+
+all-docs: docs-full
 
 docs/manual.html:	docs docs/manual.xml $(SRCDIR)/docs/html.xsl \
 			$(SRCDIR)/docs/neomutt.css $(SRCDIR)/docs/neomutt.xsl
@@ -152,6 +160,11 @@ sortcheck-docs: docs docs/manual.xml
 # Let's generate neomuttrc in all cases: it doesn't require any additional 3rd
 # party dependencies and distributions tend to rely on having it.
 all-docs: docs docs/neomuttrc
+
+docs-full docs-light:
+	@echo "Error: Documentation build requirements not met." >&2
+	@echo "Required: xsltproc, xmlcatalog, DocBook DTDs and Stylesheets" >&2
+	@exit 1
 
 clean-docs:
 	$(RM) docs/neomuttrc docs/makedoc$(EXEEXT)


### PR DESCRIPTION
Let the user build the docs when they choose.
This mirrors the change we made to the `--testing` option in afbd882591

- `configure` still checks for the doc build dependencies, but only warns if they are missing

- Deprecate the `--full-doc` and `--disable-doc` options

- Add new `make` targets:
  - `make docs-full` -- build the docs including all optional features
  - `make docs-light` -- build the docs with only the configured features

These targets can now be run on-demand.
You don't need to choose at configure time.

The target names are open to debate.

---

**Workflow**:

- `./configure [OPTIONS]`
- `make`
- coding...
- `make docs-light`
- coding...
- `make clean-docs`
- `make docs-full` 
- `make validate-docs`