### PR TITLE
IMAP: Enhance stability with re-entrancy protection and fixes

### DIFF
--- a/imap/adata.c
+++ b/imap/adata.c
@@ -55,8 +55,12 @@ static int imap_timeout_observer(struct NotifyCallback *nc)
 
   if ((adata->state >= IMAP_AUTHENTICATED) && (now >= (adata->lastread + c_imap_keep_alive)))
   {
+    if (adata->checking)
+      return 0;
+    adata->checking = true;
     mutt_debug(LL_DEBUG5, "imap_keep_alive\n");
     imap_check_mailbox(adata->mailbox, true);
+    adata->checking = false;
   }
 
   mutt_debug(LL_DEBUG5, "imap timeout done\n");

--- a/imap/adata.h
+++ b/imap/adata.h
@@ -41,6 +41,7 @@ struct ImapAccountData
   struct Connection *conn;        ///< Connection to IMAP server
   bool recovering;                ///< Recovering after a fatal error
   bool closing;                   ///< If true, we are waiting for CLOSE completion
+  bool checking;                  ///< If true, imap_check_mailbox is in progress (re-entrancy guard)
   unsigned char state;            ///< ImapState, e.g. #IMAP_AUTHENTICATED
   unsigned char status;           ///< ImapFlags, e.g. #IMAP_FATAL
   /* let me explain capstr: SASL needs the capability string (not bits).

--- a/imap/command.c
+++ b/imap/command.c
@@ -201,12 +201,7 @@ static void cmd_handle_fatal(struct ImapAccountData *adata)
   if (!mdata)
     return;
 
-  if ((adata->state >= IMAP_SELECTED) && (mdata->reopen & IMAP_REOPEN_ALLOW))
-  {
-    mx_fastclose_mailbox(adata->mailbox, true);
-    mutt_error(_("Mailbox %s@%s closed"), adata->conn->account.user,
-               adata->conn->account.host);
-  }
+  bool was_selected = (adata->state >= IMAP_SELECTED);
 
   imap_close_connection(adata);
   if (!adata->recovering)
@@ -232,6 +227,16 @@ static void cmd_handle_fatal(struct ImapAccountData *adata)
     {
       mutt_message(_("Reconnected to %s"), adata->conn->account.host);
       adata->retry_count = 0; // Reset on success
+
+      if (was_selected && (imap_reopen_mailbox(adata) == 0))
+      {
+        mutt_message(_("Reopened mailbox on %s"), adata->conn->account.host);
+      }
+      else if (was_selected)
+      {
+        mutt_error(_("Reconnected to %s but failed to reopen mailbox"),
+                   adata->conn->account.host);
+      }
     }
     else
     {
@@ -1425,9 +1430,17 @@ int imap_exec(struct ImapAccountData *adata, const char *cmdstr, ImapCmdFlags fl
 
     if (idle_time > IMAP_CONN_STALE_THRESHOLD)
     {
-      mutt_debug(LL_DEBUG2, "Connection idle for %ld seconds, sending NOOP to verify\n",
-                 (long) idle_time);
-      /* Connection may be stale - let the command proceed and handle any error */
+      static bool probing = false;
+      if (!probing)
+      {
+        mutt_debug(LL_DEBUG2, "Connection idle for %ld seconds, sending NOOP probe\n",
+                   (long) idle_time);
+        probing = true;
+        int noop_rc = imap_exec(adata, "NOOP", IMAP_CMD_POLL);
+        probing = false;
+        if (noop_rc == IMAP_EXEC_FATAL)
+          return IMAP_EXEC_FATAL;
+      }
     }
   }
 
@@ -1517,7 +1530,7 @@ void imap_cmd_finish(struct ImapAccountData *adata)
 
   struct ImapMboxData *mdata = imap_mdata_get(adata->mailbox);
 
-  if (mdata && mdata->reopen & IMAP_REOPEN_ALLOW)
+  if (mdata && (mdata->reopen & IMAP_REOPEN_ALLOW) && !(mdata->reopen & IMAP_SYNC_IN_PROGRESS))
   {
     // First remove expunged emails from the msn_index
     if (mdata->reopen & IMAP_EXPUNGE_PENDING)

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2072,6 +2072,156 @@ int imap_login(struct ImapAccountData *adata)
 }
 
 /**
+ * imap_select_and_poll - Send SELECT and parse the untagged responses
+ * @param m        Mailbox
+ * @param[out] countp  Number of messages reported by EXISTS
+ * @retval  0 Success
+ * @retval -1 Failure (protocol error or parse error)
+ *
+ * Issues the SELECT command via imap_mbox_select() and then reads the
+ * untagged responses, populating mdata fields (flags, uidvalidity,
+ * uid_next, modseq, readonly) and returning the EXISTS count.  Both
+ * imap_mbox_open and imap_reopen_mailbox share this code path.
+ */
+static int imap_select_and_poll(struct Mailbox *m, int *countp)
+{
+  struct ImapAccountData *adata = imap_adata_get(m);
+  struct ImapMboxData *mdata = imap_mdata_get(m);
+
+  imap_mbox_select(m);
+
+  int count = 0;
+  int rc;
+  do
+  {
+    char *pc = NULL;
+
+    rc = imap_cmd_step(adata);
+    if (rc != IMAP_RES_CONTINUE)
+      break;
+
+    if (!mutt_strn_equal(adata->buf, "* ", 2))
+      continue;
+    pc = imap_next_word(adata->buf);
+
+    /* Obtain list of available flags here, may be overridden by a
+     * PERMANENTFLAGS tag in the OK response */
+    if (mutt_istr_startswith(pc, "FLAGS"))
+    {
+      /* don't override PERMANENTFLAGS */
+      if (STAILQ_EMPTY(&mdata->flags))
+      {
+        mutt_debug(LL_DEBUG3, "Getting mailbox FLAGS\n");
+        pc = get_flags(&mdata->flags, pc);
+        if (!pc)
+          return -1;
+      }
+    }
+    else if (mutt_istr_startswith(pc, "OK [PERMANENTFLAGS"))
+    {
+      /* PERMANENTFLAGS are massaged to look like FLAGS, then override FLAGS */
+      mutt_debug(LL_DEBUG3, "Getting mailbox PERMANENTFLAGS\n");
+      /* safe to call on NULL */
+      mutt_list_free(&mdata->flags);
+      /* skip "OK [PERMANENT" so syntax is the same as FLAGS */
+      pc += 13;
+      pc = get_flags(&(mdata->flags), pc);
+      if (!pc)
+        return -1;
+    }
+    else if (mutt_istr_startswith(pc, "OK [UIDVALIDITY"))
+    {
+      /* save UIDVALIDITY for the header cache */
+      mutt_debug(LL_DEBUG3, "Getting mailbox UIDVALIDITY\n");
+      pc += 3;
+      pc = imap_next_word(pc);
+      if (!mutt_str_atoui(pc, &mdata->uidvalidity))
+        return -1;
+    }
+    else if (mutt_istr_startswith(pc, "OK [UIDNEXT"))
+    {
+      mutt_debug(LL_DEBUG3, "Getting mailbox UIDNEXT\n");
+      pc += 3;
+      pc = imap_next_word(pc);
+      if (!mutt_str_atoui(pc, &mdata->uid_next))
+        return -1;
+    }
+    else if (mutt_istr_startswith(pc, "OK [HIGHESTMODSEQ"))
+    {
+      mutt_debug(LL_DEBUG3, "Getting mailbox HIGHESTMODSEQ\n");
+      pc += 3;
+      pc = imap_next_word(pc);
+      if (!mutt_str_atoull(pc, &mdata->modseq))
+        return -1;
+    }
+    else if (mutt_istr_startswith(pc, "OK [NOMODSEQ"))
+    {
+      mutt_debug(LL_DEBUG3, "Mailbox has NOMODSEQ set\n");
+      mdata->modseq = 0;
+    }
+    else
+    {
+      pc = imap_next_word(pc);
+      if (mutt_istr_startswith(pc, "EXISTS"))
+      {
+        count = mdata->new_mail_count;
+        mdata->new_mail_count = 0;
+      }
+    }
+  } while (rc == IMAP_RES_CONTINUE);
+
+  if (rc == IMAP_RES_NO)
+  {
+    char *s = imap_next_word(adata->buf); /* skip seq */
+    s = imap_next_word(s);                /* Skip response */
+    mutt_error("%s", s);
+    return -1;
+  }
+
+  if (rc != IMAP_RES_OK)
+    return -1;
+
+  /* check for READ-ONLY notification */
+  if (mutt_istr_startswith(imap_get_qualifier(adata->buf), "[READ-ONLY]") &&
+      !(adata->capabilities & IMAP_CAP_ACL))
+  {
+    mutt_debug(LL_DEBUG2, "Mailbox is read-only\n");
+    m->readonly = true;
+  }
+
+  /* dump the mailbox flags we've found */
+  const short c_debug_level = cs_subset_number(NeoMutt->sub, "debug_level");
+  if (c_debug_level > LL_DEBUG2)
+  {
+    if (STAILQ_EMPTY(&mdata->flags))
+    {
+      mutt_debug(LL_DEBUG3, "No folder flags found\n");
+    }
+    else
+    {
+      struct ListNode *np = NULL;
+      struct Buffer *flag_buffer = buf_pool_get();
+      buf_printf(flag_buffer, "Mailbox flags: ");
+      STAILQ_FOREACH(np, &mdata->flags, entries)
+      {
+        buf_add_printf(flag_buffer, "[%s] ", np->data);
+      }
+      mutt_debug(LL_DEBUG3, "%s\n", buf_string(flag_buffer));
+      buf_pool_release(&flag_buffer);
+    }
+  }
+
+  if (!((m->rights & MUTT_ACL_DELETE) || (m->rights & MUTT_ACL_SEEN) ||
+        (m->rights & MUTT_ACL_WRITE) || (m->rights & MUTT_ACL_INSERT)))
+  {
+    m->readonly = true;
+  }
+
+  *countp = count;
+  return 0;
+}
+
+/**
  * imap_mbox_open - Open a mailbox - Implements MxOps::mbox_open() - @ingroup mx_mbox_open
  */
 static enum MxOpenReturns imap_mbox_open(struct Mailbox *m)
@@ -2081,7 +2231,6 @@ static enum MxOpenReturns imap_mbox_open(struct Mailbox *m)
 
   char buf[PATH_MAX] = { 0 };
   int count = 0;
-  int rc;
 
   struct ImapAccountData *adata = imap_adata_get(m);
   struct ImapMboxData *mdata = imap_mdata_get(m);
@@ -2128,132 +2277,8 @@ static enum MxOpenReturns imap_mbox_open(struct Mailbox *m)
   if (c_imap_check_subscribed)
     imap_exec(adata, "LSUB \"\" \"*\"", IMAP_CMD_QUEUE);
 
-  imap_mbox_select(m);
-
-  do
-  {
-    char *pc = NULL;
-
-    rc = imap_cmd_step(adata);
-    if (rc != IMAP_RES_CONTINUE)
-      break;
-
-    if (!mutt_strn_equal(adata->buf, "* ", 2))
-      continue;
-    pc = imap_next_word(adata->buf);
-
-    /* Obtain list of available flags here, may be overridden by a
-     * PERMANENTFLAGS tag in the OK response */
-    if (mutt_istr_startswith(pc, "FLAGS"))
-    {
-      /* don't override PERMANENTFLAGS */
-      if (STAILQ_EMPTY(&mdata->flags))
-      {
-        mutt_debug(LL_DEBUG3, "Getting mailbox FLAGS\n");
-        pc = get_flags(&mdata->flags, pc);
-        if (!pc)
-          goto fail;
-      }
-    }
-    else if (mutt_istr_startswith(pc, "OK [PERMANENTFLAGS"))
-    {
-      /* PERMANENTFLAGS are massaged to look like FLAGS, then override FLAGS */
-      mutt_debug(LL_DEBUG3, "Getting mailbox PERMANENTFLAGS\n");
-      /* safe to call on NULL */
-      mutt_list_free(&mdata->flags);
-      /* skip "OK [PERMANENT" so syntax is the same as FLAGS */
-      pc += 13;
-      pc = get_flags(&(mdata->flags), pc);
-      if (!pc)
-        goto fail;
-    }
-    else if (mutt_istr_startswith(pc, "OK [UIDVALIDITY"))
-    {
-      /* save UIDVALIDITY for the header cache */
-      mutt_debug(LL_DEBUG3, "Getting mailbox UIDVALIDITY\n");
-      pc += 3;
-      pc = imap_next_word(pc);
-      if (!mutt_str_atoui(pc, &mdata->uidvalidity))
-        goto fail;
-    }
-    else if (mutt_istr_startswith(pc, "OK [UIDNEXT"))
-    {
-      mutt_debug(LL_DEBUG3, "Getting mailbox UIDNEXT\n");
-      pc += 3;
-      pc = imap_next_word(pc);
-      if (!mutt_str_atoui(pc, &mdata->uid_next))
-        goto fail;
-    }
-    else if (mutt_istr_startswith(pc, "OK [HIGHESTMODSEQ"))
-    {
-      mutt_debug(LL_DEBUG3, "Getting mailbox HIGHESTMODSEQ\n");
-      pc += 3;
-      pc = imap_next_word(pc);
-      if (!mutt_str_atoull(pc, &mdata->modseq))
-        goto fail;
-    }
-    else if (mutt_istr_startswith(pc, "OK [NOMODSEQ"))
-    {
-      mutt_debug(LL_DEBUG3, "Mailbox has NOMODSEQ set\n");
-      mdata->modseq = 0;
-    }
-    else
-    {
-      pc = imap_next_word(pc);
-      if (mutt_istr_startswith(pc, "EXISTS"))
-      {
-        count = mdata->new_mail_count;
-        mdata->new_mail_count = 0;
-      }
-    }
-  } while (rc == IMAP_RES_CONTINUE);
-
-  if (rc == IMAP_RES_NO)
-  {
-    char *s = imap_next_word(adata->buf); /* skip seq */
-    s = imap_next_word(s);                /* Skip response */
-    mutt_error("%s", s);
+  if (imap_select_and_poll(m, &count) < 0)
     goto fail;
-  }
-
-  if (rc != IMAP_RES_OK)
-    goto fail;
-
-  /* check for READ-ONLY notification */
-  if (mutt_istr_startswith(imap_get_qualifier(adata->buf), "[READ-ONLY]") &&
-      !(adata->capabilities & IMAP_CAP_ACL))
-  {
-    mutt_debug(LL_DEBUG2, "Mailbox is read-only\n");
-    m->readonly = true;
-  }
-
-  /* dump the mailbox flags we've found */
-  const short c_debug_level = cs_subset_number(NeoMutt->sub, "debug_level");
-  if (c_debug_level > LL_DEBUG2)
-  {
-    if (STAILQ_EMPTY(&mdata->flags))
-    {
-      mutt_debug(LL_DEBUG3, "No folder flags found\n");
-    }
-    else
-    {
-      struct ListNode *np = NULL;
-      struct Buffer *flag_buffer = buf_pool_get();
-      buf_printf(flag_buffer, "Mailbox flags: ");
-      STAILQ_FOREACH(np, &mdata->flags, entries)
-      {
-        buf_add_printf(flag_buffer, "[%s] ", np->data);
-      }
-      mutt_debug(LL_DEBUG3, "%s\n", buf_string(flag_buffer));
-      buf_pool_release(&flag_buffer);
-    }
-  }
-
-  if (!((m->rights & MUTT_ACL_DELETE) || (m->rights & MUTT_ACL_SEEN) ||
-        (m->rights & MUTT_ACL_WRITE) || (m->rights & MUTT_ACL_INSERT)))
-  {
-    m->readonly = true;
-  }
 
   mx_alloc_memory(m, count);
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1695,13 +1695,31 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
     return -1;
   }
 
-  /* This function is only called when the calling code expects the context
-   * to be changed. */
-  imap_allow_reopen(m);
+  /* Mark sync in progress to prevent expunge/newmail processing mid-sync.
+   * Do NOT set IMAP_REOPEN_ALLOW here — it makes timeouts destructive
+   * by allowing imap_cmd_finish to process expunges during sync commands. */
+  mdata->reopen |= IMAP_SYNC_IN_PROGRESS;
 
   enum MxStatus check = imap_check_mailbox(m, false);
   if (check == MX_STATUS_ERROR)
+  {
+    /* Persist pending flag changes to hcache before aborting, so they
+     * survive a reconnect and can be replayed on next sync. */
+#ifdef USE_HCACHE
+    imap_hcache_open(adata, mdata, true);
+    for (int i = 0; i < m->msg_count; i++)
+    {
+      struct Email *e = m->emails[i];
+      if (!e)
+        break;
+      if (e->active && e->changed)
+        imap_hcache_put(mdata, e);
+    }
+    imap_hcache_close(mdata);
+#endif
+    mdata->reopen &= ~IMAP_SYNC_IN_PROGRESS;
     return check;
+  }
 
   /* if we are expunging anyway, we can do deleted messages very quickly... */
   if (expunge && (m->rights & MUTT_ACL_DELETE))
@@ -1714,6 +1732,7 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
     if (rc < 0)
     {
       mutt_error(_("Expunge failed"));
+      mdata->reopen &= ~IMAP_SYNC_IN_PROGRESS;
       return rc;
     }
 
@@ -1816,6 +1835,7 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
       if (query_yesorno(_("Error saving flags. Close anyway?"), MUTT_NO) == MUTT_YES)
       {
         adata->state = IMAP_AUTHENTICATED;
+        mdata->reopen &= ~IMAP_SYNC_IN_PROGRESS;
         return 0;
       }
     }
@@ -1823,6 +1843,7 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
     {
       mutt_error(_("Error saving flags"));
     }
+    mdata->reopen &= ~IMAP_SYNC_IN_PROGRESS;
     return -1;
   }
 
@@ -1844,6 +1865,10 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
   }
   m->changed = false;
 
+  /* Now that sync is done, allow reopen for the EXPUNGE phase. */
+  mdata->reopen &= ~IMAP_SYNC_IN_PROGRESS;
+  imap_allow_reopen(m);
+
   /* We must send an EXPUNGE command if we're not closing. */
   if (expunge && !close && (m->rights & MUTT_ACL_DELETE))
   {
@@ -1855,6 +1880,7 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
     {
       mdata->reopen &= ~IMAP_EXPUNGE_EXPECTED;
       imap_error(_("imap_sync_mailbox: EXPUNGE failed"), adata->buf);
+      mdata->reopen &= ~IMAP_SYNC_IN_PROGRESS;
       return -1;
     }
     mdata->reopen &= ~IMAP_EXPUNGE_EXPECTED;
@@ -2219,6 +2245,72 @@ static int imap_select_and_poll(struct Mailbox *m, int *countp)
 
   *countp = count;
   return 0;
+}
+
+/**
+ * imap_reopen_mailbox - Re-SELECT the current mailbox after reconnecting
+ * @param adata Imap Account data (must be in IMAP_AUTHENTICATED state)
+ * @retval  0 Success
+ * @retval -1 Failure
+ *
+ * After a connection drop and successful reconnect, re-SELECT the previously
+ * open mailbox, clear stale message state, and re-fetch all headers so the
+ * index is repopulated.  This avoids the destructive mx_fastclose_mailbox()
+ * path that used to leave the user with an empty screen.
+ */
+int imap_reopen_mailbox(struct ImapAccountData *adata)
+{
+  if (!adata || !adata->mailbox)
+    return -1;
+
+  struct Mailbox *m = adata->mailbox;
+  struct ImapMboxData *mdata = imap_mdata_get(m);
+  if (!mdata)
+    return -1;
+
+  mutt_debug(LL_DEBUG1, "Re-selecting mailbox %s after reconnect\n", mdata->name);
+
+  for (int i = 0; i < m->msg_count; i++)
+  {
+    struct Email *e = m->emails[i];
+    if (!e)
+      continue;
+    imap_edata_free((void **) &e->edata);
+    email_free(&m->emails[i]);
+  }
+  m->msg_count = 0;
+  m->msg_unread = 0;
+  m->msg_flagged = 0;
+  m->msg_new = 0;
+  m->msg_deleted = 0;
+  m->size = 0;
+  m->vcount = 0;
+
+  imap_mdata_cache_reset(mdata);
+
+  mdata->new_mail_count = 0;
+  mdata->reopen = IMAP_OPEN_NO_FLAGS;
+  mdata->check_status = IMAP_OPEN_NO_FLAGS;
+
+  int count = 0;
+  if (imap_select_and_poll(m, &count) < 0)
+    goto fail;
+
+  mx_alloc_memory(m, count);
+
+  if ((count > 0) && (imap_read_headers(m, 1, count, true) < 0))
+    goto fail;
+
+  mutt_debug(LL_DEBUG1, "Reopened mailbox %s with %d messages\n", mdata->name, m->msg_count);
+  mailbox_changed(m, NT_MAILBOX_UPDATE);
+  mailbox_changed(m, NT_MAILBOX_RESORT);
+  return 0;
+
+fail:
+  mutt_debug(LL_DEBUG1, "Failed to reopen mailbox %s\n", mdata->name);
+  if (adata->state == IMAP_SELECTED)
+    adata->state = IMAP_AUTHENTICATED;
+  return -1;
 }
 
 /**

--- a/imap/private.h
+++ b/imap/private.h
@@ -66,6 +66,7 @@ typedef uint8_t ImapOpenFlags;         ///< Flags, e.g. #MUTT_THREAD_COLLAPSE
 #define IMAP_EXPUNGE_PENDING  (1 << 2) ///< Messages on the server have been expunged
 #define IMAP_NEWMAIL_PENDING  (1 << 3) ///< New mail is waiting on the server
 #define IMAP_FLAGS_PENDING    (1 << 4) ///< Flags have changed on the server
+#define IMAP_SYNC_IN_PROGRESS (1 << 5) ///< Sync is in progress, block expunge/newmail processing
 
 typedef uint8_t ImapCmdFlags;          ///< Flags for imap_exec(), e.g. #IMAP_CMD_PASS
 #define IMAP_CMD_NO_FLAGS          0   ///< No flags are set
@@ -189,6 +190,7 @@ int imap_login(struct ImapAccountData *adata);
 int imap_sync_message_for_copy(struct Mailbox *m, struct Email *e, struct Buffer *cmd, enum QuadOption *err_continue);
 bool imap_has_flag(struct ListHead *flag_list, const char *flag);
 int imap_adata_find(const char *path, struct ImapAccountData **adata, struct ImapMboxData **mdata);
+int imap_reopen_mailbox(struct ImapAccountData *adata);
 
 /* auth.c */
 int imap_authenticate(struct ImapAccountData *adata);


### PR DESCRIPTION
This PR is from @0-wiz-0 (and Claude Opus 4.6)

Below is the results of Claude's audit of the IMAP code.

Fixes: #4815 

---

## `IMAP` Timeout Audit - Findings

### The Core Problem: cmd_handle_fatal destroys the mailbox on timeout

When a timeout occurs during a command (e.g., `NOOP` poll, flag sync), the sequence is:

1. `imap_exec()` at [imap/command.c:1447-1452](https://github.com/neomutt/neomutt/blob/89fdd3af6685720375693c0cb33723dcfe502803/imap/command.c#L1447-L1452) - poll times out -\> calls `cmd_handle_fatal()`
2. `cmd_handle_fatal()` at [imap/command.c:201-204](https://github.com/neomutt/neomutt/blob/89fdd3af6685720375693c0cb33723dcfe502803/imap/command.c#L201-L204) - if `IMAP_REOPEN_ALLOW` is set, calls `mx_fastclose_mailbox()` which frees all emails ([mx.c:435-443](https://github.com/neomutt/neomutt/blob/89fdd3af6685720375693c0cb33723dcfe502803/mx.c#L435-L443))
3. Then it tries to reconnect ([imap/command.c:225-248](https://github.com/neomutt/neomutt/blob/89fdd3af6685720375693c0cb33723dcfe502803/imap/command.c#L225-L248)) via `imap_login()`

This is the root cause of "messages not displayed": the mailbox's email array is destroyed before reconnection even starts.
Even if reconnection succeeds, the mailbox is empty - there's no code to re-`SELECT` and re-fetch headers after a successful reconnect.

### Bug 1: Reconnect succeeds but mailbox stays empty

`cmd_handle_fatal()` at [imap/command.c:231](https://github.com/neomutt/neomutt/blob/89fdd3af6685720375693c0cb33723dcfe502803/imap/command.c#L231) successfully reconnects via `imap_login()`, but:

- The connection state goes to `IMAP_AUTHENTICATED` (not `IMAP_SELECTED` )
- No mailbox is re-`SELECT`ed
- No headers are re-fetched
- `adata->mailbox` still points to the now-gutted mailbox (emails freed)

The user sees an empty index.

### Bug 2: Flag save fails silently after timeout + reconnect

In `imap_sync_mailbox()` at [imap/imap.c:1580](https://github.com/neomutt/neomutt/blob/89fdd3af6685720375693c0cb33723dcfe502803/imap/imap.c#L1580):

```c
 enum MxStatus check = imap_check_mailbox(m, false);
 if (check = `MX_STATUS_ERROR`)
   return check;
```

If a timeout triggers `cmd_handle_fatal()` -\> `mx_fastclose_mailbox()` during this call, the emails are freed.
But the return is `MX_STATUS_ERROR` (-2), and the caller ([mx.c](https://github.com/neomutt/neomutt/blob/89fdd3af6685720375693c0cb33723dcfe502803/mx.c)) gets an error but the local changes (read flags, deletions) are already lost because the Email objects were freed.
There is no mechanism to persist pending changes before the close or replay them after reconnect.

### Bug 3: `IMAP_REOPEN_ALLOW` makes timeouts destructive at the wrong time

`imap_sync_mailbox()` calls imap_allow_reopen(m) at [imap/imap.c:1578](https://github.com/neomutt/neomutt/blob/89fdd3af6685720375693c0cb33723dcfe502803/imap/imap.c#L1578) which sets `IMAP_REOPEN_ALLOW` before the `NOOP`/sync commands.
This means any timeout during the sync path triggers the destructive mx_fastclose_mailbox branch in `cmd_handle_fatal()`.
The reopen flag is intended for handling server-side expunges, not connection errors.

### Bug 4: Stale connection check is dead code

[imap/command.c:1421-1426](https://github.com/neomutt/neomutt/blob/89fdd3af6685720375693c0cb33723dcfe502803/imap/command.c#L1421-L1426) checks idle_time > `IMAP_CONN_STALE_THRESHOLD` but only logs a debug message.
It doesn't actually send a `NOOP` probe - the comment says "let the command proceed and handle any error."
This means stale connections are detected only after they fail, which triggers the destructive fatal handler.

### Bug 5: Timeout observer can trigger during sync

`imap_timeout_observer()` in [imap/adata.c:56-59](https://github.com/neomutt/neomutt/blob/89fdd3af6685720375693c0cb33723dcfe502803/imap/adata.c#L56-L59) calls `imap_check_mailbox()` on keepalive timer.
If the main thread is mid-sync, this re-entrant call could cause state corruption since there's no mutex or re-entrancy guard.
