### PR TITLE
main: fix dupe no-mail message

### DIFF
--- a/main.c
+++ b/main.c
@@ -1628,7 +1628,6 @@ int main(int argc, char *argv[], char *envp[])
       if (mutt_mailbox_check(NULL, csflags) == 0)
       {
         mutt_message(_("No mailbox with new mail"));
-        repeat_error = true;
         goto main_curses; // TEST37: neomutt -Z (no new mail)
       }
       buf_reset(folder);


### PR DESCRIPTION
When running `neomutt -Z`, don't repeat the message if there's no new mail.

Fixes: #4868