### PR TITLE
Avoid function name clash on Solaris

### DIFF
--- a/mutt/base64.c
+++ b/mutt/base64.c
@@ -85,7 +85,7 @@ const int Index64[128] = {
 };
 
 /**
- * b64_encode - Convert raw bytes to NUL-terminated base64 string
+ * b64_encode_common - Convert raw bytes to NUL-terminated base64 string
  * @param in     Input buffer for the raw bytes
  * @param inlen  Length of the input buffer
  * @param out    Output buffer for the base64 encoded string
@@ -98,7 +98,7 @@ const int Index64[128] = {
  * NUL-byte is returned (equivalent to calling strlen() on the output buffer
  * after this function returns).
  */
-static size_t b64_encode(const char *in, size_t inlen, char *out, size_t outlen,
+static size_t b64_encode_common(const char *in, size_t inlen, char *out, size_t outlen,
                          const char *alpha)
 {
   if (!in || !out)
@@ -143,11 +143,11 @@ static size_t b64_encode(const char *in, size_t inlen, char *out, size_t outlen,
  * @param outlen Length of the output buffer
  * @retval num Length of the string written to the output buffer
  *
- * @sa b64_encode()
+ * @sa b64_encode_common()
  */
 size_t mutt_b64_encode(const char *in, size_t inlen, char *out, size_t outlen)
 {
-  return b64_encode(in, inlen, out, outlen, B64Chars);
+  return b64_encode_common(in, inlen, out, outlen, B64Chars);
 }
 
 /**
@@ -158,11 +158,11 @@ size_t mutt_b64_encode(const char *in, size_t inlen, char *out, size_t outlen)
  * @param outlen Length of the output buffer
  * @retval num Length of the string written to the output buffer
  *
- * @sa b64_encode()
+ * @sa b64_encode_common()
  */
 size_t mutt_b64_encode_urlsafe(const char *in, size_t inlen, char *out, size_t outlen)
 {
-  return b64_encode(in, inlen, out, outlen, B64CharsUrlSafe);
+  return b64_encode_common(in, inlen, out, outlen, B64CharsUrlSafe);
 }
 
 /**


### PR DESCRIPTION
Sadly Solaris did add b64_encode to <string.h> by PSARC/2015/178. Renaming the function in base64.c resolves that conflict.

* **What does this PR do?**

Resolves a function name conflict between base64.c and <string.h> on Solaris. Without that there is this error:

```
../../neomutt-20260105/mutt/base64.c:101:15: error: conflicting types for 'b64_encode'; have 'size_t(const char *, size_t,  char *, size_t,  const char *)' {aka 'long unsigned int(const char *, long unsigned int,  char *, long unsigned int
,  const char *)'}
  101 | static size_t b64_encode(const char *in, size_t inlen, char *out, size_t outlen,
      |               ^~~~~~~~~~
In file included from ../../neomutt-20260105/mutt/array.h:34,
                 from ../../neomutt-20260105/mutt/string2.h:33,
                 from ../../neomutt-20260105/mutt/base64.c:37:
/usr/include/string.h:223:16: note: previous declaration of 'b64_encode' with type 'ssize_t(char * restrict,  size_t,  const void * restrict,  size_t,  const char *, uint64_t)' {aka 'long int(char * restrict,  long unsigned int,  const voi
d * restrict,  long unsigned int,  const char *, long unsigned int)'}
  223 | extern ssize_t b64_encode(char *_RESTRICT_KYWD outbuf, size_t outbufsz,
      |                ^~~~~~~~~~
make[1]: *** [Makefile:758: mutt/base64.o] Error 1
```



* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - All builds and tests are passing

The build now passes on Solaris. I haven't tried yet to run tests ...

* **What are the relevant issue numbers?**

None filled