### PR TITLE
smime: improve config parsing

### DIFF
--- a/smime/smime_keys
+++ b/smime/smime_keys
@@ -213,7 +213,8 @@ Couldn't look up the value of the neomutt variable "$var".
 You must set this in your neomutt config file. See contrib/smime.rc for an example.
 EOF
 
-  $answer =~ /\"(.*?)\"/ and return bsd_glob($1, GLOB_TILDE | GLOB_NOCHECK);
+  $answer =~ /^\s*(?:set\s+)?\Q$var\E\s*=\s*"(.*?)"/
+    and return bsd_glob($1, GLOB_TILDE | GLOB_NOCHECK);
 
   $answer =~ /^NeoMutt (.*?) / and die<<EOF;
 This script requires neomutt 1.5.0 or later. You are using neomutt $1.


### PR DESCRIPTION
The `smime_keys` script asks NeoMutt for config values, for:

- `smime_keys`
- `smime_certificates`
- `smime_ca_location`

NeoMutt used to output in the form:

```
smime_keys = "value"
```

but recent versions output:

```
set smime_keys = "value"
```

Change the script to accept either form.