### PR TITLE
Make the Message Window more visible

### DIFF
--- a/alias/dlg_alias.c
+++ b/alias/dlg_alias.c
@@ -445,15 +445,7 @@ int alias_complete(struct Buffer *buf, struct ConfigSubset *sub)
     mutt_pattern_alias_func(NULL, &mdata, PAA_VISIBLE, NULL);
   }
 
-  struct MuttWindow *hidden_prompt = alias_dialog_hide_prompt();
-  const bool selected = dlg_alias(&mdata);
-  if (hidden_prompt)
-  {
-    window_set_visible(hidden_prompt, true);
-    msgcont_push_window(hidden_prompt);
-  }
-
-  if (!selected)
+  if (!dlg_alias(&mdata))
     goto done;
 
   buf_reset(buf);

--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -452,16 +452,8 @@ int query_complete(struct Buffer *buf, struct ConfigSubset *sub)
     alias_array_alias_add(&mdata.ava, *ap);
   }
 
-  struct MuttWindow *hidden_prompt = alias_dialog_hide_prompt();
-  const bool selected = dlg_query(buf, &mdata);
-  if (hidden_prompt)
-  {
-    window_set_visible(hidden_prompt, true);
-    msgcont_push_window(hidden_prompt);
-  }
-
   /* multiple results, choose from query menu */
-  if (!selected)
+  if (!dlg_query(buf, &mdata))
     goto done;
 
   buf_reset(buf);

--- a/alias/gui.c
+++ b/alias/gui.c
@@ -64,29 +64,6 @@ int alias_config_observer(struct NotifyCallback *nc)
 }
 
 /**
- * alias_dialog_hide_prompt - Hide the stacked prompt during alias/query selection
- * @retval ptr Hidden prompt window
- * @retval NULL No prompt was hidden
- */
-struct MuttWindow *alias_dialog_hide_prompt(void)
-{
-  struct MuttWindow *msgwin = msgcont_get_msgwin();
-  struct MuttWindow *focus = window_get_focus();
-  if (!msgwin || !focus || (focus == msgwin))
-    return NULL;
-
-  struct MuttWindow *msgcont = msgwin->parent;
-  if (!msgcont || (focus->parent != msgcont))
-    return NULL;
-
-  struct MuttWindow **wp_top = ARRAY_LAST(&msgcont->children);
-  if (!wp_top || (*wp_top != focus))
-    return NULL;
-
-  return msgcont_pop_window();
-}
-
-/**
  * alias_set_title - Create a title string for the Menu
  * @param sbar      Simple Bar Window
  * @param menu_name Menu name

--- a/alias/gui.h
+++ b/alias/gui.h
@@ -70,8 +70,6 @@ int  alias_array_alias_add    (struct AliasViewArray *ava, struct Alias *alias);
 int  alias_array_alias_delete (struct AliasViewArray *ava, const struct Alias *alias);
 int  alias_array_count_visible(struct AliasViewArray *ava);
 
-struct MuttWindow *alias_dialog_hide_prompt(void);
-
 void alias_set_title(struct MuttWindow *sbar, char *menu_name, char *limit);
 int alias_recalc(struct MuttWindow *win);
 

--- a/editor/functions.c
+++ b/editor/functions.c
@@ -40,6 +40,7 @@
 #include "menu/lib.h"
 #include "enter.h"
 #include "module_data.h"
+#include "mutt_logging.h"
 #include "state.h"
 #include "wdata.h"
 
@@ -483,6 +484,7 @@ static int op_help(struct EnterFunctionData *fdata, const struct KeyEvent *event
  */
 static int op_redraw(struct EnterFunctionData *fdata, const struct KeyEvent *event)
 {
+  mutt_clear_error();
   clearok(stdscr, true);
   mutt_resize_screen();
   window_invalidate_all();

--- a/editor/window.c
+++ b/editor/window.c
@@ -249,6 +249,39 @@ static bool enter_recursor(struct MuttWindow *win)
 }
 
 /**
+ * enter_window_observer - Notification that a Window has changed - Implements ::observer_t - @ingroup observer_api
+ *
+ * This function is triggered by changes to the windows:
+ * - State (this window): refresh the window
+ * - Delete (this window): clean up the observer
+ */
+static int enter_window_observer(struct NotifyCallback *nc)
+{
+  if (nc->event_type != NT_WINDOW)
+    return 0;
+  if (!nc->global_data || !nc->event_data)
+    return -1;
+
+  struct MuttWindow *win = nc->global_data;
+  struct EventWindow *ev_w = nc->event_data;
+  if (ev_w->win != win)
+    return 0;
+
+  if (nc->event_subtype == NT_WINDOW_STATE)
+  {
+    win->actions |= WA_REPAINT;
+    mutt_debug(LL_DEBUG5, "window state done, request WA_REPAINT\n");
+  }
+  else if (nc->event_subtype == NT_WINDOW_DELETE)
+  {
+    notify_observer_remove(win->notify, enter_window_observer, win);
+    mutt_debug(LL_DEBUG5, "window delete done\n");
+  }
+
+  return 0;
+}
+
+/**
  * mw_get_field_notify - Ask the user for a string and call a notify function on keypress
  * @param[in]  prompt   Prompt
  * @param[in]  buf      Buffer for the result
@@ -305,6 +338,8 @@ int mw_get_field_notify(const char *prompt, struct Buffer *buf, CompletionFlags 
   win->recalc = enter_recalc;
   win->repaint = enter_repaint;
   win->recursor = enter_recursor;
+
+  notify_observer_add(win->notify, NT_WINDOW, enter_window_observer, win);
 
   window_redraw(win);
 

--- a/gui/msgcont.c
+++ b/gui/msgcont.c
@@ -33,6 +33,7 @@
 #include "core/lib.h"
 #include "msgcont.h"
 #include "module_data.h"
+#include "msgwin.h"
 #include "mutt_window.h"
 #ifdef USE_DEBUG_WINDOW
 #include "debug/lib.h"
@@ -130,10 +131,9 @@ struct MuttWindow *msgcont_pop_window(void)
   {
     window_set_visible(win_top, true);
     win_top->actions |= WA_RECALC;
-
-    if (mod_data->bottom_bar)
-      mod_data->bottom_bar->req_rows = win_top->req_rows;
   }
+
+  msgcont_recalc_rows();
 
   mutt_window_reflow(NULL);
   window_redraw(NULL);
@@ -154,16 +154,24 @@ void msgcont_push_window(struct MuttWindow *win)
     return;
 
   struct MuttWindow *mc = mod_data->message_container;
+  const bool keep_msgwin = msgwin_has_text();
 
-  // Hide the current top window
-  struct MuttWindow **wp_top = ARRAY_LAST(&mc->children);
-  if (wp_top)
-    window_set_visible(*wp_top, false);
+  // Hide all currently visible children: the new window will take over the
+  // space.  If the Message Window currently holds any text, it should remain
+  // visible so the user still sees the message.
+  struct MuttWindow **wp = NULL;
+  ARRAY_FOREACH(wp, &mc->children)
+  {
+    if (!(*wp)->state.visible)
+      continue;
+    if (keep_msgwin && ((*wp)->type == WT_MESSAGE))
+      continue;
+    window_set_visible(*wp, false);
+  }
 
   mutt_window_add_child(mc, win);
 
-  if (mod_data->bottom_bar)
-    mod_data->bottom_bar->req_rows = win->req_rows;
+  msgcont_recalc_rows();
 
   mutt_window_reflow(NULL);
   window_redraw(NULL);

--- a/gui/msgcont.c
+++ b/gui/msgcont.c
@@ -54,6 +54,48 @@ struct MuttWindow *msgcont_new(void)
 }
 
 /**
+ * msgcont_recalc_rows - Recalculate the Bottom Bar height
+ *
+ * Sum the req_rows of all visible children of the Message Container and
+ * apply the result to the Bottom Bar's req_rows.  The caller is responsible
+ * for triggering a reflow if needed.
+ */
+void msgcont_recalc_rows(void)
+{
+  struct GuiModuleData *mod_data = neomutt_get_module_data(NeoMutt, MODULE_ID_GUI);
+  if (!mod_data || !mod_data->message_container || !mod_data->bottom_bar)
+    return;
+
+  struct MuttWindow *mc = mod_data->message_container;
+  int rows = 0;
+  struct MuttWindow **wp = NULL;
+  ARRAY_FOREACH(wp, &mc->children)
+  {
+    if (!(*wp)->state.visible)
+      continue;
+    rows += MAX(0, (*wp)->req_rows);
+  }
+
+  if (rows < 1)
+    rows = 1;
+
+  mod_data->bottom_bar->req_rows = rows;
+}
+
+/**
+ * msgcont_num_windows - Count the Windows in the Message Container
+ * @retval num Number of children windows
+ */
+int msgcont_num_windows(void)
+{
+  struct GuiModuleData *mod_data = neomutt_get_module_data(NeoMutt, MODULE_ID_GUI);
+  if (!mod_data || !mod_data->message_container)
+    return 0;
+
+  return ARRAY_SIZE(&mod_data->message_container->children);
+}
+
+/**
  * msgcont_pop_window - Remove the last Window from the Container Stack
  * @retval ptr Window removed from the stack
  */

--- a/gui/msgcont.h
+++ b/gui/msgcont.h
@@ -29,5 +29,7 @@ struct MuttWindow *msgcont_get_msgwin(void);
 struct MuttWindow *msgcont_new(void);
 struct MuttWindow *msgcont_pop_window(void);
 void               msgcont_push_window(struct MuttWindow *win);
+void               msgcont_recalc_rows(void);
+int                msgcont_num_windows(void);
 
 #endif /* MUTT_GUI_MSGCONT_H */

--- a/gui/msgwin.c
+++ b/gui/msgwin.c
@@ -178,13 +178,16 @@ static int msgwin_recalc(struct MuttWindow *win)
  */
 int msgwin_calc_rows(struct MsgWinWindowData *wdata, int cols, const char *str)
 {
-  if (!wdata || !str || !*str)
+  if (!wdata)
     return 0;
 
   for (int i = 0; i < MSGWIN_MAX_ROWS; i++)
   {
     ARRAY_FREE(&wdata->rows[i]);
   }
+
+  if (!str || !*str)
+    return 0;
 
   int width = 0;  ///< Screen width used
   int offset = 0; ///< Offset into str
@@ -254,11 +257,16 @@ static int msgwin_repaint(struct MuttWindow *win)
   struct MsgWinWindowData *wdata = win->wdata;
 
   const char *str = buf_string(wdata->text);
-  for (int i = 0; i < MSGWIN_MAX_ROWS; i++)
+  const int max_rows = MIN(MSGWIN_MAX_ROWS, win->state.rows);
+  for (int i = 0; i < max_rows; i++)
   {
     mutt_window_move(win, i, 0);
     if (ARRAY_EMPTY(&wdata->rows[i]))
+    {
+      mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
+      mutt_window_clrtoeol(win);
       break;
+    }
 
     struct MwChunk *chunk = NULL;
     ARRAY_FOREACH(chunk, &wdata->rows[i])
@@ -269,8 +277,6 @@ static int msgwin_repaint(struct MuttWindow *win)
     mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
     mutt_window_clrtoeol(win);
   }
-  mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
-  mutt_window_clrtoeol(win);
 
   mutt_window_get_coords(win, &wdata->row, &wdata->col);
 
@@ -314,9 +320,7 @@ void msgwin_set_rows(struct MuttWindow *win, short rows)
   {
     win->req_rows = rows;
 
-    struct GuiModuleData *mod_data = neomutt_get_module_data(NeoMutt, MODULE_ID_GUI);
-    if (mod_data && mod_data->bottom_bar)
-      mod_data->bottom_bar->req_rows = rows;
+    msgcont_recalc_rows();
 
     mutt_window_reflow(NULL);
   }
@@ -488,6 +492,10 @@ void msgwin_add_text_n(struct MuttWindow *win, const char *text, int bytes,
  * @param color Colour for text
  *
  * @note The text string will be copied
+ *
+ * If the Message Window is currently hidden (because another Window has been
+ * pushed on top of it in the Message Container) it will make itself visible
+ * and trigger a reflow so the message is shown to the user.
  */
 void msgwin_set_text(struct MuttWindow *win, const char *text, enum ColorId color)
 {
@@ -496,9 +504,13 @@ void msgwin_set_text(struct MuttWindow *win, const char *text, enum ColorId colo
   if (!win)
     return;
 
+  const bool hidden = !win->state.visible;
+
   struct MsgWinWindowData *wdata = win->wdata;
 
-  if (mutt_str_equal(buf_string(wdata->text), text))
+  // If the text is unchanged: nothing to do, except reveal the window if it
+  // was hidden so the user actually sees it.
+  if (mutt_str_equal(buf_string(wdata->text), text) && !hidden)
     return;
 
   buf_strcpy(wdata->text, text);
@@ -515,6 +527,18 @@ void msgwin_set_text(struct MuttWindow *win, const char *text, enum ColorId colo
   mutt_debug(LL_DEBUG5, "MW SET: %zu, %s\n", buf_len(wdata->text),
              buf_string(wdata->text));
 
+  // If the window was hidden, reveal it and reflow so the message is seen.
+  if (!win->state.visible)
+  {
+    window_set_visible(win, true);
+    int rows = msgwin_calc_rows(wdata, win->state.cols, buf_string(wdata->text));
+    win->req_rows = CLAMP(rows, 1, MSGWIN_MAX_ROWS);
+    msgcont_recalc_rows();
+    win->actions |= WA_RECALC;
+    window_redraw(NULL);
+    return;
+  }
+
   int rows = msgwin_calc_rows(wdata, win->state.cols, buf_string(wdata->text));
   msgwin_set_rows(win, rows);
   win->actions |= WA_RECALC;
@@ -523,10 +547,45 @@ void msgwin_set_text(struct MuttWindow *win, const char *text, enum ColorId colo
 /**
  * msgwin_clear_text - Clear the text in the Message Window
  * @param win Message Window
+ *
+ * Clear the displayed text.  If the Message Window is not the only Window in
+ * the Message Container, it is also hidden and the Windows are reflowed.
  */
 void msgwin_clear_text(struct MuttWindow *win)
 {
-  msgwin_set_text(win, NULL, MT_COLOR_NORMAL);
+  if (!win)
+    win = msgcont_get_msgwin();
+  if (!win)
+    return;
+
+  struct MsgWinWindowData *wdata = win->wdata;
+
+  // Force-clear even if the window was hidden (msgwin_set_text would skip it).
+  if (!buf_is_empty(wdata->text))
+  {
+    buf_reset(wdata->text);
+    ARRAY_FREE(&wdata->chars);
+    for (int i = 0; i < MSGWIN_MAX_ROWS; i++)
+    {
+      ARRAY_FREE(&wdata->rows[i]);
+    }
+
+    if (win->state.visible)
+    {
+      int rows = msgwin_calc_rows(wdata, win->state.cols, buf_string(wdata->text));
+      msgwin_set_rows(win, rows);
+      win->actions |= WA_RECALC;
+    }
+  }
+
+  // If the Message Window isn't alone in the stack, hide it again so the
+  // Window beneath us regains the space.
+  if (win->state.visible && (msgcont_num_windows() > 1))
+  {
+    window_set_visible(win, false);
+    msgcont_recalc_rows();
+    window_redraw(NULL);
+  }
 }
 
 /**

--- a/gui/msgwin.c
+++ b/gui/msgwin.c
@@ -539,3 +539,20 @@ struct MuttWindow *msgwin_get_window(void)
 {
   return msgcont_get_msgwin();
 }
+
+/**
+ * msgwin_has_text - Does the Message Window currently hold any text?
+ * @retval true The Message Window currently displays a message
+ *
+ * Used by msgcont_push_window() to decide whether the Message Window should
+ * remain visible when another Window is pushed on top of it.
+ */
+bool msgwin_has_text(void)
+{
+  struct MuttWindow *win = msgcont_get_msgwin();
+  if (!win || !win->wdata)
+    return false;
+
+  const struct MsgWinWindowData *wdata = win->wdata;
+  return !buf_is_empty(wdata->text);
+}

--- a/gui/msgwin.h
+++ b/gui/msgwin.h
@@ -29,6 +29,7 @@
 struct MuttWindow;
 
 void               msgwin_clear_text(struct MuttWindow *win);
+bool               msgwin_has_text  (void);
 struct MuttWindow *msgwin_new       (bool interactive);
 void               msgwin_add_text  (struct MuttWindow *win, const char *text, const struct AttrColor *ac_color);
 void               msgwin_add_text_n(struct MuttWindow *win, const char *text, int bytes, const struct AttrColor *ac_color);

--- a/imap/message.c
+++ b/imap/message.c
@@ -712,6 +712,7 @@ static int read_headers_normal_eval_cache(struct ImapAccountData *adata,
   if (m->verbose)
   {
     /* L10N: Comparing the cached data with the IMAP server's data */
+    mutt_clear_error();
     progress = progress_new(MUTT_PROGRESS_READ, msn_end);
     progress_set_message(progress, _("Evaluating cache..."));
   }
@@ -948,6 +949,7 @@ static int read_headers_condstore_qresync_updates(struct ImapAccountData *adata,
   if (m->verbose)
   {
     /* L10N: Fetching IMAP flag changes, using the CONDSTORE extension */
+    mutt_clear_error();
     progress = progress_new(MUTT_PROGRESS_READ, msn_end);
     progress_set_message(progress, _("Fetching flag updates..."));
   }
@@ -1182,6 +1184,7 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
 
   if (m->verbose)
   {
+    mutt_clear_error();
     progress = progress_new(MUTT_PROGRESS_READ, msn_end);
     progress_set_message(progress, _("Fetching message headers..."));
   }
@@ -1593,6 +1596,7 @@ int imap_append_message(struct Mailbox *m, struct Message *msg)
 
   if (m->verbose)
   {
+    mutt_clear_error();
     progress = progress_new(MUTT_PROGRESS_NET, len);
     progress_set_message(progress, _("Uploading message..."));
   }

--- a/menu/observer.c
+++ b/menu/observer.c
@@ -120,7 +120,10 @@ static int menu_window_observer(struct NotifyCallback *nc)
     notify_observer_remove(NeoMutt->sub->notify, menu_config_observer, menu);
     notify_observer_remove(win->notify, menu_window_observer, menu);
     mutt_color_observer_remove(menu_color_observer, menu);
-    msgwin_clear_text(NULL);
+    // If a prompt is still stacked in the Message Container, preserve any
+    // revealed warning/error so the user can see why the dialog closed.
+    if (msgcont_num_windows() <= 1)
+      msgwin_clear_text(NULL);
     mutt_debug(LL_DEBUG5, "window delete done\n");
   }
 

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -135,6 +135,7 @@ int log_disp_curses(time_t stamp, const char *file, int line, const char *functi
     enum ColorId cid = MT_COLOR_NORMAL;
     switch (level)
     {
+      case LL_PERROR:
       case LL_ERROR:
         mutt_beep(false);
         cid = MT_COLOR_ERROR;


### PR DESCRIPTION
Update the MessageWindow to control its own visibility.

Most of the commits are tidying up.
The last commit, 4aebd7e23f, does the work.

https://github.com/user-attachments/assets/b628a7b5-1df5-487f-9f8e-1208ff967c74

The Message Container is a stack of MuttWindow.
The default window displays error messages.

When this space is needed, e.g. for user input, another window is pushed into the stack and it takes the focus.
If an error occurs when another window is focused, the message may not be seen.  

![msgwin](https://raw.githubusercontent.com/neomutt/gfx/main/screenshots/window/message-window.svg)

---

**Scenario**:

- User prompt: "Enter filename:"
- User enters a bad filename
- `mutt_error("Bad filename: %s", filename);`
- MessageWindow realises that is isn't current visible, so:
  - make MessageWindow visible
  - reflow all the windows