### PR TITLE
Add Repeat-Count to all Work Functions

### DIFF
--- a/alias/functions.c
+++ b/alias/functions.c
@@ -196,13 +196,18 @@ static int op_create_alias(struct AliasFunctionData *fdata, const struct KeyEven
  * @param avpa   AliasView Array to populate
  * @param mdata  Alias Menu data
  * @param tagged Use tagged AliasViews (tag-prefix)
+ * @param count   Repeat-count (0 or 1 == just the current selection)
  * @retval num Number of AliasViews added
  *
- * If @a tagged is true, the array is filled with the tagged AliasViews.
- * Otherwise, the array is filled with just the current selection.
+ * If @a tagged is true, the array is filled with the tagged AliasViews and
+ * @a count is ignored.
+ *
+ * Otherwise the array is filled with the current selection and the next
+ * @a count - 1 visible AliasViews. Overruns are silently capped at the end
+ * of the visible list.
  */
 static int alias_add_selection(struct AliasViewPtrArray *avpa,
-                               struct AliasMenuData *mdata, bool tagged)
+                               struct AliasMenuData *mdata, bool tagged, int count)
 {
   if (!avpa || !mdata)
     return 0;
@@ -220,9 +225,19 @@ static int alias_add_selection(struct AliasViewPtrArray *avpa,
   {
     struct Menu *menu = mdata->menu;
     const int index = menu_get_index(menu);
-    struct AliasView *av = ARRAY_GET(&mdata->ava, index);
-    if (av)
-      ARRAY_ADD(avpa, av);
+    if ((index < 0) || (index >= menu->max))
+      return 0;
+
+    int n = (count > 1) ? count : 1;
+    if ((index + n) > menu->max)
+      n = menu->max - index;
+
+    for (int i = 0; i < n; i++)
+    {
+      struct AliasView *av = ARRAY_GET(&mdata->ava, index + i);
+      if (av)
+        ARRAY_ADD(avpa, av);
+    }
   }
 
   return ARRAY_SIZE(avpa);
@@ -252,6 +267,9 @@ static void alias_apply_set_deleted(struct AliasViewPtrArray *avpa, bool deleted
  * This function handles:
  * - OP_DELETE
  * - OP_UNDELETE
+ *
+ * Supports repeat-count: `5<delete-entry>` deletes the current entry and the
+ * next 4. Overruns are silently capped at the end of the visible list.
  */
 static int op_delete(struct AliasFunctionData *fdata, const struct KeyEvent *event)
 {
@@ -260,7 +278,7 @@ static int op_delete(struct AliasFunctionData *fdata, const struct KeyEvent *eve
   const bool deleted = (event->op == OP_DELETE);
 
   struct AliasViewPtrArray avpa = ARRAY_HEAD_INITIALIZER;
-  alias_add_selection(&avpa, mdata, menu->tag_prefix);
+  alias_add_selection(&avpa, mdata, menu->tag_prefix, event->count);
   if (ARRAY_EMPTY(&avpa))
   {
     ARRAY_FREE(&avpa);

--- a/alias/functions.c
+++ b/alias/functions.c
@@ -192,6 +192,61 @@ static int op_create_alias(struct AliasFunctionData *fdata, const struct KeyEven
 }
 
 /**
+ * alias_add_selection - Build a working set of AliasView pointers for an action
+ * @param avpa   AliasView Array to populate
+ * @param mdata  Alias Menu data
+ * @param tagged Use tagged AliasViews (tag-prefix)
+ * @retval num Number of AliasViews added
+ *
+ * If @a tagged is true, the array is filled with the tagged AliasViews.
+ * Otherwise, the array is filled with just the current selection.
+ */
+static int alias_add_selection(struct AliasViewPtrArray *avpa,
+                               struct AliasMenuData *mdata, bool tagged)
+{
+  if (!avpa || !mdata)
+    return 0;
+
+  if (tagged)
+  {
+    struct AliasView *avp = NULL;
+    ARRAY_FOREACH(avp, &mdata->ava)
+    {
+      if (avp->is_tagged)
+        ARRAY_ADD(avpa, avp);
+    }
+  }
+  else
+  {
+    struct Menu *menu = mdata->menu;
+    const int index = menu_get_index(menu);
+    struct AliasView *av = ARRAY_GET(&mdata->ava, index);
+    if (av)
+      ARRAY_ADD(avpa, av);
+  }
+
+  return ARRAY_SIZE(avpa);
+}
+
+/**
+ * alias_apply_set_deleted - Apply the deleted flag to a working set of AliasViews
+ * @param avpa Working set of AliasView pointers
+ * @param deleted true to mark as deleted, false to undelete
+ */
+static void alias_apply_set_deleted(struct AliasViewPtrArray *avpa, bool deleted)
+{
+  if (!avpa)
+    return;
+
+  struct AliasView **avpp = NULL;
+  ARRAY_FOREACH(avpp, avpa)
+  {
+    if (*avpp)
+      (*avpp)->is_deleted = deleted;
+  }
+}
+
+/**
  * op_delete - delete the current entry - Implements ::alias_function_t - @ingroup alias_function_api
  *
  * This function handles:
@@ -202,31 +257,31 @@ static int op_delete(struct AliasFunctionData *fdata, const struct KeyEvent *eve
 {
   struct AliasMenuData *mdata = fdata->wdata;
   struct Menu *menu = mdata->menu;
-  const int op = event->op;
+  const bool deleted = (event->op == OP_DELETE);
+
+  struct AliasViewPtrArray avpa = ARRAY_HEAD_INITIALIZER;
+  alias_add_selection(&avpa, mdata, menu->tag_prefix);
+  if (ARRAY_EMPTY(&avpa))
+  {
+    ARRAY_FREE(&avpa);
+    return FR_NO_ACTION;
+  }
+  alias_apply_set_deleted(&avpa, deleted);
+  const int num = ARRAY_SIZE(&avpa);
+  ARRAY_FREE(&avpa);
 
   if (menu->tag_prefix)
   {
-    struct AliasView *avp = NULL;
-    ARRAY_FOREACH(avp, &mdata->ava)
-    {
-      if (avp->is_tagged)
-        avp->is_deleted = (op == OP_DELETE);
-    }
     menu_queue_redraw(menu, MENU_REDRAW_INDEX);
   }
   else
   {
-    int index = menu_get_index(menu);
-    struct AliasView *av = ARRAY_GET(&mdata->ava, index);
-    if (!av)
-      return FR_NO_ACTION;
-
-    av->is_deleted = (op == OP_DELETE);
-    menu_queue_redraw(menu, MENU_REDRAW_CURRENT);
+    const int index = menu_get_index(menu);
+    menu_queue_redraw(menu, (num > 1) ? MENU_REDRAW_INDEX : MENU_REDRAW_CURRENT);
     const bool c_resolve = cs_subset_bool(mdata->sub, "resolve");
-    if (c_resolve && (index < (menu->max - 1)))
+    if (c_resolve && ((index + num) < menu->max))
     {
-      menu_set_index(menu, index + 1);
+      menu_set_index(menu, index + num);
       menu_queue_redraw(menu, MENU_REDRAW_INDEX);
     }
   }

--- a/alias/gui.h
+++ b/alias/gui.h
@@ -45,7 +45,8 @@ struct AliasView
   bool is_visible  : 1; ///< Is visible?
   struct Alias *alias;  ///< Alias
 };
-ARRAY_HEAD(AliasViewArray, struct AliasView);
+ARRAY_HEAD(AliasViewArray,    struct AliasView);
+ARRAY_HEAD(AliasViewPtrArray, struct AliasView *);
 
 /**
  * struct AliasMenuData - AliasView array wrapper with Pattern information - @extends Menu

--- a/attach/attach.h
+++ b/attach/attach.h
@@ -25,6 +25,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+#include "mutt/lib.h"
 
 struct Body;
 
@@ -43,6 +44,7 @@ struct AttachPtr
   bool decrypted : 1;   ///< Not part of message as stored in the email->body
   bool collapsed : 1;   ///< Group is collapsed
 };
+ARRAY_HEAD(AttachPtrArray, struct AttachPtr *);
 
 /**
  * ExpandoDataAttach - Expando UIDs for Attachments

--- a/attach/functions.c
+++ b/attach/functions.c
@@ -261,7 +261,54 @@ static int op_attach_collapse(struct AttachFunctionData *fdata, const struct Key
 }
 
 /**
+ * attach_apply_set_deleted - Apply the deleted flag to a working set of attachments
+ * @param[in]  apa         Working set of AttachPtr pointers
+ * @param[in]  deleted     true to mark as deleted, false to undelete
+ * @param[out] num_changed Number of attachments actually changed
+ * @param[out] num_blocked Number of attachments rejected (non-multipart)
+ *
+ * Only multipart attachments may be deleted. Non-multipart attachments in
+ * the working set are skipped and counted in @a num_blocked.
+ */
+static void attach_apply_set_deleted(struct AttachPtrArray *apa, bool deleted,
+                                     int *num_changed, int *num_blocked)
+{
+  int changed = 0;
+  int blocked = 0;
+
+  if (apa)
+  {
+    struct AttachPtr **app = NULL;
+    ARRAY_FOREACH(app, apa)
+    {
+      struct AttachPtr *ap = *app;
+      if (!ap || !ap->body)
+        continue;
+
+      if (deleted && (ap->parent_type != TYPE_MULTIPART))
+      {
+        blocked++;
+        continue;
+      }
+
+      ap->body->deleted = deleted;
+      changed++;
+    }
+  }
+
+  if (num_changed)
+    *num_changed = changed;
+  if (num_blocked)
+    *num_blocked = blocked;
+}
+
+/**
  * op_attach_delete - delete the current entry - Implements ::attach_function_t - @ingroup attach_function_api
+ *
+ * Supports repeat-count: `5<delete-entry>` deletes the current entry and the
+ * next 4 (only multipart attachments can be deleted; non-multipart entries in
+ * the working set are silently skipped). Overruns are silently capped at the
+ * end of the list.
  */
 static int op_attach_delete(struct AttachFunctionData *fdata, const struct KeyEvent *event)
 {
@@ -293,8 +340,6 @@ static int op_attach_delete(struct AttachFunctionData *fdata, const struct KeyEv
     mutt_message(_("Deletion of attachments from signed messages may invalidate the signature"));
   }
 
-  bool deleted = false;
-  bool blocked = false;
   struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
   if (aa_add_selection(&aa, priv->actx, priv->menu, priv->menu->tag_prefix,
                        event->count) < 0)
@@ -303,41 +348,43 @@ static int op_attach_delete(struct AttachFunctionData *fdata, const struct KeyEv
     return FR_ERROR;
   }
 
-  struct AttachPtr **app = NULL;
-  ARRAY_FOREACH(app, &aa)
+  if (ARRAY_EMPTY(&aa))
   {
-    if ((*app)->parent_type == TYPE_MULTIPART)
-    {
-      (*app)->body->deleted = true;
-      deleted = true;
-    }
-    else
-    {
-      mutt_message(_("Only deletion of multipart attachments is supported"));
-      blocked = true;
-    }
+    ARRAY_FREE(&aa);
+    return FR_NO_ACTION;
   }
 
-  if (deleted)
-  {
-    if (ARRAY_SIZE(&aa) > 1)
-    {
-      menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
-    }
-    else
-    {
-      const bool c_resolve = cs_subset_bool(fdata->n->sub, "resolve");
-      const int index = menu_get_index(priv->menu) + 1;
-      if (c_resolve && (index < priv->menu->max))
-        menu_set_index(priv->menu, index);
-      else
-        menu_queue_redraw(priv->menu, MENU_REDRAW_CURRENT);
-    }
-  }
-
+  int changed = 0;
+  int blocked = 0;
+  attach_apply_set_deleted(&aa, true, &changed, &blocked);
+  const int num = ARRAY_SIZE(&aa);
   ARRAY_FREE(&aa);
 
-  return deleted ? FR_SUCCESS : (blocked ? FR_ERROR : FR_NO_ACTION);
+  if (blocked > 0)
+    mutt_message(_("Only deletion of multipart attachments is supported"));
+
+  if (changed == 0)
+    return blocked ? FR_ERROR : FR_NO_ACTION;
+
+  if (priv->menu->tag_prefix)
+  {
+    menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
+  }
+  else
+  {
+    const bool c_resolve = cs_subset_bool(fdata->n->sub, "resolve");
+    const int next = menu_get_index(priv->menu) + num;
+    if (c_resolve && (next < priv->menu->max))
+    {
+      menu_set_index(priv->menu, next);
+    }
+    else
+    {
+      menu_queue_redraw(priv->menu, (num > 1) ? MENU_REDRAW_INDEX : MENU_REDRAW_CURRENT);
+    }
+  }
+
+  return FR_SUCCESS;
 }
 
 /**
@@ -397,6 +444,9 @@ static int op_attach_save(struct AttachFunctionData *fdata, const struct KeyEven
 
 /**
  * op_attach_undelete - undelete the current entry - Implements ::attach_function_t - @ingroup attach_function_api
+ *
+ * Supports repeat-count: `5<undelete-entry>` undeletes the current entry and
+ * the next 4. Overruns are silently capped at the end of the list.
  */
 static int op_attach_undelete(struct AttachFunctionData *fdata, const struct KeyEvent *event)
 {
@@ -412,31 +462,34 @@ static int op_attach_undelete(struct AttachFunctionData *fdata, const struct Key
     return FR_ERROR;
   }
 
-  struct AttachPtr **app = NULL;
-  ARRAY_FOREACH(app, &aa)
+  if (ARRAY_EMPTY(&aa))
   {
-    (*app)->body->deleted = false;
+    ARRAY_FREE(&aa);
+    return FR_NO_ACTION;
   }
 
-  if (ARRAY_SIZE(&aa) > 1)
+  attach_apply_set_deleted(&aa, false, NULL, NULL);
+  const int num = ARRAY_SIZE(&aa);
+  ARRAY_FREE(&aa);
+
+  if (priv->menu->tag_prefix)
   {
     menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
   }
   else
   {
     const bool c_resolve = cs_subset_bool(fdata->n->sub, "resolve");
-    const int index = menu_get_index(priv->menu) + 1;
-    if (c_resolve && (index < priv->menu->max))
+    const int next = menu_get_index(priv->menu) + num;
+    if (c_resolve && (next < priv->menu->max))
     {
-      menu_set_index(priv->menu, index);
+      menu_set_index(priv->menu, next);
     }
     else
     {
-      menu_queue_redraw(priv->menu, MENU_REDRAW_CURRENT);
+      menu_queue_redraw(priv->menu, (num > 1) ? MENU_REDRAW_INDEX : MENU_REDRAW_CURRENT);
     }
   }
 
-  ARRAY_FREE(&aa);
   return FR_SUCCESS;
 }
 

--- a/attach/functions.c
+++ b/attach/functions.c
@@ -212,50 +212,30 @@ static bool check_readonly(struct Mailbox *m)
 
 /**
  * recvattach_extract_pgp_keys - Extract PGP keys from attachments
- * @param actx Attachment context
- * @param menu Menu listing attachments
+ * @param aa Selected attachments
  */
-static void recvattach_extract_pgp_keys(struct AttachCtx *actx, struct Menu *menu)
+static void recvattach_extract_pgp_keys(struct AttachPtrArray *aa)
 {
-  if (menu->tag_prefix)
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, aa)
   {
-    for (int i = 0; i < actx->idxlen; i++)
-    {
-      if (actx->idx[i]->body->tagged)
-      {
-        crypt_pgp_extract_key_from_attachment(actx->idx[i]->fp, actx->idx[i]->body);
-      }
-    }
-  }
-  else
-  {
-    struct AttachPtr *cur_att = current_attachment(actx, menu);
-    crypt_pgp_extract_key_from_attachment(cur_att->fp, cur_att->body);
+    crypt_pgp_extract_key_from_attachment((*app)->fp, (*app)->body);
   }
 }
 
 /**
  * recvattach_pgp_check_traditional - Is the Attachment inline PGP?
- * @param actx Attachment to check
- * @param menu Menu listing Attachments
- * @retval 1 The (tagged) Attachment(s) are inline PGP
- *
- * @note If the menu->tagprefix is set, all the tagged attachments will be checked.
+ * @param aa Selected attachments
+ * @retval 1 Any selected Attachment is inline PGP
  */
-static int recvattach_pgp_check_traditional(struct AttachCtx *actx, struct Menu *menu)
+static int recvattach_pgp_check_traditional(struct AttachPtrArray *aa)
 {
   int rc = 0;
 
-  if (menu->tag_prefix)
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, aa)
   {
-    for (int i = 0; i < actx->idxlen; i++)
-      if (actx->idx[i]->body->tagged)
-        rc = rc || crypt_pgp_check_traditional(actx->idx[i]->fp, actx->idx[i]->body, true);
-  }
-  else
-  {
-    struct AttachPtr *cur_att = current_attachment(actx, menu);
-    rc = crypt_pgp_check_traditional(cur_att->fp, cur_att->body, true);
+    rc = rc || crypt_pgp_check_traditional((*app)->fp, (*app)->body, true);
   }
 
   return rc;
@@ -315,50 +295,47 @@ static int op_attach_delete(struct AttachFunctionData *fdata, const struct KeyEv
 
   bool deleted = false;
   bool blocked = false;
-  if (priv->menu->tag_prefix)
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  if (aa_add_selection(&aa, priv->actx, priv->menu, priv->menu->tag_prefix,
+                       event->count) < 0)
   {
-    for (int i = 0; i < priv->menu->max; i++)
-    {
-      if (priv->actx->idx[i]->body->tagged)
-      {
-        if (priv->actx->idx[i]->parent_type == TYPE_MULTIPART)
-        {
-          priv->actx->idx[i]->body->deleted = true;
-          deleted = true;
-          menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
-        }
-        else
-        {
-          blocked = true;
-          mutt_message(_("Only deletion of multipart attachments is supported"));
-        }
-      }
-    }
+    ARRAY_FREE(&aa);
+    return FR_ERROR;
   }
-  else
+
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, &aa)
   {
-    struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
-    if (cur_att->parent_type == TYPE_MULTIPART)
+    if ((*app)->parent_type == TYPE_MULTIPART)
     {
-      cur_att->body->deleted = true;
+      (*app)->body->deleted = true;
       deleted = true;
-      const bool c_resolve = cs_subset_bool(fdata->n->sub, "resolve");
-      const int index = menu_get_index(priv->menu) + 1;
-      if (c_resolve && (index < priv->menu->max))
-      {
-        menu_set_index(priv->menu, index);
-      }
-      else
-      {
-        menu_queue_redraw(priv->menu, MENU_REDRAW_CURRENT);
-      }
     }
     else
     {
-      blocked = true;
       mutt_message(_("Only deletion of multipart attachments is supported"));
+      blocked = true;
     }
   }
+
+  if (deleted)
+  {
+    if (ARRAY_SIZE(&aa) > 1)
+    {
+      menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
+    }
+    else
+    {
+      const bool c_resolve = cs_subset_bool(fdata->n->sub, "resolve");
+      const int index = menu_get_index(priv->menu) + 1;
+      if (c_resolve && (index < priv->menu->max))
+        menu_set_index(priv->menu, index);
+      else
+        menu_queue_redraw(priv->menu, MENU_REDRAW_CURRENT);
+    }
+  }
+
+  ARRAY_FREE(&aa);
 
   return deleted ? FR_SUCCESS : (blocked ? FR_ERROR : FR_NO_ACTION);
 }
@@ -380,9 +357,10 @@ static int op_attach_edit_type(struct AttachFunctionData *fdata, const struct Ke
 static int op_attach_pipe(struct AttachFunctionData *fdata, const struct KeyEvent *event)
 {
   struct AttachPrivateData *priv = fdata->priv;
-  struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
-  mutt_pipe_attachment_list(priv->actx, cur_att->fp, priv->menu->tag_prefix,
-                            cur_att->body, false);
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  aa_add_selection(&aa, priv->actx, priv->menu, priv->menu->tag_prefix, event->count);
+  mutt_pipe_attachment_list(&aa, false);
+  ARRAY_FREE(&aa);
   return FR_SUCCESS;
 }
 
@@ -392,9 +370,10 @@ static int op_attach_pipe(struct AttachFunctionData *fdata, const struct KeyEven
 static int op_attach_print(struct AttachFunctionData *fdata, const struct KeyEvent *event)
 {
   struct AttachPrivateData *priv = fdata->priv;
-  struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
-  mutt_print_attachment_list(priv->actx, cur_att->fp, priv->menu->tag_prefix,
-                             cur_att->body);
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  aa_add_selection(&aa, priv->actx, priv->menu, priv->menu->tag_prefix, event->count);
+  mutt_print_attachment_list(&aa);
+  ARRAY_FREE(&aa);
   return FR_SUCCESS;
 }
 
@@ -404,14 +383,15 @@ static int op_attach_print(struct AttachFunctionData *fdata, const struct KeyEve
 static int op_attach_save(struct AttachFunctionData *fdata, const struct KeyEvent *event)
 {
   struct AttachPrivateData *priv = fdata->priv;
-  struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
-  mutt_save_attachment_list(priv->actx, cur_att->fp, priv->menu->tag_prefix,
-                            cur_att->body, priv->actx->email, priv->menu);
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  aa_add_selection(&aa, priv->actx, priv->menu, priv->menu->tag_prefix, event->count);
+  mutt_save_attachment_list(&aa, priv->actx->email, priv->menu);
 
   const bool c_resolve = cs_subset_bool(fdata->n->sub, "resolve");
   const int index = menu_get_index(priv->menu) + 1;
-  if (!priv->menu->tag_prefix && c_resolve && (index < priv->menu->max))
+  if ((ARRAY_SIZE(&aa) == 1) && c_resolve && (index < priv->menu->max))
     menu_set_index(priv->menu, index);
+  ARRAY_FREE(&aa);
   return FR_SUCCESS;
 }
 
@@ -424,21 +404,26 @@ static int op_attach_undelete(struct AttachFunctionData *fdata, const struct Key
   if (check_readonly(priv->mailbox))
     return FR_ERROR;
 
-  if (priv->menu->tag_prefix)
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  if (aa_add_selection(&aa, priv->actx, priv->menu, priv->menu->tag_prefix,
+                       event->count) < 0)
   {
-    for (int i = 0; i < priv->menu->max; i++)
-    {
-      if (priv->actx->idx[i]->body->tagged)
-      {
-        priv->actx->idx[i]->body->deleted = false;
-        menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
-      }
-    }
+    ARRAY_FREE(&aa);
+    return FR_ERROR;
+  }
+
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, &aa)
+  {
+    (*app)->body->deleted = false;
+  }
+
+  if (ARRAY_SIZE(&aa) > 1)
+  {
+    menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
   }
   else
   {
-    struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
-    cur_att->body->deleted = false;
     const bool c_resolve = cs_subset_bool(fdata->n->sub, "resolve");
     const int index = menu_get_index(priv->menu) + 1;
     if (c_resolve && (index < priv->menu->max))
@@ -451,6 +436,7 @@ static int op_attach_undelete(struct AttachFunctionData *fdata, const struct Key
     }
   }
 
+  ARRAY_FREE(&aa);
   return FR_SUCCESS;
 }
 
@@ -518,9 +504,10 @@ static int op_bounce_message(struct AttachFunctionData *fdata, const struct KeyE
   struct AttachPrivateData *priv = fdata->priv;
   if (check_attach(priv))
     return FR_ERROR;
-  struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
-  attach_bounce_message(priv->mailbox, cur_att->fp, priv->actx,
-                        priv->menu->tag_prefix ? NULL : cur_att->body);
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  aa_add_selection(&aa, priv->actx, priv->menu, priv->menu->tag_prefix, event->count);
+  attach_bounce_message(&aa, priv->mailbox);
+  ARRAY_FREE(&aa);
   menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
   return FR_SUCCESS;
 }
@@ -531,12 +518,14 @@ static int op_bounce_message(struct AttachFunctionData *fdata, const struct KeyE
 static int op_check_traditional(struct AttachFunctionData *fdata, const struct KeyEvent *event)
 {
   struct AttachPrivateData *priv = fdata->priv;
-  if (((WithCrypto & APPLICATION_PGP) != 0) &&
-      recvattach_pgp_check_traditional(priv->actx, priv->menu))
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  aa_add_selection(&aa, priv->actx, priv->menu, priv->menu->tag_prefix, event->count);
+  if (((WithCrypto & APPLICATION_PGP) != 0) && recvattach_pgp_check_traditional(&aa))
   {
     priv->actx->email->security = crypt_query(NULL);
     menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
   }
+  ARRAY_FREE(&aa);
   return FR_SUCCESS;
 }
 
@@ -548,8 +537,10 @@ static int op_compose_to_sender(struct AttachFunctionData *fdata, const struct K
   struct AttachPrivateData *priv = fdata->priv;
   if (check_attach(priv))
     return FR_ERROR;
-  struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
-  mutt_attach_mail_sender(priv->actx, priv->menu->tag_prefix ? NULL : cur_att->body);
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  aa_add_selection(&aa, priv->actx, priv->menu, priv->menu->tag_prefix, event->count);
+  mutt_attach_mail_sender(&aa);
+  ARRAY_FREE(&aa);
   menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
   return FR_SUCCESS;
 }
@@ -585,7 +576,10 @@ static int op_extract_keys(struct AttachFunctionData *fdata, const struct KeyEve
   if (!(WithCrypto & APPLICATION_PGP))
     return FR_NO_ACTION;
 
-  recvattach_extract_pgp_keys(priv->actx, priv->menu);
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  aa_add_selection(&aa, priv->actx, priv->menu, priv->menu->tag_prefix, event->count);
+  recvattach_extract_pgp_keys(&aa);
+  ARRAY_FREE(&aa);
   menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
 
   return FR_SUCCESS;
@@ -608,9 +602,10 @@ static int op_forward_message(struct AttachFunctionData *fdata, const struct Key
   struct AttachPrivateData *priv = fdata->priv;
   if (check_attach(priv))
     return FR_ERROR;
-  struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
-  mutt_attach_forward(cur_att->fp, priv->actx->email, priv->actx,
-                      priv->menu->tag_prefix ? NULL : cur_att->body, SEND_NO_FLAGS);
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  aa_add_selection(&aa, priv->actx, priv->menu, priv->menu->tag_prefix, event->count);
+  mutt_attach_forward(&aa, priv->actx->email, priv->actx, SEND_NO_FLAGS);
+  ARRAY_FREE(&aa);
   menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
   return FR_SUCCESS;
 }
@@ -663,9 +658,10 @@ static int op_reply(struct AttachFunctionData *fdata, const struct KeyEvent *eve
   else if (op == OP_LIST_REPLY)
     flags |= SEND_LIST_REPLY;
 
-  struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
-  mutt_attach_reply(cur_att->fp, priv->mailbox, priv->actx->email, priv->actx,
-                    priv->menu->tag_prefix ? NULL : cur_att->body, flags);
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  aa_add_selection(&aa, priv->actx, priv->menu, priv->menu->tag_prefix, event->count);
+  mutt_attach_reply(&aa, priv->mailbox, priv->actx->email, priv->actx, flags);
+  ARRAY_FREE(&aa);
   menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
   return FR_SUCCESS;
 }
@@ -678,9 +674,10 @@ static int op_resend(struct AttachFunctionData *fdata, const struct KeyEvent *ev
   struct AttachPrivateData *priv = fdata->priv;
   if (check_attach(priv))
     return FR_ERROR;
-  struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
-  mutt_attach_resend(cur_att->fp, priv->mailbox, priv->actx,
-                     priv->menu->tag_prefix ? NULL : cur_att->body);
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  aa_add_selection(&aa, priv->actx, priv->menu, priv->menu->tag_prefix, event->count);
+  mutt_attach_resend(&aa, priv->mailbox);
+  ARRAY_FREE(&aa);
   menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
   return FR_SUCCESS;
 }
@@ -707,8 +704,10 @@ static int op_followup(struct AttachFunctionData *fdata, const struct KeyEvent *
       (query_quadoption(_("Reply by mail as poster prefers?"), fdata->n->sub,
                         "followup_to_poster") != MUTT_YES))
   {
-    mutt_attach_reply(cur_att->fp, priv->mailbox, priv->actx->email, priv->actx,
-                      priv->menu->tag_prefix ? NULL : cur_att->body, SEND_NEWS | SEND_REPLY);
+    struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+    aa_add_selection(&aa, priv->actx, priv->menu, priv->menu->tag_prefix, event->count);
+    mutt_attach_reply(&aa, priv->mailbox, priv->actx->email, priv->actx, SEND_NEWS | SEND_REPLY);
+    ARRAY_FREE(&aa);
     menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
     return FR_SUCCESS;
   }
@@ -724,9 +723,10 @@ static int op_forward_to_group(struct AttachFunctionData *fdata, const struct Ke
   struct AttachPrivateData *priv = fdata->priv;
   if (check_attach(priv))
     return FR_ERROR;
-  struct AttachPtr *cur_att = current_attachment(priv->actx, priv->menu);
-  mutt_attach_forward(cur_att->fp, priv->actx->email, priv->actx,
-                      priv->menu->tag_prefix ? NULL : cur_att->body, SEND_NEWS);
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  aa_add_selection(&aa, priv->actx, priv->menu, priv->menu->tag_prefix, event->count);
+  mutt_attach_forward(&aa, priv->actx->email, priv->actx, SEND_NEWS);
+  ARRAY_FREE(&aa);
   menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
   return FR_SUCCESS;
 }

--- a/attach/mutt_attach.h
+++ b/attach/mutt_attach.h
@@ -30,6 +30,7 @@
 #include "mutt/lib.h"
 
 struct AttachCtx;
+struct AttachPtrArray;
 struct Body;
 struct ConfigSubset;
 struct Email;
@@ -61,9 +62,9 @@ enum SaveAttach
 
 int mutt_attach_display_loop(struct ConfigSubset *sub, struct Menu *menu, int op, struct Email *e, struct AttachCtx *actx, bool recv);
 
-void mutt_save_attachment_list (struct AttachCtx *actx, FILE *fp, bool tag, struct Body *b, struct Email *e, struct Menu *menu);
-void mutt_pipe_attachment_list (struct AttachCtx *actx, FILE *fp, bool tag, struct Body *b, bool filter);
-void mutt_print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag, struct Body *b);
+void mutt_save_attachment_list (struct AttachPtrArray *aa, struct Email *e, struct Menu *menu);
+void mutt_pipe_attachment_list (struct AttachPtrArray *aa, bool filter);
+void mutt_print_attachment_list(struct AttachPtrArray *aa);
 
 int mutt_view_attachment(FILE *fp, struct Body *b, enum ViewAttachMode mode, struct Email *e, struct AttachCtx *actx, struct MuttWindow *win);
 

--- a/attach/recvattach.c
+++ b/attach/recvattach.c
@@ -415,20 +415,16 @@ cleanup:
 }
 
 /**
- * mutt_save_attachment_list - Save a list of attachments
- * @param actx Attachment context
- * @param fp   File handle for the attachment (OPTIONAL)
- * @param tag  If true, only save the tagged attachments
- * @param b    First Attachment
- * @param e  Email
+ * mutt_save_attachment_list - Save a list of selected attachments
+ * @param aa   Selected attachments
+ * @param e    Parent email
  * @param menu Menu listing attachments
  */
-void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
-                               struct Body *b, struct Email *e, struct Menu *menu)
+void mutt_save_attachment_list(struct AttachPtrArray *aa, struct Email *e, struct Menu *menu)
 {
   char *directory = NULL;
   int rc = 1;
-  int last = menu_get_index(menu);
+  int last = menu ? menu_get_index(menu) : 0;
   FILE *fp_out = NULL;
   int saved_attachments = 0;
 
@@ -439,81 +435,74 @@ void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
   const char *const c_attach_sep = cs_subset_string(NeoMutt->sub, "attach_sep");
   const bool c_attach_save_without_prompting = cs_subset_bool(NeoMutt->sub, "attach_save_without_prompting");
 
-  /* Iterate through attachments (or just the single one if not tagging).
-   * Behavior depends on attach_split: if true, save each to its own file;
-   * if false, concatenate all into one file with optional separator. */
-  for (int i = 0; !tag || (i < actx->idxlen); i++)
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, aa)
   {
-    if (tag)
-    {
-      fp = actx->idx[i]->fp;
-      b = actx->idx[i]->body;
-    }
-    if (!tag || b->tagged)
-    {
-      if (c_attach_split)
-      {
-        if (tag && menu && b->aptr)
-        {
-          menu_set_index(menu, b->aptr->num);
-          menu_queue_redraw(menu, MENU_REDRAW_MOTION);
+    FILE *fp = (*app)->fp;
+    struct Body *b = (*app)->body;
 
-          menu_redraw(menu);
-        }
-        if (c_attach_save_without_prompting)
-        {
-          // Save each file, with no prompting, using the configured 'AttachSaveDir'
-          rc = save_without_prompting(fp, b, e);
-          if (rc == 0)
-            saved_attachments++;
-        }
-        else
-        {
-          // Save each file, prompting the user for the location each time.
-          if (query_save_attachment(fp, b, e, &directory) == -1)
-            break;
-        }
+    /* Iterate through attachments.
+     * Behavior depends on attach_split: if true, save each to its own file;
+     * if false, concatenate all into one file with optional separator. */
+    if (c_attach_split)
+    {
+      if (menu)
+      {
+        menu_set_index(menu, (*app)->num);
+        menu_queue_redraw(menu, MENU_REDRAW_MOTION);
+        menu_redraw(menu);
+      }
+      if (c_attach_save_without_prompting)
+      {
+        // Save each file, with no prompting, using the configured 'AttachSaveDir'
+        rc = save_without_prompting(fp, b, e);
+        if (rc == 0)
+          saved_attachments++;
       }
       else
       {
-        enum SaveAttach opt = MUTT_SAVE_NO_FLAGS;
-
-        if (buf_is_empty(buf))
-        {
-          buf_strcpy(buf, mutt_path_basename(NONULL(b->filename)));
-          prepend_savedir(buf);
-
-          struct FileCompletionData cdata = { false, NULL, NULL, NULL, NULL };
-          if ((mw_get_field(_("Save to file: "), buf, MUTT_COMP_CLEAR, HC_FILE,
-                            &CompleteFileOps, &cdata) != 0) ||
-              buf_is_empty(buf))
-          {
-            goto cleanup;
-          }
-          expand_path(buf, false);
-          if (mutt_check_overwrite(b->filename, buf_string(buf), tfile, &opt, NULL))
-            goto cleanup;
-        }
-        else
-        {
-          opt = MUTT_SAVE_APPEND;
-        }
-
-        rc = save_attachment_flowed_helper(fp, b, buf_string(tfile), opt, e);
-        if ((rc == 0) && c_attach_sep && (fp_out = mutt_file_fopen(buf_string(tfile), "a")))
-        {
-          fprintf(fp_out, "%s", c_attach_sep);
-          mutt_file_fclose(&fp_out);
-        }
+        // Save each file, prompting the user for the location each time.
+        if (query_save_attachment(fp, b, e, &directory) == -1)
+          break;
       }
     }
-    if (!tag)
-      break;
+    else
+    {
+      enum SaveAttach opt = MUTT_SAVE_NO_FLAGS;
+
+      if (buf_is_empty(buf))
+      {
+        buf_strcpy(buf, mutt_path_basename(NONULL(b->filename)));
+        prepend_savedir(buf);
+
+        struct FileCompletionData cdata = { false, NULL, NULL, NULL, NULL };
+        if ((mw_get_field(_("Save to file: "), buf, MUTT_COMP_CLEAR, HC_FILE,
+                          &CompleteFileOps, &cdata) != 0) ||
+            buf_is_empty(buf))
+        {
+          goto cleanup;
+        }
+        expand_path(buf, false);
+        if (mutt_check_overwrite(b->filename, buf_string(buf), tfile, &opt, NULL))
+          goto cleanup;
+      }
+      else
+      {
+        opt = MUTT_SAVE_APPEND;
+      }
+
+      rc = save_attachment_flowed_helper(fp, b, buf_string(tfile), opt, e);
+      if ((rc == 0) && c_attach_sep && (fp_out = mutt_file_fopen(buf_string(tfile), "a")))
+      {
+        fprintf(fp_out, "%s", c_attach_sep);
+        mutt_file_fclose(&fp_out);
+      }
+    }
   }
 
   FREE(&directory);
 
-  if (tag && menu)
+  if ((ARRAY_SIZE(aa) > 1) && menu)
   {
     menu_set_index(menu, last);
     menu_queue_redraw(menu, MENU_REDRAW_MOTION);
@@ -678,53 +667,43 @@ bail:
 
 /**
  * pipe_attachment_list - Pipe a list of attachments to a command
- * @param command Command to pipe the attachment to
- * @param actx    Attachment context
- * @param fp      File handle to the attachment (OPTIONAL)
- * @param tag     If true, only save the tagged attachments
- * @param top     First Attachment
+ * @param command Command to pipe the attachments to
+ * @param aa      Selected attachments
  * @param filter  Is this command a filter?
  * @param state   File state for decoding the attachments
  */
-static void pipe_attachment_list(const char *command, struct AttachCtx *actx,
-                                 FILE *fp, bool tag, struct Body *top,
+static void pipe_attachment_list(const char *command, struct AttachPtrArray *aa,
                                  bool filter, struct State *state)
 {
   const bool c_attach_split = cs_subset_bool(NeoMutt->sub, "attach_split");
-  for (int i = 0; !tag || (i < actx->idxlen); i++)
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, aa)
   {
-    if (tag)
-    {
-      fp = actx->idx[i]->fp;
-      top = actx->idx[i]->body;
-    }
-    if (!tag || top->tagged)
-    {
-      if (!filter && !c_attach_split)
-        pipe_attachment(fp, top, state);
-      else
-        query_pipe_attachment(command, fp, top, filter);
-    }
-    if (!tag)
-      break;
+    FILE *fp = (*app)->fp;
+    struct Body *b = (*app)->body;
+
+    if (!filter && !c_attach_split)
+      pipe_attachment(fp, b, state);
+    else
+      query_pipe_attachment(command, fp, b, filter);
   }
 }
 
 /**
- * mutt_pipe_attachment_list - Pipe a list of attachments to a command
- * @param actx   Attachment context
- * @param fp     File handle to the attachment (OPTIONAL)
- * @param tag    If true, only save the tagged attachments
- * @param b      First Attachment
+ * mutt_pipe_attachment_list - Pipe selected attachments to a command
+ * @param aa     Selected attachments
  * @param filter Is this command a filter?
  */
-void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
-                               struct Body *b, bool filter)
+void mutt_pipe_attachment_list(struct AttachPtrArray *aa, bool filter)
 {
   struct State state = { 0 };
   struct Buffer *buf = NULL;
 
-  if (fp)
+  if (ARRAY_EMPTY(aa))
+    return;
+
+  struct AttachPtr **first = ARRAY_GET(aa, 0);
+  if (first && (*first)->fp)
     filter = false; /* sanity check: we can't filter in the recv case yet */
 
   buf = buf_pool_get();
@@ -748,7 +727,7 @@ void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
     mutt_endwin();
     pid_t pid = filter_create(buf_string(buf), &state.fp_out, NULL, NULL,
                               NeoMutt->env);
-    pipe_attachment_list(buf_string(buf), actx, fp, tag, b, filter, &state);
+    pipe_attachment_list(buf_string(buf), aa, filter, &state);
     mutt_file_fclose(&state.fp_out);
     const bool c_wait_key = cs_subset_bool(NeoMutt->sub, "wait_key");
     if ((filter_wait(pid) != 0) || c_wait_key)
@@ -756,7 +735,7 @@ void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
   }
   else
   {
-    pipe_attachment_list(buf_string(buf), actx, fp, tag, b, filter, &state);
+    pipe_attachment_list(buf_string(buf), aa, filter, &state);
   }
 
 cleanup:
@@ -765,157 +744,133 @@ cleanup:
 
 /**
  * can_print - Do we know how to print this attachment type?
- * @param actx Attachment
- * @param b    Body of email
- * @param tag  Apply to all tagged Attachments
+ * @param aa Selected attachments
  * @retval true (all) the Attachment(s) are printable
  */
-static bool can_print(struct AttachCtx *actx, struct Body *b, bool tag)
+static bool can_print(struct AttachPtrArray *aa)
 {
   char type[256] = { 0 };
 
-  for (int i = 0; !tag || (i < actx->idxlen); i++)
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, aa)
   {
-    if (tag)
-      b = actx->idx[i]->body;
+    struct Body *b = (*app)->body;
     snprintf(type, sizeof(type), "%s/%s", BODY_TYPE(b), b->subtype);
-    if (!tag || b->tagged)
+    if (!mailcap_lookup(b, type, sizeof(type), NULL, MUTT_MC_PRINT))
     {
-      if (!mailcap_lookup(b, type, sizeof(type), NULL, MUTT_MC_PRINT))
+      if (!mutt_istr_equal("text/plain", b->subtype) &&
+          !mutt_istr_equal("application/postscript", b->subtype))
       {
-        if (!mutt_istr_equal("text/plain", b->subtype) &&
-            !mutt_istr_equal("application/postscript", b->subtype))
+        if (!mutt_can_decode(b))
         {
-          if (!mutt_can_decode(b))
-          {
-            /* L10N: s gets replaced by a MIME type, e.g. "text/plain" or
-               application/octet-stream.  */
-            mutt_error(_("I don't know how to print %s attachments"), type);
-            return false;
-          }
+          /* L10N: s gets replaced by a MIME type, e.g. "text/plain" or
+             application/octet-stream.  */
+          mutt_error(_("I don't know how to print %s attachments"), type);
+          return false;
         }
       }
     }
-    if (!tag)
-      break;
   }
   return true;
 }
 
 /**
  * print_attachment_list - Print a list of Attachments
- * @param actx  Attachment context
- * @param fp    File handle to the attachment (OPTIONAL)
- * @param tag   Apply to all tagged Attachments
- * @param b     First Attachment
+ * @param aa    Selected attachments
  * @param state File state for decoding the attachments
  */
-static void print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
-                                  struct Body *b, struct State *state)
+static void print_attachment_list(struct AttachPtrArray *aa, struct State *state)
 {
   char type[256] = { 0 };
 
   const bool c_attach_split = cs_subset_bool(NeoMutt->sub, "attach_split");
   const char *const c_attach_sep = cs_subset_string(NeoMutt->sub, "attach_sep");
 
-  for (int i = 0; !tag || (i < actx->idxlen); i++)
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, aa)
   {
-    if (tag)
+    FILE *fp = (*app)->fp;
+    struct Body *b = (*app)->body;
+
+    snprintf(type, sizeof(type), "%s/%s", BODY_TYPE(b), b->subtype);
+    if (!c_attach_split && !mailcap_lookup(b, type, sizeof(type), NULL, MUTT_MC_PRINT))
     {
-      fp = actx->idx[i]->fp;
-      b = actx->idx[i]->body;
-    }
-    if (!tag || b->tagged)
-    {
-      snprintf(type, sizeof(type), "%s/%s", BODY_TYPE(b), b->subtype);
-      if (!c_attach_split && !mailcap_lookup(b, type, sizeof(type), NULL, MUTT_MC_PRINT))
+      if (mutt_istr_equal("text/plain", b->subtype) ||
+          mutt_istr_equal("application/postscript", b->subtype))
       {
-        if (mutt_istr_equal("text/plain", b->subtype) ||
-            mutt_istr_equal("application/postscript", b->subtype))
-        {
-          pipe_attachment(fp, b, state);
-        }
-        else if (mutt_can_decode(b))
-        {
-          /* decode and print */
+        pipe_attachment(fp, b, state);
+      }
+      else if (mutt_can_decode(b))
+      {
+        /* decode and print */
 
-          FILE *fp_in = NULL;
-          struct Buffer *newfile = buf_pool_get();
+        FILE *fp_in = NULL;
+        struct Buffer *newfile = buf_pool_get();
 
-          buf_mktemp(newfile);
-          if (mutt_decode_save_attachment(fp, b, buf_string(newfile),
-                                          STATE_PRINTING, MUTT_SAVE_NO_FLAGS) == 0)
+        buf_mktemp(newfile);
+        if (mutt_decode_save_attachment(fp, b, buf_string(newfile),
+                                        STATE_PRINTING, MUTT_SAVE_NO_FLAGS) == 0)
+        {
+          if (!state->fp_out)
           {
-            if (!state->fp_out)
-            {
-              mutt_error("BUG in print_attachment_list().  Please report this. ");
-              mutt_file_unlink(buf_string(newfile));
-              buf_pool_release(&newfile);
-              return;
-            }
-
-            fp_in = mutt_file_fopen(buf_string(newfile), "r");
-            if (fp_in)
-            {
-              mutt_file_copy_stream(fp_in, state->fp_out);
-              mutt_file_fclose(&fp_in);
-              if (c_attach_sep)
-                state_puts(state, c_attach_sep);
-            }
+            mutt_error("BUG in print_attachment_list().  Please report this. ");
+            mutt_file_unlink(buf_string(newfile));
+            buf_pool_release(&newfile);
+            return;
           }
-          mutt_file_unlink(buf_string(newfile));
-          buf_pool_release(&newfile);
+
+          fp_in = mutt_file_fopen(buf_string(newfile), "r");
+          if (fp_in)
+          {
+            mutt_file_copy_stream(fp_in, state->fp_out);
+            mutt_file_fclose(&fp_in);
+            if (c_attach_sep)
+              state_puts(state, c_attach_sep);
+          }
         }
-      }
-      else
-      {
-        mutt_print_attachment(fp, b);
+        mutt_file_unlink(buf_string(newfile));
+        buf_pool_release(&newfile);
       }
     }
-    if (!tag)
-      break;
+    else
+    {
+      mutt_print_attachment(fp, b);
+    }
   }
 }
 
 /**
- * mutt_print_attachment_list - Print a list of Attachments
- * @param actx Attachment context
- * @param fp   File handle to the attachment (OPTIONAL)
- * @param tag  Apply to all tagged Attachments
- * @param b    First Attachment
+ * mutt_print_attachment_list - Print selected attachments
+ * @param aa Selected attachments
  */
-void mutt_print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag, struct Body *b)
+void mutt_print_attachment_list(struct AttachPtrArray *aa)
 {
   char prompt[128] = { 0 };
   struct State state = { 0 };
-  int tagmsgcount = 0;
+  const int count = ARRAY_SIZE(aa);
 
-  if (tag)
-    for (int i = 0; i < actx->idxlen; i++)
-      if (actx->idx[i]->body->tagged)
-        tagmsgcount++;
+  if (count == 0)
+    return;
 
   snprintf(prompt, sizeof(prompt),
-           tag ? ngettext("Print tagged attachment?", "Print %d tagged attachments?", tagmsgcount) :
-                 _("Print attachment?"),
-           tagmsgcount);
+           ngettext("Print attachment?", "Print %d attachments?", count), count);
   if (query_quadoption(prompt, NeoMutt->sub, "print") != MUTT_YES)
     return;
 
   const bool c_attach_split = cs_subset_bool(NeoMutt->sub, "attach_split");
   if (c_attach_split)
   {
-    print_attachment_list(actx, fp, tag, b, &state);
+    print_attachment_list(aa, &state);
   }
   else
   {
-    if (!can_print(actx, b, tag))
+    if (!can_print(aa))
       return;
     mutt_endwin();
     const char *const c_print_command = cs_subset_string(NeoMutt->sub, "print_command");
     pid_t pid = filter_create(NONULL(c_print_command), &state.fp_out, NULL,
                               NULL, NeoMutt->env);
-    print_attachment_list(actx, fp, tag, b, &state);
+    print_attachment_list(aa, &state);
     mutt_file_fclose(&state.fp_out);
     const bool c_wait_key = cs_subset_bool(NeoMutt->sub, "wait_key");
     if ((filter_wait(pid) != 0) || c_wait_key)
@@ -1040,21 +995,30 @@ int mutt_attach_display_loop(struct ConfigSubset *sub, struct Menu *menu, int op
       case OP_PIPE:
       {
         struct AttachPtr *cur_att = current_attachment(actx, menu);
-        mutt_pipe_attachment_list(actx, cur_att->fp, false, cur_att->body, false);
+        struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+        ARRAY_ADD(&aa, cur_att);
+        mutt_pipe_attachment_list(&aa, false);
+        ARRAY_FREE(&aa);
         op = OP_ATTACH_VIEW;
         break;
       }
       case OP_ATTACH_PRINT:
       {
         struct AttachPtr *cur_att = current_attachment(actx, menu);
-        mutt_print_attachment_list(actx, cur_att->fp, false, cur_att->body);
+        struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+        ARRAY_ADD(&aa, cur_att);
+        mutt_print_attachment_list(&aa);
+        ARRAY_FREE(&aa);
         op = OP_ATTACH_VIEW;
         break;
       }
       case OP_ATTACH_SAVE:
       {
         struct AttachPtr *cur_att = current_attachment(actx, menu);
-        mutt_save_attachment_list(actx, cur_att->fp, false, cur_att->body, e, NULL);
+        struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+        ARRAY_ADD(&aa, cur_att);
+        mutt_save_attachment_list(&aa, e, NULL);
+        ARRAY_FREE(&aa);
         op = OP_ATTACH_VIEW;
         break;
       }
@@ -1232,37 +1196,95 @@ void mutt_update_recvattach_menu(struct AttachCtx *actx, struct Menu *menu, bool
 }
 
 /**
- * ba_add_tagged - Get an array of tagged Attachments
- * @param ba   Empty BodyArray to populate
+ * aa_add_tagged - Get an array of tagged Attachments
+ * @param aa   Empty AttachPtrArray to populate
  * @param actx List of Attachments
- * @param menu Menu
  * @retval num Number of selected Attachments
  * @retval -1  Error
  */
-int ba_add_tagged(struct BodyArray *ba, struct AttachCtx *actx, struct Menu *menu)
+static int aa_add_tagged(struct AttachPtrArray *aa, struct AttachCtx *actx)
 {
-  if (!ba || !actx || !menu)
+  if (!aa || !actx)
     return -1;
 
-  if (menu->tag_prefix)
+  for (int i = 0; i < actx->idxlen; i++)
   {
-    for (int i = 0; i < actx->idxlen; i++)
-    {
-      struct Body *b = actx->idx[i]->body;
-      if (b->tagged)
-      {
-        ARRAY_ADD(ba, b);
-      }
-    }
+    if (actx->idx[i]->body->tagged)
+      ARRAY_ADD(aa, actx->idx[i]);
   }
-  else
+
+  return ARRAY_SIZE(aa);
+}
+
+/**
+ * aa_add_selection - Build a working set of Attachments for an action
+ * @param aa         Empty AttachPtrArray to populate
+ * @param actx       List of Attachments
+ * @param menu       Menu
+ * @param use_tagged Use tagged attachments
+ * @param count      Repeat-count (0 or 1 == current selection)
+ * @retval num Number of selected Attachments
+ * @retval -1  Error
+ */
+int aa_add_selection(struct AttachPtrArray *aa, struct AttachCtx *actx,
+                     struct Menu *menu, bool use_tagged, int count)
+{
+  if (!aa || !actx || !menu)
+    return -1;
+
+  if (use_tagged)
+    return aa_add_tagged(aa, actx);
+
+  const int index = menu_get_index(menu);
+  if ((index < 0) || (index >= actx->vcount))
+    return -1;
+
+  int n = (count > 1) ? count : 1;
+  if ((index + n) > actx->vcount)
+    n = actx->vcount - index;
+
+  for (int i = 0; i < n; i++)
   {
-    struct AttachPtr *cur = current_attachment(actx, menu);
-    if (!cur)
+    const int rindex = actx->v2r[index + i];
+    if ((rindex < 0) || (rindex >= actx->idxlen))
       return -1;
 
-    ARRAY_ADD(ba, cur->body);
+    ARRAY_ADD(aa, actx->idx[rindex]);
   }
 
-  return ARRAY_SIZE(ba);
+  return ARRAY_SIZE(aa);
+}
+
+/**
+ * ba_add_selection - Build a working set of attachment bodies for an action
+ * @param ba         Empty BodyArray to populate
+ * @param actx       List of Attachments
+ * @param menu       Menu
+ * @param use_tagged Use tagged attachments
+ * @param count      Repeat-count (0 or 1 == current selection)
+ * @retval num Number of selected Attachments
+ * @retval -1  Error
+ */
+int ba_add_selection(struct BodyArray *ba, struct AttachCtx *actx,
+                     struct Menu *menu, bool use_tagged, int count)
+{
+  if (!ba)
+    return -1;
+
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  if (aa_add_selection(&aa, actx, menu, use_tagged, count) < 0)
+  {
+    ARRAY_FREE(&aa);
+    return -1;
+  }
+
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, &aa)
+  {
+    ARRAY_ADD(ba, (*app)->body);
+  }
+
+  const int rc = ARRAY_SIZE(ba);
+  ARRAY_FREE(&aa);
+  return rc;
 }

--- a/attach/recvattach.h
+++ b/attach/recvattach.h
@@ -27,6 +27,7 @@
 #include <stdio.h>
 
 struct AttachCtx;
+struct AttachPtrArray;
 struct Body;
 struct BodyArray;
 struct ConfigSubset;
@@ -44,6 +45,7 @@ struct AttachPtr *current_attachment(struct AttachCtx *actx, struct Menu *menu);
 void mutt_update_recvattach_menu(struct AttachCtx *actx, struct Menu *menu, bool init);
 void recvattach_edit_content_type(struct AttachCtx *actx, struct Menu *menu, struct Email *e);
 
-int ba_add_tagged(struct BodyArray *ba, struct AttachCtx *actx, struct Menu *menu);
+int aa_add_selection(struct AttachPtrArray *aa, struct AttachCtx *actx, struct Menu *menu, bool use_tagged, int count);
+int ba_add_selection(struct BodyArray *ba,      struct AttachCtx *actx, struct Menu *menu, bool use_tagged, int count);
 
 #endif /* MUTT_ATTACH_RECVATTACH_H */

--- a/attach/recvcmd.c
+++ b/attach/recvcmd.c
@@ -77,76 +77,74 @@ static bool check_msg(struct Body *b, bool err)
 }
 
 /**
- * check_all_msg - Are all the Attachments RFC822 messages?
- * @param actx Attachment context
- * @param b    Current message
+ * check_all_msg - Are all the selected Attachments RFC822 messages?
+ * @param aa   Selected attachments
  * @param err  If true, report errors
  * @retval true All parts are RFC822 messages
  */
-static bool check_all_msg(struct AttachCtx *actx, struct Body *b, bool err)
+static bool check_all_msg(struct AttachPtrArray *aa, bool err)
 {
-  if (b && !check_msg(b, err))
-    return false;
-  if (!b)
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, aa)
   {
-    for (short i = 0; i < actx->idxlen; i++)
-    {
-      if (actx->idx[i]->body->tagged)
-      {
-        if (!check_msg(actx->idx[i]->body, err))
-          return false;
-      }
-    }
+    if (!check_msg((*app)->body, err))
+      return false;
   }
   return true;
 }
 
 /**
- * check_can_decode - Can we decode all tagged attachments?
- * @param actx Attachment context
- * @param b    Body of email
- * @retval true All tagged attachments are decodable
+ * check_can_decode - Can we decode all selected attachments?
+ * @param aa Selected attachments
+ * @retval true All selected attachments are decodable
  */
-static bool check_can_decode(struct AttachCtx *actx, struct Body *b)
+static bool check_can_decode(struct AttachPtrArray *aa)
 {
-  if (b)
-    return mutt_can_decode(b);
-
-  for (short i = 0; i < actx->idxlen; i++)
-    if (actx->idx[i]->body->tagged && !mutt_can_decode(actx->idx[i]->body))
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, aa)
+  {
+    if (!mutt_can_decode((*app)->body))
       return false;
+  }
 
   return true;
 }
 
 /**
- * count_tagged - Count the number of tagged attachments
- * @param actx Attachment context
- * @retval num Number of tagged attachments
+ * aa_contains_body - Does the selection contain a Body?
+ * @param aa Selected attachments
+ * @param b  Candidate Body
+ * @retval true Body is selected
  */
-static short count_tagged(struct AttachCtx *actx)
+static bool aa_contains_body(struct AttachPtrArray *aa, const struct Body *b)
 {
-  short count = 0;
-  for (short i = 0; i < actx->idxlen; i++)
-    if (actx->idx[i]->body->tagged)
-      count++;
+  if (!b)
+    return false;
 
-  return count;
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, aa)
+  {
+    if ((*app)->body == b)
+      return true;
+  }
+
+  return false;
 }
 
 /**
- * count_tagged_children - Tagged children below a multipart/message attachment
+ * count_selected_children - Selected children below a multipart/message attachment
  * @param actx Attachment context
  * @param i    Index of first attachment
- * @retval num Number of tagged attachments
+ * @param aa   Selected attachments
+ * @retval num Number of selected attachments
  */
-static short count_tagged_children(struct AttachCtx *actx, short i)
+static short count_selected_children(struct AttachCtx *actx, short i, struct AttachPtrArray *aa)
 {
   short level = actx->idx[i]->level;
   short count = 0;
 
   while ((++i < actx->idxlen) && (level < actx->idx[i]->level))
-    if (actx->idx[i]->body->tagged)
+    if (aa_contains_body(aa, actx->idx[i]->body))
       count++;
 
   return count;
@@ -154,18 +152,15 @@ static short count_tagged_children(struct AttachCtx *actx, short i)
 
 /**
  * attach_bounce_message - Bounce function, from the attachment menu
- * @param m    Mailbox
- * @param fp   Handle of message
- * @param actx Attachment context
- * @param b    Body of email
+ * @param aa Selected attachments
+ * @param m  Mailbox
  */
-void attach_bounce_message(struct Mailbox *m, FILE *fp, struct AttachCtx *actx,
-                           struct Body *b)
+void attach_bounce_message(struct AttachPtrArray *aa, struct Mailbox *m)
 {
-  if (!m || !fp || !actx)
+  if (!m || ARRAY_EMPTY(aa))
     return;
 
-  if (!check_all_msg(actx, b, true))
+  if (!check_all_msg(aa, true))
     return;
 
   struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
@@ -174,36 +169,23 @@ void attach_bounce_message(struct Mailbox *m, FILE *fp, struct AttachCtx *actx,
 
   /* RFC5322 mandates a From: header, so warn before bouncing
    * messages without one */
-  if (b)
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, aa)
   {
-    if (TAILQ_EMPTY(&b->email->env->from))
+    if (TAILQ_EMPTY(&(*app)->body->email->env->from))
     {
       mutt_error(_("Warning: message contains no From: header"));
       mutt_clear_error();
-    }
-  }
-  else
-  {
-    for (short i = 0; i < actx->idxlen; i++)
-    {
-      if (actx->idx[i]->body->tagged)
-      {
-        if (TAILQ_EMPTY(&actx->idx[i]->body->email->env->from))
-        {
-          mutt_error(_("Warning: message contains no From: header"));
-          mutt_clear_error();
-          break;
-        }
-      }
+      break;
     }
   }
 
   /* one or more messages? */
-  int num_msg = b ? 1 : count_tagged(actx);
+  const int num_msg = ARRAY_SIZE(aa);
   if (num_msg == 1)
     buf_strcpy(prompt, _("Bounce message to: "));
   else
-    buf_strcpy(prompt, _("Bounce tagged messages to: "));
+    buf_strcpy(prompt, _("Bounce messages to: "));
 
   if ((mw_get_field(buf_string(prompt), buf, MUTT_COMP_NO_FLAGS, HC_ALIAS,
                     &CompleteAliasOps, NULL) != 0) ||
@@ -246,22 +228,11 @@ void attach_bounce_message(struct Mailbox *m, FILE *fp, struct AttachCtx *actx,
   msgwin_clear_text(NULL);
 
   int rc = 0;
-  if (b)
+  ARRAY_FOREACH(app, aa)
   {
-    rc = mutt_bounce_message(fp, m, b->email, &al, NeoMutt->sub);
-  }
-  else
-  {
-    for (short i = 0; i < actx->idxlen; i++)
+    if (mutt_bounce_message((*app)->fp, m, (*app)->body->email, &al, NeoMutt->sub))
     {
-      if (actx->idx[i]->body->tagged)
-      {
-        if (mutt_bounce_message(actx->idx[i]->fp, m, actx->idx[i]->body->email,
-                                &al, NeoMutt->sub))
-        {
-          rc = 1;
-        }
-      }
+      rc = 1;
     }
   }
 
@@ -278,54 +249,42 @@ done:
 
 /**
  * mutt_attach_resend - Resend-message, from the attachment menu
- * @param fp   File containing email
- * @param m    Current mailbox
- * @param actx Attachment context
- * @param b    Attachment
+ * @param aa Selected attachments
+ * @param m  Current mailbox
  */
-void mutt_attach_resend(FILE *fp, struct Mailbox *m, struct AttachCtx *actx, struct Body *b)
+void mutt_attach_resend(struct AttachPtrArray *aa, struct Mailbox *m)
 {
-  if (!check_all_msg(actx, b, true))
+  if (!check_all_msg(aa, true))
     return;
 
-  if (b)
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, aa)
   {
-    mutt_resend_message(fp, m, b->email, NeoMutt->sub);
-  }
-  else
-  {
-    for (short i = 0; i < actx->idxlen; i++)
-    {
-      if (actx->idx[i]->body->tagged)
-      {
-        mutt_resend_message(actx->idx[i]->fp, m, actx->idx[i]->body->email,
-                            NeoMutt->sub);
-      }
-    }
+    mutt_resend_message((*app)->fp, m, (*app)->body->email, NeoMutt->sub);
   }
 }
 
 /**
- * find_common_parent - Find a common parent message for the tagged attachments
+ * find_common_parent - Find a common parent message for the selected attachments
  * @param actx    Attachment context
- * @param nattach Number of tagged attachments
+ * @param aa      Selected attachments
  * @retval ptr Parent attachment
  * @retval NULL Failure, no common parent
  */
-static struct AttachPtr *find_common_parent(struct AttachCtx *actx, short nattach)
+static struct AttachPtr *find_common_parent(struct AttachCtx *actx, struct AttachPtrArray *aa)
 {
   short i;
-  short nchildren;
+  const short nattach = ARRAY_SIZE(aa);
 
   for (i = 0; i < actx->idxlen; i++)
-    if (actx->idx[i]->body->tagged)
+    if (aa_contains_body(aa, actx->idx[i]->body))
       break;
 
   while (--i >= 0)
   {
     if (mutt_is_message_type(actx->idx[i]->body->type, actx->idx[i]->body->subtype))
     {
-      nchildren = count_tagged_children(actx, i);
+      const short nchildren = count_selected_children(actx, i, aa);
       if (nchildren == nattach)
         return actx->idx[i];
     }
@@ -360,19 +319,21 @@ static int is_parent(short i, struct AttachCtx *actx, const struct Body *b)
 }
 
 /**
- * find_parent - Find the parent of an Attachment
- * @param actx    Attachment context
- * @param b       Attachment (OPTIONAL)
- * @param nattach Use the nth attachment
+ * find_parent - Find the parent of a selected Attachment set
+ * @param actx Attachment context
+ * @param aa   Selected attachments
  * @retval ptr  Parent attachment
  * @retval NULL No parent exists
  */
-static struct AttachPtr *find_parent(struct AttachCtx *actx, struct Body *b, short nattach)
+static struct AttachPtr *find_parent(struct AttachCtx *actx, struct AttachPtrArray *aa)
 {
   struct AttachPtr *parent = NULL;
+  const short nattach = ARRAY_SIZE(aa);
 
-  if (b)
+  if (nattach == 1)
   {
+    struct AttachPtr **app = ARRAY_GET(aa, 0);
+    struct Body *b = app ? (*app)->body : NULL;
     for (short i = 0; i < actx->idxlen; i++)
     {
       if (mutt_is_message_type(actx->idx[i]->body->type, actx->idx[i]->body->subtype) &&
@@ -386,7 +347,7 @@ static struct AttachPtr *find_parent(struct AttachCtx *actx, struct Body *b, sho
   }
   else if (nattach)
   {
-    parent = find_common_parent(actx, nattach);
+    parent = find_common_parent(actx, aa);
   }
 
   return parent;
@@ -440,20 +401,21 @@ static void include_header(bool quote, FILE *fp_in, struct Email *e,
 /**
  * copy_problematic_attachments - Attach the body parts which can't be decoded
  * @param[out] last  Body pointer to update
- * @param[in]  actx  Attachment context
+ * @param[in]  aa    Selected attachments
  * @param[in]  force If true, attach parts that can't be decoded
  * @retval ptr Pointer to last Body part
  *
  * This code is shared by forwarding and replying.
  */
 static struct Body **copy_problematic_attachments(struct Body **last,
-                                                  struct AttachCtx *actx, bool force)
+                                                  struct AttachPtrArray *aa, bool force)
 {
-  for (short i = 0; i < actx->idxlen; i++)
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, aa)
   {
-    if (actx->idx[i]->body->tagged && (force || !mutt_can_decode(actx->idx[i]->body)))
+    if (force || !mutt_can_decode((*app)->body))
     {
-      if (mutt_body_copy(actx->idx[i]->fp, last, actx->idx[i]->body) == -1)
+      if (mutt_body_copy((*app)->fp, last, (*app)->body) == -1)
         return NULL; /* XXXXX - may lead to crashes */
       last = &((*last)->next);
     }
@@ -463,16 +425,14 @@ static struct Body **copy_problematic_attachments(struct Body **last,
 
 /**
  * attach_forward_bodies - Forward one or several MIME bodies
- * @param fp      File to read from
- * @param e       Email
- * @param actx    Attachment Context
- * @param b       Body of email
- * @param nattach Number of tagged attachments
+ * @param e    Email
+ * @param actx Attachment Context
+ * @param aa   Selected attachments
  *
  * (non-message types)
  */
-static void attach_forward_bodies(FILE *fp, struct Email *e, struct AttachCtx *actx,
-                                  struct Body *b, short nattach)
+static void attach_forward_bodies(struct Email *e, struct AttachCtx *actx,
+                                  struct AttachPtrArray *aa)
 {
   bool mime_fwd_all = false;
   bool mime_fwd_any = true;
@@ -481,11 +441,16 @@ static void attach_forward_bodies(FILE *fp, struct Email *e, struct AttachCtx *a
   enum QuadOption ans = MUTT_NO;
   struct Buffer *tempfile = NULL;
   struct Buffer *prefix = buf_pool_get();
+  const short nattach = ARRAY_SIZE(aa);
+  struct AttachPtr **first = ARRAY_GET(aa, 0);
+  struct AttachPtr *current = first ? *first : NULL;
+  struct Body *b = current ? current->body : NULL;
+  FILE *fp = current ? current->fp : NULL;
 
   /* First, find the parent message.
    * Note: This could be made an option by just
    * putting the following lines into an if block.  */
-  struct AttachPtr *parent = find_parent(actx, b, nattach);
+  struct AttachPtr *parent = find_parent(actx, aa);
   if (parent)
   {
     e_parent = parent->body->email;
@@ -553,9 +518,9 @@ static void attach_forward_bodies(FILE *fp, struct Email *e, struct AttachCtx *a
 
   /* shortcut MIMEFWDREST when there is only one attachment.
    * Is this intuitive?  */
-  if (!mime_fwd_all && !b && (nattach > 1) && !check_can_decode(actx, b))
+  if (!mime_fwd_all && (nattach > 1) && !check_can_decode(aa))
   {
-    ans = query_quadoption(_("Can't decode all tagged attachments.  MIME-forward the others?"),
+    ans = query_quadoption(_("Can't decode all selected attachments.  MIME-forward the others?"),
                            NeoMutt->sub, "mime_forward_rest");
     if (ans == MUTT_ABORT)
       goto bail;
@@ -577,7 +542,7 @@ static void attach_forward_bodies(FILE *fp, struct Email *e, struct AttachCtx *a
   /* where do we append new MIME parts? */
   struct Body **last = &e_tmp->body;
 
-  if (b)
+  if (nattach == 1)
   {
     /* single body case */
 
@@ -599,18 +564,19 @@ static void attach_forward_bodies(FILE *fp, struct Email *e, struct AttachCtx *a
 
     if (!mime_fwd_all)
     {
-      for (int i = 0; i < actx->idxlen; i++)
+      struct AttachPtr **app = NULL;
+      ARRAY_FOREACH(app, aa)
       {
-        if (actx->idx[i]->body->tagged && mutt_can_decode(actx->idx[i]->body))
+        if (mutt_can_decode((*app)->body))
         {
-          state.fp_in = actx->idx[i]->fp;
-          mutt_body_handler(actx->idx[i]->body, &state);
+          state.fp_in = (*app)->fp;
+          mutt_body_handler((*app)->body, &state);
           state_putc(&state, '\n');
         }
       }
     }
 
-    if (mime_fwd_any && !copy_problematic_attachments(last, actx, mime_fwd_all))
+    if (mime_fwd_any && !copy_problematic_attachments(last, aa, mime_fwd_all))
       goto bail;
   }
 
@@ -643,9 +609,7 @@ bail:
 
 /**
  * attach_forward_msgs - Forward one or several message-type attachments
- * @param fp    File handle to attachment
- * @param actx  Attachment Context
- * @param b     Attachment to forward (OPTIONAL)
+ * @param aa    Selected attachments
  * @param flags Send mode, see #SendFlags
  *
  * This is different from the previous function since we want to mimic the
@@ -655,9 +619,16 @@ bail:
  * context structure to find messages, while, on the attachment menu, messages
  * are referenced through the attachment index.
  */
-static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx, struct Body *b, SendFlags flags)
+static void attach_forward_msgs(struct AttachPtrArray *aa, SendFlags flags)
 {
-  struct Email *e_cur = NULL;
+  struct AttachPtr **first = ARRAY_GET(aa, 0);
+  if (!first)
+    return;
+
+  struct AttachPtr *current = *first;
+  FILE *fp = current->fp;
+  struct Body *b = current->body;
+  struct Email *e_cur = current->body->email;
   struct Email *e_tmp = NULL;
   enum QuadOption ans;
   struct Body **last = NULL;
@@ -665,22 +636,6 @@ static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx, struct Body *b
   FILE *fp_tmp = NULL;
 
   CopyHeaderFlags chflags = CH_DECODE;
-
-  if (b)
-  {
-    e_cur = b->email;
-  }
-  else
-  {
-    for (short i = 0; i < actx->idxlen; i++)
-    {
-      if (actx->idx[i]->body->tagged)
-      {
-        e_cur = actx->idx[i]->body->email;
-        break;
-      }
-    }
-  }
 
   e_tmp = email_new();
   e_tmp->env = mutt_env_new();
@@ -721,7 +676,7 @@ static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx, struct Body *b
       }
     }
 
-    if (b)
+    if (ARRAY_SIZE(aa) == 1)
     {
       mutt_forward_intro(b->email, fp_tmp, NeoMutt->sub);
       mutt_copy_message_fp(fp_tmp, fp, b->email, cmflags, chflags, 0);
@@ -729,15 +684,12 @@ static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx, struct Body *b
     }
     else
     {
-      for (short i = 0; i < actx->idxlen; i++)
+      struct AttachPtr **app = NULL;
+      ARRAY_FOREACH(app, aa)
       {
-        if (actx->idx[i]->body->tagged)
-        {
-          mutt_forward_intro(actx->idx[i]->body->email, fp_tmp, NeoMutt->sub);
-          mutt_copy_message_fp(fp_tmp, actx->idx[i]->fp,
-                               actx->idx[i]->body->email, cmflags, chflags, 0);
-          mutt_forward_trailer(actx->idx[i]->body->email, fp_tmp, NeoMutt->sub);
-        }
+        mutt_forward_intro((*app)->body->email, fp_tmp, NeoMutt->sub);
+        mutt_copy_message_fp(fp_tmp, (*app)->fp, (*app)->body->email, cmflags, chflags, 0);
+        mutt_forward_trailer((*app)->body->email, fp_tmp, NeoMutt->sub);
       }
     }
     mutt_file_fclose(&fp_tmp);
@@ -745,19 +697,17 @@ static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx, struct Body *b
   else if (ans == MUTT_YES) /* do MIME encapsulation - we don't need to do much here */
   {
     last = &e_tmp->body;
-    if (b)
+    if (ARRAY_SIZE(aa) == 1)
     {
       mutt_body_copy(fp, last, b);
     }
     else
     {
-      for (short i = 0; i < actx->idxlen; i++)
+      struct AttachPtr **app = NULL;
+      ARRAY_FOREACH(app, aa)
       {
-        if (actx->idx[i]->body->tagged)
-        {
-          mutt_body_copy(actx->idx[i]->fp, last, actx->idx[i]->body);
-          last = &((*last)->next);
-        }
+        mutt_body_copy((*app)->fp, last, (*app)->body);
+        last = &((*last)->next);
       }
     }
   }
@@ -779,31 +729,29 @@ cleanup:
 }
 
 /**
- * mutt_attach_forward - Forward an Attachment
- * @param fp    Handle to the attachment
+ * mutt_attach_forward - Forward selected attachments
+ * @param aa    Selected attachments
  * @param e     Email
  * @param actx  Attachment Context
- * @param b     Current message
  * @param flags Send mode, see #SendFlags
  */
-void mutt_attach_forward(FILE *fp, struct Email *e, struct AttachCtx *actx,
-                         struct Body *b, SendFlags flags)
+void mutt_attach_forward(struct AttachPtrArray *aa, struct Email *e,
+                         struct AttachCtx *actx, SendFlags flags)
 {
-  if (check_all_msg(actx, b, false))
+  if (check_all_msg(aa, false))
   {
-    attach_forward_msgs(fp, actx, b, flags);
+    attach_forward_msgs(aa, flags);
   }
   else
   {
-    const short nattach = count_tagged(actx);
-    attach_forward_bodies(fp, e, actx, b, nattach);
+    attach_forward_bodies(e, actx, aa);
   }
 }
 
 /**
  * attach_reply_envelope_defaults - Create the envelope defaults for a reply
  * @param env    Envelope to fill in
- * @param actx   Attachment Context
+ * @param aa     Selected attachments
  * @param parent Parent Email
  * @param flags  Flags, see #SendFlags
  * @retval  0 Success
@@ -811,15 +759,15 @@ void mutt_attach_forward(FILE *fp, struct Email *e, struct AttachCtx *actx,
  *
  * This function can be invoked in two ways.
  *
- * Either, parent is NULL.  In this case, all tagged bodies are of a message type,
+ * Either, parent is NULL.  In this case, all selected bodies are of a message type,
  * and the header information is fetched from them.
  *
- * Or, parent is non-NULL.  In this case, cur is the common parent of all the
- * tagged attachments.
+ * Or, parent is non-NULL.  In this case, parent is the common parent of all the
+ * selected attachments.
  *
  * Note that this code is horribly similar to envelope_defaults() from send.c.
  */
-static int attach_reply_envelope_defaults(struct Envelope *env, struct AttachCtx *actx,
+static int attach_reply_envelope_defaults(struct Envelope *env, struct AttachPtrArray *aa,
                                           struct Email *parent, SendFlags flags)
 {
   struct Envelope *curenv = NULL;
@@ -832,20 +780,18 @@ static int attach_reply_envelope_defaults(struct Envelope *env, struct AttachCtx
   }
   else
   {
-    for (short i = 0; i < actx->idxlen; i++)
+    struct AttachPtr **app = NULL;
+    ARRAY_FOREACH(app, aa)
     {
-      if (actx->idx[i]->body->tagged)
-      {
-        e = actx->idx[i]->body->email;
-        curenv = e->env;
-        break;
-      }
+      e = (*app)->body->email;
+      curenv = e->env;
+      break;
     }
   }
 
   if (!curenv || !e)
   {
-    mutt_error(_("Can't find any tagged messages"));
+    mutt_error(_("Can't find any selected messages"));
     return -1;
   }
 
@@ -866,11 +812,10 @@ static int attach_reply_envelope_defaults(struct Envelope *env, struct AttachCtx
     }
     else
     {
-      for (short i = 0; i < actx->idxlen; i++)
+      struct AttachPtr **app = NULL;
+      ARRAY_FOREACH(app, aa)
       {
-        if (actx->idx[i]->body->tagged &&
-            (mutt_fetch_recips(env, actx->idx[i]->body->email->env, flags,
-                               NeoMutt->sub) == -1))
+        if (mutt_fetch_recips(env, (*app)->body->email->env, flags, NeoMutt->sub) == -1)
         {
           return -1;
         }
@@ -893,13 +838,10 @@ static int attach_reply_envelope_defaults(struct Envelope *env, struct AttachCtx
   }
   else
   {
-    for (short i = 0; i < actx->idxlen; i++)
+    struct AttachPtr **app = NULL;
+    ARRAY_FOREACH(app, aa)
     {
-      if (actx->idx[i]->body->tagged)
-      {
-        mutt_add_to_reference_headers(env, actx->idx[i]->body->email->env,
-                                      NeoMutt->sub);
-      }
+      mutt_add_to_reference_headers(env, (*app)->body->email->env, NeoMutt->sub);
     }
   }
 
@@ -935,19 +877,25 @@ static void attach_include_reply(FILE *fp, FILE *fp_tmp, struct Email *e)
 
 /**
  * mutt_attach_reply - Attach a reply
- * @param fp    File handle to reply
+ * @param aa    Selected attachments
  * @param m     Mailbox
  * @param e     Email
  * @param actx  Attachment Context
- * @param b     Current message
  * @param flags Send mode, see #SendFlags
  */
-void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
-                       struct AttachCtx *actx, struct Body *b, SendFlags flags)
+void mutt_attach_reply(struct AttachPtrArray *aa, struct Mailbox *m,
+                       struct Email *e, struct AttachCtx *actx, SendFlags flags)
 {
   bool mime_reply_any = false;
 
-  short nattach = 0;
+  const short nattach = ARRAY_SIZE(aa);
+  struct AttachPtr **first = ARRAY_GET(aa, 0);
+  if (!first)
+    return;
+
+  struct AttachPtr *current = *first;
+  FILE *fp = current->fp;
+  struct Body *b = current->body;
   struct AttachPtr *parent = NULL;
   struct Email *e_parent = NULL;
   FILE *fp_parent = NULL;
@@ -965,10 +913,9 @@ void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
 
   /* Determine the parent message for the reply: either the selected
    * attachment's parent or the top-level email if not nested */
-  if (!check_all_msg(actx, b, false))
+  if (!check_all_msg(aa, false))
   {
-    nattach = count_tagged(actx);
-    parent = find_parent(actx, b, nattach);
+    parent = find_parent(actx, aa);
     if (parent)
     {
       e_parent = parent->body->email;
@@ -982,9 +929,9 @@ void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
   }
 
   /* Check if non-decodable attachments should be MIME-encapsulated */
-  if ((nattach > 1) && !check_can_decode(actx, b))
+  if ((nattach > 1) && !check_can_decode(aa))
   {
-    const enum QuadOption ans = query_quadoption(_("Can't decode all tagged attachments.  MIME-encapsulate the others?"),
+    const enum QuadOption ans = query_quadoption(_("Can't decode all selected attachments.  MIME-encapsulate the others?"),
                                                  NeoMutt->sub, "mime_forward_rest");
     if (ans == MUTT_ABORT)
       goto cleanup;
@@ -999,7 +946,7 @@ void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
   e_tmp = email_new();
   e_tmp->env = mutt_env_new();
 
-  if (attach_reply_envelope_defaults(e_tmp->env, actx,
+  if (attach_reply_envelope_defaults(e_tmp->env, aa,
                                      e_parent ? e_parent : (b ? b->email : NULL),
                                      flags) == -1)
   {
@@ -1050,7 +997,7 @@ void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
     if (c_header)
       include_header(true, fp_parent, e_parent, fp_tmp, buf_string(prefix));
 
-    if (b)
+    if (nattach == 1)
     {
       if (mutt_can_decode(b))
       {
@@ -1065,12 +1012,13 @@ void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
     }
     else
     {
-      for (short i = 0; i < actx->idxlen; i++)
+      struct AttachPtr **app = NULL;
+      ARRAY_FOREACH(app, aa)
       {
-        if (actx->idx[i]->body->tagged && mutt_can_decode(actx->idx[i]->body))
+        if (mutt_can_decode((*app)->body))
         {
-          state.fp_in = actx->idx[i]->fp;
-          mutt_body_handler(actx->idx[i]->body, &state);
+          state.fp_in = (*app)->fp;
+          mutt_body_handler((*app)->body, &state);
           state_putc(&state, '\n');
         }
       }
@@ -1078,30 +1026,31 @@ void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
 
     mutt_make_attribution_trailer(e_parent, fp_tmp, NeoMutt->sub);
 
-    if (mime_reply_any && !b && !copy_problematic_attachments(&e_tmp->body, actx, false))
+    if (mime_reply_any && (nattach > 1) &&
+        !copy_problematic_attachments(&e_tmp->body, aa, false))
     {
       goto cleanup;
     }
   }
   else
   {
-    if (b)
+    if (nattach == 1)
     {
       attach_include_reply(fp, fp_tmp, b->email);
     }
     else
     {
-      for (short i = 0; i < actx->idxlen; i++)
+      struct AttachPtr **app = NULL;
+      ARRAY_FOREACH(app, aa)
       {
-        if (actx->idx[i]->body->tagged)
-          attach_include_reply(actx->idx[i]->fp, fp_tmp, actx->idx[i]->body->email);
+        attach_include_reply((*app)->fp, fp_tmp, (*app)->body->email);
       }
     }
   }
 
   mutt_file_fclose(&fp_tmp);
 
-  ARRAY_ADD(&ea, e_parent ? e_parent : (b ? b->email : NULL));
+  ARRAY_ADD(&ea, e_parent ? e_parent : b->email);
   if (mutt_send_message(flags, e_tmp, buf_string(tempfile), NULL, &ea, NeoMutt->sub) == 0)
   {
     mutt_set_flag(m, e, MUTT_REPLIED, true, true);
@@ -1122,12 +1071,11 @@ cleanup:
 
 /**
  * mutt_attach_mail_sender - Compose an email to the sender in the email attachment
- * @param actx Attachment Context
- * @param b    Current attachment
+ * @param aa Selected attachments
  */
-void mutt_attach_mail_sender(struct AttachCtx *actx, struct Body *b)
+void mutt_attach_mail_sender(struct AttachPtrArray *aa)
 {
-  if (!check_all_msg(actx, b, 0))
+  if (!check_all_msg(aa, false))
   {
     /* L10N: You will see this error message if you invoke <compose-to-sender>
        when you are on a normal attachment.  */
@@ -1138,25 +1086,14 @@ void mutt_attach_mail_sender(struct AttachCtx *actx, struct Body *b)
   struct Email *e_tmp = email_new();
   e_tmp->env = mutt_env_new();
 
-  if (b)
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, aa)
   {
-    if (mutt_fetch_recips(e_tmp->env, b->email->env, SEND_TO_SENDER, NeoMutt->sub) == -1)
+    if (mutt_fetch_recips(e_tmp->env, (*app)->body->email->env, SEND_TO_SENDER,
+                          NeoMutt->sub) == -1)
     {
       email_free(&e_tmp);
       return;
-    }
-  }
-  else
-  {
-    for (int i = 0; i < actx->idxlen; i++)
-    {
-      if (actx->idx[i]->body->tagged &&
-          (mutt_fetch_recips(e_tmp->env, actx->idx[i]->body->email->env,
-                             SEND_TO_SENDER, NeoMutt->sub) == -1))
-      {
-        email_free(&e_tmp);
-        return;
-      }
     }
   }
 

--- a/attach/recvcmd.h
+++ b/attach/recvcmd.h
@@ -23,18 +23,17 @@
 #ifndef MUTT_ATTACH_RECVCMD_H
 #define MUTT_ATTACH_RECVCMD_H
 
-#include <stdio.h>
 #include "send/lib.h"
 
 struct AttachCtx;
-struct Body;
+struct AttachPtrArray;
 struct Email;
 struct Mailbox;
 
-void attach_bounce_message  (struct Mailbox *m, FILE *fp, struct AttachCtx *actx, struct Body *b);
-void mutt_attach_resend     (FILE *fp, struct Mailbox *m, struct AttachCtx *actx, struct Body *b);
-void mutt_attach_forward    (FILE *fp, struct Email *e, struct AttachCtx *actx, struct Body *b, SendFlags flags);
-void mutt_attach_reply      (FILE *fp, struct Mailbox *m, struct Email *e, struct AttachCtx *actx, struct Body *b, SendFlags flags);
-void mutt_attach_mail_sender(struct AttachCtx *actx, struct Body *b);
+void attach_bounce_message  (struct AttachPtrArray *aa, struct Mailbox *m);
+void mutt_attach_resend     (struct AttachPtrArray *aa, struct Mailbox *m);
+void mutt_attach_forward    (struct AttachPtrArray *aa, struct Email *e, struct AttachCtx *actx, SendFlags flags);
+void mutt_attach_reply      (struct AttachPtrArray *aa, struct Mailbox *m, struct Email *e, struct AttachCtx *actx, SendFlags flags);
+void mutt_attach_mail_sender(struct AttachPtrArray *aa);
 
 #endif /* MUTT_ATTACH_RECVCMD_H */

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -28,6 +28,7 @@
  */
 
 #include "config.h"
+#include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -163,6 +164,59 @@ void destroy_state(struct BrowserState *state)
 // -----------------------------------------------------------------------------
 
 /**
+ * browser_add_selection - Build a working set of FolderFile pointers for an action
+ * @param ffpa   FolderFile Array to populate
+ * @param state  Browser state (source of entries)
+ * @param menu   Menu
+ * @param tagged Use tagged entries (tag-prefix)
+ * @param count  Repeat-count (0 or 1 == just the current selection)
+ * @retval num Number of entries added
+ *
+ * If @a tagged is true, the array is filled with the tagged entries (in
+ * source order) and @a count is ignored.
+ *
+ * Otherwise the array is filled with the current selection and the next
+ * @a count - 1 entries. Overruns are silently capped at the end of the list.
+ */
+static int browser_add_selection(struct FolderFilePtrArray *ffpa, struct BrowserState *state,
+                                 struct Menu *menu, bool tagged, int count)
+{
+  if (!ffpa || !state || !menu)
+    return 0;
+
+  const int max = ARRAY_SIZE(&state->entry);
+
+  if (tagged)
+  {
+    struct FolderFile *ff = NULL;
+    ARRAY_FOREACH(ff, &state->entry)
+    {
+      if (ff->tagged)
+        ARRAY_ADD(ffpa, ff);
+    }
+  }
+  else
+  {
+    const int index = menu_get_index(menu);
+    if ((index < 0) || (index >= max))
+      return 0;
+
+    int n = (count > 1) ? count : 1;
+    if ((index + n) > max)
+      n = max - index;
+
+    for (int i = 0; i < n; i++)
+    {
+      struct FolderFile *ff = ARRAY_GET(&state->entry, index + i);
+      if (ff)
+        ARRAY_ADD(ffpa, ff);
+    }
+  }
+
+  return ARRAY_SIZE(ffpa);
+}
+
+/**
  * op_browser_new_file - Select a new file in this directory - Implements ::browser_function_t - @ingroup browser_function_api
  */
 static int op_browser_new_file(struct BrowserPrivateData *priv, const struct KeyEvent *event)
@@ -187,55 +241,103 @@ static int op_browser_new_file(struct BrowserPrivateData *priv, const struct Key
 }
 
 /**
+ * browser_apply_subscribe_nntp - Subscribe/unsubscribe to NNTP newsgroups
+ * @param ffpa      Working set of FolderFiles
+ * @param adata     NNTP account
+ * @param subscribe true to subscribe, false to unsubscribe
+ */
+static void browser_apply_subscribe_nntp(struct FolderFilePtrArray *ffpa,
+                                         struct NntpAccountData *adata, bool subscribe)
+{
+  if (!ffpa || !adata)
+    return;
+
+  struct FolderFile **ffp = NULL;
+  ARRAY_FOREACH(ffp, ffpa)
+  {
+    struct FolderFile *ff = *ffp;
+    if (!ff || !ff->name)
+      continue;
+    if (subscribe)
+      mutt_newsgroup_subscribe(adata, ff->name);
+    else
+      mutt_newsgroup_unsubscribe(adata, ff->name);
+  }
+}
+
+/**
+ * browser_apply_subscribe_imap - Subscribe/unsubscribe to IMAP mailboxes
+ * @param ffpa      Working set of FolderFiles
+ * @param subscribe true to subscribe, false to unsubscribe
+ */
+static void browser_apply_subscribe_imap(struct FolderFilePtrArray *ffpa, bool subscribe)
+{
+  if (!ffpa)
+    return;
+
+  struct Buffer *buf = buf_pool_get();
+  struct FolderFile **ffp = NULL;
+  ARRAY_FOREACH(ffp, ffpa)
+  {
+    struct FolderFile *ff = *ffp;
+    if (!ff || !ff->name)
+      continue;
+    buf_strcpy(buf, ff->name);
+    expand_path(buf, false);
+    imap_subscribe(buf_string(buf), subscribe);
+  }
+  buf_pool_release(&buf);
+}
+
+/**
  * op_browser_subscribe - Subscribe to current mbox (IMAP/NNTP only) - Implements ::browser_function_t - @ingroup browser_function_api
  *
  * This function handles:
  * - OP_BROWSER_SUBSCRIBE
  * - OP_BROWSER_UNSUBSCRIBE
+ *
+ * Supports repeat-count: `5<subscribe>` operates on the current entry and the
+ * next 4. Overruns are silently capped at the end of the list.
  */
 static int op_browser_subscribe(struct BrowserPrivateData *priv, const struct KeyEvent *event)
 {
   struct NntpModuleData *mod_data = neomutt_get_module_data(NeoMutt, MODULE_ID_NNTP);
-  const int op = event->op;
+  const bool subscribe = (event->op == OP_BROWSER_SUBSCRIBE);
   const bool tagged = priv->menu->tag_prefix && (priv->menu->num_tagged > 0);
+
+  if (ARRAY_EMPTY(&priv->state.entry))
+  {
+    mutt_error(OptNews ? _("No newsgroups match the mask") : _("There are no mailboxes"));
+    return FR_ERROR;
+  }
+
+  struct FolderFilePtrArray ffpa = ARRAY_HEAD_INITIALIZER;
+  browser_add_selection(&ffpa, &priv->state, priv->menu, tagged, event->count);
+  if (ARRAY_EMPTY(&ffpa))
+  {
+    ARRAY_FREE(&ffpa);
+    return FR_NO_ACTION;
+  }
+  const int num = ARRAY_SIZE(&ffpa);
 
   if (OptNews)
   {
     struct NntpAccountData *adata = mod_data->current_news_srv;
-
-    if (ARRAY_EMPTY(&priv->state.entry))
-    {
-      mutt_error(_("No newsgroups match the mask"));
-      return FR_ERROR;
-    }
-
     int rc = nntp_newsrc_parse(adata);
     if (rc < 0)
+    {
+      ARRAY_FREE(&ffpa);
       return FR_ERROR;
-
-    if (tagged)
-    {
-      struct FolderFile *ff = NULL;
-      ARRAY_FOREACH(ff, &priv->state.entry)
-      {
-        if (!ff->tagged)
-          continue;
-        if (op == OP_BROWSER_SUBSCRIBE)
-          mutt_newsgroup_subscribe(adata, ff->name);
-        else
-          mutt_newsgroup_unsubscribe(adata, ff->name);
-      }
     }
-    else
-    {
-      int index = menu_get_index(priv->menu);
-      struct FolderFile *ff = ARRAY_GET(&priv->state.entry, index);
-      if (op == OP_BROWSER_SUBSCRIBE)
-        mutt_newsgroup_subscribe(adata, ff->name);
-      else
-        mutt_newsgroup_unsubscribe(adata, ff->name);
 
-      menu_set_index(priv->menu, index + 1);
+    browser_apply_subscribe_nntp(&ffpa, adata, subscribe);
+
+    if (!tagged)
+    {
+      const int index = menu_get_index(priv->menu);
+      const int next = index + num;
+      if (next < ARRAY_SIZE(&priv->state.entry))
+        menu_set_index(priv->menu, next);
     }
 
     menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
@@ -245,35 +347,10 @@ static int op_browser_subscribe(struct BrowserPrivateData *priv, const struct Ke
   }
   else
   {
-    if (ARRAY_EMPTY(&priv->state.entry))
-    {
-      mutt_error(_("There are no mailboxes"));
-      return FR_ERROR;
-    }
-
-    struct Buffer *buf = buf_pool_get();
-    if (tagged)
-    {
-      struct FolderFile *ff = NULL;
-      ARRAY_FOREACH(ff, &priv->state.entry)
-      {
-        if (!ff->tagged)
-          continue;
-        buf_strcpy(buf, ff->name);
-        expand_path(buf, false);
-        imap_subscribe(buf_string(buf), (op == OP_BROWSER_SUBSCRIBE));
-      }
-    }
-    else
-    {
-      int index = menu_get_index(priv->menu);
-      struct FolderFile *ff = ARRAY_GET(&priv->state.entry, index);
-      buf_strcpy(buf, ff->name);
-      expand_path(buf, false);
-      imap_subscribe(buf_string(buf), (op == OP_BROWSER_SUBSCRIBE));
-    }
-    buf_pool_release(&buf);
+    browser_apply_subscribe_imap(&ffpa, subscribe);
   }
+
+  ARRAY_FREE(&ffpa);
   return FR_SUCCESS;
 }
 
@@ -351,19 +428,50 @@ static int op_browser_view_file(struct BrowserPrivateData *priv, const struct Ke
 }
 
 /**
+ * browser_apply_catchup - (Un)catchup a working set of newsgroups
+ * @param ffpa  Working set of FolderFiles
+ * @param m     Mailbox
+ * @param adata NNTP account
+ * @param up    true to catchup, false to uncatchup
+ * @retval ptr  Last NntpMboxData touched (NULL if nothing changed)
+ */
+static struct NntpMboxData *browser_apply_catchup(struct FolderFilePtrArray *ffpa,
+                                                  struct Mailbox *m,
+                                                  struct NntpAccountData *adata, bool up)
+{
+  if (!ffpa || !adata)
+    return NULL;
+
+  struct NntpMboxData *mdata = NULL;
+  struct FolderFile **ffp = NULL;
+  ARRAY_FOREACH(ffp, ffpa)
+  {
+    struct FolderFile *ff = *ffp;
+    if (!ff || !ff->name)
+      continue;
+    if (up)
+      mdata = mutt_newsgroup_catchup(m, adata, ff->name);
+    else
+      mdata = mutt_newsgroup_uncatchup(m, adata, ff->name);
+  }
+  return mdata;
+}
+
+/**
  * op_catchup - Mark all articles in newsgroup as read - Implements ::browser_function_t - @ingroup browser_function_api
  *
  * This function handles:
  * - OP_CATCHUP
  * - OP_UNCATCHUP
+ *
+ * Supports repeat-count: `5<catchup>` operates on the current entry and the
+ * next 4. Overruns are silently capped at the end of the list.
  */
 static int op_catchup(struct BrowserPrivateData *priv, const struct KeyEvent *event)
 {
   struct NntpModuleData *mod_data = neomutt_get_module_data(NeoMutt, MODULE_ID_NNTP);
   if (!OptNews)
     return FR_NOT_IMPL;
-
-  struct NntpMboxData *mdata = NULL;
 
   int rc = nntp_newsrc_parse(mod_data->current_news_srv);
   if (rc < 0)
@@ -373,37 +481,29 @@ static int op_catchup(struct BrowserPrivateData *priv, const struct KeyEvent *ev
     return FR_ERROR;
 
   const bool tagged = priv->menu->tag_prefix && (priv->menu->num_tagged > 0);
-  if (tagged)
-  {
-    struct FolderFile *ff = NULL;
-    ARRAY_FOREACH(ff, &priv->state.entry)
-    {
-      if (!ff->tagged)
-        continue;
-      if (event->op == OP_CATCHUP)
-        mdata = mutt_newsgroup_catchup(priv->mailbox, mod_data->current_news_srv, ff->name);
-      else
-        mdata = mutt_newsgroup_uncatchup(priv->mailbox,
-                                         mod_data->current_news_srv, ff->name);
-    }
-    if (mdata)
-      nntp_newsrc_update(mod_data->current_news_srv);
-  }
-  else
-  {
-    int index = menu_get_index(priv->menu);
-    struct FolderFile *ff = ARRAY_GET(&priv->state.entry, index);
-    if (event->op == OP_CATCHUP)
-      mdata = mutt_newsgroup_catchup(priv->mailbox, mod_data->current_news_srv, ff->name);
-    else
-      mdata = mutt_newsgroup_uncatchup(priv->mailbox, mod_data->current_news_srv, ff->name);
 
-    if (mdata)
+  struct FolderFilePtrArray ffpa = ARRAY_HEAD_INITIALIZER;
+  browser_add_selection(&ffpa, &priv->state, priv->menu, tagged, event->count);
+  if (ARRAY_EMPTY(&ffpa))
+  {
+    ARRAY_FREE(&ffpa);
+    return FR_NO_ACTION;
+  }
+  const int num = ARRAY_SIZE(&ffpa);
+
+  struct NntpMboxData *mdata = browser_apply_catchup(&ffpa, priv->mailbox,
+                                                     mod_data->current_news_srv,
+                                                     (event->op == OP_CATCHUP));
+  ARRAY_FREE(&ffpa);
+
+  if (mdata)
+  {
+    nntp_newsrc_update(mod_data->current_news_srv);
+    if (!tagged)
     {
-      nntp_newsrc_update(mod_data->current_news_srv);
-      index = menu_get_index(priv->menu) + 1;
-      if (index < priv->menu->max)
-        menu_set_index(priv->menu, index);
+      const int next = menu_get_index(priv->menu) + num;
+      if (next < priv->menu->max)
+        menu_set_index(priv->menu, next);
     }
   }
 
@@ -565,7 +665,53 @@ static int op_create_mailbox(struct BrowserPrivateData *priv, const struct KeyEv
 }
 
 /**
+ * browser_apply_delete_mailbox - Delete a working set of IMAP mailboxes
+ * @param[in]  ffpa       Working set of FolderFiles (ascending source order)
+ * @param[in]  state      Browser state (source array)
+ * @param[in]  m          Current mailbox
+ * @param[out] num_failed Number of mailbox deletions that failed
+ * @retval num Number of mailboxes successfully deleted (and removed from state)
+ *
+ * Iterates the working set in reverse so that ARRAY_REMOVE() does not
+ * invalidate the pointers we still need.
+ */
+static int browser_apply_delete_mailbox(struct FolderFilePtrArray *ffpa,
+                                        struct BrowserState *state,
+                                        struct Mailbox *m, int *num_failed)
+{
+  int deleted = 0;
+  int failed = 0;
+
+  if (ffpa && state)
+  {
+    struct FolderFile **ffp = NULL;
+    ARRAY_FOREACH_REVERSE(ffp, ffpa)
+    {
+      struct FolderFile *ff = *ffp;
+      if (!ff || !ff->name)
+        continue;
+      if (imap_delete_mailbox(m, ff->name) != 0)
+      {
+        failed++;
+        continue;
+      }
+      FREE(&ff->name);
+      FREE(&ff->desc);
+      ARRAY_REMOVE(&state->entry, ff);
+      deleted++;
+    }
+  }
+
+  if (num_failed)
+    *num_failed = failed;
+  return deleted;
+}
+
+/**
  * op_delete_mailbox - Delete the current mailbox (IMAP only) - Implements ::browser_function_t - @ingroup browser_function_api
+ *
+ * Supports repeat-count: `5<delete-mailbox>` deletes the current entry and
+ * the next 4. Overruns are silently capped at the end of the list.
  */
 static int op_delete_mailbox(struct BrowserPrivateData *priv, const struct KeyEvent *event)
 {
@@ -573,101 +719,69 @@ static int op_delete_mailbox(struct BrowserPrivateData *priv, const struct KeyEv
     return FR_ERROR;
 
   const bool tagged = priv->menu->tag_prefix && (priv->menu->num_tagged > 0);
-  char msg[128] = { 0 };
 
-  if (tagged)
+  struct FolderFilePtrArray ffpa = ARRAY_HEAD_INITIALIZER;
+  browser_add_selection(&ffpa, &priv->state, priv->menu, tagged, event->count);
+  if (ARRAY_EMPTY(&ffpa))
   {
-    struct FolderFile *ff = NULL;
-    bool failed = false;
-    ARRAY_FOREACH(ff, &priv->state.entry)
-    {
-      if (!ff->tagged)
-        continue;
-      if (!ff->imap)
-      {
-        mutt_error(_("Delete is only supported for IMAP mailboxes"));
-        return FR_ERROR;
-      }
-      // TODO(sileht): It could be better to select INBOX instead. But I
-      // don't want to manipulate Mailboxes/mailbox->account here for now.
-      // Let's just protect neomutt against crash for now. #1417
-      if (mutt_str_equal(mailbox_path(priv->mailbox), ff->name))
-      {
-        mutt_error(_("Can't delete currently selected mailbox"));
-        return FR_ERROR;
-      }
-    }
-
-    snprintf(msg, sizeof(msg), _("Really delete %d tagged mailboxes?"),
-             priv->menu->num_tagged);
-    if (query_yesorno(msg, MUTT_NO) != MUTT_YES)
-    {
-      mutt_message(_("Mailbox not deleted"));
-      return FR_NO_ACTION;
-    }
-
-    int deleted = 0;
-    ARRAY_FOREACH_REVERSE(ff, &priv->state.entry)
-    {
-      if (!ff->tagged)
-        continue;
-      if (imap_delete_mailbox(priv->mailbox, ff->name) != 0)
-      {
-        mutt_error(_("Mailbox deletion failed"));
-        failed = true;
-        continue;
-      }
-      /* free the mailbox from the browser */
-      FREE(&ff->name);
-      FREE(&ff->desc);
-      /* and move all other entries up */
-      ARRAY_REMOVE(&priv->state.entry, ff);
-      deleted++;
-    }
-    mutt_message(_("%d mailboxes deleted"), deleted);
-    init_menu(&priv->state, priv->menu, priv->mailbox, priv->sbar);
-    return failed ? FR_ERROR : FR_SUCCESS;
-  }
-
-  int index = menu_get_index(priv->menu);
-  struct FolderFile *ff = ARRAY_GET(&priv->state.entry, index);
-  if (!ff->imap)
-  {
-    mutt_error(_("Delete is only supported for IMAP mailboxes"));
-    return FR_ERROR;
-  }
-
-  // TODO(sileht): It could be better to select INBOX instead. But I
-  // don't want to manipulate Mailboxes/mailbox->account here for now.
-  // Let's just protect neomutt against crash for now. #1417
-  if (mutt_str_equal(mailbox_path(priv->mailbox), ff->name))
-  {
-    mutt_error(_("Can't delete currently selected mailbox"));
-    return FR_ERROR;
-  }
-
-  snprintf(msg, sizeof(msg), _("Really delete mailbox \"%s\"?"), ff->name);
-  if (query_yesorno(msg, MUTT_NO) != MUTT_YES)
-  {
-    mutt_message(_("Mailbox not deleted"));
+    ARRAY_FREE(&ffpa);
     return FR_NO_ACTION;
   }
 
-  if (imap_delete_mailbox(priv->mailbox, ff->name) != 0)
+  // Pre-flight validation
+  struct FolderFile **ffp = NULL;
+  ARRAY_FOREACH(ffp, &ffpa)
   {
-    mutt_error(_("Mailbox deletion failed"));
-    return FR_ERROR;
+    struct FolderFile *ff = *ffp;
+    if (!ff->imap)
+    {
+      mutt_error(_("Delete is only supported for IMAP mailboxes"));
+      ARRAY_FREE(&ffpa);
+      return FR_ERROR;
+    }
+    // TODO(sileht): It could be better to select INBOX instead. But I
+    // don't want to manipulate Mailboxes/mailbox->account here for now.
+    // Let's just protect neomutt against crash for now. #1417
+    if (mutt_str_equal(mailbox_path(priv->mailbox), ff->name))
+    {
+      mutt_error(_("Can't delete currently selected mailbox"));
+      ARRAY_FREE(&ffpa);
+      return FR_ERROR;
+    }
   }
 
-  /* free the mailbox from the browser */
-  FREE(&ff->name);
-  FREE(&ff->desc);
-  /* and move all other entries up */
-  ARRAY_REMOVE(&priv->state.entry, ff);
-  mutt_message(_("Mailbox deleted"));
-  init_menu(&priv->state, priv->menu, priv->mailbox, priv->sbar);
+  const int num = ARRAY_SIZE(&ffpa);
+  char msg[128] = { 0 };
+  if (num > 1)
+  {
+    snprintf(msg, sizeof(msg), _("Really delete %d tagged mailboxes?"), num);
+  }
+  else
+  {
+    struct FolderFile *ff = *ARRAY_FIRST(&ffpa);
+    snprintf(msg, sizeof(msg), _("Really delete mailbox \"%s\"?"), ff->name);
+  }
+  if (query_yesorno(msg, MUTT_NO) != MUTT_YES)
+  {
+    mutt_message(_("Mailbox not deleted"));
+    ARRAY_FREE(&ffpa);
+    return FR_NO_ACTION;
+  }
 
-  return FR_SUCCESS;
+  int failed = 0;
+  const int deleted = browser_apply_delete_mailbox(&ffpa, &priv->state,
+                                                   priv->mailbox, &failed);
+  ARRAY_FREE(&ffpa);
+
+  if (failed > 0)
+    mutt_error(_("Mailbox deletion failed"));
+  else if (num > 1)
+    mutt_message(_("%d mailboxes deleted"), deleted);
+  else if (deleted == 1)
+    mutt_message(_("Mailbox deleted"));
+
+  init_menu(&priv->state, priv->menu, priv->mailbox, priv->sbar);
+  return failed ? FR_ERROR : FR_SUCCESS;
 }
 
 /**

--- a/browser/lib.h
+++ b/browser/lib.h
@@ -102,8 +102,8 @@ struct FolderFile
 
   int gen;                 ///< Unique id, used for (un)sorting
 };
-
 ARRAY_HEAD(BrowserEntryArray, struct FolderFile);
+ARRAY_HEAD(FolderFilePtrArray, struct FolderFile *);
 
 /**
  * ExpandoDataFolder - Expando UIDs for the File Browser

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -667,7 +667,7 @@ static int move_attachment(struct ComposeSharedData *shared, bool up)
 
   struct Body *cur_body = cur_att->body;
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  ba_add_tagged(&ba, actx, menu);
+  // ba_add_tagged(&ba, actx, menu);
   if (ARRAY_EMPTY(&ba))
     goto done;
 
@@ -1300,7 +1300,7 @@ static int op_attach_edit_content_id(struct ComposeFunctionData *fdata,
   struct Buffer *buf = buf_pool_get();
   struct Buffer *cid = buf_pool_get();
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  ba_add_tagged(&ba, actx, menu);
+  // ba_add_tagged(&ba, actx, menu);
 
   struct AttachPtr *cur_att = current_attachment(actx, menu);
 
@@ -1391,7 +1391,7 @@ static int op_attach_edit_description(struct ComposeFunctionData *fdata,
   /* header names should not be translated */
   if (mw_get_field("Description: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) == 0)
   {
-    ba_add_tagged(&ba, actx, menu);
+    // ba_add_tagged(&ba, actx, menu);
 
     bool changed = false;
     struct Body **bp = NULL;
@@ -1443,7 +1443,7 @@ static int op_attach_edit_encoding(struct ComposeFunctionData *fdata,
     int enc = mutt_check_encoding(buf_string(buf));
     if ((enc != ENC_OTHER) && (enc != ENC_UUENCODED))
     {
-      ba_add_tagged(&ba, actx, menu);
+      // ba_add_tagged(&ba, actx, menu);
 
       bool changed = false;
       struct Body **bp = NULL;
@@ -1497,7 +1497,7 @@ static int op_attach_edit_language(struct ComposeFunctionData *fdata,
   buf_strcpy(buf, cur_att->body->language);
   if (mw_get_field("Content-Language: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) == 0)
   {
-    ba_add_tagged(&ba, actx, menu);
+    // ba_add_tagged(&ba, actx, menu);
 
     bool changed = false;
     struct Body **bp = NULL;
@@ -1543,7 +1543,7 @@ static int op_attach_edit_mime(struct ComposeFunctionData *fdata, const struct K
   int rc = FR_NO_ACTION;
   struct Menu *menu = shared->adata->menu;
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  ba_add_tagged(&ba, actx, menu);
+  // ba_add_tagged(&ba, actx, menu);
   if (ARRAY_EMPTY(&ba))
     goto done;
 
@@ -1612,8 +1612,8 @@ static int op_attach_filter(struct ComposeFunctionData *fdata, const struct KeyE
   }
 
   const int op = event->op;
-  mutt_pipe_attachment_list(actx, NULL, menu->tag_prefix, cur_att->body,
-                            (op == OP_ATTACH_FILTER));
+  // mutt_pipe_attachment_list(actx, NULL, menu->tag_prefix, cur_att->body,
+  //                           (op == OP_ATTACH_FILTER));
   if (op == OP_ATTACH_FILTER) /* cte might have changed */
   {
     menu_queue_redraw(menu, menu->tag_prefix ? MENU_REDRAW_FULL : MENU_REDRAW_CURRENT);
@@ -1637,7 +1637,7 @@ static int op_attach_get_attachment(struct ComposeFunctionData *fdata,
   int rc = FR_ERROR;
   struct Menu *menu = shared->adata->menu;
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  ba_add_tagged(&ba, actx, menu);
+  // ba_add_tagged(&ba, actx, menu);
   if (ARRAY_EMPTY(&ba))
     goto done;
 
@@ -1941,7 +1941,7 @@ static int op_attach_print(struct ComposeFunctionData *fdata, const struct KeyEv
     return FR_ERROR;
   }
 
-  mutt_print_attachment_list(actx, NULL, menu->tag_prefix, cur_att->body);
+  // mutt_print_attachment_list(actx, NULL, menu->tag_prefix, cur_att->body);
   /* no send2hook, since this doesn't modify the message */
   return FR_SUCCESS;
 }
@@ -1995,7 +1995,7 @@ static int op_attach_save(struct ComposeFunctionData *fdata, const struct KeyEve
     return FR_ERROR;
   }
 
-  mutt_save_attachment_list(actx, NULL, menu->tag_prefix, cur_att->body, NULL, menu);
+  // mutt_save_attachment_list(actx, NULL, menu->tag_prefix, cur_att->body, NULL, menu);
   /* no send2hook, since this doesn't modify the message */
   return FR_SUCCESS;
 }
@@ -2015,7 +2015,7 @@ static int op_attach_toggle_disposition(struct ComposeFunctionData *fdata,
   int rc = FR_NO_ACTION;
   struct Menu *menu = shared->adata->menu;
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  ba_add_tagged(&ba, actx, menu);
+  // ba_add_tagged(&ba, actx, menu);
 
   struct Body **bp = NULL;
   ARRAY_FOREACH(bp, &ba)
@@ -2046,7 +2046,7 @@ static int op_attach_toggle_recode(struct ComposeFunctionData *fdata,
   int rc = FR_NO_ACTION;
   struct Menu *menu = shared->adata->menu;
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  ba_add_tagged(&ba, actx, menu);
+  // ba_add_tagged(&ba, actx, menu);
 
   struct Body **bp = NULL;
   ARRAY_FOREACH(bp, &ba)
@@ -2098,7 +2098,7 @@ static int op_attach_toggle_unlink(struct ComposeFunctionData *fdata,
   int rc = FR_NO_ACTION;
   struct Menu *menu = shared->adata->menu;
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  ba_add_tagged(&ba, actx, menu);
+  // ba_add_tagged(&ba, actx, menu);
 
   struct Body **bp = NULL;
   ARRAY_FOREACH(bp, &ba)
@@ -2192,7 +2192,7 @@ static int op_attach_update_encoding(struct ComposeFunctionData *fdata,
   int rc = FR_NO_ACTION;
   struct Menu *menu = shared->adata->menu;
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  ba_add_tagged(&ba, actx, menu);
+  // ba_add_tagged(&ba, actx, menu);
   if (ARRAY_EMPTY(&ba))
     goto done;
 

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -608,40 +608,55 @@ static int next_sibling(struct AttachCtx *actx, int index)
 }
 
 /**
- * tagged_attachments_are_siblings - Check whether tagged attachments are siblings
- * @param e    Email
- * @param actx Attachment context
- * @retval true Tagged attachments are siblings
+ * body_array_contains - Does a selection contain a body?
+ * @param ba Selected attachments
+ * @param b  Body to find
+ * @retval true Body is selected
  */
-static bool tagged_attachments_are_siblings(struct Email *e, struct AttachCtx *actx)
+static bool body_array_contains(struct BodyArray *ba, const struct Body *b)
 {
-  if (!e || !actx)
+  struct Body **bp = NULL;
+  ARRAY_FOREACH(bp, ba)
+  {
+    if (*bp == b)
+      return true;
+  }
+
+  return false;
+}
+
+/**
+ * selected_attachments_are_siblings - Check whether selected attachments are siblings
+ * @param e  Email
+ * @param ba Selected attachments
+ * @retval true Selected attachments are siblings
+ */
+static bool selected_attachments_are_siblings(struct Email *e, struct BodyArray *ba)
+{
+  if (!e || !ba)
     return false;
 
   int level = -1;
   struct Body *parent = NULL;
-
-  for (int i = 0; i < actx->idxlen; i++)
+  struct Body **bp = NULL;
+  ARRAY_FOREACH(bp, ba)
   {
-    struct AttachPtr *ap = actx->idx[i];
-    if (!ap->body->tagged)
-      continue;
-
     struct Body *this_parent = NULL;
-    if (ap->level > 0)
+    struct Body *body = *bp;
+    if (body->aptr && (body->aptr->level > 0))
     {
-      if (!attach_body_parent(e->body, NULL, ap->body, &this_parent))
+      if (!attach_body_parent(e->body, NULL, body, &this_parent))
         return false;
     }
 
     if (level == -1)
     {
-      level = ap->level;
+      level = body->aptr ? body->aptr->level : 0;
       parent = this_parent;
       continue;
     }
 
-    if ((level != ap->level) || (parent != this_parent))
+    if ((level != (body->aptr ? body->aptr->level : 0)) || (parent != this_parent))
       return false;
   }
 
@@ -649,12 +664,23 @@ static bool tagged_attachments_are_siblings(struct Email *e, struct AttachCtx *a
 }
 
 /**
+ * selection_redraw_flags - Choose redraw flags for a selection
+ * @param count Number of selected attachments
+ * @retval redraw flags for the selection
+ */
+static MenuRedrawFlags selection_redraw_flags(size_t count)
+{
+  return (count > 1) ? MENU_REDRAW_FULL : MENU_REDRAW_CURRENT;
+}
+
+/**
  * move_attachment - Move attachments in the attachment list
  * @param shared Shared compose data
  * @param up     If true, move up, otherwise move down
+ * @param count  Repeat-count
  * @retval enum #FunctionRetval
  */
-static int move_attachment(struct ComposeSharedData *shared, bool up)
+static int move_attachment(struct ComposeSharedData *shared, bool up, int count)
 {
   struct AttachCtx *actx = shared->adata->actx;
   if (!check_count(actx))
@@ -667,13 +693,13 @@ static int move_attachment(struct ComposeSharedData *shared, bool up)
 
   struct Body *cur_body = cur_att->body;
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  // ba_add_tagged(&ba, actx, menu);
+  ba_add_selection(&ba, actx, menu, menu->tag_prefix, count);
   if (ARRAY_EMPTY(&ba))
     goto done;
 
-  if (menu->tag_prefix && !tagged_attachments_are_siblings(shared->email, actx))
+  if ((ARRAY_SIZE(&ba) > 1) && !selected_attachments_are_siblings(shared->email, &ba))
   {
-    mutt_error(_("Tagged attachments must be siblings"));
+    mutt_error(_("Selected attachments must be siblings"));
     ARRAY_FREE(&ba);
     return FR_ERROR;
   }
@@ -688,7 +714,7 @@ static int move_attachment(struct ComposeSharedData *shared, bool up)
       const int previdx = prev_sibling(actx, index);
       if (previdx < 0)
         continue;
-      if (menu->tag_prefix && actx->idx[previdx]->body->tagged)
+      if (body_array_contains(&ba, actx->idx[previdx]->body))
         continue;
 
       compose_attach_swap(shared->email, actx, previdx, index);
@@ -704,7 +730,7 @@ static int move_attachment(struct ComposeSharedData *shared, bool up)
       const int nextidx = next_sibling(actx, index);
       if (nextidx < 0)
         continue;
-      if (menu->tag_prefix && actx->idx[nextidx]->body->tagged)
+      if (body_array_contains(&ba, actx->idx[nextidx]->body))
         continue;
 
       compose_attach_swap(shared->email, actx, index, nextidx);
@@ -735,13 +761,15 @@ done:
 }
 
 /**
- * group_attachments - Group tagged attachments into a multipart group
+ * group_attachments - Group selected attachments into a multipart group
  * @param  shared     Shared compose data
  * @param  subtype    MIME subtype
+ * @param  ba         Selected attachments
  * @retval FR_SUCCESS Success
  * @retval FR_ERROR   Failure
  */
-static int group_attachments(struct ComposeSharedData *shared, char *subtype)
+static int group_attachments(struct ComposeSharedData *shared, char *subtype,
+                             struct BodyArray *ba)
 {
   struct AttachCtx *actx = shared->adata->actx;
   int group_level = -1;
@@ -750,8 +778,7 @@ static int group_attachments(struct ComposeSharedData *shared, char *subtype)
   // Attachments to be grouped must have the same parent
   for (int i = 0; i < actx->idxlen; i++)
   {
-    // check if all tagged attachments are at same level
-    if (actx->idx[i]->body->tagged)
+    if (body_array_contains(ba, actx->idx[i]->body))
     {
       if (group_level == -1)
       {
@@ -791,7 +818,7 @@ static int group_attachments(struct ComposeSharedData *shared, char *subtype)
   // Can't group all attachments unless at top level
   if (bptr_parent)
   {
-    if (shared->adata->menu->num_tagged == attach_body_count(bptr_parent->parts, false))
+    if (ARRAY_SIZE(ba) == attach_body_count(bptr_parent->parts, false))
     {
       mutt_error(_("Can't leave group with only one attachment"));
       return FR_ERROR;
@@ -803,8 +830,8 @@ static int group_attachments(struct ComposeSharedData *shared, char *subtype)
   group->subtype = mutt_str_dup(subtype);
   group->encoding = ENC_7BIT;
 
-  struct Body *bptr_first = NULL;     // first tagged attachment
-  struct Body *bptr = NULL;           // current tagged attachment
+  struct Body *bptr_first = NULL;     // first selected attachment
+  struct Body *bptr = NULL;           // current selected attachment
   struct Body *group_parent = NULL;   // parent of group
   struct Body *group_previous = NULL; // previous body to group
   struct Body *group_part = NULL;     // current attachment in group
@@ -815,9 +842,9 @@ static int group_attachments(struct ComposeSharedData *shared, char *subtype)
   for (int i = 0; i < actx->idxlen; i++)
   {
     bptr = actx->idx[i]->body;
-    if (bptr->tagged)
+    if (body_array_contains(ba, bptr))
     {
-      // set group properties based on first tagged attachment
+      // set group properties based on first selected attachment
       if (!bptr_first)
       {
         group->disposition = bptr->disposition;
@@ -838,8 +865,11 @@ static int group_attachments(struct ComposeSharedData *shared, char *subtype)
         }
       }
 
-      shared->adata->menu->num_tagged--;
-      bptr->tagged = false;
+      if (bptr->tagged)
+      {
+        shared->adata->menu->num_tagged--;
+        bptr->tagged = false;
+      }
       bptr->aptr->level++;
       bptr->aptr->parent_type = TYPE_MULTIPART;
 
@@ -1216,19 +1246,23 @@ static int op_attach_detach(struct ComposeFunctionData *fdata, const struct KeyE
 
   struct Menu *menu = shared->adata->menu;
   int rc = FR_NO_ACTION;
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  aa_add_selection(&aa, actx, menu, menu->tag_prefix, event->count);
 
-  if (menu->tag_prefix)
+  if (ARRAY_SIZE(&aa) > 1)
   {
-    for (int i = actx->idxlen - 1; i >= 0; i--)
+    for (int i = ARRAY_SIZE(&aa) - 1; i >= 0; i--)
     {
-      struct AttachPtr *ap = actx->idx[i];
-      if (!ap->body->tagged)
+      struct AttachPtr **app = ARRAY_GET(&aa, i);
+      if (!app || !*app)
         continue;
+      struct AttachPtr *ap = *app;
 
       if (ap->unowned)
         ap->body->unlink = false;
 
-      if (delete_attachment(actx, i, fdata->n->sub) == 0)
+      const int index = body_index(actx, ap->body);
+      if ((index >= 0) && (delete_attachment(actx, index, fdata->n->sub) == 0))
         rc = FR_SUCCESS;
     }
 
@@ -1241,6 +1275,7 @@ static int op_attach_detach(struct ComposeFunctionData *fdata, const struct KeyE
           menu->num_tagged++;
       }
       update_menu(actx, menu, false);
+      ARRAY_FREE(&aa);
       return FR_ERROR;
     }
   }
@@ -1260,6 +1295,7 @@ static int op_attach_detach(struct ComposeFunctionData *fdata, const struct KeyE
           menu->num_tagged++;
       }
       update_menu(actx, menu, false);
+      ARRAY_FREE(&aa);
       return FR_ERROR;
     }
 
@@ -1281,6 +1317,7 @@ static int op_attach_detach(struct ComposeFunctionData *fdata, const struct KeyE
     shared->email->body = actx->idx[0]->body;
 
   exec_message_hook(NULL, shared->email, CMD_SEND2_HOOK);
+  ARRAY_FREE(&aa);
   return rc;
 }
 
@@ -1300,7 +1337,7 @@ static int op_attach_edit_content_id(struct ComposeFunctionData *fdata,
   struct Buffer *buf = buf_pool_get();
   struct Buffer *cid = buf_pool_get();
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  // ba_add_tagged(&ba, actx, menu);
+  ba_add_selection(&ba, actx, menu, menu->tag_prefix, event->count);
 
   struct AttachPtr *cur_att = current_attachment(actx, menu);
 
@@ -1346,7 +1383,7 @@ static int op_attach_edit_content_id(struct ComposeFunctionData *fdata,
 
       if (changed)
       {
-        menu_queue_redraw(menu, menu->tag_prefix ? MENU_REDRAW_FULL : MENU_REDRAW_CURRENT);
+        menu_queue_redraw(menu, selection_redraw_flags(ARRAY_SIZE(&ba)));
         notify_send(shared->email->notify, NT_EMAIL, NT_EMAIL_CHANGE_ATTACH, NULL);
         exec_message_hook(NULL, shared->email, CMD_SEND2_HOOK);
         rc = FR_SUCCESS;
@@ -1391,7 +1428,7 @@ static int op_attach_edit_description(struct ComposeFunctionData *fdata,
   /* header names should not be translated */
   if (mw_get_field("Description: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) == 0)
   {
-    // ba_add_tagged(&ba, actx, menu);
+    ba_add_selection(&ba, actx, menu, menu->tag_prefix, event->count);
 
     bool changed = false;
     struct Body **bp = NULL;
@@ -1406,7 +1443,7 @@ static int op_attach_edit_description(struct ComposeFunctionData *fdata,
 
     if (changed)
     {
-      menu_queue_redraw(menu, menu->tag_prefix ? MENU_REDRAW_FULL : MENU_REDRAW_CURRENT);
+      menu_queue_redraw(menu, selection_redraw_flags(ARRAY_SIZE(&ba)));
       exec_message_hook(NULL, shared->email, CMD_SEND2_HOOK);
       rc = FR_SUCCESS;
     }
@@ -1443,7 +1480,7 @@ static int op_attach_edit_encoding(struct ComposeFunctionData *fdata,
     int enc = mutt_check_encoding(buf_string(buf));
     if ((enc != ENC_OTHER) && (enc != ENC_UUENCODED))
     {
-      // ba_add_tagged(&ba, actx, menu);
+      ba_add_selection(&ba, actx, menu, menu->tag_prefix, event->count);
 
       bool changed = false;
       struct Body **bp = NULL;
@@ -1458,7 +1495,7 @@ static int op_attach_edit_encoding(struct ComposeFunctionData *fdata,
 
       if (changed)
       {
-        menu_queue_redraw(menu, menu->tag_prefix ? MENU_REDRAW_FULL : MENU_REDRAW_CURRENT);
+        menu_queue_redraw(menu, selection_redraw_flags(ARRAY_SIZE(&ba)));
         notify_send(shared->email->notify, NT_EMAIL, NT_EMAIL_CHANGE_ATTACH, NULL);
         mutt_clear_error();
         exec_message_hook(NULL, shared->email, CMD_SEND2_HOOK);
@@ -1497,7 +1534,7 @@ static int op_attach_edit_language(struct ComposeFunctionData *fdata,
   buf_strcpy(buf, cur_att->body->language);
   if (mw_get_field("Content-Language: ", buf, MUTT_COMP_NO_FLAGS, HC_OTHER, NULL, NULL) == 0)
   {
-    // ba_add_tagged(&ba, actx, menu);
+    ba_add_selection(&ba, actx, menu, menu->tag_prefix, event->count);
 
     bool changed = false;
     struct Body **bp = NULL;
@@ -1512,7 +1549,7 @@ static int op_attach_edit_language(struct ComposeFunctionData *fdata,
 
     if (changed)
     {
-      menu_queue_redraw(menu, menu->tag_prefix ? MENU_REDRAW_FULL : MENU_REDRAW_CURRENT);
+      menu_queue_redraw(menu, selection_redraw_flags(ARRAY_SIZE(&ba)));
       notify_send(shared->email->notify, NT_EMAIL, NT_EMAIL_CHANGE_ATTACH, NULL);
       exec_message_hook(NULL, shared->email, CMD_SEND2_HOOK);
       rc = FR_SUCCESS;
@@ -1543,7 +1580,7 @@ static int op_attach_edit_mime(struct ComposeFunctionData *fdata, const struct K
   int rc = FR_NO_ACTION;
   struct Menu *menu = shared->adata->menu;
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  // ba_add_tagged(&ba, actx, menu);
+  ba_add_selection(&ba, actx, menu, menu->tag_prefix, event->count);
   if (ARRAY_EMPTY(&ba))
     goto done;
 
@@ -1604,20 +1641,26 @@ static int op_attach_filter(struct ComposeFunctionData *fdata, const struct KeyE
     return FR_ERROR;
 
   struct Menu *menu = shared->adata->menu;
-  struct AttachPtr *cur_att = current_attachment(actx, menu);
-  if (cur_att->body->type == TYPE_MULTIPART)
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  aa_add_selection(&aa, actx, menu, menu->tag_prefix, event->count);
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, &aa)
   {
-    mutt_error(_("Can't filter multipart attachments"));
-    return FR_ERROR;
+    if ((*app)->body->type == TYPE_MULTIPART)
+    {
+      ARRAY_FREE(&aa);
+      mutt_error(_("Can't filter multipart attachments"));
+      return FR_ERROR;
+    }
   }
 
   const int op = event->op;
-  // mutt_pipe_attachment_list(actx, NULL, menu->tag_prefix, cur_att->body,
-  //                           (op == OP_ATTACH_FILTER));
+  mutt_pipe_attachment_list(&aa, (op == OP_ATTACH_FILTER));
   if (op == OP_ATTACH_FILTER) /* cte might have changed */
   {
-    menu_queue_redraw(menu, menu->tag_prefix ? MENU_REDRAW_FULL : MENU_REDRAW_CURRENT);
+    menu_queue_redraw(menu, selection_redraw_flags(ARRAY_SIZE(&aa)));
   }
+  ARRAY_FREE(&aa);
   notify_send(shared->email->notify, NT_EMAIL, NT_EMAIL_CHANGE_ATTACH, NULL);
   exec_message_hook(NULL, shared->email, CMD_SEND2_HOOK);
   return FR_SUCCESS;
@@ -1637,7 +1680,7 @@ static int op_attach_get_attachment(struct ComposeFunctionData *fdata,
   int rc = FR_ERROR;
   struct Menu *menu = shared->adata->menu;
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  // ba_add_tagged(&ba, actx, menu);
+  ba_add_selection(&ba, actx, menu, menu->tag_prefix, event->count);
   if (ARRAY_EMPTY(&ba))
     goto done;
 
@@ -1667,78 +1710,100 @@ done:
 }
 
 /**
- * op_attach_group_alts - Group tagged attachments as 'multipart/alternative' - Implements ::compose_function_t - @ingroup compose_function_api
+ * op_attach_group_alts - Group selected attachments as 'multipart/alternative' - Implements ::compose_function_t - @ingroup compose_function_api
  */
 static int op_attach_group_alts(struct ComposeFunctionData *fdata, const struct KeyEvent *event)
 {
   struct ComposeSharedData *shared = fdata->shared;
-  if (shared->adata->menu->num_tagged < 2)
+  struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
+  ba_add_selection(&ba, shared->adata->actx, shared->adata->menu,
+                   shared->adata->menu->tag_prefix, event->count);
+  if (ARRAY_SIZE(&ba) < 2)
   {
-    mutt_error(_("Grouping 'alternatives' requires at least 2 tagged messages"));
+    ARRAY_FREE(&ba);
+    mutt_error(_("Grouping 'alternatives' requires at least 2 selected attachments"));
     return FR_ERROR;
   }
 
-  return group_attachments(shared, "alternative");
+  const int rc = group_attachments(shared, "alternative", &ba);
+  ARRAY_FREE(&ba);
+  return rc;
 }
 
 /**
- * op_attach_group_lingual - Group tagged attachments as 'multipart/multilingual' - Implements ::compose_function_t - @ingroup compose_function_api
+ * op_attach_group_lingual - Group selected attachments as 'multipart/multilingual' - Implements ::compose_function_t - @ingroup compose_function_api
  */
 static int op_attach_group_lingual(struct ComposeFunctionData *fdata,
                                    const struct KeyEvent *event)
 {
   struct ComposeSharedData *shared = fdata->shared;
-  if (shared->adata->menu->num_tagged < 2)
+  struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
+  ba_add_selection(&ba, shared->adata->actx, shared->adata->menu,
+                   shared->adata->menu->tag_prefix, event->count);
+  if (ARRAY_SIZE(&ba) < 2)
   {
-    mutt_error(_("Grouping 'multilingual' requires at least 2 tagged messages"));
+    ARRAY_FREE(&ba);
+    mutt_error(_("Grouping 'multilingual' requires at least 2 selected attachments"));
     return FR_ERROR;
   }
 
-  /* traverse to see whether all the parts have Content-Language: set */
   int tagged_with_lang_num = 0;
-  for (struct Body *b = shared->email->body; b; b = b->next)
-    if (b->tagged && b->language && *b->language)
+  struct Body **bp = NULL;
+  ARRAY_FOREACH(bp, &ba)
+  {
+    if ((*bp)->language && *(*bp)->language)
       tagged_with_lang_num++;
+  }
 
-  if (shared->adata->menu->num_tagged != tagged_with_lang_num)
+  if (ARRAY_SIZE(&ba) != tagged_with_lang_num)
   {
     if (query_yesorno(_("Not all parts have 'Content-Language' set, continue?"),
                       MUTT_YES) != MUTT_YES)
     {
+      ARRAY_FREE(&ba);
       mutt_message(_("Not sending this message"));
       return FR_ERROR;
     }
   }
 
-  return group_attachments(shared, "multilingual");
+  const int rc = group_attachments(shared, "multilingual", &ba);
+  ARRAY_FREE(&ba);
+  return rc;
 }
 
 /**
- * op_attach_group_related - Group tagged attachments as 'multipart/related' - Implements ::compose_function_t - @ingroup compose_function_api
+ * op_attach_group_related - Group selected attachments as 'multipart/related' - Implements ::compose_function_t - @ingroup compose_function_api
  */
 static int op_attach_group_related(struct ComposeFunctionData *fdata,
                                    const struct KeyEvent *event)
 {
   struct ComposeSharedData *shared = fdata->shared;
-  if (shared->adata->menu->num_tagged < 2)
+  struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
+  ba_add_selection(&ba, shared->adata->actx, shared->adata->menu,
+                   shared->adata->menu->tag_prefix, event->count);
+  if (ARRAY_SIZE(&ba) < 2)
   {
-    mutt_error(_("Grouping 'related' requires at least 2 tagged messages"));
+    ARRAY_FREE(&ba);
+    mutt_error(_("Grouping 'related' requires at least 2 selected attachments"));
     return FR_ERROR;
   }
 
-  // ensure Content-ID is set for tagged attachments
-  for (struct Body *b = shared->email->body; b; b = b->next)
+  // ensure Content-ID is set for selected attachments
+  struct Body **bp = NULL;
+  ARRAY_FOREACH(bp, &ba)
   {
-    if (!b->tagged || (b->type == TYPE_MULTIPART))
+    if ((*bp)->type == TYPE_MULTIPART)
       continue;
 
-    if (!b->content_id)
+    if (!(*bp)->content_id)
     {
-      b->content_id = gen_cid();
+      (*bp)->content_id = gen_cid();
     }
   }
 
-  return group_attachments(shared, "related");
+  const int rc = group_attachments(shared, "related", &ba);
+  ARRAY_FREE(&ba);
+  return rc;
 }
 
 /**
@@ -1747,8 +1812,8 @@ static int op_attach_group_related(struct ComposeFunctionData *fdata,
 static int op_attach_move_down(struct ComposeFunctionData *fdata, const struct KeyEvent *event)
 {
   struct ComposeSharedData *shared = fdata->shared;
-  if (shared->adata->menu->tag_prefix)
-    return move_attachment(shared, false);
+  if (shared->adata->menu->tag_prefix || (event->count > 1))
+    return move_attachment(shared, false, event->count);
 
   int index = menu_get_index(shared->adata->menu);
 
@@ -1807,8 +1872,8 @@ static int op_attach_move_down(struct ComposeFunctionData *fdata, const struct K
 static int op_attach_move_up(struct ComposeFunctionData *fdata, const struct KeyEvent *event)
 {
   struct ComposeSharedData *shared = fdata->shared;
-  if (shared->adata->menu->tag_prefix)
-    return move_attachment(shared, true);
+  if (shared->adata->menu->tag_prefix || (event->count > 1))
+    return move_attachment(shared, true, event->count);
 
   int index = menu_get_index(shared->adata->menu);
   if (index < 0)
@@ -1934,14 +1999,21 @@ static int op_attach_print(struct ComposeFunctionData *fdata, const struct KeyEv
     return FR_ERROR;
 
   struct Menu *menu = shared->adata->menu;
-  struct AttachPtr *cur_att = current_attachment(actx, menu);
-  if (cur_att->body->type == TYPE_MULTIPART)
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  aa_add_selection(&aa, actx, menu, menu->tag_prefix, event->count);
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, &aa)
   {
-    mutt_error(_("Can't print multipart attachments"));
-    return FR_ERROR;
+    if ((*app)->body->type == TYPE_MULTIPART)
+    {
+      ARRAY_FREE(&aa);
+      mutt_error(_("Can't print multipart attachments"));
+      return FR_ERROR;
+    }
   }
 
-  // mutt_print_attachment_list(actx, NULL, menu->tag_prefix, cur_att->body);
+  mutt_print_attachment_list(&aa);
+  ARRAY_FREE(&aa);
   /* no send2hook, since this doesn't modify the message */
   return FR_SUCCESS;
 }
@@ -1988,14 +2060,21 @@ static int op_attach_save(struct ComposeFunctionData *fdata, const struct KeyEve
     return FR_ERROR;
 
   struct Menu *menu = shared->adata->menu;
-  struct AttachPtr *cur_att = current_attachment(actx, menu);
-  if (cur_att->body->type == TYPE_MULTIPART)
+  struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+  aa_add_selection(&aa, actx, menu, menu->tag_prefix, event->count);
+  struct AttachPtr **app = NULL;
+  ARRAY_FOREACH(app, &aa)
   {
-    mutt_error(_("Can't save multipart attachments"));
-    return FR_ERROR;
+    if ((*app)->body->type == TYPE_MULTIPART)
+    {
+      ARRAY_FREE(&aa);
+      mutt_error(_("Can't save multipart attachments"));
+      return FR_ERROR;
+    }
   }
 
-  // mutt_save_attachment_list(actx, NULL, menu->tag_prefix, cur_att->body, NULL, menu);
+  mutt_save_attachment_list(&aa, NULL, menu);
+  ARRAY_FREE(&aa);
   /* no send2hook, since this doesn't modify the message */
   return FR_SUCCESS;
 }
@@ -2015,7 +2094,7 @@ static int op_attach_toggle_disposition(struct ComposeFunctionData *fdata,
   int rc = FR_NO_ACTION;
   struct Menu *menu = shared->adata->menu;
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  // ba_add_tagged(&ba, actx, menu);
+  ba_add_selection(&ba, actx, menu, menu->tag_prefix, event->count);
 
   struct Body **bp = NULL;
   ARRAY_FOREACH(bp, &ba)
@@ -2025,7 +2104,7 @@ static int op_attach_toggle_disposition(struct ComposeFunctionData *fdata,
   }
 
   if (rc == FR_SUCCESS)
-    menu_queue_redraw(menu, menu->tag_prefix ? MENU_REDRAW_FULL : MENU_REDRAW_CURRENT);
+    menu_queue_redraw(menu, selection_redraw_flags(ARRAY_SIZE(&ba)));
 
   ARRAY_FREE(&ba);
   notify_send(shared->email->notify, NT_EMAIL, NT_EMAIL_CHANGE_ATTACH, NULL);
@@ -2046,7 +2125,7 @@ static int op_attach_toggle_recode(struct ComposeFunctionData *fdata,
   int rc = FR_NO_ACTION;
   struct Menu *menu = shared->adata->menu;
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  // ba_add_tagged(&ba, actx, menu);
+  ba_add_selection(&ba, actx, menu, menu->tag_prefix, event->count);
 
   struct Body **bp = NULL;
   ARRAY_FOREACH(bp, &ba)
@@ -2065,7 +2144,7 @@ static int op_attach_toggle_recode(struct ComposeFunctionData *fdata,
     return FR_ERROR;
   }
 
-  if (!menu->tag_prefix)
+  if (ARRAY_SIZE(&ba) == 1)
   {
     struct AttachPtr *cur_att = current_attachment(actx, menu);
     if (cur_att->body->noconv)
@@ -2078,7 +2157,7 @@ static int op_attach_toggle_recode(struct ComposeFunctionData *fdata,
     mutt_clear_error();
   }
 
-  menu_queue_redraw(menu, menu->tag_prefix ? MENU_REDRAW_FULL : MENU_REDRAW_CURRENT);
+  menu_queue_redraw(menu, selection_redraw_flags(ARRAY_SIZE(&ba)));
   ARRAY_FREE(&ba);
   exec_message_hook(NULL, shared->email, CMD_SEND2_HOOK);
   return FR_SUCCESS;
@@ -2098,7 +2177,7 @@ static int op_attach_toggle_unlink(struct ComposeFunctionData *fdata,
   int rc = FR_NO_ACTION;
   struct Menu *menu = shared->adata->menu;
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  // ba_add_tagged(&ba, actx, menu);
+  ba_add_selection(&ba, actx, menu, menu->tag_prefix, event->count);
 
   struct Body **bp = NULL;
   ARRAY_FOREACH(bp, &ba)
@@ -2192,7 +2271,7 @@ static int op_attach_update_encoding(struct ComposeFunctionData *fdata,
   int rc = FR_NO_ACTION;
   struct Menu *menu = shared->adata->menu;
   struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
-  // ba_add_tagged(&ba, actx, menu);
+  ba_add_selection(&ba, actx, menu, menu->tag_prefix, event->count);
   if (ARRAY_EMPTY(&ba))
     goto done;
 

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -9612,6 +9612,14 @@ Limit to messages matching: ~d 19950120-19951031
         requiring the <quote>tag-prefix</quote>.
       </para>
       <para>
+        Many line-based action functions also honour a numeric repeat-count.
+        Without <quote>tag-prefix</quote>, a command like
+        <literal>5&lt;delete-message&gt;</literal> applies to the current entry
+        and the next four visible entries, silently stopping at the end of the
+        list. If <quote>tag-prefix</quote> is active, tagged entries still take
+        precedence and the repeat-count is ignored.
+      </para>
+      <para>
         In <link linkend="macro"><command>macro</command></link>s or
         <link linkend="push"><command>push</command></link> commands, you can
         use the <literal>&lt;tag-prefix-cond&gt;</literal> operator. If there

--- a/external.c
+++ b/external.c
@@ -431,25 +431,27 @@ cleanup:
  * mutt_print_message - Print a message
  * @param m  Mailbox
  * @param ea Array of Emails to print
+ * @retval true The messages were printed
+ * @retval false Printing was cancelled or failed
  */
-void mutt_print_message(struct Mailbox *m, struct EmailArray *ea)
+bool mutt_print_message(struct Mailbox *m, struct EmailArray *ea)
 {
   if (!m || !ea)
-    return;
+    return false;
 
   const enum QuadOption c_print = cs_subset_quad(NeoMutt->sub, "print");
   const char *const c_print_command = cs_subset_string(NeoMutt->sub, "print_command");
   if (c_print && !c_print_command)
   {
     mutt_message(_("No printing command has been defined"));
-    return;
+    return false;
   }
 
   int msg_count = ARRAY_SIZE(ea);
   const char *msg = ngettext("Print message?", "Print tagged messages?", msg_count);
   if (query_quadoption(msg, NeoMutt->sub, "print") != MUTT_YES)
   {
-    return;
+    return false;
   }
 
   const bool c_print_decode = cs_subset_bool(NeoMutt->sub, "print_decode");
@@ -457,12 +459,12 @@ void mutt_print_message(struct Mailbox *m, struct EmailArray *ea)
   if (pipe_message(m, ea, c_print_command, c_print_decode, true, c_print_split, "\f") == 0)
   {
     mutt_message(ngettext("Message printed", "Messages printed", msg_count));
+    return true;
   }
-  else
-  {
-    mutt_message(ngettext("Message could not be printed",
-                          "Messages could not be printed", msg_count));
-  }
+
+  mutt_message(ngettext("Message could not be printed",
+                        "Messages could not be printed", msg_count));
+  return false;
 }
 
 /**

--- a/external.h
+++ b/external.h
@@ -61,7 +61,7 @@ void mutt_display_address(struct Envelope *env);
 bool mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp);
 void mutt_enter_command(struct MuttWindow *win);
 void mutt_pipe_message(struct Mailbox *m, struct EmailArray *ea);
-void mutt_print_message(struct Mailbox *m, struct EmailArray *ea);
+bool mutt_print_message(struct Mailbox *m, struct EmailArray *ea);
 int  mutt_save_message(struct Mailbox *m, struct EmailArray *ea, enum MessageSaveOpt save_opt, enum MessageTransformOpt transform_opt);
 int  mutt_save_message_mbox(struct Mailbox *m_src, struct Email *e, enum MessageSaveOpt save_opt, enum MessageTransformOpt transform_opt, struct Mailbox *m_dst);
 bool mutt_select_sort(bool reverse);

--- a/index/functions.c
+++ b/index/functions.c
@@ -450,6 +450,151 @@ bool index_next_undeleted(struct MuttWindow *win_index)
   return true;
 }
 
+/**
+ * ea_add_selection - Build a working set of Emails for an action
+ * @param ea         Empty EmailArray to populate
+ * @param mv         Current MailboxView
+ * @param e          Current Email
+ * @param use_tagged Use tagged emails
+ * @param count      Repeat-count (0 or 1 == just the current selection)
+ * @retval num Number of selected emails
+ * @retval -1  Error
+ */
+static int ea_add_selection(struct EmailArray *ea, struct MailboxView *mv,
+                            struct Email *e, bool use_tagged, int count)
+{
+  if (!ea)
+    return -1;
+
+  if (use_tagged)
+    return ea_add_tagged(ea, mv, e, true);
+
+  if (!mv || !mv->mailbox || !e)
+    return -1;
+
+  const int index = e->vnum;
+  if ((index < 0) || (index >= mv->mailbox->vcount))
+    return -1;
+
+  int n = (count > 1) ? count : 1;
+  if ((index + n) > mv->mailbox->vcount)
+    n = mv->mailbox->vcount - index;
+
+  for (int i = 0; i < n; i++)
+  {
+    struct Email *sel = mutt_get_virt_email(mv->mailbox, index + i);
+    if (sel)
+      ARRAY_ADD(ea, sel);
+  }
+
+  return ARRAY_SIZE(ea);
+}
+
+/**
+ * thread_target - Get the thread/subthread target for an email
+ * @param e         Email
+ * @param subthread If true, use the current subthread
+ * @retval ptr Thread/subthread target
+ */
+static struct MuttThread *thread_target(struct Email *e, bool subthread)
+{
+  if (!e || !e->thread)
+    return NULL;
+
+  struct MuttThread *thread = e->thread;
+  if (!subthread)
+  {
+    while (thread->parent)
+      thread = thread->parent;
+  }
+
+  return thread;
+}
+
+/**
+ * ea_contains_thread_target - Does the array already include this thread target?
+ * @param ea        Selected emails
+ * @param e         Candidate email
+ * @param subthread If true, compare subthreads instead of top-level threads
+ * @retval true The target is already represented in the array
+ */
+static bool ea_contains_thread_target(struct EmailArray *ea, struct Email *e, bool subthread)
+{
+  if (!ea || !e)
+    return false;
+
+  struct MuttThread *target = thread_target(e, subthread);
+  if (!target)
+    return false;
+
+  struct Email **ep = NULL;
+  ARRAY_FOREACH(ep, ea)
+  {
+    if (thread_target(*ep, subthread) == target)
+      return true;
+  }
+
+  return false;
+}
+
+/**
+ * ea_add_selection_threads - Build a working set of threads/subthreads
+ * @param ea         Empty EmailArray to populate
+ * @param mv         Current MailboxView
+ * @param e          Current Email
+ * @param use_tagged Use tagged emails
+ * @param subthread  If true, act on subthreads
+ * @param count      Repeat-count (0 or 1 == just the current thread/subthread)
+ * @retval num Number of selected threads/subthreads
+ * @retval -1  Error
+ */
+static int ea_add_selection_threads(struct EmailArray *ea,
+                                    struct MailboxView *mv, struct Email *e,
+                                    bool use_tagged, bool subthread, int count)
+{
+  if (!ea)
+    return -1;
+
+  if (!use_tagged)
+  {
+    if (!mv || !mv->mailbox || !e)
+      return -1;
+
+    const int index = e->vnum;
+    if ((index < 0) || (index >= mv->mailbox->vcount))
+      return -1;
+
+    const int n = (count > 1) ? count : 1;
+    for (int i = index; (i < mv->mailbox->vcount) && (ARRAY_SIZE(ea) < n); i++)
+    {
+      struct Email *sel = mutt_get_virt_email(mv->mailbox, i);
+      if (!sel || ea_contains_thread_target(ea, sel, subthread))
+        continue;
+
+      ARRAY_ADD(ea, sel);
+    }
+    return ARRAY_SIZE(ea);
+  }
+
+  if (!mv || !mv->mailbox || !mv->mailbox->emails)
+    return -1;
+
+  struct Mailbox *m = mv->mailbox;
+  for (int i = 0; i < m->msg_count; i++)
+  {
+    struct Email *et = m->emails[i];
+    if (!et)
+      break;
+    if (!message_is_tagged(et))
+      continue;
+
+    if (!ea_contains_thread_target(ea, et, subthread))
+      ARRAY_ADD(ea, et);
+  }
+
+  return ARRAY_SIZE(ea);
+}
+
 // -----------------------------------------------------------------------------
 
 /**
@@ -565,7 +710,13 @@ static int op_delete(struct IndexFunctionData *fdata, const struct KeyEvent *eve
     return FR_ERROR;
 
   struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
-  ea_add_tagged(&ea, shared->mailbox_view, shared->email, priv->tag_prefix);
+  ea_add_selection(&ea, shared->mailbox_view, shared->email, priv->tag_prefix,
+                   event->count);
+  if (ARRAY_EMPTY(&ea))
+  {
+    ARRAY_FREE(&ea);
+    return FR_NO_ACTION;
+  }
 
   mutt_emails_set_flag(shared->mailbox, &ea, MUTT_DELETE, true);
   mutt_emails_set_flag(shared->mailbox, &ea, MUTT_PURGE, (event->op == OP_PURGE_MESSAGE));
@@ -584,86 +735,6 @@ static int op_delete(struct IndexFunctionData *fdata, const struct KeyEvent *eve
   }
 
   return FR_SUCCESS;
-}
-
-/**
- * thread_target - Get the thread/subthread target for an email
- * @param e         Email
- * @param subthread If true, use the current subthread
- * @retval ptr Thread/subthread target
- */
-static struct MuttThread *thread_target(struct Email *e, bool subthread)
-{
-  if (!e || !e->thread)
-    return NULL;
-
-  struct MuttThread *thread = e->thread;
-  if (!subthread)
-  {
-    while (thread->parent)
-      thread = thread->parent;
-  }
-
-  return thread;
-}
-
-/**
- * ea_add_tagged_threads - Get an array of unique tagged threads/subthreads
- * @param ea         Empty EmailArray to populate
- * @param mv         Current MailboxView
- * @param e          Current Email
- * @param use_tagged Use tagged emails
- * @param subthread  If true, act on subthreads
- * @retval num Number of selected threads/subthreads
- * @retval -1  Error
- */
-static int ea_add_tagged_threads(struct EmailArray *ea, struct MailboxView *mv,
-                                 struct Email *e, bool use_tagged, bool subthread)
-{
-  if (!ea)
-    return -1;
-
-  if (!use_tagged)
-  {
-    if (!e)
-      return -1;
-
-    ARRAY_ADD(ea, e);
-    return ARRAY_SIZE(ea);
-  }
-
-  if (!mv || !mv->mailbox || !mv->mailbox->emails)
-    return -1;
-
-  struct Mailbox *m = mv->mailbox;
-  for (int i = 0; i < m->msg_count; i++)
-  {
-    struct Email *et = m->emails[i];
-    if (!et)
-      break;
-    if (!message_is_tagged(et))
-      continue;
-
-    struct MuttThread *target = thread_target(et, subthread);
-    if (!target)
-      continue;
-
-    bool exists = false;
-    struct Email **ep = NULL;
-    ARRAY_FOREACH(ep, ea)
-    {
-      if (thread_target(*ep, subthread) == target)
-      {
-        exists = true;
-        break;
-      }
-    }
-
-    if (!exists)
-      ARRAY_ADD(ea, et);
-  }
-
-  return ARRAY_SIZE(ea);
 }
 
 /**
@@ -690,12 +761,15 @@ static void update_thread_email(struct IndexPrivateData *priv, struct Email *ema
 }
 
 /**
- * op_main_change_thread - Open/close/collapse tagged threads
+ * op_main_change_thread - Open/close/collapse a working set of threads
  * @param fdata Index function data
+ * @param ea    Working set of thread roots
  * @param mode  Collapse mode to apply
+ * @param tagged Use tagged threads
  * @retval enum #FunctionRetval
  */
-static int op_main_change_thread(struct IndexFunctionData *fdata, enum CollapseMode mode)
+static int op_main_change_thread(struct IndexFunctionData *fdata, struct EmailArray *ea,
+                                 enum CollapseMode mode, bool tagged)
 {
   struct IndexSharedData *shared = fdata->shared;
   struct IndexPrivateData *priv = fdata->priv;
@@ -705,18 +779,13 @@ static int op_main_change_thread(struct IndexFunctionData *fdata, enum CollapseM
     return FR_ERROR;
   }
 
-  struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
-  ea_add_tagged_threads(&ea, shared->mailbox_view, shared->email, true, false);
-  if (ARRAY_EMPTY(&ea))
-  {
-    ARRAY_FREE(&ea);
+  if (!ea || ARRAY_EMPTY(ea))
     return FR_NO_ACTION;
-  }
 
   bool changed = false;
   bool blocked = false;
   struct Email **ep = NULL;
-  ARRAY_FOREACH(ep, &ea)
+  ARRAY_FOREACH(ep, ea)
   {
     struct Email *e = *ep;
     if (!e)
@@ -759,7 +828,6 @@ static int op_main_change_thread(struct IndexFunctionData *fdata, enum CollapseM
         break;
     }
   }
-  ARRAY_FREE(&ea);
 
   if (!changed)
   {
@@ -772,7 +840,10 @@ static int op_main_change_thread(struct IndexFunctionData *fdata, enum CollapseM
   }
 
   mutt_set_vnum(shared->mailbox);
-  update_thread_email(priv, shared->email);
+  if (tagged)
+    update_thread_email(priv, shared->email);
+  else
+    resolve_email(priv, shared, RESOLVE_NEXT_THREAD, ARRAY_SIZE(ea));
   menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
   notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, NULL);
   return FR_SUCCESS;
@@ -803,7 +874,8 @@ static int op_delete_thread(struct IndexFunctionData *fdata, const struct KeyEve
   const bool subthread = (op == OP_DELETE_SUBTHREAD);
   int rc = 0;
   struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
-  ea_add_tagged_threads(&ea, shared->mailbox_view, shared->email, priv->tag_prefix, subthread);
+  ea_add_selection_threads(&ea, shared->mailbox_view, shared->email,
+                           priv->tag_prefix, subthread, event->count);
 
   struct Email **ep = NULL;
   ARRAY_FOREACH(ep, &ea)
@@ -941,7 +1013,14 @@ static int op_edit_label(struct IndexFunctionData *fdata, const struct KeyEvent 
   struct IndexSharedData *shared = fdata->shared;
   struct IndexPrivateData *priv = fdata->priv;
   struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
-  ea_add_tagged(&ea, shared->mailbox_view, shared->email, priv->tag_prefix);
+  ea_add_selection(&ea, shared->mailbox_view, shared->email, priv->tag_prefix,
+                   event->count);
+  if (ARRAY_EMPTY(&ea))
+  {
+    ARRAY_FREE(&ea);
+    return FR_NO_ACTION;
+  }
+  const int num = ARRAY_SIZE(&ea);
   int num_changed = mutt_label_message(shared->mailbox_view, &ea);
   ARRAY_FREE(&ea);
 
@@ -954,7 +1033,7 @@ static int op_edit_label(struct IndexFunctionData *fdata, const struct KeyEvent 
     mutt_message(ngettext("%d label changed", "%d labels changed", num_changed), num_changed);
 
     if (!priv->tag_prefix)
-      resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED, 1);
+      resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED, num);
     return FR_SUCCESS;
   }
 
@@ -1077,26 +1156,30 @@ static int op_flag_message(struct IndexFunctionData *fdata, const struct KeyEven
     return FR_ERROR;
 
   struct Mailbox *m = shared->mailbox;
+  struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
+  ea_add_selection(&ea, shared->mailbox_view, shared->email, priv->tag_prefix,
+                   event->count);
+  if (ARRAY_EMPTY(&ea))
+  {
+    ARRAY_FREE(&ea);
+    return FR_NO_ACTION;
+  }
+  const int num = ARRAY_SIZE(&ea);
+
+  struct Email **ep = NULL;
+  ARRAY_FOREACH(ep, &ea)
+  mutt_set_flag(m, *ep, MUTT_FLAG, !(*ep)->flagged, true);
+  ARRAY_FREE(&ea);
+
   if (priv->tag_prefix)
   {
-    for (size_t i = 0; i < m->msg_count; i++)
-    {
-      struct Email *e = m->emails[i];
-      if (!e)
-        break;
-      if (message_is_tagged(e))
-        mutt_set_flag(m, e, MUTT_FLAG, !e->flagged, true);
-    }
-
     menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
   }
   else
   {
-    if (!shared->email)
-      return FR_NO_ACTION;
-    mutt_set_flag(m, shared->email, MUTT_FLAG, !shared->email->flagged, true);
-
-    resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED, 1);
+    resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED, num);
+    if (num > 1)
+      menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
   }
 
   return FR_SUCCESS;
@@ -1473,29 +1556,12 @@ static int op_main_close_thread(struct IndexFunctionData *fdata, const struct Ke
 {
   struct IndexSharedData *shared = fdata->shared;
   struct IndexPrivateData *priv = fdata->priv;
-  if (!mutt_using_threads())
-  {
-    mutt_warning(_("Threading is not enabled"));
-    return FR_ERROR;
-  }
-
-  if (priv->tag_prefix)
-    return op_main_change_thread(fdata, COLLAPSE_MODE_CLOSE);
-
-  if (!shared->email || shared->email->collapsed)
-    return FR_NO_ACTION;
-
-  if (!mutt_thread_can_collapse(shared->email))
-  {
-    mutt_warning(_("Thread contains unread or flagged messages"));
-    return FR_ERROR;
-  }
-
-  menu_set_index(priv->menu, mutt_collapse_thread(shared->email));
-  mutt_set_vnum(shared->mailbox);
-  menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
-  notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, NULL);
-  return FR_SUCCESS;
+  struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
+  ea_add_selection_threads(&ea, shared->mailbox_view, shared->email,
+                           priv->tag_prefix, false, event->count);
+  const int rc = op_main_change_thread(fdata, &ea, COLLAPSE_MODE_CLOSE, priv->tag_prefix);
+  ARRAY_FREE(&ea);
+  return rc;
 }
 
 /**
@@ -1505,42 +1571,12 @@ static int op_main_collapse_thread(struct IndexFunctionData *fdata, const struct
 {
   struct IndexSharedData *shared = fdata->shared;
   struct IndexPrivateData *priv = fdata->priv;
-  if (!mutt_using_threads())
-  {
-    mutt_warning(_("Threading is not enabled"));
-    return FR_ERROR;
-  }
-
-  if (priv->tag_prefix)
-    return op_main_change_thread(fdata, COLLAPSE_MODE_TOGGLE);
-
-  if (!shared->email)
-    return FR_NO_ACTION;
-
-  if (shared->email->collapsed)
-  {
-    int index = mutt_uncollapse_thread(shared->email);
-    mutt_set_vnum(shared->mailbox);
-    const bool c_uncollapse_jump = cs_subset_bool(shared->sub, "uncollapse_jump");
-    if (c_uncollapse_jump)
-      index = mutt_thread_next_unread(shared->email);
-    menu_set_index(priv->menu, index);
-  }
-  else if (mutt_thread_can_collapse(shared->email))
-  {
-    menu_set_index(priv->menu, mutt_collapse_thread(shared->email));
-    mutt_set_vnum(shared->mailbox);
-  }
-  else
-  {
-    mutt_error(_("Thread contains unread or flagged messages"));
-    return FR_ERROR;
-  }
-
-  menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
-  notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, NULL);
-
-  return FR_SUCCESS;
+  struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
+  ea_add_selection_threads(&ea, shared->mailbox_view, shared->email,
+                           priv->tag_prefix, false, event->count);
+  const int rc = op_main_change_thread(fdata, &ea, COLLAPSE_MODE_TOGGLE, priv->tag_prefix);
+  ARRAY_FREE(&ea);
+  return rc;
 }
 
 /**
@@ -1573,28 +1609,12 @@ static int op_main_open_thread(struct IndexFunctionData *fdata, const struct Key
 {
   struct IndexSharedData *shared = fdata->shared;
   struct IndexPrivateData *priv = fdata->priv;
-  if (!mutt_using_threads())
-  {
-    mutt_warning(_("Threading is not enabled"));
-    return FR_ERROR;
-  }
-
-  if (priv->tag_prefix)
-    return op_main_change_thread(fdata, COLLAPSE_MODE_OPEN);
-
-  if (!shared->email || !shared->email->collapsed)
-    return FR_NO_ACTION;
-
-  int index = mutt_uncollapse_thread(shared->email);
-  mutt_set_vnum(shared->mailbox);
-  const bool c_uncollapse_jump = cs_subset_bool(shared->sub, "uncollapse_jump");
-  if (c_uncollapse_jump)
-    index = mutt_thread_next_unread(shared->email);
-  menu_set_index(priv->menu, index);
-  menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
-  notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, NULL);
-
-  return FR_SUCCESS;
+  struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
+  ea_add_selection_threads(&ea, shared->mailbox_view, shared->email,
+                           priv->tag_prefix, false, event->count);
+  const int rc = op_main_change_thread(fdata, &ea, COLLAPSE_MODE_OPEN, priv->tag_prefix);
+  ARRAY_FREE(&ea);
+  return rc;
 }
 
 /**
@@ -1724,7 +1744,13 @@ static int op_main_link_threads(struct IndexFunctionData *fdata, const struct Ke
   {
     struct MailboxView *mv = shared->mailbox_view;
     struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
-    ea_add_tagged(&ea, mv, NULL, true);
+    ea_add_selection(&ea, mv, e, priv->tag_prefix, event->count);
+    if (!priv->tag_prefix)
+    {
+      struct Email **ep = ARRAY_GET(&ea, 0);
+      if (ep && (*ep == e))
+        ARRAY_REMOVE(&ea, ep);
+    }
 
     if (mutt_link_threads(e, &ea, m))
     {
@@ -1761,6 +1787,7 @@ static int op_main_modify_tags(struct IndexFunctionData *fdata, const struct Key
   struct IndexPrivateData *priv = fdata->priv;
   int rc = FR_ERROR;
   struct Buffer *buf = NULL;
+  struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
 
   if (!shared->mailbox)
     goto done;
@@ -1794,14 +1821,17 @@ static int op_main_modify_tags(struct IndexFunctionData *fdata, const struct Key
     goto done;
   }
 
-  if (priv->tag_prefix)
+  ea_add_selection(&ea, shared->mailbox_view, shared->email, priv->tag_prefix,
+                   event->count);
+  const int num = ARRAY_SIZE(&ea);
+
+  if (priv->tag_prefix || (num > 1))
   {
-    /* Batch mode: apply the tag change to all tagged messages */
     struct Progress *progress = NULL;
 
     if (m->verbose)
     {
-      progress = progress_new(MUTT_PROGRESS_WRITE, m->msg_tagged);
+      progress = progress_new(MUTT_PROGRESS_WRITE, num);
       progress_set_message(progress, _("Update tags..."));
     }
 
@@ -1809,13 +1839,11 @@ static int op_main_modify_tags(struct IndexFunctionData *fdata, const struct Key
     if (m->type == MUTT_NOTMUCH)
       nm_db_longrun_init(m, true);
 #endif
-    for (int px = 0, i = 0; i < m->msg_count; i++)
+    struct Email **ep = NULL;
+    int px = 0;
+    ARRAY_FOREACH(ep, &ea)
     {
-      struct Email *e = m->emails[i];
-      if (!e)
-        break;
-      if (!message_is_tagged(e))
-        continue;
+      struct Email *e = *ep;
 
       progress_update(progress, ++px, -1);
       mx_tags_commit(m, e, buf_string(buf));
@@ -1837,10 +1865,12 @@ static int op_main_modify_tags(struct IndexFunctionData *fdata, const struct Key
       nm_db_longrun_done(m);
 #endif
     menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
+    if (!priv->tag_prefix)
+      resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED,
+                    (op == OP_MAIN_MODIFY_TAGS_THEN_HIDE) ? 1 : num);
   }
   else
   {
-    /* Single message mode: apply tag change to the current message only */
     if (mx_tags_commit(m, shared->email, buf_string(buf)))
     {
       mutt_message(_("Failed to modify tags, aborting"));
@@ -1858,11 +1888,13 @@ static int op_main_modify_tags(struct IndexFunctionData *fdata, const struct Key
       m->changed = true;
     }
 
-    resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED, 1);
+    resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED,
+                  (op == OP_MAIN_MODIFY_TAGS_THEN_HIDE) ? 1 : num);
   }
   rc = FR_SUCCESS;
 
 done:
+  ARRAY_FREE(&ea);
   buf_pool_release(&buf);
   return rc;
 }
@@ -2245,28 +2277,27 @@ static int op_main_quasi_delete(struct IndexFunctionData *fdata, const struct Ke
 {
   struct IndexSharedData *shared = fdata->shared;
   struct IndexPrivateData *priv = fdata->priv;
-  if (priv->tag_prefix)
+  struct Mailbox *m = shared->mailbox;
+  struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
+  ea_add_selection(&ea, shared->mailbox_view, shared->email, priv->tag_prefix,
+                   event->count);
+  if (ARRAY_EMPTY(&ea))
   {
-    struct Mailbox *m = shared->mailbox;
-    for (size_t i = 0; i < m->msg_count; i++)
-    {
-      struct Email *e = m->emails[i];
-      if (!e)
-        break;
-      if (message_is_tagged(e))
-      {
-        e->quasi_deleted = true;
-        m->changed = true;
-      }
-    }
+    ARRAY_FREE(&ea);
+    return FR_NO_ACTION;
   }
-  else
+  const int num = ARRAY_SIZE(&ea);
+
+  struct Email **ep = NULL;
+  ARRAY_FOREACH(ep, &ea)
   {
-    if (!shared->email)
-      return FR_NO_ACTION;
-    shared->email->quasi_deleted = true;
-    shared->mailbox->changed = true;
+    (*ep)->quasi_deleted = true;
+    m->changed = true;
   }
+  ARRAY_FREE(&ea);
+
+  if (priv->tag_prefix || (num > 1))
+    menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
 
   return FR_SUCCESS;
 }
@@ -2293,7 +2324,9 @@ static int op_main_read_thread(struct IndexFunctionData *fdata, const struct Key
   const bool subthread = (op != OP_MAIN_READ_THREAD);
   int rc = 0;
   struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
-  ea_add_tagged_threads(&ea, shared->mailbox_view, shared->email, priv->tag_prefix, subthread);
+  ea_add_selection_threads(&ea, shared->mailbox_view, shared->email,
+                           priv->tag_prefix, subthread, event->count);
+  const int num = ARRAY_SIZE(&ea);
 
   struct Email **ep = NULL;
   ARRAY_FOREACH(ep, &ea)
@@ -2309,16 +2342,13 @@ static int op_main_read_thread(struct IndexFunctionData *fdata, const struct Key
 
   if (priv->tag_prefix)
   {
-    const enum ResolveMethod rm = (op == OP_MAIN_READ_THREAD) ? RESOLVE_NEXT_THREAD :
-                                                                RESOLVE_NEXT_SUBTHREAD;
-    resolve_email(priv, shared, rm, 1);
     menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
     return FR_SUCCESS;
   }
 
   const enum ResolveMethod rm = (op == OP_MAIN_READ_THREAD) ? RESOLVE_NEXT_THREAD :
                                                               RESOLVE_NEXT_SUBTHREAD;
-  resolve_email(priv, shared, rm, 1);
+  resolve_email(priv, shared, rm, num);
   menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
   return FR_SUCCESS;
 }
@@ -2357,7 +2387,14 @@ static int op_main_set_flag(struct IndexFunctionData *fdata, const struct KeyEve
   struct IndexSharedData *shared = fdata->shared;
   struct IndexPrivateData *priv = fdata->priv;
   struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
-  ea_add_tagged(&ea, shared->mailbox_view, shared->email, priv->tag_prefix);
+  ea_add_selection(&ea, shared->mailbox_view, shared->email, priv->tag_prefix,
+                   event->count);
+  if (ARRAY_EMPTY(&ea))
+  {
+    ARRAY_FREE(&ea);
+    return FR_NO_ACTION;
+  }
+  const int num = ARRAY_SIZE(&ea);
 
   if (mw_change_flag(shared->mailbox, &ea, (event->op == OP_MAIN_SET_FLAG)) == 0)
   {
@@ -2367,7 +2404,9 @@ static int op_main_set_flag(struct IndexFunctionData *fdata, const struct KeyEve
     }
     else
     {
-      resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED, 1);
+      resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED, num);
+      if (num > 1)
+        menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
     }
   }
   ARRAY_FREE(&ea);
@@ -2666,7 +2705,14 @@ static int op_print(struct IndexFunctionData *fdata, const struct KeyEvent *even
   struct IndexSharedData *shared = fdata->shared;
   struct IndexPrivateData *priv = fdata->priv;
   struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
-  ea_add_tagged(&ea, shared->mailbox_view, shared->email, priv->tag_prefix);
+  ea_add_selection(&ea, shared->mailbox_view, shared->email, priv->tag_prefix,
+                   event->count);
+  if (ARRAY_EMPTY(&ea))
+  {
+    ARRAY_FREE(&ea);
+    return FR_NO_ACTION;
+  }
+  const int num = ARRAY_SIZE(&ea);
   mutt_print_message(shared->mailbox, &ea);
   ARRAY_FREE(&ea);
 
@@ -2675,7 +2721,8 @@ static int op_print(struct IndexFunctionData *fdata, const struct KeyEvent *even
   const bool c_imap_peek = cs_subset_bool(shared->sub, "imap_peek");
   if ((shared->mailbox->type == MUTT_IMAP) && !c_imap_peek)
   {
-    menu_queue_redraw(priv->menu, (priv->tag_prefix ? MENU_REDRAW_INDEX : MENU_REDRAW_CURRENT));
+    menu_queue_redraw(priv->menu,
+                      ((priv->tag_prefix || (num > 1)) ? MENU_REDRAW_INDEX : MENU_REDRAW_CURRENT));
   }
 
   return FR_SUCCESS;
@@ -2817,7 +2864,14 @@ static int op_save(struct IndexFunctionData *fdata, const struct KeyEvent *event
     return FR_NOT_IMPL;
 
   struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
-  ea_add_tagged(&ea, shared->mailbox_view, shared->email, priv->tag_prefix);
+  ea_add_selection(&ea, shared->mailbox_view, shared->email, priv->tag_prefix,
+                   event->count);
+  if (ARRAY_EMPTY(&ea))
+  {
+    ARRAY_FREE(&ea);
+    return FR_NO_ACTION;
+  }
+  const int num = ARRAY_SIZE(&ea);
 
   const enum MessageSaveOpt save_opt = ((op == OP_SAVE) || (op == OP_DECODE_SAVE) ||
                                         (op == OP_DECRYPT_SAVE)) ?
@@ -2836,7 +2890,7 @@ static int op_save(struct IndexFunctionData *fdata, const struct KeyEvent *event
   }
   ARRAY_FREE(&ea);
 
-  if (priv->tag_prefix)
+  if (priv->tag_prefix || (num > 1))
     menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
 
   return (rc == -1) ? FR_ERROR : FR_SUCCESS;
@@ -2990,33 +3044,35 @@ static int op_toggle_new(struct IndexFunctionData *fdata, const struct KeyEvent 
     return FR_ERROR;
 
   struct Mailbox *m = shared->mailbox;
+  struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
+  ea_add_selection(&ea, shared->mailbox_view, shared->email, priv->tag_prefix,
+                   event->count);
+  if (ARRAY_EMPTY(&ea))
+  {
+    ARRAY_FREE(&ea);
+    return FR_NO_ACTION;
+  }
+  const int num = ARRAY_SIZE(&ea);
+
+  struct Email **ep = NULL;
+  ARRAY_FOREACH(ep, &ea)
+  {
+    if ((*ep)->read || (*ep)->old)
+      mutt_set_flag(m, *ep, MUTT_NEW, true, true);
+    else
+      mutt_set_flag(m, *ep, MUTT_READ, true, true);
+  }
+  ARRAY_FREE(&ea);
+
   if (priv->tag_prefix)
   {
-    for (size_t i = 0; i < m->msg_count; i++)
-    {
-      struct Email *e = m->emails[i];
-      if (!e)
-        break;
-      if (!message_is_tagged(e))
-        continue;
-
-      if (e->read || e->old)
-        mutt_set_flag(m, e, MUTT_NEW, true, true);
-      else
-        mutt_set_flag(m, e, MUTT_READ, true, true);
-    }
     menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
   }
   else
   {
-    if (!shared->email)
-      return FR_NO_ACTION;
-    if (shared->email->read || shared->email->old)
-      mutt_set_flag(m, shared->email, MUTT_NEW, true, true);
-    else
-      mutt_set_flag(m, shared->email, MUTT_READ, true, true);
-
-    resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED, 1);
+    resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED, num);
+    if (num > 1)
+      menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
   }
 
   return FR_SUCCESS;
@@ -3044,7 +3100,14 @@ static int op_undelete(struct IndexFunctionData *fdata, const struct KeyEvent *e
     return FR_ERROR;
 
   struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
-  ea_add_tagged(&ea, shared->mailbox_view, shared->email, priv->tag_prefix);
+  ea_add_selection(&ea, shared->mailbox_view, shared->email, priv->tag_prefix,
+                   event->count);
+  if (ARRAY_EMPTY(&ea))
+  {
+    ARRAY_FREE(&ea);
+    return FR_NO_ACTION;
+  }
+  const int num = ARRAY_SIZE(&ea);
 
   mutt_emails_set_flag(shared->mailbox, &ea, MUTT_DELETE, false);
   mutt_emails_set_flag(shared->mailbox, &ea, MUTT_PURGE, false);
@@ -3056,7 +3119,9 @@ static int op_undelete(struct IndexFunctionData *fdata, const struct KeyEvent *e
   }
   else
   {
-    resolve_email(priv, shared, RESOLVE_NEXT_EMAIL, 1);
+    resolve_email(priv, shared, RESOLVE_NEXT_EMAIL, num);
+    if (num > 1)
+      menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
   }
 
   return FR_SUCCESS;
@@ -3084,7 +3149,9 @@ static int op_undelete_thread(struct IndexFunctionData *fdata, const struct KeyE
   const bool subthread = (op != OP_UNDELETE_THREAD);
   int rc = 0;
   struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
-  ea_add_tagged_threads(&ea, shared->mailbox_view, shared->email, priv->tag_prefix, subthread);
+  ea_add_selection_threads(&ea, shared->mailbox_view, shared->email,
+                           priv->tag_prefix, subthread, event->count);
+  const int num = ARRAY_SIZE(&ea);
 
   struct Email **ep = NULL;
   ARRAY_FOREACH(ep, &ea)
@@ -3103,16 +3170,13 @@ static int op_undelete_thread(struct IndexFunctionData *fdata, const struct KeyE
 
   if (priv->tag_prefix)
   {
-    const enum ResolveMethod rm = (op == OP_UNDELETE_THREAD) ? RESOLVE_NEXT_THREAD :
-                                                               RESOLVE_NEXT_SUBTHREAD;
-    resolve_email(priv, shared, rm, 1);
     menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
     return FR_SUCCESS;
   }
 
   const enum ResolveMethod rm = (op == OP_UNDELETE_THREAD) ? RESOLVE_NEXT_THREAD :
                                                              RESOLVE_NEXT_SUBTHREAD;
-  resolve_email(priv, shared, rm, 1);
+  resolve_email(priv, shared, rm, num);
   menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
   return FR_SUCCESS;
 }

--- a/index/functions.c
+++ b/index/functions.c
@@ -2713,13 +2713,16 @@ static int op_print(struct IndexFunctionData *fdata, const struct KeyEvent *even
     return FR_NO_ACTION;
   }
   const int num = ARRAY_SIZE(&ea);
-  mutt_print_message(shared->mailbox, &ea);
+  const bool printed = mutt_print_message(shared->mailbox, &ea);
   ARRAY_FREE(&ea);
+
+  if (printed && !priv->tag_prefix)
+    resolve_email(priv, shared, RESOLVE_NEXT_EMAIL, num);
 
   /* in an IMAP folder index with imap_peek=no, printing could change
    * new or old messages status to read. Redraw what's needed.  */
   const bool c_imap_peek = cs_subset_bool(shared->sub, "imap_peek");
-  if ((shared->mailbox->type == MUTT_IMAP) && !c_imap_peek)
+  if (printed && (shared->mailbox->type == MUTT_IMAP) && !c_imap_peek)
   {
     menu_queue_redraw(priv->menu,
                       ((priv->tag_prefix || (num > 1)) ? MENU_REDRAW_INDEX : MENU_REDRAW_CURRENT));

--- a/postpone/functions.c
+++ b/postpone/functions.c
@@ -91,13 +91,17 @@ void postponed_init_keys(struct NeoMutt *n, struct SubMenu *sm_generic)
  * @param menu   Postpone Menu
  * @param m      Mailbox
  * @param tagged Use tagged emails (tag-prefix)
+ * @param count  Repeat-count (0 or 1 == just the current selection)
  * @retval num Number of emails added
  *
- * If @a tagged is true, the array is filled with the tagged emails.
- * Otherwise, the array is filled with just the current selection.
+ * If @a tagged is true, the array is filled with the tagged emails and
+ * @a count is ignored.
+ *
+ * Otherwise the array is filled with the current selection and the next
+ * @a count - 1 emails.  Overruns are silently capped at the end of the list.
  */
 static int postpone_add_selection(struct EmailArray *ea, struct Menu *menu,
-                                  struct Mailbox *m, bool tagged)
+                                  struct Mailbox *m, bool tagged, int count)
 {
   if (!ea || !menu || !m || !m->emails)
     return 0;
@@ -116,9 +120,17 @@ static int postpone_add_selection(struct EmailArray *ea, struct Menu *menu,
     const int index = menu_get_index(menu);
     if ((index < 0) || (index >= m->msg_count))
       return 0;
-    struct Email *e = m->emails[index];
-    if (e)
-      ARRAY_ADD(ea, e);
+
+    int n = (count > 1) ? count : 1;
+    if ((index + n) > m->msg_count)
+      n = m->msg_count - index;
+
+    for (int i = 0; i < n; i++)
+    {
+      struct Email *e = m->emails[index + i];
+      if (e)
+        ARRAY_ADD(ea, e);
+    }
   }
 
   return ARRAY_SIZE(ea);
@@ -155,6 +167,9 @@ static void postpone_apply_set_deleted(struct Mailbox *m, struct EmailArray *ea,
  * This function handles:
  * - OP_DELETE
  * - OP_UNDELETE
+ *
+ * Supports repeat-count: `5<delete-entry>` deletes the current entry and the
+ * next 4. Overruns are silently capped at the end of the list.
  */
 static int op_delete(struct PostponeData *pd, const struct KeyEvent *event)
 {
@@ -167,23 +182,26 @@ static int op_delete(struct PostponeData *pd, const struct KeyEvent *event)
 
   /* should deleted draft messages be saved in the trash folder? */
   struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
-  postpone_add_selection(&ea, menu, m, menu->tag_prefix);
+  postpone_add_selection(&ea, menu, m, menu->tag_prefix, event->count);
+  const int num = ARRAY_SIZE(&ea);
   postpone_apply_set_deleted(m, &ea, bf);
   ARRAY_FREE(&ea);
 
   const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
-  if (!menu->tag_prefix && c_resolve && (index < (menu->max - 1)))
+  if (!menu->tag_prefix && c_resolve && ((index + num) < menu->max))
   {
-    menu_set_index(menu, index + 1);
-    if (index >= (menu->top + menu->page_len))
+    const int new_index = index + num;
+    menu_set_index(menu, new_index);
+    if (new_index >= (menu->top + menu->page_len))
     {
-      menu->top = index;
+      menu->top = new_index;
       menu_queue_redraw(menu, MENU_REDRAW_INDEX);
     }
   }
   else
   {
-    menu_queue_redraw(menu, menu->tag_prefix ? MENU_REDRAW_INDEX : MENU_REDRAW_CURRENT);
+    menu_queue_redraw(menu, (menu->tag_prefix || (num > 1)) ? MENU_REDRAW_INDEX :
+                                                              MENU_REDRAW_CURRENT);
   }
 
   return FR_SUCCESS;

--- a/postpone/functions.c
+++ b/postpone/functions.c
@@ -28,9 +28,11 @@
  */
 
 #include "config.h"
+#include <stdbool.h>
 #include <stddef.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
+#include "email/lib.h"
 #include "core/lib.h"
 #include "gui/lib.h"
 #include "mutt.h"
@@ -84,6 +86,70 @@ void postponed_init_keys(struct NeoMutt *n, struct SubMenu *sm_generic)
 }
 
 /**
+ * postpone_add_selection - Build a working set of Emails for an action
+ * @param ea     Empty EmailArray to populate
+ * @param menu   Postpone Menu
+ * @param m      Mailbox
+ * @param tagged Use tagged emails (tag-prefix)
+ * @retval num Number of emails added
+ *
+ * If @a tagged is true, the array is filled with the tagged emails.
+ * Otherwise, the array is filled with just the current selection.
+ */
+static int postpone_add_selection(struct EmailArray *ea, struct Menu *menu,
+                                  struct Mailbox *m, bool tagged)
+{
+  if (!ea || !menu || !m || !m->emails)
+    return 0;
+
+  if (tagged)
+  {
+    for (int i = 0; i < m->msg_count; i++)
+    {
+      struct Email *e = m->emails[i];
+      if (e && e->tagged)
+        ARRAY_ADD(ea, e);
+    }
+  }
+  else
+  {
+    const int index = menu_get_index(menu);
+    if ((index < 0) || (index >= m->msg_count))
+      return 0;
+    struct Email *e = m->emails[index];
+    if (e)
+      ARRAY_ADD(ea, e);
+  }
+
+  return ARRAY_SIZE(ea);
+}
+
+/**
+ * postpone_apply_set_deleted - Apply the deleted flag to a working set of Emails
+ * @param m       Mailbox
+ * @param ea      Working set of Emails
+ * @param deleted true to mark as deleted, false to undelete
+ *
+ * Also updates the postponed message count.
+ */
+static void postpone_apply_set_deleted(struct Mailbox *m, struct EmailArray *ea, bool deleted)
+{
+  if (!m || !ea)
+    return;
+
+  struct Email **ep = NULL;
+  ARRAY_FOREACH(ep, ea)
+  {
+    if (*ep)
+      mutt_set_flag(m, *ep, MUTT_DELETE, deleted, true);
+  }
+
+  struct PostponeModuleData *mod_data = neomutt_get_module_data(NeoMutt, MODULE_ID_POSTPONE);
+  if (mod_data)
+    mod_data->post_count = m->msg_count - m->msg_deleted;
+}
+
+/**
  * op_delete - Delete the current entry - Implements ::postpone_function_t - @ingroup postpone_function_api
  *
  * This function handles:
@@ -98,22 +164,13 @@ static int op_delete(struct PostponeData *pd, const struct KeyEvent *event)
 
   const int index = menu_get_index(menu);
   const bool bf = (event->op == OP_DELETE);
+
   /* should deleted draft messages be saved in the trash folder? */
-  if (menu->tag_prefix)
-  {
-    for (int i = 0; i < m->msg_count; i++)
-    {
-      struct Email *e = m->emails[i];
-      if (e && e->tagged)
-        mutt_set_flag(m, e, MUTT_DELETE, bf, true);
-    }
-  }
-  else
-  {
-    mutt_set_flag(m, m->emails[index], MUTT_DELETE, bf, true);
-  }
-  struct PostponeModuleData *mod_data = neomutt_get_module_data(NeoMutt, MODULE_ID_POSTPONE);
-  mod_data->post_count = m->msg_count - m->msg_deleted;
+  struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
+  postpone_add_selection(&ea, menu, m, menu->tag_prefix);
+  postpone_apply_set_deleted(m, &ea, bf);
+  ARRAY_FREE(&ea);
+
   const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
   if (!menu->tag_prefix && c_resolve && (index < (menu->max - 1)))
   {

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -49,7 +49,8 @@ ATTACH_OBJS	= test/attach/mutt_actx_add_attach.o \
 		  test/attach/mutt_actx_add_fp.o \
 		  test/attach/mutt_actx_entries_free.o \
 		  test/attach/mutt_actx_free.o \
-		  test/attach/mutt_actx_new.o
+		  test/attach/mutt_actx_new.o \
+		  test/attach/selection.o
 
 BASE64_OBJS	= test/base64/mutt_b64_buffer_decode.o \
 		  test/base64/mutt_b64_buffer_encode.o \

--- a/test/attach/selection.c
+++ b/test/attach/selection.c
@@ -1,0 +1,152 @@
+/**
+ * @file
+ * Test code for attachment selection helpers
+ *
+ * @authors
+ * Copyright (C) 2026 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include "mutt/lib.h"
+#include "email/lib.h"
+#include "attach/lib.h"
+#include "menu/lib.h"
+#include "test_common.h"
+
+static void check_attach_selection(struct AttachPtrArray *aa,
+                                   struct AttachPtr *expected[], size_t expected_len)
+{
+  TEST_CHECK_NUM_EQ(ARRAY_SIZE(aa), expected_len);
+
+  for (size_t i = 0; i < expected_len; i++)
+  {
+    TEST_CHECK(*ARRAY_GET(aa, i) == expected[i]);
+  }
+}
+
+static void check_body_selection(struct BodyArray *ba, struct Body *expected[], size_t expected_len)
+{
+  TEST_CHECK_NUM_EQ(ARRAY_SIZE(ba), expected_len);
+
+  for (size_t i = 0; i < expected_len; i++)
+  {
+    TEST_CHECK(*ARRAY_GET(ba, i) == expected[i]);
+  }
+}
+
+void test_aa_add_selection(void)
+{
+  // int aa_add_selection(struct AttachPtrArray *aa, struct AttachCtx *actx,
+  //                      struct Menu *menu, bool use_tagged, int count);
+
+  struct Body b1 = { 0 };
+  struct Body b2 = { 0 };
+  struct Body b3 = { 0 };
+  struct Body b4 = { 0 };
+  struct AttachPtr a1 = { .body = &b1 };
+  struct AttachPtr a2 = { .body = &b2 };
+  struct AttachPtr a3 = { .body = &b3 };
+  struct AttachPtr a4 = { .body = &b4 };
+  struct AttachPtr *idx[] = { &a1, &a2, &a3, &a4 };
+  short v2r[] = { 2, 0, 3, 1 };
+  struct AttachCtx actx = {
+    .idx = idx,
+    .idxlen = 4,
+    .v2r = v2r,
+    .vcount = 4,
+  };
+  struct Menu menu = { .current = 1 };
+
+  {
+    struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+    struct AttachPtr *expected[] = { &a1 };
+    TEST_CHECK_NUM_EQ(aa_add_selection(&aa, &actx, &menu, false, 0), 1);
+    check_attach_selection(&aa, expected, sizeof(expected) / sizeof(expected[0]));
+    ARRAY_FREE(&aa);
+  }
+
+  {
+    struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+    struct AttachPtr *expected[] = { &a1 };
+    TEST_CHECK_NUM_EQ(aa_add_selection(&aa, &actx, &menu, false, 1), 1);
+    check_attach_selection(&aa, expected, sizeof(expected) / sizeof(expected[0]));
+    ARRAY_FREE(&aa);
+  }
+
+  {
+    struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+    struct AttachPtr *expected[] = { &a1, &a4, &a2 };
+    TEST_CHECK_NUM_EQ(aa_add_selection(&aa, &actx, &menu, false, 3), 3);
+    check_attach_selection(&aa, expected, sizeof(expected) / sizeof(expected[0]));
+    ARRAY_FREE(&aa);
+  }
+
+  {
+    struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+    struct AttachPtr *expected[] = { &a1, &a4, &a2 };
+    TEST_CHECK_NUM_EQ(aa_add_selection(&aa, &actx, &menu, false, 99), 3);
+    check_attach_selection(&aa, expected, sizeof(expected) / sizeof(expected[0]));
+    ARRAY_FREE(&aa);
+  }
+
+  {
+    struct AttachPtrArray aa = ARRAY_HEAD_INITIALIZER;
+    b2.tagged = true;
+    b4.tagged = true;
+    menu.current = 0;
+
+    struct AttachPtr *expected[] = { &a2, &a4 };
+    TEST_CHECK_NUM_EQ(aa_add_selection(&aa, &actx, &menu, true, 99), 2);
+    check_attach_selection(&aa, expected, sizeof(expected) / sizeof(expected[0]));
+
+    b2.tagged = false;
+    b4.tagged = false;
+    ARRAY_FREE(&aa);
+  }
+}
+
+void test_ba_add_selection(void)
+{
+  // int ba_add_selection(struct BodyArray *ba, struct AttachCtx *actx,
+  //                      struct Menu *menu, bool use_tagged, int count);
+
+  struct Body b1 = { 0 };
+  struct Body b2 = { 0 };
+  struct Body b3 = { 0 };
+  struct AttachPtr a1 = { .body = &b1 };
+  struct AttachPtr a2 = { .body = &b2 };
+  struct AttachPtr a3 = { .body = &b3 };
+  struct AttachPtr *idx[] = { &a1, &a2, &a3 };
+  short v2r[] = { 1, 2, 0 };
+  struct AttachCtx actx = {
+    .idx = idx,
+    .idxlen = 3,
+    .v2r = v2r,
+    .vcount = 3,
+  };
+  struct Menu menu = { .current = 1 };
+
+  struct BodyArray ba = ARRAY_HEAD_INITIALIZER;
+  struct Body *expected[] = { &b3, &b1 };
+  TEST_CHECK_NUM_EQ(ba_add_selection(&ba, &actx, &menu, false, 2), 2);
+  check_body_selection(&ba, expected, sizeof(expected) / sizeof(expected[0]));
+  ARRAY_FREE(&ba);
+}

--- a/test/common.c
+++ b/test/common.c
@@ -49,12 +49,11 @@
 #include "complete/lib.h"
 #include "key/lib.h"
 #include "send/lib.h"
-#include "color/module_data.h"
 #include "external.h"
-#include "key/module_data.h"
 #include "mx.h"
 
 struct AttachCtx;
+struct AttachPtrArray;
 struct Notify;
 struct PagerView;
 
@@ -317,8 +316,7 @@ const char *mutt_make_version(void)
   return "VERSION";
 }
 
-void attach_bounce_message(struct Mailbox *m, FILE *fp, struct AttachCtx *actx,
-                           struct Body *b)
+void attach_bounce_message(struct AttachPtrArray *aa, struct Mailbox *m)
 {
 }
 
@@ -341,21 +339,21 @@ int mutt_aside_thread(struct Email *e, bool forwards, bool subthreads)
   return 0;
 }
 
-void mutt_attach_forward(FILE *fp, struct Email *e, struct AttachCtx *actx,
-                         struct Body *b, SendFlags flags)
+void mutt_attach_forward(struct AttachPtrArray *aa, struct Email *e,
+                         struct AttachCtx *actx, SendFlags flags)
 {
 }
 
-void mutt_attach_mail_sender(struct AttachCtx *actx, struct Body *b)
+void mutt_attach_mail_sender(struct AttachPtrArray *aa)
 {
 }
 
-void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
-                       struct AttachCtx *actx, struct Body *b, SendFlags flags)
+void mutt_attach_reply(struct AttachPtrArray *aa, struct Mailbox *m,
+                       struct Email *e, struct AttachCtx *actx, SendFlags flags)
 {
 }
 
-void mutt_attach_resend(FILE *fp, struct Mailbox *m, struct AttachCtx *actx, struct Body *b)
+void mutt_attach_resend(struct AttachPtrArray *aa, struct Mailbox *m)
 {
 }
 

--- a/test/common.c
+++ b/test/common.c
@@ -446,8 +446,9 @@ void mutt_pipe_message(struct Mailbox *m, struct EmailArray *ea)
 {
 }
 
-void mutt_print_message(struct Mailbox *m, struct EmailArray *ea)
+bool mutt_print_message(struct Mailbox *m, struct EmailArray *ea)
 {
+  return true;
 }
 
 int mutt_save_message(struct Mailbox *m, struct EmailArray *ea,

--- a/test/main.c
+++ b/test/main.c
@@ -82,6 +82,8 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_mutt_array_api)                                       \
                                                                                \
   /* attach */                                                                 \
+  NEOMUTT_TEST_ITEM(test_aa_add_selection)                                     \
+  NEOMUTT_TEST_ITEM(test_ba_add_selection)                                     \
   NEOMUTT_TEST_ITEM(test_mutt_actx_add_attach)                                 \
   NEOMUTT_TEST_ITEM(test_mutt_actx_add_body)                                   \
   NEOMUTT_TEST_ITEM(test_mutt_actx_add_fp)                                     \


### PR DESCRIPTION
**Work in Progress**

Add Repeat-Count support to all of the functions that do some work.

Recent commits have added "repeat-count" support to the key handling code.
This allows you to type <kbd>5j</kbd> and have the cursor move down 5 lines.
(where <kbd>j</kbd> has the default binding to `<next-undeleted>`)

This is working for all of the motion functions.

This PR extends the feature to include all functions.
Now, typing <kbd>5d</kbd>, in the Index, will delete five emails.