### PR TITLE
config: warn user of valid values on invalid input

### DIFF
--- a/config/bool.c
+++ b/config/bool.c
@@ -73,8 +73,10 @@ static int bool_string_set(void *var, struct ConfigDef *cdef, const char *value,
 
   if (num < 0)
   {
-    buf_printf(err, _("Invalid boolean value: %s"), value);
-    return CSR_ERR_INVALID | CSR_INV_TYPE;
+    buf_printf(err, _("Invalid value for %s"), cdef->name);
+    buf_addch(err, '\n');
+    buf_add_printf(err, _("Choose from: %s"), "no, yes");
+    return CSR_ERR_INVALID | CSR_INV_TYPE | CSR_INV_WARNING;
   }
 
   if (var)

--- a/config/enum.c
+++ b/config/enum.c
@@ -55,8 +55,18 @@ static int enum_string_set(void *var, struct ConfigDef *cdef, const char *value,
   int num = mutt_map_get_value(value, ed->lookup);
   if (num < 0)
   {
-    buf_printf(err, _("Invalid enum value: %s"), value);
-    return CSR_ERR_INVALID | CSR_INV_TYPE;
+    buf_printf(err, _("Invalid value for %s"), cdef->name);
+    buf_addch(err, '\n');
+    struct Buffer *list = buf_pool_get();
+    for (int i = 0; i < ed->count; i++)
+    {
+      if (i > 0)
+        buf_addstr(list, ", ");
+      buf_addstr(list, ed->lookup[i].name);
+    }
+    buf_add_printf(err, _("Choose from: %s"), buf_string(list));
+    buf_pool_release(&list);
+    return CSR_ERR_INVALID | CSR_INV_TYPE | CSR_INV_WARNING;
   }
 
   if (var)

--- a/config/quad.c
+++ b/config/quad.c
@@ -77,8 +77,18 @@ static int quad_string_set(void *var, struct ConfigDef *cdef, const char *value,
 
   if (num < 0)
   {
-    buf_printf(err, _("Invalid quad value: %s"), value);
-    return CSR_ERR_INVALID | CSR_INV_TYPE;
+    buf_printf(err, _("Invalid value for %s"), cdef->name);
+    buf_addch(err, '\n');
+    struct Buffer *list = buf_pool_get();
+    for (size_t i = 0; QuadValues[i]; i++)
+    {
+      if (i > 0)
+        buf_addstr(list, ", ");
+      buf_addstr(list, QuadValues[i]);
+    }
+    buf_add_printf(err, _("Choose from: %s"), buf_string(list));
+    buf_pool_release(&list);
+    return CSR_ERR_INVALID | CSR_INV_TYPE | CSR_INV_WARNING;
   }
 
   if (var)

--- a/config/set.h
+++ b/config/set.h
@@ -45,6 +45,7 @@
 #define CSR_INV_TYPE      (1 << 4) ///< Value is not valid for the type
 #define CSR_INV_VALIDATOR (1 << 5) ///< Value was rejected by the validator
 #define CSV_INV_NOT_IMPL  (1 << 6) ///< Operation not permitted for the type
+#define CSR_INV_WARNING   (1 << 7) ///< Report as a warning, not an error
 
 /// Mask to extract the result code from CSR_* flags
 #define CSR_RESULT_MASK 0x0F

--- a/config/sort.c
+++ b/config/sort.c
@@ -87,8 +87,37 @@ static int sort_string_set(void *var, struct ConfigDef *cdef, const char *value,
 
   if (id < 0)
   {
-    buf_printf(err, _("Invalid sort name: %s"), value);
-    return CSR_ERR_INVALID | CSR_INV_TYPE;
+    buf_printf(err, _("Invalid value for %s"), cdef->name);
+    const struct Mapping *map = (const struct Mapping *) cdef->data;
+    if (map)
+    {
+      buf_addch(err, '\n');
+      struct Buffer *list = buf_pool_get();
+      int count = 0;
+      for (int i = 0; map[i].name; i++)
+      {
+        // Skip compatibility aliases (duplicate values)
+        bool dominated = false;
+        for (int j = 0; j < i; j++)
+        {
+          if (map[j].value == map[i].value)
+          {
+            dominated = true;
+            break;
+          }
+        }
+        if (dominated)
+          continue;
+
+        if (count > 0)
+          buf_addstr(list, ", ");
+        buf_addstr(list, map[i].name);
+        count++;
+      }
+      buf_add_printf(err, _("Choose from: %s"), buf_string(list));
+      buf_pool_release(&list);
+    }
+    return CSR_ERR_INVALID | CSR_INV_TYPE | CSR_INV_WARNING;
   }
 
   id |= flags;

--- a/hcache/config.c
+++ b/hcache/config.c
@@ -29,6 +29,7 @@
  */
 
 #include "config.h"
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include "mutt/lib.h"
@@ -69,8 +70,23 @@ static int hcache_backend_validator(const struct ConfigDef *cdef,
   if (store_is_valid_backend(str))
     return CSR_SUCCESS;
 
-  buf_printf(err, _("Invalid value for option %s: %s"), cdef->name, str);
-  return CSR_ERR_INVALID;
+  buf_printf(err, _("Invalid value for %s"), cdef->name);
+  buf_addch(err, '\n');
+  struct Slist *sl = store_backend_list();
+  struct Buffer *list = buf_pool_get();
+  struct ListNode *np = NULL;
+  bool first = true;
+  STAILQ_FOREACH(np, &sl->head, entries)
+  {
+    if (!first)
+      buf_addstr(list, ", ");
+    buf_addstr(list, np->data);
+    first = false;
+  }
+  buf_add_printf(err, _("Choose from: %s"), buf_string(list));
+  buf_pool_release(&list);
+  slist_free(&sl);
+  return CSR_ERR_INVALID | CSR_INV_WARNING;
 }
 
 #if defined(USE_HCACHE_COMPRESSION)
@@ -89,8 +105,23 @@ static int compress_method_validator(const struct ConfigDef *cdef,
   if (compress_get_ops(str))
     return CSR_SUCCESS;
 
-  buf_printf(err, _("Invalid value for option %s: %s"), cdef->name, str);
-  return CSR_ERR_INVALID;
+  buf_printf(err, _("Invalid value for %s"), cdef->name);
+  buf_addch(err, '\n');
+  struct Slist *sl = compress_list();
+  struct Buffer *list = buf_pool_get();
+  struct ListNode *np = NULL;
+  bool first = true;
+  STAILQ_FOREACH(np, &sl->head, entries)
+  {
+    if (!first)
+      buf_addstr(list, ", ");
+    buf_addstr(list, np->data);
+    first = false;
+  }
+  buf_add_printf(err, _("Choose from: %s"), buf_string(list));
+  buf_pool_release(&list);
+  slist_free(&sl);
+  return CSR_ERR_INVALID | CSR_INV_WARNING;
 #else
   return CSR_SUCCESS;
 #endif

--- a/parse/set.c
+++ b/parse/set.c
@@ -140,7 +140,11 @@ enum CommandResult command_set_set(struct Buffer *name, struct Buffer *value,
     rc = cs_subset_he_string_set(NeoMutt->sub, he, value->data, err);
   }
   if (CSR_RESULT(rc) != CSR_SUCCESS)
-    return MUTT_CMD_ERROR; // LCOV_EXCL_LINE
+  {
+    if (rc & CSR_INV_WARNING)
+      return MUTT_CMD_WARNING;
+    return MUTT_CMD_ERROR;
+  }
 
   return MUTT_CMD_SUCCESS;
 }


### PR DESCRIPTION
When a **user sets** a config option to an **invalid value** for types where the set of valid values is known,
**show a helpful warning** instead of a terse error.

Add a `CSR_INV_WARNING` flag to signal that an invalid-value message includes guidance.

e.g. the user sees:
> Invalid value for header_cache_backend
> Choose from: lmdb, gdbm
