### PR TITLE
Use optreset on Solaris too

### DIFF
--- a/cli/parse.c
+++ b/cli/parse.c
@@ -181,7 +181,7 @@ bool cli_parse(int argc, char *const *argv, struct CommandLine *cli)
 
   opterr = 0; // We'll handle the errors
 // Always initialise getopt() or the tests will fail
-#if defined(BSD) || defined(__APPLE__)
+#if defined(BSD) || defined(__APPLE__) || defined(__sun)
   optreset = 1;
   optind = 1;
 #else


### PR DESCRIPTION
Without that neomutt on Solaris treats any and all commandline arguments as an address.

* **What does this PR do?**

Fix commandline parsing on Solaris

* **Screenshots (if relevant)**

$ neomutt -h
...
To: /scratch/vmarek/mail/components/components-vlad/neomutt/build/amd64/neomutt@ST_userland_build, -h@ST_userland_build, 

:)

* **What are the relevant issue numbers?**

none

Thank you for neomutt