### PR TITLE
key: add repeat-count support for macros

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -2389,6 +2389,17 @@
 ** leaking information about your current location.
 */
 
+{ "macro_repeat_max", DT_NUMBER, 1000 },
+/*
+** .pp
+** When a macro is invoked with a numeric prefix (e.g. \fC5<F5>\fP), this
+** variable caps how many times the macro body is expanded.  This bounds the
+** size of the input queue and prevents runaway counts from monopolising
+** NeoMutt.
+** .pp
+** A value of 0 disables the cap (use with care).
+*/
+
 { "mail_check", DT_NUMBER, 5 },
 /*
 ** .pp

--- a/key/get.c
+++ b/key/get.c
@@ -50,21 +50,20 @@
 /// XXX
 static const int MaxKeyLoop = 64;
 
-/// Maximum number of times a macro may be repeated via a count prefix
-static const int MacroRepeatMax = 1000;
-
 /**
  * mutt_push_macro_repeated - Push a macro string into the input queue, optionally repeated
  * @param macro Macro string to expand
  * @param count Number of times to repeat (0 or 1 means once)
  *
- * The repeat count is clamped to #MacroRepeatMax to bound queue growth.
+ * The repeat count is clamped to `$macro_repeat_max` to bound queue growth.
  */
 void mutt_push_macro_repeated(char *macro, int count)
 {
   int repeat = (count > 0) ? count : 1;
-  if (repeat > MacroRepeatMax)
-    repeat = MacroRepeatMax;
+
+  const short c_macro_repeat_max = cs_subset_number(NeoMutt->sub, "macro_repeat_max");
+  if ((c_macro_repeat_max > 0) && (repeat > c_macro_repeat_max))
+    repeat = c_macro_repeat_max;
 
   for (int i = 0; i < repeat; i++)
     generic_tokenize_push_string(macro);

--- a/key/get.c
+++ b/key/get.c
@@ -50,6 +50,26 @@
 /// XXX
 static const int MaxKeyLoop = 64;
 
+/// Maximum number of times a macro may be repeated via a count prefix
+static const int MacroRepeatMax = 1000;
+
+/**
+ * mutt_push_macro_repeated - Push a macro string into the input queue, optionally repeated
+ * @param macro Macro string to expand
+ * @param count Number of times to repeat (0 or 1 means once)
+ *
+ * The repeat count is clamped to #MacroRepeatMax to bound queue growth.
+ */
+void mutt_push_macro_repeated(char *macro, int count)
+{
+  int repeat = (count > 0) ? count : 1;
+  if (repeat > MacroRepeatMax)
+    repeat = MacroRepeatMax;
+
+  for (int i = 0; i < repeat; i++)
+    generic_tokenize_push_string(macro);
+}
+
 // It's not possible to unget more than one char under some curses libs,
 // so roll our own input buffering routines.
 
@@ -538,7 +558,7 @@ struct KeyEvent km_dokey(const struct MenuDefinition *md, GetChFlags flags)
             return (struct KeyEvent) { 0, OP_NULL, 0 };
           }
 
-          generic_tokenize_push_string(pending_exact->macro);
+          mutt_push_macro_repeated(pending_exact->macro, count_digits > 0 ? count : 0);
           state = DKS_START;
           count = 0;
           count_digits = 0;
@@ -701,7 +721,7 @@ struct KeyEvent km_dokey(const struct MenuDefinition *md, GetChFlags flags)
         return (struct KeyEvent) { event.ch, OP_NULL, 0 };
       }
 
-      generic_tokenize_push_string(map->macro);
+      mutt_push_macro_repeated(map->macro, count_digits > 0 ? count : 0);
       state = DKS_START;
       count = 0;
       count_digits = 0;

--- a/key/get.h
+++ b/key/get.h
@@ -86,6 +86,7 @@ void             mutt_flush_macro_to_endcond (void);
 struct KeyEvent  mutt_getch                  (GetChFlags flags);
 int              mutt_monitor_getch          (void);
 void             mutt_push_macro_event       (int ch, int op);
+void             mutt_push_macro_repeated    (char *macro, int count);
 void             mutt_unget_ch               (int ch);
 void             mutt_unget_op               (int op);
 

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -473,6 +473,9 @@ struct ConfigDef MainVars[] = {
   { "local_date_header", DT_BOOL, true, 0, NULL,
     "Convert the date in the Date header of sent emails into local timezone, UTC otherwise"
   },
+  { "macro_repeat_max", DT_NUMBER|D_INTEGER_NOT_NEGATIVE, 1000, 0, NULL,
+    "Maximum number of times a macro may be repeated via a numeric prefix"
+  },
   { "mail_check", DT_NUMBER|D_INTEGER_NOT_NEGATIVE, 5, 0, NULL,
     "Number of seconds before NeoMutt checks for new mail"
   },

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -468,6 +468,8 @@ IDNA_OBJS	= test/idna/mutt_idna_intl_to_local.o \
 
 IMAP_OBJS	= test/imap/msg_set.o
 
+KEY_OBJS	= test/key/mutt_push_macro_repeated.o
+
 LIST_OBJS	= test/list/common.o \
 		  test/list/mutt_list_clear.o \
 		  test/list/mutt_list_copy_tail.o \
@@ -733,7 +735,8 @@ BUILD_DIRS	= $(PWD)/test/account $(PWD)/test/address $(PWD)/test/array \
 		  $(PWD)/test/filter $(PWD)/test/from $(PWD)/test/fuzzy \
 		  $(PWD)/test/group $(PWD)/test/gui $(PWD)/test/hash \
 		  $(PWD)/test/history $(PWD)/test/idna $(PWD)/test/imap \
-		  $(PWD)/test/list $(PWD)/test/logging $(PWD)/test/mailbox \
+		  $(PWD)/test/key $(PWD)/test/list $(PWD)/test/logging \
+		  $(PWD)/test/mailbox \
 		  $(PWD)/test/mapping $(PWD)/test/mbyte $(PWD)/test/md5 \
 		  $(PWD)/test/memory $(PWD)/test/neo $(PWD)/test/notify \
 		  $(PWD)/test/notmuch $(PWD)/test/parameter $(PWD)/test/parse \
@@ -778,6 +781,7 @@ TEST_OBJS	= test/common.o test/main.o test/module.o \
 		  $(HISTORY_OBJS) \
 		  $(IDNA_OBJS) \
 		  $(IMAP_OBJS) \
+		  $(KEY_OBJS) \
 		  $(LIST_OBJS) \
 		  $(LOGGING_OBJS) \
 		  $(MAILBOX_OBJS) \

--- a/test/key/mutt_push_macro_repeated.c
+++ b/test/key/mutt_push_macro_repeated.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <stddef.h>
 #include "mutt/lib.h"
+#include "config/lib.h"
 #include "core/lib.h"
 #include "key/lib.h"
 #include "key/module_data.h"
@@ -61,11 +62,18 @@ void test_mutt_push_macro_repeated(void)
   TEST_CHECK_NUM_EQ(ARRAY_SIZE(&mod_data->macro_events), 3);
   mutt_flushinp();
 
-  // Counts above the cap are clamped to MacroRepeatMax (== 1000)
+  // Counts above the cap are clamped to $macro_repeat_max (default 1000)
   char macro2[] = "x";
   mutt_push_macro_repeated(macro2, 9999);
   TEST_CHECK_NUM_EQ(ARRAY_SIZE(&mod_data->macro_events), 1000);
   mutt_flushinp();
+
+  // Lower the cap and verify it's honoured
+  cs_str_native_set(NeoMutt->sub->cs, "macro_repeat_max", 7, NULL);
+  mutt_push_macro_repeated(macro2, 50);
+  TEST_CHECK_NUM_EQ(ARRAY_SIZE(&mod_data->macro_events), 7);
+  mutt_flushinp();
+  cs_str_reset(NeoMutt->sub->cs, "macro_repeat_max", NULL);
 
   // Verify ordering: a 3-char macro expanded twice should pop in macro order, twice
   mutt_push_macro_repeated(macro1, 2);

--- a/test/key/mutt_push_macro_repeated.c
+++ b/test/key/mutt_push_macro_repeated.c
@@ -1,0 +1,82 @@
+/**
+ * @file
+ * Test code for mutt_push_macro_repeated()
+ *
+ * @authors
+ * Copyright (C) 2026 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "key/lib.h"
+#include "key/module_data.h"
+#include "test_common.h"
+
+void test_mutt_push_macro_repeated(void)
+{
+  // void mutt_push_macro_repeated(char *macro, int count);
+
+  struct KeyModuleData *mod_data = neomutt_get_module_data(NeoMutt, MODULE_ID_KEY);
+
+  // Make sure we start with an empty queue
+  mutt_flushinp();
+  TEST_CHECK_NUM_EQ(ARRAY_SIZE(&mod_data->macro_events), 0);
+
+  // Bare push: count == 0 should expand once
+  char macro1[] = "abc";
+  mutt_push_macro_repeated(macro1, 0);
+  TEST_CHECK_NUM_EQ(ARRAY_SIZE(&mod_data->macro_events), 3);
+  mutt_flushinp();
+
+  // count == 1 should also expand exactly once
+  mutt_push_macro_repeated(macro1, 1);
+  TEST_CHECK_NUM_EQ(ARRAY_SIZE(&mod_data->macro_events), 3);
+  mutt_flushinp();
+
+  // count == 5 should expand 5 times -> 15 events
+  mutt_push_macro_repeated(macro1, 5);
+  TEST_CHECK_NUM_EQ(ARRAY_SIZE(&mod_data->macro_events), 15);
+  mutt_flushinp();
+
+  // Negative count is treated as a single expansion
+  mutt_push_macro_repeated(macro1, -3);
+  TEST_CHECK_NUM_EQ(ARRAY_SIZE(&mod_data->macro_events), 3);
+  mutt_flushinp();
+
+  // Counts above the cap are clamped to MacroRepeatMax (== 1000)
+  char macro2[] = "x";
+  mutt_push_macro_repeated(macro2, 9999);
+  TEST_CHECK_NUM_EQ(ARRAY_SIZE(&mod_data->macro_events), 1000);
+  mutt_flushinp();
+
+  // Verify ordering: a 3-char macro expanded twice should pop in macro order, twice
+  mutt_push_macro_repeated(macro1, 2);
+  TEST_CHECK_NUM_EQ(ARRAY_SIZE(&mod_data->macro_events), 6);
+
+  const char expected[] = "abcabc";
+  for (int i = 0; i < 6; i++)
+  {
+    struct KeyEvent *ev = array_pop(&mod_data->macro_events);
+    TEST_CHECK(ev != NULL);
+    TEST_CHECK_NUM_EQ(ev->ch, (unsigned char) expected[i]);
+  }
+  TEST_CHECK_NUM_EQ(ARRAY_SIZE(&mod_data->macro_events), 0);
+}

--- a/test/main.c
+++ b/test/main.c
@@ -535,6 +535,9 @@ void test_fini(void);
   /* imap */                                                                   \
   NEOMUTT_TEST_ITEM(test_imap_msg_set)                                         \
                                                                                \
+  /* key */                                                                    \
+  NEOMUTT_TEST_ITEM(test_mutt_push_macro_repeated)                             \
+                                                                               \
   /* list */                                                                   \
   NEOMUTT_TEST_ITEM(test_mutt_list_clear)                                      \
   NEOMUTT_TEST_ITEM(test_mutt_list_copy_tail)                                  \

--- a/test/module.c
+++ b/test/module.c
@@ -35,6 +35,7 @@ static struct ConfigDef TestVars[] = {
   { "config_charset",          DT_STRING,                                      0,                         0, NULL },
   { "debug_level",             DT_NUMBER,                                      0,                         0, NULL },
   { "folder",                  DT_STRING|D_STRING_MAILBOX,                     IP "/home/mutt/Mail",      0, NULL },
+  { "macro_repeat_max",        DT_NUMBER|D_INTEGER_NOT_NEGATIVE,               1000,                      0, NULL },
   { "mbox",                    DT_STRING|D_STRING_MAILBOX,                     IP "/home/mutt/mbox",      0, NULL },
   { "postponed",               DT_STRING|D_STRING_MAILBOX,                     IP "/home/mutt/postponed", 0, NULL },
   { "record",                  DT_STRING|D_STRING_MAILBOX,                     IP "/home/mutt/sent",      0, NULL },


### PR DESCRIPTION
Currently, macros ignore the repeat-count.

Given the macro:

```rust
macro index <F5> "<next-entry><next-entry><delete-entry>"
```

the user types <kbd>5\<F5\></kbd>.
This is now expanded to `NND` `NND` `NND` `NND` `NND`

**Note**: Functions like `<delete-entry>` are still subject to `$resolve`.

The number of repetitions is clamped to 1000 to bound queue growth from runaway counts.

The second commit turns the hard limit into a new config option: `$macro_repeat_max`.