### PR TITLE
alias: hide mail prompt

### DIFF
--- a/alias/dlg_alias.c
+++ b/alias/dlg_alias.c
@@ -445,7 +445,15 @@ int alias_complete(struct Buffer *buf, struct ConfigSubset *sub)
     mutt_pattern_alias_func(NULL, &mdata, PAA_VISIBLE, NULL);
   }
 
-  if (!dlg_alias(&mdata))
+  struct MuttWindow *hidden_prompt = alias_dialog_hide_prompt();
+  const bool selected = dlg_alias(&mdata);
+  if (hidden_prompt)
+  {
+    window_set_visible(hidden_prompt, true);
+    msgcont_push_window(hidden_prompt);
+  }
+
+  if (!selected)
     goto done;
 
   buf_reset(buf);

--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -452,8 +452,16 @@ int query_complete(struct Buffer *buf, struct ConfigSubset *sub)
     alias_array_alias_add(&mdata.ava, *ap);
   }
 
+  struct MuttWindow *hidden_prompt = alias_dialog_hide_prompt();
+  const bool selected = dlg_query(buf, &mdata);
+  if (hidden_prompt)
+  {
+    window_set_visible(hidden_prompt, true);
+    msgcont_push_window(hidden_prompt);
+  }
+
   /* multiple results, choose from query menu */
-  if (!dlg_query(buf, &mdata))
+  if (!selected)
     goto done;
 
   buf_reset(buf);

--- a/alias/gui.c
+++ b/alias/gui.c
@@ -64,6 +64,29 @@ int alias_config_observer(struct NotifyCallback *nc)
 }
 
 /**
+ * alias_dialog_hide_prompt - Hide the stacked prompt during alias/query selection
+ * @retval ptr Hidden prompt window
+ * @retval NULL No prompt was hidden
+ */
+struct MuttWindow *alias_dialog_hide_prompt(void)
+{
+  struct MuttWindow *msgwin = msgcont_get_msgwin();
+  struct MuttWindow *focus = window_get_focus();
+  if (!msgwin || !focus || (focus == msgwin))
+    return NULL;
+
+  struct MuttWindow *msgcont = msgwin->parent;
+  if (!msgcont || (focus->parent != msgcont))
+    return NULL;
+
+  struct MuttWindow **wp_top = ARRAY_LAST(&msgcont->children);
+  if (!wp_top || (*wp_top != focus))
+    return NULL;
+
+  return msgcont_pop_window();
+}
+
+/**
  * alias_set_title - Create a title string for the Menu
  * @param sbar      Simple Bar Window
  * @param menu_name Menu name

--- a/alias/gui.h
+++ b/alias/gui.h
@@ -70,6 +70,8 @@ int  alias_array_alias_add    (struct AliasViewArray *ava, struct Alias *alias);
 int  alias_array_alias_delete (struct AliasViewArray *ava, const struct Alias *alias);
 int  alias_array_count_visible(struct AliasViewArray *ava);
 
+struct MuttWindow *alias_dialog_hide_prompt(void);
+
 void alias_set_title(struct MuttWindow *sbar, char *menu_name, char *limit);
 int alias_recalc(struct MuttWindow *win);
 


### PR DESCRIPTION
The Message Window is actually a Container with a stack of Windows.
Only the top-most Window is visible.

The Alias Dialog can be triggered by auto-completion of the `<mail>` `To:` prompt.
When this happens, the `To:` prompt is still visible and it obscures any warnings or errors.

Temporarily hide (pop) the `To:` prompt from the stack, then restore it afterwards.

---

**Steps**:
- `<mail>` (<kbd>m</kbd>)
- Either:
   - `<complete>` (<kbd>\<Tab\></kbd> by default) -\> Alias Dialog
   - `<complete-query>` (<kbd>Ctrl-T</kbd> by default) -\> Query Dialog
- `<backspace>` (or any unbound key)

**Results**:
- Error message visible