### PR TITLE
key: add named keys for config-special characters

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -4589,6 +4589,42 @@ set alias_file=~/.mail_aliases
                 <entry>Space bar</entry>
               </row>
               <row>
+                <entry>&lt;hash&gt;</entry>
+                <entry># (hash/comment character)</entry>
+              </row>
+              <row>
+                <entry>&lt;semicolon&gt;</entry>
+                <entry>; (semicolon/command separator)</entry>
+              </row>
+              <row>
+                <entry>&lt;doublequote&gt;</entry>
+                <entry>" (double quote)</entry>
+              </row>
+              <row>
+                <entry>&lt;quote&gt;</entry>
+                <entry>' (single quote/apostrophe)</entry>
+              </row>
+              <row>
+                <entry>&lt;backslash&gt;</entry>
+                <entry>\ (backslash)</entry>
+              </row>
+              <row>
+                <entry>&lt;backtick&gt;</entry>
+                <entry>` (backtick)</entry>
+              </row>
+              <row>
+                <entry>&lt;dollar&gt;</entry>
+                <entry>$ (dollar sign)</entry>
+              </row>
+              <row>
+                <entry>&lt;less&gt;</entry>
+                <entry>&lt; (less-than)</entry>
+              </row>
+              <row>
+                <entry>&lt;greater&gt;</entry>
+                <entry>&gt; (greater-than)</entry>
+              </row>
+              <row>
                 <entry>&lt;f1&gt;</entry>
                 <entry>function key 1</entry>
               </row>
@@ -4609,6 +4645,16 @@ set alias_file=~/.mail_aliases
           <emphasis>key</emphasis> does not need to be enclosed in quotes unless
           it contains a space (<quote>&#160;</quote>) or semi-colon
           (<quote>;</quote>).
+          Characters that are special to the config parser
+          (<literal>#</literal>, <literal>;</literal>,
+          <literal>"</literal>, <literal>'</literal>,
+          <literal>\</literal>, <literal>`</literal>,
+          <literal>$</literal>, <literal>&lt;</literal>,
+          <literal>&gt;</literal>)
+          can also be referred to by their symbolic names, e.g.
+          <literal>&lt;hash&gt;</literal>,
+          <literal>&lt;semicolon&gt;</literal>,
+          <literal>&lt;backslash&gt;</literal>, etc.
         </para>
         <para>
           <emphasis>function</emphasis> specifies which action to take when

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -226,6 +226,14 @@ a three digit octal number prefixed with a \(lq\fB\(rs\fP\(rq or as a symbolic
 name. The \fB<what-key>\fP function can be used to explore keycode and
 symbolic names for the keys on your keyboard.
 .IP
+Characters that are special to the config parser
+(\fB#\fP, \fB;\fP, \fB"\fP, \fB'\fP, \fB\(rs\fP, \fB`\fP, \fB$\fP,
+\fB<\fP, \fB>\fP)
+can also be referred to by their symbolic names:
+\fB<hash>\fP, \fB<semicolon>\fP, \fB<doublequote>\fP, \fB<quote>\fP,
+\fB<backslash>\fP, \fB<backtick>\fP, \fB<dollar>\fP, \fB<less>\fP,
+\fB<greater>\fP.
+.IP
 \fIfunction\fP specifies which action to take when key is pressed. Note that
 the function name is to be specified without angle brackets.
 .IP

--- a/key/keymap.c
+++ b/key/keymap.c
@@ -63,6 +63,15 @@ static struct Mapping KeyNames[] = {
   { "<Esc>",         '\033' }, // Escape
   { "<Tab>",         '\t' },
   { "<Space>",       ' ' },
+  { "<Hash>",        '#' },
+  { "<Semicolon>",   ';' },
+  { "<DoubleQuote>", '"' },
+  { "<Quote>",       '\'' },
+  { "<Backslash>",   '\\' },
+  { "<Backtick>",    '`' },
+  { "<Dollar>",      '$' },
+  { "<Less>",        '<' },
+  { "<Greater>",     '>' },
 #ifdef KEY_BTAB
   { "<BackTab>",     KEY_BTAB },
 #endif


### PR DESCRIPTION
Add named key aliases for characters that are special to the config parser and require quoting/escaping when used in bind/macro commands:

- `<Backslash>`
- `<Backtick>`
- `<Dollar>`
- `<DoubleQuote>`
- `<Greater>`
- `<Hash>`   
- `<Less>`
- `<Quote>`
- `<Semicolon>`

This allows users to write e.g.
```
bind index <Hash> next-entry
```
instead of:
```
bind index "#" next-entry
```

Add the new symbolic key names to:

- manual.xml.head: symbolic key names table and bind quoting section
- neomuttrc.man.head: bind command description
