### PR TITLE
Don't unnecessarily rebuild docs and po

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ fuzz/date-fuzz
 *.gc??
 *.Po
 *.Tpo
+*.keepme
 coverage
 coverage.info
 html

--- a/docs/Makefile.autosetup
+++ b/docs/Makefile.autosetup
@@ -11,16 +11,16 @@ docs/makedoc$(EXEEXT): $(SRCDIR)/docs/makedoc.c
 	$(CC_FOR_BUILD) -I. $(CFLAGS_FOR_BUILD) $(LDFLAGS_FOR_BUILD) \
 	    -o $@ $(SRCDIR)/docs/makedoc.c
 
-docs/neomuttrc: docs docs/makedoc$(EXEEXT) $(SRCDIR)/docs/neomuttrc.head \
+docs/neomuttrc: docs/.keepme docs/makedoc$(EXEEXT) $(SRCDIR)/docs/neomuttrc.head \
 		$(SRCDIR)/docs/config.c
 	sed -e 's,@docdir@,$(docdir),' $(SRCDIR)/docs/neomuttrc.head \
 	    > docs/neomuttrc
 	$(MAKEDOC_CPP) $(SRCDIR)/docs/config.c | docs/makedoc$(EXEEXT) -c | \
 	   sed 's/ \+$$//' >> docs/neomuttrc
 
-.PHONY: docs
-docs:
+docs/.keepme:
 	$(MKDIR_P) docs
+	touch docs/.keepme
 
 @if BUILD_DOC
 
@@ -36,14 +36,14 @@ srcdir_DOCFILES = $(SRCDIR)/ChangeLog.md \
 		  $(SRCDIR)/docs/CONTRIBUTING.md $(SRCDIR)/SECURITY.md \
 		  $(SRCDIR)/INSTALL.md $(SRCDIR)/LICENSE.md $(SRCDIR)/README.md
 
-all-docs:	docs $(CHUNKED_DOCFILES) docs/index.html docs/manual.txt \
+all-docs:	docs/.keepme $(CHUNKED_DOCFILES) docs/index.html docs/manual.txt \
 		docs/manual.html docs/neomuttrc docs/neomutt.1 docs/neomuttrc.5
 
-docs/manual.html:	docs docs/manual.xml $(SRCDIR)/docs/html.xsl \
+docs/manual.html:	docs/.keepme docs/manual.xml $(SRCDIR)/docs/html.xsl \
 			$(SRCDIR)/docs/neomutt.css $(SRCDIR)/docs/neomutt.xsl
 	xsltproc --nonet -o $@ $(SRCDIR)/docs/html.xsl docs/manual.xml
 
-docs/manual.txt: docs docs/manual.html
+docs/manual.txt: docs/.keepme docs/manual.html
 	-LC_ALL=C w3m -T text/html -I utf-8 -O utf-8 -dump docs/manual.html > $@ || \
 	LC_ALL=C lynx -localhost -dump -nolist -nonumbers -with_backspaces \
 		-display_charset=us-ascii docs/manual.html > $@ || \
@@ -52,11 +52,11 @@ docs/manual.txt: docs docs/manual.html
 
 $(CHUNKED_DOCFILES): docs/index.html
 
-docs/index.html: docs $(SRCDIR)/docs/chunk.xsl $(SRCDIR)/docs/neomutt.xsl \
+docs/index.html: docs/.keepme $(SRCDIR)/docs/chunk.xsl $(SRCDIR)/docs/neomutt.xsl \
 		$(SRCDIR)/docs/neomutt.css docs/manual.xml
 	xsltproc --nonet -o docs/ $(SRCDIR)/docs/chunk.xsl docs/manual.xml > /dev/null 2>&1
 
-docs/neomuttrc.5:	docs docs/makedoc$(EXEEXT) $(SRCDIR)/docs/config.c \
+docs/neomuttrc.5:	docs/.keepme docs/makedoc$(EXEEXT) $(SRCDIR)/docs/config.c \
 		$(SRCDIR)/docs/neomuttrc.man.head $(SRCDIR)/docs/neomuttrc.man.tail
 	( sed -e "/^\.TH/s|@MAN_DATE@|$(PACKAGE_DATE)|" \
 	    $(SRCDIR)/docs/neomuttrc.man.head && \
@@ -74,7 +74,7 @@ docs/neomutt.1:
 	    $(SRCDIR)/docs/neomutt.man \
 	) | sed 's/ \+$$//' > $@
 
-docs/manual.xml:	docs docs/makedoc$(EXEEXT) $(SRCDIR)/docs/gen-map-doc \
+docs/manual.xml:	docs/.keepme docs/makedoc$(EXEEXT) $(SRCDIR)/docs/gen-map-doc \
 		$(SRCDIR)/docs/manual.xml.head $(SRCDIR)/docs/manual.xml.tail \
 		$(FUNCTION_SRC) $(SRCDIR)/docs/config.c $(SRCDIR)/gui/opcodes.h
 	( sed -e "s/@VERSION@/$(PACKAGE_DATE)/; s!/usr/libexec!$(libexecdir)!g" \
@@ -118,12 +118,12 @@ uninstall-docs:
 	$(RM) $(DESTDIR)$(sysconfdir)/neomuttrc
 
 clean-docs:
-	$(RM) docs/*.html docs/neomuttrc.5 docs/neomutt.1 \
+	$(RM) docs/.keepme docs/*.html docs/neomuttrc.5 docs/neomutt.1 \
 	    docs/makedoc$(EXEEXT) docs/makedoc.o \
 	    docs/makedoc.Po docs/manual.txt docs/manual.xml \
 	    docs/neomuttrc
 
-validate-docs: docs all-docs
+validate-docs: docs/.keepme all-docs
 	xmllint --noout --noblanks --postvalid docs/manual.xml
 	mandoc -T lint $(SRCDIR)/docs/mbox.5
 	mandoc -T lint $(SRCDIR)/docs/mmdf.5
@@ -139,7 +139,7 @@ spellcheck-docs:
 	-aspell -d american --mode=ccpp --encoding=utf-8 -p \
 	    docs/neomutt.pwl check docs/config.c
 
-sortcheck-docs: docs docs/manual.xml
+sortcheck-docs: docs/.keepme docs/manual.xml
 	sed -n -e '1,/^<sect1 id="variables">/d' \
 	    -e '1,/^<sect1 id="functions">/s/<sect2 id="\([^"]*\)">/\1/p' \
 	    < docs/manual.xml > docs/vars.tmp.1
@@ -151,7 +151,7 @@ sortcheck-docs: docs docs/manual.xml
 @else
 # Let's generate neomuttrc in all cases: it doesn't require any additional 3rd
 # party dependencies and distributions tend to rely on having it.
-all-docs: docs docs/neomuttrc
+all-docs: docs/.keepme docs/neomuttrc
 
 clean-docs:
 	$(RM) docs/neomuttrc docs/makedoc$(EXEEXT)

--- a/po/Makefile.autosetup
+++ b/po/Makefile.autosetup
@@ -16,11 +16,11 @@ MOFILES		= po/bg.mo po/ca.mo po/cs.mo po/da.mo po/de.mo po/el.mo \
 		po/zh_CN.mo po/zh_TW.mo
 POTFILE		= po/$(PACKAGE).pot
 
-all-po:	po $(MOFILES)
+all-po:	po/.keepme $(MOFILES)
 
-.PHONY: po
-po:
+po/.keepme:
 	$(MKDIR_P) po
+	touch po/.keepme
 
 .SUFFIXES: .mo .po
 .po.mo:
@@ -30,6 +30,7 @@ clean-po:
 	$(RM) $(MOFILES)
 	$(RM) $(POTFILE)
 	$(RM) po/*~ po/POTFILES
+	$(RM) po/.keepme
 
 install-po: all-po
 	@catalogs='$(MOFILES)'; \
@@ -54,11 +55,11 @@ update-po: clean-po
 	$(MAKE) $(PACKAGE).pot-update
 	$(MAKE) all-po
 
-po/POTFILES: po
+po/POTFILES: po/.keepme
 	@echo gui/opcodes.h > $@
 	@(cd $(SRCDIR); find . -type f -name '*.c') | grep -v -e test/ -e jimsh0 -e docs/ -e conststrings -e git_ver >> $@
 
-$(PACKAGE).pot-update: po po/POTFILES
+$(PACKAGE).pot-update: po/.keepme po/POTFILES
 	$(XGETTEXT) --default-domain=$(PACKAGE) --directory=$(SRCDIR) \
 	    $(XGETTEXT_OPTIONS) \
 	    --files-from=po/POTFILES \


### PR DESCRIPTION
The `docs` phony target was tricky: it's invalidated by outputs being saved in the directory.

Instead, mkdir it when needed.

This fixes `make; make; make` rebuilding the docs three times.