### PR TITLE
lua: fix parsing

### DIFF
--- a/lua/commands.c
+++ b/lua/commands.c
@@ -65,29 +65,26 @@ enum CommandResult parse_lua(const struct Command *cmd, struct Buffer *line,
     return MUTT_CMD_WARNING;
   }
 
-  struct Buffer *token = buf_pool_get();
+  // From here on, use the remainder of `line`, raw
   enum CommandResult rc = MUTT_CMD_ERROR;
 
-  parse_extract_token(token, line, TOKEN_NO_FLAGS);
-
   lua_init_state(&LuaState);
-  mutt_debug(LL_DEBUG2, "%s\n", buf_string(token));
+  mutt_debug(LL_DEBUG2, "%s\n", line->dptr);
 
-  if (luaL_dostring(LuaState, buf_string(token)) != LUA_OK)
+  if (luaL_dostring(LuaState, line->dptr) != LUA_OK)
   {
-    mutt_debug(LL_DEBUG2, "%s -> failure\n", buf_string(token));
-    buf_printf(err, "%s: %s", buf_string(token), lua_tostring(LuaState, -1));
+    mutt_debug(LL_DEBUG2, "%s -> failure\n", line->dptr);
+    buf_printf(err, "%s: %s", line->dptr, lua_tostring(LuaState, -1));
     /* pop error message from the stack */
     lua_pop(LuaState, 1);
     goto done;
   }
-  mutt_debug(LL_DEBUG2, "%s -> success\n", buf_string(token));
+  mutt_debug(LL_DEBUG2, "%s -> success\n", line->dptr);
   buf_reset(line); // Clear the rest of the line
 
   rc = MUTT_CMD_SUCCESS;
 
 done:
-  buf_pool_release(&token);
   return rc;
 }
 

--- a/test/command/parse_lua.c
+++ b/test/command/parse_lua.c
@@ -38,7 +38,7 @@ static const struct CommandTest Tests[] = {
   // clang-format off
   // lua <lua-command>
   { MUTT_CMD_WARNING, "" },
-  { MUTT_CMD_SUCCESS, "'local num = 42'" },
+  { MUTT_CMD_SUCCESS, "local num = 42" },
   { MUTT_CMD_ERROR,   NULL },
   // clang-format on
 };


### PR DESCRIPTION
Unlike NeoMutt commands, we pass the Lua command to the Lua interpreter, unfiltered.

Fixes: #4834 

I standardised the handling of all the commands, but `lua` works slightly differently.
It needs the rest of the line, raw.