### PR TITLE
Fix memmove in mutt_str_expand_tabs

### DIFF
--- a/compose/preview.c
+++ b/compose/preview.c
@@ -185,7 +185,7 @@ static void draw_preview(struct MuttWindow *win, struct PreviewWindowData *wdata
 
       content_lines++;
 
-      line = mutt_str_expand_tabs(line, &line_len, 8);
+      mutt_str_expand_tabs(&line, &line_len, 8);
 
       // Check how much of the string fits into the window width.
       size_t width = 0;

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -587,46 +587,67 @@ void mw_what_key(void)
 
 /**
  * mutt_str_expand_tabs - Convert tabs to spaces in a string
- * @param str       Input string
+ * @param str       Input/output string
  * @param len       Length of the string
  * @param tabwidth  The number of spaces per indentation-level
  *
  * Replace tab characters (`\t`) with spaces in the string. The string will be
  * resized to fit the expanded version if necessary.
  */
-char *mutt_str_expand_tabs(char *str, size_t *len, int tabwidth)
+void mutt_str_expand_tabs(char **str, size_t *len, int tabwidth)
 {
-  if (!str || !len || (tabwidth < 1))
-    return NULL;
+  if (!str || !*str || !len || (tabwidth < 1))
+  {
+    return;
+  }
+
+  char *in = *str;
 
   // calculate how much space we need
   size_t required_len = 0;
-  for (int i = 0; (i < *len) && (str[i] != '\0'); i++)
+  bool found_tabs = false;
+  for (int i = 0; (i < *len) && (in[i] != '\0'); i++)
   {
-    if (str[i] == '\t')
+    if (in[i] == '\t')
+    {
+      found_tabs = true;
       required_len += tabwidth; // cheat, just assume full tab width
+    }
     else
       required_len++;
   }
 
-  // resize the string if there isn't enough space
-  while (required_len > *len)
+  if (!found_tabs)
   {
-    *len += 256;
-    MUTT_MEM_REALLOC(&str, *len, char);
+    return;
   }
 
-  // expand tabs
-  for (int i = 0; str[i] != '\0'; i++)
+  // resize the string if there isn't enough space
+  if (required_len > *len)
   {
-    if (str[i] == '\t')
+    *len = ROUND_UP(required_len, 256);
+  }
+  char* out = MUTT_MEM_CALLOC(*len, char);
+
+  // expand tabs
+  for (int i = 0, o = 0; in[i] != '\0'; i++)
+  {
+    if (in[i] == '\t')
     {
-      int num_cells = mutt_strnwidth(str, i);
+      // TODO - we could keep a running width instead of recomputing this from
+      // scratch for each encountered tab.
+      int num_cells = mutt_strnwidth(out, o);
       int indent = abs((num_cells % tabwidth) - tabwidth);
-      memmove(str + i + indent, str + i + 1, *len - (i + indent) - indent);
-      memset(str + i, ' ', indent);
+      memset(out + o, ' ', indent);
+      o += indent;
+    }
+    else
+    {
+      out[o] = in[i];
+      ++o;
     }
   }
 
-  return str;
+  FREE(str);
+  *str = out;
 }

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -614,12 +614,21 @@ void mutt_str_expand_tabs(char **str, size_t *len, int tabwidth)
       required_len += tabwidth; // cheat, just assume full tab width
     }
     else
+    {
       required_len++;
+    }
   }
 
   if (!found_tabs)
   {
     return;
+  }
+
+  // tab expansion can fill in the whole buffer; we need to make some more room
+  // for the \0-terminator.
+  if (required_len == *len)
+  {
+    ++required_len;
   }
 
   // resize the string if there isn't enough space

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -636,7 +636,7 @@ void mutt_str_expand_tabs(char **str, size_t *len, int tabwidth)
   {
     *len = ROUND_UP(required_len, 256);
   }
-  char* out = MUTT_MEM_CALLOC(*len, char);
+  char *out = MUTT_MEM_CALLOC(*len, char);
 
   // expand tabs
   for (int i = 0, o = 0; in[i] != '\0'; i++)

--- a/gui/curs_lib.h
+++ b/gui/curs_lib.h
@@ -54,7 +54,7 @@ void         mutt_need_hard_redraw(void);
 void         mutt_paddstr(struct MuttWindow *win, int n, const char *s);
 void         mutt_query_exit(void);
 void         mutt_refresh(void);
-char *       mutt_str_expand_tabs(char *str, size_t *len, int tabwidth);
+void         mutt_str_expand_tabs(char **str, size_t *len, int tabwidth);
 size_t       mutt_strwidth(const char *s);
 size_t       mutt_strnwidth(const char *s, size_t len);
 size_t       mutt_wstr_trunc(const char *src, size_t maxlen, size_t maxwid, size_t *width);

--- a/test/gui/mutt_str_expand_tabs.c
+++ b/test/gui/mutt_str_expand_tabs.c
@@ -39,6 +39,16 @@ void test_mutt_str_expand_tabs(void)
 {
   // char *mutt_str_expand_tabs(char *str, size_t *len, int tabwidth);
 
+  /* Explicit test for null-termination */
+  {
+    size_t len = 8;
+    char *buf = MUTT_MEM_CALLOC(len, char);
+    buf[0] = '\t';
+    mutt_str_expand_tabs(&buf, &len, 8);
+    TEST_CHECK_STR_EQ(buf, "        ");
+    FREE(&buf);
+  }
+
   static struct TestCase tests[] = {
     // clang-format off
     { "\tapple",      "    apple",     4 },

--- a/test/gui/mutt_str_expand_tabs.c
+++ b/test/gui/mutt_str_expand_tabs.c
@@ -39,11 +39,6 @@ void test_mutt_str_expand_tabs(void)
 {
   // char *mutt_str_expand_tabs(char *str, size_t *len, int tabwidth);
 
-  {
-    TEST_CHECK(mutt_str_expand_tabs(NULL, 0, 4) == NULL);
-    TEST_CHECK(mutt_str_expand_tabs("", 0, 4) == NULL);
-  }
-
   static struct TestCase tests[] = {
     // clang-format off
     { "\tapple",      "    apple",     4 },
@@ -72,9 +67,9 @@ void test_mutt_str_expand_tabs(void)
       TEST_CASE(tests[i].in);
       char *str = mutt_str_dup(tests[i].in);
       size_t len = mutt_str_len(str);
-      char *result = mutt_str_expand_tabs(str, &len, tests[i].tabwidth);
-      TEST_CHECK_STR_EQ(result, tests[i].result);
-      FREE(&result);
+      mutt_str_expand_tabs(&str, &len, tests[i].tabwidth);
+      TEST_CHECK_STR_EQ(str, tests[i].result);
+      FREE(&str);
     }
   }
 }


### PR DESCRIPTION
This changes mutt_str_expand_tabs to do its things in a freshly allocated string instead of in-place.
This prevents a bug when moving the remainder of the string after making space for a new tab.