### PR TITLE
index: add explicit open/close thread functions

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -2132,6 +2132,26 @@ color sidebar_divider    color8  default     <emphasis role="comment"># Dark gre
                 <entry>toggle collapse for all threads</entry>
               </row>
               <row>
+                <entry></entry>
+                <entry><literal>&lt;open-thread&gt;</literal></entry>
+                <entry>open the current thread</entry>
+              </row>
+              <row>
+                <entry></entry>
+                <entry><literal>&lt;open-all-threads&gt;</literal></entry>
+                <entry>open all threads</entry>
+              </row>
+              <row>
+                <entry></entry>
+                <entry><literal>&lt;close-thread&gt;</literal></entry>
+                <entry>collapse the current thread</entry>
+              </row>
+              <row>
+                <entry></entry>
+                <entry><literal>&lt;close-all-threads&gt;</literal></entry>
+                <entry>collapse all threads</entry>
+              </row>
+              <row>
                 <entry>P</entry>
                 <entry><literal>&lt;parent-message&gt;</literal></entry>
                 <entry>jump to parent message in thread</entry>

--- a/gui/opcodes.h
+++ b/gui/opcodes.h
@@ -526,6 +526,12 @@ const char *opcodes_get_name       (int op);
   /* L10N: Help screen description for OP_MAIN_CLEAR_FLAG */ \
   /*       Index: <op_main_set_flag> */ \
   _fmt(OP_MAIN_CLEAR_FLAG,                    N_("clear a status flag from a message")) \
+  /* L10N: Help screen description for OP_MAIN_CLOSE_ALL_THREADS */ \
+  /*       Index: <op_main_close_all_threads> */ \
+  _fmt(OP_MAIN_CLOSE_ALL_THREADS,             N_("collapse all threads")) \
+  /* L10N: Help screen description for OP_MAIN_CLOSE_THREAD */ \
+  /*       Index: <op_main_close_thread> */ \
+  _fmt(OP_MAIN_CLOSE_THREAD,                  N_("collapse current thread")) \
   /* L10N: Help screen description for OP_MAIN_COLLAPSE_ALL */ \
   /*       Index: <op_main_collapse_all> */ \
   _fmt(OP_MAIN_COLLAPSE_ALL,                  N_("collapse/uncollapse all threads")) \
@@ -578,6 +584,12 @@ const char *opcodes_get_name       (int op);
   /* L10N: Help screen description for OP_MAIN_NEXT_UNREAD_MAILBOX */ \
   /*       Index: <op_main_next_unread_mailbox> */ \
   _fmt(OP_MAIN_NEXT_UNREAD_MAILBOX,           N_("open next mailbox with new mail")) \
+  /* L10N: Help screen description for OP_MAIN_OPEN_ALL_THREADS */ \
+  /*       Index: <op_main_open_all_threads> */ \
+  _fmt(OP_MAIN_OPEN_ALL_THREADS,              N_("uncollapse all threads")) \
+  /* L10N: Help screen description for OP_MAIN_OPEN_THREAD */ \
+  /*       Index: <op_main_open_thread> */ \
+  _fmt(OP_MAIN_OPEN_THREAD,                   N_("uncollapse current thread")) \
   /* L10N: Help screen description for OP_MAIN_PARENT_MESSAGE */ \
   /*       Index: <op_main_root_message> */ \
   _fmt(OP_MAIN_PARENT_MESSAGE,                N_("jump to parent message in thread")) \

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -149,17 +149,14 @@ bool check_acl(struct Mailbox *m, AclFlags acl, const char *msg)
 
 /**
  * collapse_all - Collapse/uncollapse all threads
- * @param mv     Mailbox View
- * @param menu   current menu
- * @param toggle toggle collapsed state
+ * @param mv   Mailbox View
+ * @param menu Current menu
+ * @param mode Collapse mode
  *
- * This function is called by the OP_MAIN_COLLAPSE_ALL command and on folder
- * enter if the `$collapse_all` option is set. In the first case, the @a toggle
- * parameter is 1 to actually toggle collapsed/uncollapsed state on all
- * threads. In the second case, the @a toggle parameter is 0, actually turning
- * this function into a one-way collapse.
+ * This function is called by OP_MAIN_COLLAPSE_ALL, by the one-way open/close
+ * commands, and on folder enter if the `$collapse_all` option is set.
  */
-void collapse_all(struct MailboxView *mv, struct Menu *menu, int toggle)
+void collapse_all(struct MailboxView *mv, struct Menu *menu, enum CollapseMode mode)
 {
   if (!mv || !mv->mailbox || (mv->mailbox->msg_count == 0) || !menu)
     return;
@@ -172,12 +169,31 @@ void collapse_all(struct MailboxView *mv, struct Menu *menu, int toggle)
 
   /* Figure out what the current message would be after folding / unfolding,
    * so that we can restore the cursor in a sane way afterwards. */
-  if (e_cur->collapsed && toggle)
-    final = mutt_uncollapse_thread(e_cur);
-  else if (mutt_thread_can_collapse(e_cur))
-    final = mutt_collapse_thread(e_cur);
-  else
-    final = e_cur->vnum;
+  switch (mode)
+  {
+    case COLLAPSE_MODE_TOGGLE:
+      if (e_cur->collapsed)
+        final = mutt_uncollapse_thread(e_cur);
+      else if (mutt_thread_can_collapse(e_cur))
+        final = mutt_collapse_thread(e_cur);
+      else
+        final = e_cur->vnum;
+      break;
+
+    case COLLAPSE_MODE_CLOSE:
+      if (mutt_thread_can_collapse(e_cur))
+        final = mutt_collapse_thread(e_cur);
+      else
+        final = e_cur->vnum;
+      break;
+
+    case COLLAPSE_MODE_OPEN:
+      if (e_cur->collapsed)
+        final = mutt_uncollapse_thread(e_cur);
+      else
+        final = e_cur->vnum;
+      break;
+  }
 
   if (final == -1)
     return;
@@ -187,7 +203,10 @@ void collapse_all(struct MailboxView *mv, struct Menu *menu, int toggle)
     return;
 
   /* Iterate all threads, perform collapse/uncollapse as needed */
-  mv->collapsed = toggle ? !mv->collapsed : true;
+  if (mode == COLLAPSE_MODE_TOGGLE)
+    mv->collapsed = !mv->collapsed;
+  else
+    mv->collapsed = (mode == COLLAPSE_MODE_CLOSE);
   mutt_thread_collapse(mv->threads, mv->collapsed);
 
   /* Restore the cursor */
@@ -707,7 +726,7 @@ void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *oldcount,
 
   const bool c_collapse_all = cs_subset_bool(shared->sub, "collapse_all");
   if (mutt_using_threads() && c_collapse_all)
-    collapse_all(shared->mailbox_view, menu, 0);
+    collapse_all(shared->mailbox_view, menu, COLLAPSE_MODE_CLOSE);
 
   mutt_clear_error();
   /* force the mailbox check after we have changed the folder */
@@ -1138,7 +1157,7 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
   const bool c_collapse_all = cs_subset_bool(shared->sub, "collapse_all");
   if (mutt_using_threads() && c_collapse_all)
   {
-    collapse_all(shared->mailbox_view, priv->menu, 0);
+    collapse_all(shared->mailbox_view, priv->menu, COLLAPSE_MODE_CLOSE);
     menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
   }
 

--- a/index/functions.c
+++ b/index/functions.c
@@ -100,6 +100,8 @@ static const struct MenuFuncOp OpIndex[] = { /* map: index */
 #endif
   { "check-traditional-pgp",         OP_CHECK_TRADITIONAL },
   { "clear-flag",                    OP_MAIN_CLEAR_FLAG },
+  { "close-all-threads",             OP_MAIN_CLOSE_ALL_THREADS },
+  { "close-thread",                  OP_MAIN_CLOSE_THREAD },
   { "collapse-all",                  OP_MAIN_COLLAPSE_ALL },
   { "collapse-thread",               OP_MAIN_COLLAPSE_THREAD },
   { "compose-to-sender",             OP_COMPOSE_TO_SENDER },
@@ -160,6 +162,8 @@ static const struct MenuFuncOp OpIndex[] = { /* map: index */
   { "next-undeleted",                OP_MAIN_NEXT_UNDELETED },
   { "next-unread",                   OP_MAIN_NEXT_UNREAD },
   { "next-unread-mailbox",           OP_MAIN_NEXT_UNREAD_MAILBOX },
+  { "open-all-threads",              OP_MAIN_OPEN_ALL_THREADS },
+  { "open-thread",                   OP_MAIN_OPEN_THREAD },
   { "parent-message",                OP_MAIN_PARENT_MESSAGE },
   { "pipe-entry",                    OP_PIPE },
   { "pipe-message",                  OP_PIPE },
@@ -1168,9 +1172,59 @@ static int op_main_collapse_all(struct IndexSharedData *shared,
     mutt_warning(_("Threading is not enabled"));
     return FR_NO_ACTION;
   }
-  collapse_all(shared->mailbox_view, priv->menu, 1);
+  collapse_all(shared->mailbox_view, priv->menu, COLLAPSE_MODE_TOGGLE);
   notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, NULL);
 
+  return FR_SUCCESS;
+}
+
+/**
+ * op_main_close_all_threads - Collapse all threads - Implements ::index_function_t - @ingroup index_function_api
+ */
+static int op_main_close_all_threads(struct IndexSharedData *shared,
+                                     struct IndexPrivateData *priv,
+                                     const struct KeyEvent *event)
+{
+  if (!mutt_using_threads())
+  {
+    mutt_warning(_("Threading is not enabled"));
+    return FR_NO_ACTION;
+  }
+
+  if (!shared->mailbox_view || shared->mailbox_view->collapsed)
+    return FR_NO_ACTION;
+
+  collapse_all(shared->mailbox_view, priv->menu, COLLAPSE_MODE_CLOSE);
+  notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, NULL);
+
+  return FR_SUCCESS;
+}
+
+/**
+ * op_main_close_thread - Collapse current thread - Implements ::index_function_t - @ingroup index_function_api
+ */
+static int op_main_close_thread(struct IndexSharedData *shared,
+                                struct IndexPrivateData *priv, const struct KeyEvent *event)
+{
+  if (!mutt_using_threads())
+  {
+    mutt_warning(_("Threading is not enabled"));
+    return FR_NO_ACTION;
+  }
+
+  if (!shared->email || shared->email->collapsed)
+    return FR_NO_ACTION;
+
+  if (!mutt_thread_can_collapse(shared->email))
+  {
+    mutt_warning(_("Thread contains unread or flagged messages"));
+    return FR_ERROR;
+  }
+
+  menu_set_index(priv->menu, mutt_collapse_thread(shared->email));
+  mutt_set_vnum(shared->mailbox);
+  menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
+  notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, NULL);
   return FR_SUCCESS;
 }
 
@@ -1210,6 +1264,55 @@ static int op_main_collapse_thread(struct IndexSharedData *shared,
     return FR_ERROR;
   }
 
+  menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
+  notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, NULL);
+
+  return FR_SUCCESS;
+}
+
+/**
+ * op_main_open_all_threads - Open all threads - Implements ::index_function_t - @ingroup index_function_api
+ */
+static int op_main_open_all_threads(struct IndexSharedData *shared,
+                                    struct IndexPrivateData *priv,
+                                    const struct KeyEvent *event)
+{
+  if (!mutt_using_threads())
+  {
+    mutt_warning(_("Threading is not enabled"));
+    return FR_NO_ACTION;
+  }
+
+  if (!shared->mailbox_view || !shared->mailbox_view->collapsed)
+    return FR_NO_ACTION;
+
+  collapse_all(shared->mailbox_view, priv->menu, COLLAPSE_MODE_OPEN);
+  notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, NULL);
+
+  return FR_SUCCESS;
+}
+
+/**
+ * op_main_open_thread - Open current thread - Implements ::index_function_t - @ingroup index_function_api
+ */
+static int op_main_open_thread(struct IndexSharedData *shared,
+                               struct IndexPrivateData *priv, const struct KeyEvent *event)
+{
+  if (!mutt_using_threads())
+  {
+    mutt_warning(_("Threading is not enabled"));
+    return FR_NO_ACTION;
+  }
+
+  if (!shared->email || !shared->email->collapsed)
+    return FR_NO_ACTION;
+
+  int index = mutt_uncollapse_thread(shared->email);
+  mutt_set_vnum(shared->mailbox);
+  const bool c_uncollapse_jump = cs_subset_bool(shared->sub, "uncollapse_jump");
+  if (c_uncollapse_jump)
+    index = mutt_thread_next_unread(shared->email);
+  menu_set_index(priv->menu, index);
   menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
   notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, NULL);
 
@@ -1298,7 +1401,7 @@ static int op_main_limit(struct IndexSharedData *shared,
     {
       const bool c_collapse_all = cs_subset_bool(shared->sub, "collapse_all");
       if (c_collapse_all)
-        collapse_all(shared->mailbox_view, priv->menu, 0);
+        collapse_all(shared->mailbox_view, priv->menu, COLLAPSE_MODE_CLOSE);
       mutt_draw_tree(shared->mailbox_view->threads);
     }
     notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, NULL);
@@ -3254,6 +3357,8 @@ static const struct IndexFunction IndexFunctions[] = {
   { OP_MAIN_CHANGE_GROUP,                   op_main_change_group,                 CHECK_NO_FLAGS },
   { OP_MAIN_CHANGE_GROUP_READONLY,          op_main_change_group,                 CHECK_NO_FLAGS },
   { OP_MAIN_CLEAR_FLAG,                     op_main_set_flag,                     CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_VISIBLE },
+  { OP_MAIN_CLOSE_ALL_THREADS,              op_main_close_all_threads,            CHECK_IN_MAILBOX },
+  { OP_MAIN_CLOSE_THREAD,                   op_main_close_thread,                 CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_MAIN_COLLAPSE_ALL,                   op_main_collapse_all,                 CHECK_IN_MAILBOX },
   { OP_MAIN_COLLAPSE_THREAD,                op_main_collapse_thread,              CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_MAIN_DELETE_PATTERN,                 op_main_delete_pattern,               CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_READONLY },
@@ -3271,6 +3376,8 @@ static const struct IndexFunction IndexFunctions[] = {
   { OP_MAIN_NEXT_UNDELETED,                 op_main_next_undeleted,               CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_MAIN_NEXT_UNREAD,                    op_main_next_new,                     CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_MAIN_NEXT_UNREAD_MAILBOX,            op_main_next_unread_mailbox,          CHECK_IN_MAILBOX },
+  { OP_MAIN_OPEN_ALL_THREADS,               op_main_open_all_threads,             CHECK_IN_MAILBOX },
+  { OP_MAIN_OPEN_THREAD,                    op_main_open_thread,                  CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_MAIN_PARENT_MESSAGE,                 op_main_root_message,                 CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_MAIN_PREV_NEW,                       op_main_next_new,                     CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_MAIN_PREV_NEW_THEN_UNREAD,           op_main_next_new,                     CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },

--- a/index/lib.h
+++ b/index/lib.h
@@ -83,6 +83,16 @@ typedef uint8_t CheckFlags;       ///< Flags, e.g. #CHECK_IN_MAILBOX
 #define CHECK_READONLY   (1 << 3) ///< Is the mailbox readonly?
 #define CHECK_ATTACH     (1 << 4) ///< Is the user in message-attach mode?
 
+/**
+ * enum CollapseMode - Action to perform on a Thread
+ */
+enum CollapseMode
+{
+  COLLAPSE_MODE_TOGGLE, ///< Toggle collapsed state
+  COLLAPSE_MODE_CLOSE,  ///< Collapse all threads
+  COLLAPSE_MODE_OPEN,   ///< Open all threads
+};
+
 extern const struct Mapping IndexNewsHelp[];
 
 extern const struct ExpandoDefinition StatusFormatDef[];
@@ -93,7 +103,7 @@ void                    change_folder_mailbox   (struct Menu *menu, struct Mailb
 struct Mailbox *        change_folder_notmuch   (struct Menu *menu, char *buf, int buflen, int *oldcount, struct IndexSharedData *shared, bool read_only);
 void                    change_folder_string    (struct Menu *menu, struct Buffer *buf, int *oldcount, struct IndexSharedData *shared, bool read_only);
 bool                    check_acl               (struct Mailbox *m, AclFlags acl, const char *msg);
-void                    collapse_all            (struct MailboxView *mv, struct Menu *menu, int toggle);
+void                    collapse_all            (struct MailboxView *mv, struct Menu *menu, enum CollapseMode mode);
 struct Mailbox *        dlg_index               (struct MuttWindow *dlg, struct Mailbox *m);
 int                     find_first_message      (struct MailboxView *mv);
 int                     find_next_undeleted     (struct MailboxView *mv, int msgno, bool uncollapse);

--- a/test/command/parse_push.c
+++ b/test/command/parse_push.c
@@ -38,6 +38,10 @@ static const struct CommandTest Tests[] = {
   // push <string>
   { MUTT_CMD_WARNING, "" },
   { MUTT_CMD_SUCCESS, "<collapse-all>" },
+  { MUTT_CMD_SUCCESS, "<open-thread>" },
+  { MUTT_CMD_SUCCESS, "<open-all-threads>" },
+  { MUTT_CMD_SUCCESS, "<close-thread>" },
+  { MUTT_CMD_SUCCESS, "<close-all-threads>" },
   { MUTT_CMD_ERROR,   NULL },
   // clang-format on
 };


### PR DESCRIPTION
The Index has two functions to manipulate the states of threads:

- `<collapse-all>`
- `<collapse-thread>`

Despite their names, they actually toggle the state open/closed.

This PR adds new functions to explicitly open/close a thread / all threads:

- `<open-thread>`
- `<open-all-threads>`
- `<close-thread>`
- `<close-all-threads>`