### PR TITLE
Don't overwrite content_type

### DIFF
--- a/email/parse.c
+++ b/email/parse.c
@@ -424,8 +424,11 @@ int mutt_check_encoding(const char *c)
  * mutt_parse_content_type - Parse a content type
  * @param s String to parse
  * @param b Body to save the result
+ * 
+ * WARNING: this function modifies the 's' argument to segregate type, subtype,
+ * and parametners, so, e.g., a param of "text/plain" will be changed into
+ * "text\0plain".
  *
- * e.g. parse a string "inline" and set #DISP_INLINE.
  */
 void mutt_parse_content_type(const char *s, struct Body *b)
 {

--- a/send/send.c
+++ b/send/send.c
@@ -2045,7 +2045,6 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
   char *smime_sign_as = NULL;
   const char *tag = NULL;
   char *err = NULL;
-  const char *ctype = NULL;
   char *finalpath = NULL;
   struct Email *e_cur = NULL;
 
@@ -2155,10 +2154,9 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
       e_templ->body = pbody;
 
       const char *const c_content_type = cs_subset_string(sub, "content_type");
-      ctype = c_content_type;
-      if (!ctype)
-        ctype = "text/plain";
+      const char *ctype = mutt_str_dup(c_content_type ? c_content_type : "text/plain");
       mutt_parse_content_type(ctype, e_templ->body);
+      FREE(&ctype);
       e_templ->body->unlink = true;
       e_templ->body->use_disp = false;
       e_templ->body->disposition = DISP_INLINE;


### PR DESCRIPTION
`mutt_parse_content_type` [changes its argument](https://github.com/neomutt/neomutt/blob/163623ba87af607b914e367c5eb84f27083e2dc2/email/parse.c#L439-L442). Make sure we don't call it on a string coming from the user's config.

Fixes #4851