### PR TITLE
pager: fix broken message-hook

### DIFF
--- a/pager/pager.c
+++ b/pager/pager.c
@@ -73,6 +73,7 @@
 #include "color/lib.h"
 #include "index/lib.h"
 #include "display.h"
+#include "hook.h"
 #include "private_data.h"
 
 /**
@@ -296,9 +297,13 @@ static int pager_config_observer(struct NotifyCallback *nc)
   if (!nc->global_data || !nc->event_data)
     return -1;
 
-  struct EventConfig *ev_c = nc->event_data;
   struct MuttWindow *win_pager = nc->global_data;
+  struct MuttWindow *focus = window_get_focus();
+  // Either the Pager isn't visible, or isn't active
+  if (focus != win_pager)
+    return 0;
 
+  struct EventConfig *ev_c = nc->event_data;
   if (mutt_str_equal(ev_c->name, "pager_index_lines"))
   {
     config_pager_index_lines(win_pager);
@@ -317,6 +322,18 @@ static int pager_config_observer(struct NotifyCallback *nc)
       return -1;
 
     notify_send(priv->notify, NT_PAGER, NT_PAGER_VIEW, priv);
+  }
+  else if (mutt_str_equal(ev_c->name, "pager"))
+  {
+    const char *const c_pager = pager_get_pager(NeoMutt->sub);
+    if (c_pager)
+    {
+      // A message-hook has set $pager
+      // Close the Pager and let the Index handle the message
+      struct PagerPrivateData *priv = win_pager->parent->wdata;
+      priv->loop = PAGER_LOOP_QUIT;
+      mutt_push_macro_event(0, OP_DISPLAY_MESSAGE);
+    }
   }
 
   return 0;
@@ -354,6 +371,7 @@ static int pager_index_observer(struct NotifyCallback *nc)
     if (shared && shared->email && (priv->loop != PAGER_LOOP_QUIT))
     {
       priv->loop = PAGER_LOOP_RELOAD;
+      mutt_message_hook(shared->mailbox, shared->email, MUTT_MESSAGE_HOOK);
     }
     else
     {


### PR DESCRIPTION
Fix a couple of problems with the `message-hook`.
This PR is against `[release]`; I'll merge it into `[main]` as well.

## Pager Transition

In the Index, when you `<display-message>`, the `message-hook` is fired.
However, when you're in the Pager and hit, say, `<next-undeleted>`, the `message-hook` isn't fired.

**Fix** -- Fire the `message-hook` when moving between Emails in the Pager.

## External Pager

If `$pager` is set to an external command, `<display-message>` will run _that_ command to show the email.
However, if you are in the Pager, setting `$pager` isn't honoured.

**Fix** -- Update the Pager to listen to changes to `$pager`.
If set during a `message-hook`, quit the Pager and let the Index handle it.

---

There is a third long-standing problem which I'm ignoring for now.

On exiting the external command, `$prompt_after` prompts the user for `Command:`
e.g. typing <kbd>j</kbd> is interpreted as `<next-undeleted>` and the next email should be displayed.

Currently, the user is shown the Index and the command is ignored.