### PR TITLE
Add %{relative-number} expando to Index

### DIFF
--- a/debug/names_expando.c
+++ b/debug/names_expando.c
@@ -383,10 +383,12 @@ const char *name_expando_uid_mailbox(int uid)
 
 const char *name_expando_uid_menu(int uid)
 {
-  if (uid == ED_MEN_PERCENTAGE)
-    return "ED_MEN_PERCENTAGE";
-
-  return "UNKNOWN";
+  switch (uid)
+  {
+    DEBUG_NAME(ED_MEN_PERCENTAGE);
+    DEBUG_NAME(ED_MEN_RELATIVE_NUMBER);
+    DEBUG_DEFAULT;
+  }
 }
 
 const char *name_expando_uid_msg_id(int uid)

--- a/docs/config.c
+++ b/docs/config.c
@@ -2253,6 +2253,8 @@
 ** .dt \fC%m\fP      .dd \fC%{message-count}\fP       .dd Total number of message in the mailbox
 ** .dt \fC%N\fP      .dd \fC%{score}\fP               .dd Message score
 ** .dt \fC%n\fP      .dd \fC%{name}\fP                .dd Author's real name (or address if missing)
+** .dt              .dd \fC%{relative-number}\fP      .dd Vim-style relative number: the current line shows its 1-based line number
+** .dt              .dd                               .dd and other lines show their absolute distance from the current selection
 ** .dt \fC%O\fP      .dd \fC%{save-folder}\fP         .dd Original save folder where NeoMutt would formerly have Stashed the message:
 ** .dt               .dd                              .dd list name or recipient name if not sent to a list
 ** .dt \fC%P\fP      .dd \fC%{percentage}\fP          .dd Progress indicator for the built-in pager (how much of the file has been displayed)

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -939,7 +939,19 @@ int index_make_entry(struct Menu *menu, int line, int max_cols, struct Buffer *b
       max_cols -= (mutt_strwidth(c_arrow_string) + 1);
   }
 
-  return mutt_make_string(buf, max_cols, c_index_format, m, msg_in_pager, e, flags, NULL);
+  struct IndexFormatData ifd = { 0 };
+
+  ifd.email.email = e;
+  ifd.email.mailbox = m;
+  ifd.email.msg_in_pager = msg_in_pager;
+  ifd.email.menu_data = &ifd.menu;
+
+  ifd.menu.menu = menu;
+  ifd.menu.line = line;
+  ifd.menu.data = &ifd.email;
+
+  return expando_filter(c_index_format, IndexRenderCallbacks, &ifd, flags,
+                        max_cols, NeoMutt->env, buf);
 }
 
 /**

--- a/index/expando_index.c
+++ b/index/expando_index.c
@@ -1682,6 +1682,18 @@ static void mailbox_percentage(const struct ExpandoNode *node, void *data,
 }
 
 /**
+ * menu_relative_number_num - Index: Relative offset from the current selection
+ * - Implements ::get_number_t - @ingroup expando_get_number_api
+ */
+static long menu_relative_number_num(const struct ExpandoNode *node, void *data,
+                                     MuttFormatFlags flags)
+{
+  const struct EmailFormatInfo *efi = data;
+
+  return menu_relative_number(efi->menu_data);
+}
+
+/**
  * IndexRenderCallbacks - Callbacks for Index Expandos
  *
  * @sa IndexFormatDef, ExpandoDataEmail, ExpandoDataEnvelope, ExpandoDataGlobal, ExpandoDataMailbox
@@ -1740,6 +1752,7 @@ const struct ExpandoRenderCallback IndexRenderCallbacks[] = {
   { ED_MAILBOX,  ED_MBX_MAILBOX_NAME,        mailbox_mailbox_name,      NULL },
   { ED_MAILBOX,  ED_MBX_MESSAGE_COUNT,       NULL,                      mailbox_message_count },
   { ED_MAILBOX,  ED_MBX_PERCENTAGE,          mailbox_percentage,        NULL },
+  { ED_MENU,     ED_MEN_RELATIVE_NUMBER,     NULL,                      menu_relative_number_num },
   { -1, -1, NULL, NULL },
   // clang-format on
 };

--- a/index/private.h
+++ b/index/private.h
@@ -25,6 +25,7 @@
 #define MUTT_INDEX_PRIVATE_H
 
 #include <stdbool.h>
+#include "menu/format_data.h"
 
 struct IndexPrivateData;
 struct IndexSharedData;
@@ -35,10 +36,23 @@ struct ConfigSubset;
  */
 struct EmailFormatInfo
 {
-  struct Mailbox *mailbox;    ///< Current Mailbox
-  int msg_in_pager;           ///< Index of Email displayed in the Pager
-  struct Email *email;        ///< Current Email
-  const char *pager_progress; ///< String representing Pager position through Email
+  struct Mailbox *mailbox;                 ///< Current Mailbox
+  int msg_in_pager;                        ///< Index of Email displayed in the Pager
+  struct Email *email;                     ///< Current Email
+  const char *pager_progress;              ///< String representing Pager position through Email
+  const struct MenuFormatData *menu_data;  ///< Optional menu context for menu expandos
+};
+
+/**
+ * struct IndexFormatData - Wrapped data for $index_format
+ *
+ * EmailFormatInfo must remain the first field so the existing index expando
+ * callbacks can keep treating this wrapper as EmailFormatInfo.
+ */
+struct IndexFormatData
+{
+  struct EmailFormatInfo email;  ///< Email data used by existing callbacks
+  struct MenuFormatData menu;    ///< Menu context for menu expandos
 };
 
 struct MuttWindow *index_window_new(struct IndexPrivateData *priv);

--- a/menu/format_data.h
+++ b/menu/format_data.h
@@ -1,0 +1,71 @@
+/**
+ * @file
+ * Generic menu format data wrapper
+ *
+ * @authors
+ * Copyright (C) 2026 Copilot <223556219+Copilot@users.noreply.github.com>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_MENU_FORMAT_DATA_H
+#define MUTT_MENU_FORMAT_DATA_H
+
+#include "lib.h"
+
+/**
+ * @defgroup menu_format_data Menu Format Data
+ *
+ * Data structures for passing menu context to format callbacks
+ */
+
+/**
+ * struct MenuFormatData - Wrapper for menu item format data
+ *
+ * Contains a menu reference and current line number, allowing callbacks
+ * to compute relative positioning
+ */
+struct MenuFormatData
+{
+  struct Menu *menu;  ///< Current menu
+  int line;           ///< Current line being formatted
+  void *data;         ///< Item-specific data (e.g., AliasView, Email)
+};
+
+/**
+ * menu_relative_number - Calculate Vim-style relative numbering in a menu
+ * @param mfd MenuFormatData wrapper
+ * @retval num Current line number for the selection, otherwise absolute offset
+ *
+ * Returns the relative position of the current line from the selected item,
+ * matching Vim's relative number display.
+ * For example:
+ * - Current selection at line 5: returns 6
+ * - Line 3: returns 2
+ * - Line 7: returns 2
+ */
+static inline long menu_relative_number(const struct MenuFormatData *mfd)
+{
+  if (!mfd || !mfd->menu)
+    return 0;
+
+  if (mfd->line == mfd->menu->current)
+    return mfd->line + 1;
+
+  const long relative = mfd->line - mfd->menu->current;
+  return (relative < 0) ? -relative : relative;
+}
+
+#endif /* MUTT_MENU_FORMAT_DATA_H */

--- a/menu/format_data.h
+++ b/menu/format_data.h
@@ -64,8 +64,7 @@ static inline long menu_relative_number(const struct MenuFormatData *mfd)
   if (mfd->line == mfd->menu->current)
     return mfd->line + 1;
 
-  const long relative = mfd->line - mfd->menu->current;
-  return (relative < 0) ? -relative : relative;
+  return labs(mfd->line - mfd->menu->current);
 }
 
 #endif /* MUTT_MENU_FORMAT_DATA_H */

--- a/menu/lib.h
+++ b/menu/lib.h
@@ -67,6 +67,7 @@ typedef uint8_t MenuRedrawFlags;       ///< Flags, e.g. #MENU_REDRAW_INDEX
 enum ExpandoDataMenu
 {
   ED_MEN_PERCENTAGE,           ///< Menu.top, ...
+  ED_MEN_RELATIVE_NUMBER,      ///< Relative position in menu (offset from current selection)
 };
 
 /**

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -42,6 +42,7 @@
 #include "email/lib.h"
 #include "core/lib.h"
 #include "gui/lib.h"
+#include "menu/lib.h"
 #include "attach/lib.h"
 #include "expando/lib.h"
 #include "mutt_logging.h"
@@ -365,6 +366,7 @@ const struct ExpandoDefinition IndexFormatDef[] = {
   { "zt", "message-flags",       ED_EMAIL,    ED_EMA_MESSAGE_FLAGS,       NULL },
   { "[",  NULL,                  ED_EMAIL,    ED_EMA_DATE_STRF_LOCAL,     parse_index_date_local },
   { "{",  NULL,                  ED_EMAIL,    ED_EMA_DATE_STRF,           parse_index_date },
+  { NULL, "relative-number",     ED_MENU,     ED_MEN_RELATIVE_NUMBER,     NULL },
   { NULL, NULL, 0, -1, NULL }
   // clang-format on
 };


### PR DESCRIPTION
**Work in Progress**

Add a new Expando to the Index: `%{relative-number}`.
This works like Vim's `relativenumber` option.

This has only been added to the Index, for now.

### Before

```
set index_format="%5C %Z %{%b %d} %-15.15L (%<l?%4l&%4c>) %s"
```
```
38140   C Apr 23 Richard Russon  ( 14K) menu: add count prefix support for motion functions (PR #4855)
38141   C Apr 23 Richard Russon  ( 12K) ├─>
38142   C Apr 23 Richard Russon  ( 12K) ├─>
38143   C Apr 23 Richard Russon  ( 15K) ├─>
38144   C Apr 27 Richard Russon  (8.5K) ├─>Re: Repeat-Count Support for Motion Functions (PR #4855)
38145   C Apr 27 Richard Russon  (4.7K) └─>Re: Repeat-Count Support for Motion Functions (PR #4855)
38146   C Apr 24 Richard Russon  (7.7K) repeat-count: tagging intent? (PR #4856)
38147   C Apr 27 Richard Russon  (5.4K) ├─>
38148   C Apr 27 github-advanced (5.4K) ├─>
38149   C Apr 27 Richard Russon  (5.4K) ├─>
38150   C Apr 27 Richard Russon  (4.7K) └─>
38151   C Apr 25 Richard Russon  (8.9K) key: add repeat-count support for macros (PR #4857)
38152   C Apr 27 Richard Russon  (5.7K) ├─>
38153   C Apr 27 Richard Russon  (4.7K) └─>
38154   C Apr 17 Richard Russon  (9.9K) cliwatch: add benchmark workflow (PR #4847)
38155   C Apr 17 Richard Russon  (7.7K) ├─>
38156   C Apr 27 Richard Russon  (4.6K) └─>
```

### After

```
set index_format="%5{relative-number} %Z %{%b %d} %-15.15L (%<l?%4l&%4c>) %s"
```
```
    6   C Apr 23 Richard Russon  ( 14K) menu: add count prefix support for motion functions (PR #4855)
    5   C Apr 23 Richard Russon  ( 12K) ├─>
    4   C Apr 23 Richard Russon  ( 12K) ├─>
    3   C Apr 23 Richard Russon  ( 15K) ├─>
    2   C Apr 27 Richard Russon  (8.5K) ├─>Re: Repeat-Count Support for Motion Functions (PR #4855)
    1   C Apr 27 Richard Russon  (4.7K) └─>Re: Repeat-Count Support for Motion Functions (PR #4855)
38146   C Apr 24 Richard Russon  (7.7K) repeat-count: tagging intent? (PR #4856)
    1   C Apr 27 Richard Russon  (5.4K) ├─>
    2   C Apr 27 github-advanced (  91) ├─>
    3   C Apr 27 Richard Russon  (5.4K) ├─>
    4   C Apr 27 Richard Russon  (4.7K) └─>
    5   C Apr 25 Richard Russon  (8.9K) key: add repeat-count support for macros (PR #4857)
    6   C Apr 27 Richard Russon  (5.7K) ├─>
    7   C Apr 27 Richard Russon  (4.7K) └─>
    8   C Apr 17 Richard Russon  (9.9K) cliwatch: add benchmark workflow (PR #4847)
    9   C Apr 17 Richard Russon  (7.7K) ├─>
   10   C Apr 27 Richard Russon  (4.6K) └─>
```