### PR TITLE
Allow Solaris to use qsort_s

### DIFF
--- a/mutt/qsort_r.c
+++ b/mutt/qsort_r.c
@@ -27,6 +27,12 @@
  * Context-free sorting function
  */
 
+
+#ifdef __sun
+/* According to qsort(3C) Solaris needs this definition to access qsort_s */
+#define __STDC_WANT_LIB_EXT1__ 1
+#endif
+
 #include "config.h"
 #include <stddef.h>
 #include <stdlib.h>


### PR DESCRIPTION
According to qsort(3C):

       #define __STDC_WANT_LIB_EXT1__ 1
       #include <stdlib.h>

       errno_t qsort_s(void *base, rsize_t nel, rsize_t width,
           int (*compar)(const void *x, const void *y, void *context),
           void *context);

* **What does this PR do?**

This change allows Solaris to compile qsort_r.c. Otherwise one gets this error:

```
/usr/gcc/15/bin/gcc -m64 -m64 -fPIC -DPIC -O3 -ffile-prefix-map=/scratch/vmarek/mail/components/components-vlad/neomutt=. -gctf -I/usr/include/idn -I/usr/include/pcre -std=gnu99 -std=c11 -fno-delete-null-pointer-checks -D_ALL_SOURCE=1 -D_GNU_SOURCE=1 -D__EXTENSIONS__ -D_XOPEN_SOURCE_EXTENDED -I/usr/include -I/usr/include -DNCURSES_WIDECHAR -I/usr/include -I/usr/openssl/3/include -I/include -I/usr/include/ -O2 -I. -I../../neomutt-20260105 -Wall  -I../../neomutt-20260105/test -MT mutt/regex.o -MD -MP -MF mutt/regex.Tpo -c -o mutt/regex.o ../../neomutt-20260105/mutt/regex.c
../../neomutt-20260105/mutt/qsort_r.c: In function 'mutt_qsort_r':
../../neomutt-20260105/mutt/qsort_r.c:71:3: error: implicit declaration of function 'qsort_s'; did you mean 'qsort_r'? [-Wimplicit-function-declaration]
   71 |   qsort_s(base, nmemb, size, compar, sdata);
      |   ^~~~~~~
      |   qsort_r
make[1]: *** [Makefile:758: mutt/qsort_r.o] Error 1
```
