### PR TITLE
cliwatch: add benchmark workflow

### DIFF
--- a/.github/workflows/cliwatch.yml
+++ b/.github/workflows/cliwatch.yml
@@ -23,7 +23,9 @@ jobs:
         run: |
           mkdir build-cliwatch
           cd build-cliwatch
-          ../configure
+          ../configure --full-doc --autocrypt --fmemopen --gdbm --gnutls --gpgme --gss \
+            --lmdb --lua --lz4 --notmuch --pcre2 --rocksdb --sasl --tdb \
+            --testing --with-lock=fcntl --zlib --zstd
           make -j"$(nproc)" neomutt
           install -D neomutt "$HOME/.local/bin/neomutt"
 

--- a/.github/workflows/cliwatch.yml
+++ b/.github/workflows/cliwatch.yml
@@ -1,0 +1,43 @@
+name: CLIWatch Benchmarks
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    name: Benchmark neomutt
+    runs-on: ubuntu-latest
+    container: ghcr.io/neomutt/ubuntu
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Build neomutt
+        run: |
+          mkdir build-cliwatch
+          cd build-cliwatch
+          ../configure
+          make -j"$(nproc)" neomutt
+          install -D neomutt "$HOME/.local/bin/neomutt"
+
+      - name: Add neomutt to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install CLIWatch
+        run: npm install -g @cliwatch/cli
+
+      - name: Validate CLIWatch config
+        run: cliwatch validate --file cliwatch/cli-bench.yaml
+
+      - name: Run CLIWatch benchmarks
+        run: cliwatch bench --config cliwatch/cli-bench.yaml --upload
+        env:
+          AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+          CLIWATCH_API_KEY: ${{ secrets.CLIWATCH_API_KEY }}

--- a/cliwatch/cli-bench.yaml
+++ b/cliwatch/cli-bench.yaml
@@ -1,0 +1,11 @@
+# CLIWatch benchmark configuration
+# Docs: https://docs.cliwatch.com/guides/example-suites
+
+cli: neomutt
+version_command: "neomutt --version"
+
+providers:
+  - anthropic/claude-sonnet-4-5-20250929
+
+tasks:
+  - "file://tasks/*.yaml"

--- a/cliwatch/cli-bench.yaml
+++ b/cliwatch/cli-bench.yaml
@@ -7,5 +7,8 @@ version_command: "neomutt --version"
 providers:
   - anthropic/claude-sonnet-4-5-20250929
 
+help_modes:
+  - injected
+
 tasks:
   - "file://tasks/*.yaml"

--- a/cliwatch/tasks/01-basics.yaml
+++ b/cliwatch/tasks/01-basics.yaml
@@ -1,0 +1,19 @@
+# Basic tasks: verify the CLI is installed and discoverable
+
+- id: show-help
+  intent: "Show the overview help for neomutt"
+  difficulty: easy
+  category: basics
+  max_turns: 2
+  assert:
+    - exit_code: 0
+    - output_contains: "NeoMutt"
+
+- id: show-version
+  intent: "Show the version of neomutt"
+  difficulty: easy
+  category: basics
+  max_turns: 2
+  assert:
+    - exit_code: 0
+    - output_contains: "NeoMutt"

--- a/cliwatch/tasks/02-usage.yaml
+++ b/cliwatch/tasks/02-usage.yaml
@@ -1,14 +1,14 @@
 # Usage tasks: safe, non-interactive commands
 
 - id: show-all-help
-  intent: "Show detailed command-line help for all neomutt modes"
+  intent: "Show the full neomutt command-line help in one command, including the shared, help, info, send, and tui sections"
   difficulty: medium
   category: usage
-  max_turns: 3
+  max_turns: 5
   assert:
     - ran: "neomutt"
     - exit_code: 0
-    - output_contains: "shared"
+    - output_contains: "shared:"
 
 - id: show-license
   intent: "Show the license information for neomutt"

--- a/cliwatch/tasks/02-usage.yaml
+++ b/cliwatch/tasks/02-usage.yaml
@@ -1,0 +1,21 @@
+# Usage tasks: safe, non-interactive commands
+
+- id: show-all-help
+  intent: "Show detailed command-line help for all neomutt modes"
+  difficulty: medium
+  category: usage
+  max_turns: 3
+  assert:
+    - ran: "neomutt"
+    - exit_code: 0
+    - output_contains: "shared"
+
+- id: show-license
+  intent: "Show the license information for neomutt"
+  difficulty: medium
+  category: usage
+  max_turns: 3
+  assert:
+    - ran: "neomutt"
+    - exit_code: 0
+    - output_contains: "GNU General Public License"


### PR DESCRIPTION
Test of [CLIWatch](https://cliwatch.com/)

Add a CLIWatch benchmark suite for neomutt and a GitHub Actions workflow that builds the CLI, validates the benchmark config, and uploads results.
