### PR TITLE
key: add modern <C-/A-/M-/S-...> grammar

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -4473,21 +4473,65 @@ set alias_file=~/.mail_aliases
         </variablelist>
         <para>
           <emphasis>key</emphasis> is the key (or key sequence) you wish to bind.
-          To specify a control character, use the sequence
-          <emphasis>\Cx</emphasis>, where <emphasis>x</emphasis> is the letter of
-          the control character (for example, to specify control-A use
-          <quote>\Ca</quote>). Note that the case of <emphasis>x</emphasis> as
-          well as <emphasis>\C</emphasis> is ignored, so that
-          <emphasis>\CA</emphasis>, <emphasis>\Ca</emphasis>,
-          <emphasis>\cA</emphasis> and <emphasis>\ca</emphasis> are all
-          equivalent. An alternative form is to specify the key as a three digit
-          octal number prefixed with a <quote>\</quote> (for example
-          <emphasis>\177</emphasis> is equivalent to <emphasis>\c?</emphasis>).
-          You can also use the form <emphasis>&lt;177&gt;</emphasis>, which
-          allows octal numbers with an arbitrary number of digits.  In addition,
-          <emphasis>key</emphasis> may be a symbolic name as shown in <xref
-          linkend="tab-key-names"/>.
-
+          The recommended way to write modified keys is the modern
+          <emphasis>&lt;modifiers-base&gt;</emphasis> grammar, where one or
+          more of the following case-insensitive prefixes may be combined in
+          any order before the base key:
+          <itemizedlist>
+            <listitem><para><emphasis>C-</emphasis> Control</para></listitem>
+            <listitem><para><emphasis>A-</emphasis> Alt</para></listitem>
+            <listitem><para><emphasis>M-</emphasis> Meta (alias of Alt)</para></listitem>
+            <listitem><para><emphasis>S-</emphasis> Shift</para></listitem>
+          </itemizedlist>
+          For example, <emphasis>&lt;C-a&gt;</emphasis> is Ctrl-A,
+          <emphasis>&lt;A-x&gt;</emphasis> is Alt-X,
+          <emphasis>&lt;C-A-S-Right&gt;</emphasis> is Ctrl-Alt-Shift-Right
+          and <emphasis>&lt;M-Tab&gt;</emphasis> is Alt-Tab.  The base may
+          be a single character, an F-key
+          (<emphasis>&lt;F1&gt;</emphasis>…) or any of the symbolic names in
+          <xref linkend="tab-key-names"/>.  Alt is internally encoded as an
+          <emphasis>&lt;Esc&gt;</emphasis> prefix followed by the base key,
+          which matches what xterm-style terminals send.
+        </para>
+        <para>
+          The historical forms below remain fully supported and may still
+          appear in older configurations:
+          <itemizedlist>
+            <listitem>
+              <para>
+                <emphasis>\Cx</emphasis> — Ctrl modifier on letter
+                <emphasis>x</emphasis>, e.g. <emphasis>\Ca</emphasis> is
+                Ctrl-A.  The case of both <emphasis>\C</emphasis> and
+                <emphasis>x</emphasis> is ignored, so
+                <emphasis>\CA</emphasis>, <emphasis>\Ca</emphasis>,
+                <emphasis>\cA</emphasis> and <emphasis>\ca</emphasis> are all
+                equivalent.
+              </para>
+            </listitem>
+            <listitem>
+              <para>
+                <emphasis>\eX</emphasis> — Alt modifier (i.e. an
+                <emphasis>&lt;Esc&gt;</emphasis> prefix), so
+                <emphasis>\ea</emphasis> is the same as
+                <emphasis>&lt;A-a&gt;</emphasis>.
+              </para>
+            </listitem>
+            <listitem>
+              <para>
+                <emphasis>\NNN</emphasis> — a three-digit octal number, e.g.
+                <emphasis>\177</emphasis> is equivalent to
+                <emphasis>\c?</emphasis>.
+              </para>
+            </listitem>
+            <listitem>
+              <para>
+                <emphasis>&lt;NNN&gt;</emphasis> — an octal number of arbitrary
+                length wrapped in angle brackets.
+              </para>
+            </listitem>
+          </itemizedlist>
+          In addition, <emphasis>key</emphasis> may be a symbolic name as
+          shown in <xref linkend="tab-key-names"/>.
         </para>
 
         <table id="tab-key-names">

--- a/key/keymap.c
+++ b/key/keymap.c
@@ -200,6 +200,14 @@ struct Keymap *keymap_compare(struct Keymap *km1, struct Keymap *km2, size_t *po
  * keymap_get_name - Get the human name for a key
  * @param[in]  c   Key code
  * @param[out] buf Buffer for the result
+ *
+ * The key is rendered using the modern `<…>` grammar where applicable:
+ *   - control bytes  -> `<C-x>` (e.g. `0x01` -> `<C-a>`)
+ *   - 0x7f (DEL)     -> `<C-?>`
+ *   - named keys     -> table lookup (`<Up>`, `<Esc>`, …)
+ *   - F-keys         -> `<F1>`, `<F2>`, …
+ *   - printable      -> the literal character
+ *   - everything else -> `<NNN>` octal fallback
  */
 void keymap_get_name(int c, struct Buffer *buf)
 {
@@ -215,8 +223,23 @@ void keymap_get_name(int c, struct Buffer *buf)
     if (c < 0)
       c += 256;
 
-    if (c < 128)
+    if (c == 0x7f)
     {
+      buf_addstr(buf, "<C-?>");
+    }
+    else if ((c >= 1) && (c <= 26))
+    {
+      /* 0x01 .. 0x1A  ->  <C-a> .. <C-z> */
+      buf_add_printf(buf, "<C-%c>", 'a' + c - 1);
+    }
+    else if ((c >= 0x1c) && (c <= 0x1f))
+    {
+      /* 0x1c..0x1f  ->  <C-\>, <C-]>, <C-^>, <C-_> */
+      buf_add_printf(buf, "<C-%c>", '@' + c);
+    }
+    else if (c < 128)
+    {
+      /* ^@ (NUL) and any other control byte without a named entry */
       buf_addch(buf, '^');
       buf_addch(buf, (c + '@') & 0x7f);
     }
@@ -244,17 +267,51 @@ void keymap_get_name(int c, struct Buffer *buf)
  * @param[in]  km  Keybinding map
  * @param[out] buf Buffer for the result
  * @retval true Success
+ *
+ * Consecutive `<Esc>` + key pairs are folded into `<A-…>` form, so that
+ * `\ea` (which is stored internally as ESC followed by `a`) is shown as the
+ * modern `<A-a>`.  ESC followed by another ESC is not folded.
  */
 bool keymap_expand_key(struct Keymap *km, struct Buffer *buf)
 {
   if (!km || !buf)
     return false;
 
-  for (int i = 0; i < km->len; i++)
+  struct Buffer *tmp = buf_pool_get();
+
+  int i = 0;
+  while (i < km->len)
   {
-    keymap_get_name(km->keys[i], buf);
+    int c = km->keys[i];
+    /* Try to fold `<Esc> + key`  ->  `<A-key>` */
+    if ((c == '\033') && ((i + 1) < km->len) && (km->keys[i + 1] != '\033'))
+    {
+      int next = km->keys[i + 1];
+      buf_reset(tmp);
+      keymap_get_name(next, tmp);
+      const char *name = buf_string(tmp);
+      size_t nlen = buf_len(tmp);
+
+      if ((nlen >= 2) && (name[0] == '<') && (name[nlen - 1] == '>'))
+      {
+        /* Strip surrounding `<` `>` and prepend `A-` */
+        buf_addstr(buf, "<A-");
+        buf_addstr_n(buf, name + 1, nlen - 2);
+        buf_addch(buf, '>');
+      }
+      else
+      {
+        buf_add_printf(buf, "<A-%s>", name);
+      }
+      i += 2; // consumed this key and the next key
+      continue;
+    }
+
+    keymap_get_name(c, buf);
+    i++;
   }
 
+  buf_pool_release(&tmp);
   return true;
 }
 
@@ -328,11 +385,194 @@ int parse_keycode(const char *str)
 }
 
 /**
+ * apply_ctrl - Convert a base character to its Control-modified form
+ * @param ch Input character
+ * @retval num Resulting keycode (-1 on failure)
+ *
+ * Implements the standard ASCII Ctrl folding:
+ *   - letters       -> ch & 0x1f      (`C-a` -> 0x01, `C-z` -> 0x1a)
+ *   - `@` or space  -> 0x00 (NUL)
+ *   - `[` `\` `]` `^` `_` -> 0x1b..0x1f
+ *   - `?`           -> 0x7f (DEL)
+ *   - any other     -> -1
+ */
+static int apply_ctrl(int ch)
+{
+  if (mutt_isalpha(ch))
+    return mutt_toupper(ch) & 0x1f;
+  if ((ch == '@') || (ch == ' '))
+    return 0;
+  if ((ch >= '[') && (ch <= '_'))
+    return ch & 0x1f;
+  if (ch == '?')
+    return 0x7f;
+  return -1;
+}
+
+/**
+ * parse_modifier_key - Try to parse a `<C-/A-/S-/M-…>` modifier-key token
+ * @param[in]  inner Inner content of the `<…>` token (e.g. "C-A-x")
+ * @param[out] d     Buffer to write keycodes into
+ * @param[in]  max   Capacity of `d`
+ * @retval num   Number of keycodes written (>0 on success, 0 if not a
+ *               modifier-key token, -1 on parse error)
+ *
+ * Accepts any combination of the modifier prefixes (case-insensitive):
+ *   - `C-` Ctrl
+ *   - `A-` Alt
+ *   - `M-` Meta (alias of Alt)
+ *   - `S-` Shift
+ *
+ * The order of the prefixes is irrelevant, e.g. `<C-A-x>`, `<A-C-x>` and
+ * `<M-C-x>` are equivalent.
+ *
+ * The base may be:
+ *   - a single ASCII character (`<C-a>`, `<S-1>`)
+ *   - a symbolic key name (`<A-Tab>`, `<C-Up>`, `<F4>` etc.)
+ *
+ * Alt is encoded as an `<Esc>` prefix followed by the base keycode, which
+ * matches what xterm-style terminals send for `Alt-key`.
+ */
+static int parse_modifier_key(const char *inner, keycode_t *d, size_t max)
+{
+  if (!inner || !d || (max < 1))
+    return 0;
+
+  bool mod_c = false;
+  bool mod_a = false;
+  bool mod_s = false;
+  const char *s = inner;
+
+  /* Parse modifier prefixes greedily, requiring at least one character to
+   * remain after the last `X-` (otherwise `S-` could swallow the trailing
+   * dash of a real binding such as `<S->`). */
+  while ((s[0] != '\0') && (s[1] == '-') && (s[2] != '\0'))
+  {
+    char c = mutt_tolower((unsigned char) s[0]);
+    if (c == 'c')
+      mod_c = true;
+    else if ((c == 'a') || (c == 'm'))
+      mod_a = true;
+    else if (c == 's')
+      mod_s = true;
+    else
+      break;
+    s += 2;
+  }
+
+  if (!mod_c && !mod_a && !mod_s)
+    return 0; /* no modifier prefix found */
+
+  size_t base_len = strlen(s);
+  if (base_len == 0)
+    return -1;
+
+  size_t out = 0;
+
+  /* Alt becomes an ESC prefix followed by the rest. */
+  if (mod_a)
+  {
+    if (max < 2)
+      return -1;
+    d[out++] = '\033';
+  }
+
+  int base_kc = -1;
+
+  if (base_len == 1)
+  {
+    int ch = (unsigned char) s[0];
+    if (mod_s && mutt_isalpha(ch))
+      ch = mutt_toupper(ch);
+    if (mod_c)
+    {
+      ch = apply_ctrl(ch);
+      if (ch < 0)
+        return -1;
+    }
+    base_kc = ch;
+  }
+  else
+  {
+    /* Symbolic name.  Try modifier-prefixed forms first so that the
+     * `<C-Up>` / `<S-Up>` / `<A-Up>` curses-extended entries are honoured.
+     * Then fall back to the bare `<base>` lookup, in which case Ctrl/Shift
+     * modifiers cannot be applied without an explicit keycode. */
+    char buf[128] = { 0 };
+
+    if (mod_c && mod_s)
+    {
+      snprintf(buf, sizeof(buf), "<C-S-%s>", s);
+      base_kc = mutt_map_get_value(buf, KeyNames);
+      if (base_kc != -1)
+      {
+        mod_c = false;
+        mod_s = false;
+      }
+    }
+    if ((base_kc == -1) && mod_c)
+    {
+      snprintf(buf, sizeof(buf), "<C-%s>", s);
+      base_kc = mutt_map_get_value(buf, KeyNames);
+      if (base_kc != -1)
+        mod_c = false;
+    }
+    if ((base_kc == -1) && mod_s)
+    {
+      snprintf(buf, sizeof(buf), "<S-%s>", s);
+      base_kc = mutt_map_get_value(buf, KeyNames);
+      if (base_kc != -1)
+        mod_s = false;
+    }
+    if (base_kc == -1)
+    {
+      snprintf(buf, sizeof(buf), "<%s>", s);
+      base_kc = mutt_map_get_value(buf, KeyNames);
+      if (base_kc == -1)
+      {
+        int fk = parse_fkey(buf);
+        if (fk > 0)
+          base_kc = KEY_F(fk);
+      }
+      if (base_kc == -1)
+      {
+        int kc = parse_keycode(buf);
+        if (kc > 0)
+          base_kc = kc;
+      }
+    }
+
+    if (base_kc == -1)
+      return -1;
+
+    /* Any C/S modifier still active means we couldn't combine it with the
+     * special key (no curses entry, etc.) — bail out. */
+    if (mod_c || mod_s)
+      return -1;
+  }
+
+  if (base_kc <= 0)
+    return -1;
+
+  d[out++] = (keycode_t) base_kc;
+  return (int) out;
+}
+
+/**
  * parse_keys - Parse a key string into key codes
  * @param str Key string
  * @param d   Array for key codes
  * @param max Maximum length of key sequence
  * @retval num Length of key sequence
+ *
+ * Recognised forms inside `<…>`:
+ *   - Symbolic key names (`<Up>`, `<Tab>`, `<Hash>`, …) — see KeyNames
+ *   - F-keys (`<F1>`, `<F30>`, …)
+ *   - Octal keycodes (`<177>`, `<0407>`, …)
+ *   - Modifier prefixes (`<C-a>`, `<A-x>`, `<C-A-S-Right>`, …)
+ *
+ * Plain bytes (and backslash escapes that the tokenizer has already
+ * resolved) become themselves.
  */
 size_t parse_keys(const char *str, keycode_t *d, size_t max)
 {
@@ -369,6 +609,26 @@ size_t parse_keys(const char *str, keycode_t *d, size_t max)
       {
         s = t;
         *d = n;
+      }
+      else
+      {
+        /* Try the modern `<C-/A-/S-/M-…>` grammar.  The function may emit
+         * one or two keycodes (e.g. Alt-x becomes `<Esc>` + `x`). */
+        size_t inner_len = strlen(s);
+        if ((inner_len >= 3) && (s[inner_len - 1] == '>'))
+        {
+          s[inner_len - 1] = '\0'; /* temporarily strip closing `>` */
+          int written = parse_modifier_key(s + 1, d, len);
+          s[inner_len - 1] = '>';
+          if (written > 0)
+          {
+            s = t;
+            /* The bottom of the loop already advances `d` and `len` by 1.
+             * Account here for any *additional* keycodes emitted. */
+            d += (written - 1);
+            len -= (written - 1);
+          }
+        }
       }
 
       *t = c;

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -469,7 +469,8 @@ IDNA_OBJS	= test/idna/mutt_idna_intl_to_local.o \
 
 IMAP_OBJS	= test/imap/msg_set.o
 
-KEY_OBJS	= test/key/mutt_push_macro_repeated.o
+KEY_OBJS	= test/key/mutt_push_macro_repeated.o \
+		  test/key/parse_keys.o
 
 LIST_OBJS	= test/list/common.o \
 		  test/list/mutt_list_clear.o \

--- a/test/key/parse_keys.c
+++ b/test/key/parse_keys.c
@@ -1,0 +1,156 @@
+/**
+ * @file
+ * Test code for parse_keys() / keymap_get_name() with the modern key grammar
+ *
+ * @authors
+ * Copyright (C) 2026 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <string.h>
+#include "mutt/lib.h"
+#include "gui/lib.h"
+#include "key/lib.h"
+#include "test_common.h"
+
+/// Test entry for parse_keys()
+struct ParseKeysTest
+{
+  const char *input;     ///< Input string passed to parse_keys()
+  size_t expected_len;   ///< Expected number of keycodes
+  keycode_t expected[8]; ///< Expected keycodes
+};
+
+/// Test entry for keymap_get_name()
+struct GetNameTest
+{
+  int code;             ///< Input keycode
+  const char *expected; ///< Expected rendered string
+};
+
+void test_parse_keys(void)
+{
+  // size_t parse_keys(const char *str, keycode_t *d, size_t max);
+
+  static const struct ParseKeysTest tests[] = {
+    // clang-format off
+    // Plain printable
+    { "a",                1, { 'a' } },
+    { "Z",                1, { 'Z' } },
+    { "gg",               2, { 'g', 'g' } },
+
+    // Raw control byte (as the tokenizer would have produced from `\Ca`)
+    { "\x01",             1, { 0x01 } },
+
+    // Modern <C-x> grammar
+    { "<C-a>",            1, { 0x01 } },
+    { "<c-A>",            1, { 0x01 } },
+    { "<C-z>",            1, { 0x1a } },
+    { "<C-?>",            1, { 0x7f } },
+    { "<C-[>",            1, { 0x1b } },
+
+    // Modern <A-x> grammar -> ESC + base
+    { "<A-x>",            2, { 0x1b, 'x' } },
+    { "<A-?>",            2, { 0x1b, '?' } },
+
+    // <M-x> alias for <A-x>
+    { "<M-x>",            2, { 0x1b, 'x' } },
+
+    // <S-x> on a letter just uppercases
+    { "<S-a>",            1, { 'A' } },
+
+    // Combined modifiers - order independent
+    { "<C-A-x>",          2, { 0x1b, 0x18 } },
+    { "<A-C-x>",          2, { 0x1b, 0x18 } },
+    { "<M-C-x>",          2, { 0x1b, 0x18 } },
+    { "<C-S-a>",          1, { 0x01 } },
+
+    // Multi-key sequences via concatenation
+    { "g<C-a>",           2, { 'g', 0x01 } },
+    { "<A-x>g",           3, { 0x1b, 'x', 'g' } },
+    { "<A-x><A-y>",       4, { 0x1b, 'x', 0x1b, 'y' } },
+    { "<C-a><C-b><C-c>",  3, { 0x01, 0x02, 0x03 } },
+
+    // Legacy octal `<NNN>` form (still works alongside the modern grammar)
+    { "<177>",            1, { 0x7f } },
+    { "<033>",            1, { 0x1b } },
+
+    // Legacy F-key form
+    { "<f12>",            1, { KEY_F(12) } },
+
+    { NULL,               0, { 0 } },
+    // clang-format on
+  };
+
+  keycode_t out[8];
+  for (int i = 0; tests[i].input; i++)
+  {
+    TEST_CASE(tests[i].input);
+    memset(out, 0, sizeof(out));
+    size_t n = parse_keys(tests[i].input, out, countof(out));
+    TEST_CHECK_NUM_EQ(n, tests[i].expected_len);
+    for (size_t j = 0; j < tests[i].expected_len; j++)
+    {
+      TEST_CHECK_NUM_EQ(out[j], tests[i].expected[j]);
+    }
+  }
+}
+
+void test_keymap_get_name(void)
+{
+  // void keymap_get_name(int c, struct Buffer *buf);
+
+  static const struct GetNameTest tests[] = {
+    // clang-format off
+    // Control bytes use modern <C-x> form
+    { 0x01, "<C-a>"  },
+    { 0x1a, "<C-z>"  },
+    { 0x7f, "<C-?>"  },
+    { 0x1c, "<C-\\>" },
+    { 0x1d, "<C-]>"  },
+    { 0x1e, "<C-^>"  },
+    { 0x1f, "<C-_>"  },
+
+    // Named keys still use their friendly names
+    { 0x09, "<Tab>"    },
+    { 0x0a, "<Enter>"  },
+    { 0x0d, "<Return>" },
+    { 0x1b, "<Esc>"    },
+    { ' ',  "<Space>"  },
+
+    // Plain printable
+    { 'a', "a" },
+    { 'A', "A" },
+    { '5', "5" },
+
+    { -1, NULL },
+    // clang-format on
+  };
+
+  struct Buffer *buf = buf_pool_get();
+  for (int i = 0; tests[i].expected; i++)
+  {
+    TEST_CASE(tests[i].expected);
+    buf_reset(buf);
+    keymap_get_name(tests[i].code, buf);
+    TEST_CHECK_STR_EQ(buf_string(buf), tests[i].expected);
+  }
+  buf_pool_release(&buf);
+}

--- a/test/main.c
+++ b/test/main.c
@@ -539,6 +539,8 @@ void test_fini(void);
                                                                                \
   /* key */                                                                    \
   NEOMUTT_TEST_ITEM(test_mutt_push_macro_repeated)                             \
+  NEOMUTT_TEST_ITEM(test_parse_keys)                                           \
+  NEOMUTT_TEST_ITEM(test_keymap_get_name)                                      \
                                                                                \
   /* list */                                                                   \
   NEOMUTT_TEST_ITEM(test_mutt_list_clear)                                      \


### PR DESCRIPTION
**TL;DR** -- Update the keybindings to accept a modern grammar

:warning: **Work in Progress**

# Key description formats for `bind` and `macro`

Use modern prefixes for defining key bindings:

| Prefix | Meaning              |
|--------|----------------------|
| `C-`   | Control              |
| `A-`   | Alt                  |
| `M-`   | Meta (alias of `A-`) |
| `S-`   | Shift                |

Examples: `<C-a>`, `<A-x>`, `<M-Tab>`, `<C-A-S-Right>`, `<C-F5>`.

All historical forms (`\Ca`, `^a`, `\ex`, `\177`, `<177>`, `<f1>`, `<C-Up>`, ...) remain fully supported.

Below are docs for all possible key formats.

---

## 1. Plain printable character

Any single printable byte stands for itself.

| Example | Meaning       |
|---------|---------------|
| `a`     | lowercase a   |
| `Z`     | uppercase Z   |
| `1`     | digit 1       |
| `?`     | question mark |

The argument needs no quoting unless it contains a space or a semicolon.
Characters that are special to the config parser (`#`, `;`, `"`, `'`, `\`, `` ` ``, `$`, `<`, `>`) should be written using their symbolic names below (`<hash>`, `<semicolon>`, ...) or by quoting/escaping.

## 2. Backslash escape sequences (handled by the tokenizer)

These are resolved by `parse_extract_token()` *before* `parse_keys()` ever sees the argument, so they work for every command, including `bind`, `macro`, `unbind`, `unmacro`, `push`, `exec`.

| Form                | Result                                                                                     |
|---------------------|--------------------------------------------------------------------------------------------|
| `\t`                | tab (0x09)                                                                                 |
| `\r`                | carriage return (0x0d)                                                                     |
| `\n`                | newline / line feed (0x0a)                                                                 |
| `\f`                | form feed (0x0c)                                                                           |
| `\e`                | escape (0x1b) - also Alt-prefix                                                            |
| `\Cx` / `\cx`       | control-*x* (case of `C` and `x` is ignored, so `\Ca`, `\CA`, `\ca`, `\cA` are equivalent) |
| `\NNN`              | byte whose value is the **three-digit octal** number `NNN` (e.g. `\177` = DEL = `\c?`)     |
| `\\`                | a literal backslash                                                                        |
| `\"`                | a literal double quote                                                                     |
| `\<any-other-char>` | that literal character                                                                     |

## 3. Caret (control) notation - `^X`

Only enabled when the tokenizer is called with `TOKEN_CONDENSE`.
In key-related commands that means **`macro` sequences** and **`exec`** arguments.
It is **not** expanded for the *trigger* key of `bind` / `macro` / `unbind` / `unmacro`; for those, use `\Cx` or a `<...>` symbolic name instead.

| Form                 | Result                                           |
|----------------------|--------------------------------------------------|
| `^a`-`^z`, `^A`-`^Z` | control-letter (uppercased then `- '@'`)         |
| `^[`                 | escape (0x1b)                                    |
| `^^`                 | a literal `^`                                    |
| `^<any-other>`       | the literal two characters `^` and the next char |

## 4. Angle-bracket octal keycode - `<NNN>`

Inside angle brackets you may write an octal keycode of arbitrary length (see `parse_keycode()`.
Trailing whitespace before the closing `>` is allowed.

| Example    | Meaning                                |
|------------|----------------------------------------|
| `<177>`    | DEL                                    |
| `<033>`    | escape                                 |
| `<0407>`   | curses keycode 0407                    |
| `< 1001 >` | octal 1001, padding spaces are trimmed |

## 5. Function keys - `<fN>`

`parse_fkey()` recognises `<fN>` for any decimal *N* (the leading `f` is
case-insensitive).

| Example | Meaning                        |
|---------|--------------------------------|
| `<f1>`  | F1                             |
| `<F12>` | F12                            |
| `<f30>` | F30 (if the terminal sends it) |

## 6. Symbolic key names

Recognised by `parse_keys()` via the `KeyNames[]` table in key/keymap.c.
Matching is case-insensitive.

### 6a. Navigation / editing

| Symbolic name | Meaning                            |
|---------------|------------------------------------|
| `<PageUp>`    | Page Up                            |
| `<PageDown>`  | Page Down                          |
| `<Up>`        | up arrow                           |
| `<Down>`      | down arrow                         |
| `<Left>`      | left arrow                         |
| `<Right>`     | right arrow                        |
| `<Home>`      | Home                               |
| `<End>`       | End                                |
| `<Insert>`    | Insert                             |
| `<Delete>`    | Delete                             |
| `<BackSpace>` | Backspace                          |
| `<Next>`      | curses `KEY_NEXT` (when supported) |

### 6b. Whitespace / control

| Symbolic name   | Meaning                                               |
|-----------------|-------------------------------------------------------|
| `<Tab>`         | tab (also `\t`)                                       |
| `<BackTab>`     | backtab / shift-tab (when supported by curses)        |
| `<Esc>`         | escape (also `\e`)                                    |
| `<Space>`       | space bar                                             |
| `<Enter>`       | newline (`\n`)                                        |
| `<Return>`      | carriage return (`\r`)                                |
| `<KeypadEnter>` | keypad Enter (curses `KEY_ENTER`, falls back to `\n`) |

### 6c. Punctuation that is special to the config parser

These names exist so the literal character can be used safely in a `bind`.

| Symbolic name      | Character |
| ------------------ | --------- |
| `<Hash>`           | `#`       |
| `<Semicolon>`      | `;`       |
| `<DoubleQuote>`    | `"`       |
| `<Quote>`          | `'`       |
| `<Backslash>`      | `\`       |
| `<Backtick>`       | `` ` ``   |
| `<Dollar>`         | `$`       |
| `<Less>`           | `<`       |
| `<Greater>`        | `>`       |

### 6d. Modified arrow / navigation keys (curses extended)

These literals are filled in at start-up from ncurses' extended-name database (see key/extended.c).
They will only resolve to a real keycode when the terminal description provides one.
Where the curses entry is missing, the modern grammar (§7) still gives useful fallbacks for `<A-...>` (it sends `<Esc>` + base) but cannot synthesise Ctrl- or Shift-modified function keys.

| Ctrl-modified | Shift-modified | Alt-modified |
| ------------- | -------------- | ------------ |
| `<C-Up>`      | `<S-Up>`       | `<A-Up>`     |
| `<C-Down>`    | `<S-Down>`     | `<A-Down>`   |
| `<C-Left>`    | `<S-Left>`     | `<A-Left>`   |
| `<C-Right>`   | `<S-Right>`    | `<A-Right>`  |
| `<C-Home>`    | `<S-Home>`     | `<A-Home>`   |
| `<C-End>`     | `<S-End>`      | `<A-End>`    |
| `<C-Next>`    | `<S-Next>`     | `<A-Next>`   |
| `<C-Prev>`    | `<S-Prev>`     | `<A-Prev>`   |

## 7. Modern modifier grammar - `<C-/A-/M-/S-...>`

The recommended way to write any modified key is to prefix the base with one or more of `C-` (Control), `A-` (Alt), `M-` (Meta, alias of Alt) and `S-` (Shift) inside angle brackets.
Prefixes are case-insensitive and may appear in any order; each may appear at most once.

| Form              | Meaning                                            |
| ----------------- | -------------------------------------------------- |
| `<C-a>`           | Ctrl-A (= `\Ca` = `^a`, byte 0x01)                 |
| `<C-?>`           | Ctrl-? (DEL, byte 0x7f)                            |
| `<A-x>` / `<M-x>` | Alt-X (= `\ex`, ESC followed by `x`)               |
| `<S-a>`           | Shift-A (= literal `A`)                            |
| `<C-A-x>`         | Ctrl-Alt-X (= ESC + Ctrl-X)                        |
| `<A-C-x>`         | Same as `<C-A-x>` -- order is irrelevant           |
| `<C-S-Up>`        | Ctrl-Shift-Up (curses table is consulted)          |
| `<C-F5>`          | Ctrl-F5                                            |
| `<A-Tab>`         | Alt-Tab (= `\e<Tab>`)                              |

### How it resolves

`parse_keys()` for a `<...>` token tries, in order:

1. **Literal lookup** in the symbolic-name table -- so
   `<C-Up>`, `<S-Up>`, `<A-Up>` (and friends) match their curses keycode directly when the terminal advertises one.
2. **F-key / octal** parsing (`<F12>`, `<177>`).
3. **Modern modifier grammar**.  For modifier-prefixed tokens the parser strips each `X-` prefix in turn, then resolves the remaining base by:
   - For a single ASCII character the modifiers are folded: `S-` upper-cases, `C-` applies the standard control mask (`(uppercase(ch)) & 0x1f`, plus the well-known `[`, `\`, `]`, `^`, `_` and `?` cases), `A-` prepends `<Esc>`.
   - For a symbolic base the parser first tries the literal `<C-base>` / `<S-base>` / `<C-S-base>` lookup so curses extended keys are honoured, then falls back to the bare `<base>` (with `A-` adding an `<Esc>` prefix).

This means the modern grammar is **strictly additive**: every legacy form (`\Ca`, `^a`, `\ea`, `<C-Up>`, ...) keeps producing exactly the same keycodes it did before.

### Display side

Whenever NeoMutt renders a key -- in the help bar, the `dump` of bindings, the `<what-key>` prompt, attachment hints, etc. -- it now uses the modern grammar:

| Internal keycode                   | Display                            |
|------------------------------------|------------------------------------|
| `0x01`                             | `<C-a>` (was `^A`)                 |
| `0x7f`                             | `<C-?>` (was `^?`)                 |
| `0x1c..0x1f`                       | `<C-\>`, `<C-]>`, `<C-^>`, `<C-_>` |
| `<Esc>` then `x`                   | `<A-x>`                            |
| `<Esc>` then `<Up>`                | `<A-Up>`                           |
| Tab / Enter / Esc / Space / Return | unchanged (`<Tab>`, ...)           |

---

## Summary of where each form is honoured

| Form                                                   | `bind` / `unbind` / `unmacro` / `macro` *trigger* key | `macro` *sequence* / `exec` |
|--------------------------------------------------------|:-----------------------------------------------------:|:---------------------------:|
| Plain printable char                                   |                   :white_check_mark:                  |      :white_check_mark:     |
| `\t \r \n \f \e \\ \"`                                 |                   :white_check_mark:                  |      :white_check_mark:     |
| `\Cx` / `\cx`                                          |                   :white_check_mark:                  |      :white_check_mark:     |
| `\NNN` (3-digit octal)                                 |                   :white_check_mark:                  |      :white_check_mark:     |
| `^x` (caret notation)                                  |                          :x:                          |      :white_check_mark:     |
| `<NNN>` (octal in brackets)                            |                   :white_check_mark:                  |      :white_check_mark:     |
| `<fN>` function keys                                   |                   :white_check_mark:                  |      :white_check_mark:     |
| Symbolic names (`<Up>`, `<Hash>`, ...)                 |                   :white_check_mark:                  |      :white_check_mark:     |
| `<C-...>` `<S-...>` `<A-...>` arrows (curses extended) |                   :white_check_mark:                  |      :white_check_mark:     |
| **Modern `<C-/A-/M-/S-...>` grammar (§7)**             |                   :white_check_mark:                  |      :white_check_mark:     |

