### PR TITLE
mbox_check: fix has_new flag inconsistencies across backends

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1264,7 +1264,10 @@ enum MxStatus imap_check_mailbox(struct Mailbox *m, bool force)
   if (mdata->check_status & IMAP_EXPUNGE_PENDING)
     check = MX_STATUS_REOPENED;
   else if (mdata->check_status & IMAP_NEWMAIL_PENDING)
+  {
+    m->has_new = true;
     check = MX_STATUS_NEW_MAIL;
+  }
   else if (mdata->check_status & IMAP_FLAGS_PENDING)
     check = MX_STATUS_FLAGS;
   else if (rc < 0)

--- a/mh/mh.c
+++ b/mh/mh.c
@@ -1028,6 +1028,7 @@ static enum MxStatus mh_check(struct Mailbox *m)
 
   if (num_new > 0)
   {
+    m->has_new = true;
     mailbox_changed(m, NT_MAILBOX_INVALID);
     m->changed = true;
   }

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1674,7 +1674,10 @@ static enum MxStatus check_mailbox(struct Mailbox *m)
       mdata->last_loaded = mdata->last_message;
     }
     if ((rc == MX_STATUS_OK) && (m->msg_count > oldmsgcount))
+    {
+      m->has_new = true;
       rc = MX_STATUS_NEW_MAIL;
+    }
   }
 
 #ifdef USE_HCACHE

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -845,7 +845,10 @@ static enum MxStatus pop_mbox_check(struct Mailbox *m)
     return MX_STATUS_ERROR;
 
   if (rc > 0)
+  {
+    m->has_new = true;
     return MX_STATUS_NEW_MAIL;
+  }
 
   return MX_STATUS_OK;
 }


### PR DESCRIPTION
The `has_new` flag is critical for user notifications and sidebar display. When set, it triggers:
- User notification messages ("New mail in...")
- Sidebar highlighting with color_sidebar_new
- Sidebar 'N' indicator
- Mailbox count in mutt_mailbox_check()

Several backends were returning `MX_STATUS_NEW_MAIL` but failing to set the `has_new` flag, causing silent notification failures for background mailbox checking.

Backends fixed:
- IMAP: Set `has_new` when `IMAP_NEWMAIL_PENDING` is set
- POP: Set `has_new` when new messages are detected
- NNTP: Set `has_new` when new articles arrive
- MH: Set `has_new` in `mh_check()` when incorporating new messages

This ensures consistent behavior across all mailbox types for both currently-open mailboxes and background checking of other mailboxes.

Created with @copilot.
