### PR TITLE
imap: fix memory leak in msg_parse_flags

### DIFF
--- a/imap/message.c
+++ b/imap/message.c
@@ -270,6 +270,7 @@ static char *msg_parse_flags(struct ImapHeader *h, char *s)
         /* store other system flags as well (mainly \\Draft) */
         buf_addstr(buf, edata->flags_system);
         buf_join_str(buf, flag_word, ' ');
+        FREE(&edata->flags_system);
         edata->flags_system = buf_strdup(buf);
       }
       else
@@ -277,6 +278,7 @@ static char *msg_parse_flags(struct ImapHeader *h, char *s)
         /* store custom flags as well */
         buf_addstr(buf, edata->flags_remote);
         buf_join_str(buf, flag_word, ' ');
+        FREE(&edata->flags_remote);
         edata->flags_remote = buf_strdup(buf);
       }
       buf_pool_release(&buf);


### PR DESCRIPTION
When accumulating multiple custom/system flags, the loop in msg_parse_flags() overwrote edata->flags_system and
edata->flags_remote with buf_strdup() on each iteration without freeing the previous allocation. Free the old pointer
before reassigning.

* **What does this PR do?**
  * This PR fixes a memory leak reported by LeakSanitizer

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that) - no need

   - All builds and tests are passing - yes

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html) - no need

   - Code follows the [style guide](https://neomutt.org/dev/code) - yes

* **What are the relevant issue numbers?**
  * None