### PR TITLE
main: restore -C flag

### DIFF
--- a/main.c
+++ b/main.c
@@ -1188,6 +1188,9 @@ int main(int argc, char *argv[], char *envp[])
     if (OptGui)
       mutt_flushinp();
 
+    if (cli->send.use_crypto)
+      sendflags |= SEND_CLI_CRYPTO;
+
     e = email_new();
     e->env = mutt_env_new();
 


### PR DESCRIPTION
Restore [the '-C' flag](https://neomutt.org/feature/cli-crypto), which was accidentally removed in [699657c61b15](https://github.com/neomutt/neomutt/commit/699657c61b15621994b39d45596755f527d43d24)

