### PR TITLE
Update range in description of `--debug-level` and `$debug_level`

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -1110,7 +1110,7 @@
 ** The debug level controls how much information is saved to the log file. If
 ** you have a problem with NeoMutt, then enabling logging may help find the
 ** cause. Levels 1-3 will usually provide enough information for writing a bug
-** report. Levels 4,5 will be extremely verbose.
+** report. Levels 4,5,6 will be extremely verbose.
 ** .pp
 ** Warning: Logging at high levels may save private information to the file.
 ** .pp

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -20082,7 +20082,7 @@ neomutt -a image.jpg *.png -- address1 address2
               <entry>
                 Log debugging output to a file (default is
                 &quot;<literal>~/.neomuttdebug0</literal>&quot;).
-                The <literal>level</literal> can range from 1&ndash;5 and
+                The <literal>level</literal> can range from 0&ndash;6 and
                 affects verbosity (a value of 2 is recommended). Using this
                 option along with <emphasis role="bold">-l</emphasis> is useful
                 to log the early startup process (before reading any

--- a/po/bg.po
+++ b/po/bg.po
@@ -9512,8 +9512,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/bg.po
+++ b/po/bg.po
@@ -9512,8 +9512,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/ca.po
+++ b/po/ca.po
@@ -9640,8 +9640,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/ca.po
+++ b/po/ca.po
@@ -9640,8 +9640,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/cs.po
+++ b/po/cs.po
@@ -9218,8 +9218,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/cs.po
+++ b/po/cs.po
@@ -9218,8 +9218,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/da.po
+++ b/po/da.po
@@ -9378,8 +9378,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/da.po
+++ b/po/da.po
@@ -9378,8 +9378,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/de.po
+++ b/po/de.po
@@ -9075,8 +9075,8 @@ msgid "        -m, --mbox-type <type>       Set default mailbox type"
 msgstr "        -m, --mbox-type <type>       Setze Standard Mailbox Typ"
 
 #: usage.c:75
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Setze Loglevel (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Setze Loglevel (0..6)"
 
 #: usage.c:76
 msgid "        -l, --debug-file <file>      Set logging file"

--- a/po/de.po
+++ b/po/de.po
@@ -9075,8 +9075,8 @@ msgid "        -m, --mbox-type <type>       Set default mailbox type"
 msgstr "        -m, --mbox-type <type>       Setze Standard Mailbox Typ"
 
 #: usage.c:75
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Setze Loglevel (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Setze Loglevel (%d..%d)\n"
 
 #: usage.c:76
 msgid "        -l, --debug-file <file>      Set logging file"

--- a/po/el.po
+++ b/po/el.po
@@ -9441,8 +9441,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/el.po
+++ b/po/el.po
@@ -9441,8 +9441,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -9055,8 +9055,8 @@ msgid "        -m, --mbox-type <type>       Set default mailbox type"
 msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 msgid "        -l, --debug-file <file>      Set logging file"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -9055,8 +9055,8 @@ msgid "        -m, --mbox-type <type>       Set default mailbox type"
 msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 msgid "        -l, --debug-file <file>      Set logging file"

--- a/po/eo.po
+++ b/po/eo.po
@@ -9073,8 +9073,8 @@ msgid "        -m, --mbox-type <type>       Set default mailbox type"
 msgstr "        -m, --mbox-type <tipo>       Agordi la aprioran leterkestan tipon"
 
 #: usage.c:75
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <nivelo>   Agordi la protokolan nivelon (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <nivelo>   Agordi la protokolan nivelon (%d..%d)\n"
 
 #: usage.c:76
 msgid "        -l, --debug-file <file>      Set logging file"

--- a/po/eo.po
+++ b/po/eo.po
@@ -9073,8 +9073,8 @@ msgid "        -m, --mbox-type <type>       Set default mailbox type"
 msgstr "        -m, --mbox-type <tipo>       Agordi la aprioran leterkestan tipon"
 
 #: usage.c:75
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <nivelo>   Agordi la protokolan nivelon (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <nivelo>   Agordi la protokolan nivelon (0..6)"
 
 #: usage.c:76
 msgid "        -l, --debug-file <file>      Set logging file"

--- a/po/es.po
+++ b/po/es.po
@@ -9175,8 +9175,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/es.po
+++ b/po/es.po
@@ -9175,8 +9175,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/et.po
+++ b/po/et.po
@@ -9521,8 +9521,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/et.po
+++ b/po/et.po
@@ -9521,8 +9521,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/eu.po
+++ b/po/eu.po
@@ -9482,8 +9482,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/eu.po
+++ b/po/eu.po
@@ -9482,8 +9482,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/fi.po
+++ b/po/fi.po
@@ -9231,8 +9231,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/fi.po
+++ b/po/fi.po
@@ -9231,8 +9231,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/fr.po
+++ b/po/fr.po
@@ -9499,8 +9499,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/fr.po
+++ b/po/fr.po
@@ -9499,8 +9499,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/ga.po
+++ b/po/ga.po
@@ -9572,8 +9572,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/ga.po
+++ b/po/ga.po
@@ -9572,8 +9572,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/gl.po
+++ b/po/gl.po
@@ -9570,8 +9570,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/gl.po
+++ b/po/gl.po
@@ -9570,8 +9570,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/hu.po
+++ b/po/hu.po
@@ -9169,8 +9169,8 @@ msgstr "        -m, --mbox-type <típus>      Alapértelmezett postafiók típus
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Naplózási szint beállítása (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Naplózási szint beállítása (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/hu.po
+++ b/po/hu.po
@@ -9169,8 +9169,8 @@ msgstr "        -m, --mbox-type <típus>      Alapértelmezett postafiók típus
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Naplózási szint beállítása (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Naplózási szint beállítása (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/id.po
+++ b/po/id.po
@@ -9442,8 +9442,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/id.po
+++ b/po/id.po
@@ -9442,8 +9442,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/it.po
+++ b/po/it.po
@@ -9470,8 +9470,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/it.po
+++ b/po/it.po
@@ -9470,8 +9470,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/ja.po
+++ b/po/ja.po
@@ -9319,8 +9319,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/ja.po
+++ b/po/ja.po
@@ -9319,8 +9319,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/ko.po
+++ b/po/ko.po
@@ -9479,8 +9479,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/ko.po
+++ b/po/ko.po
@@ -9479,8 +9479,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/lt.po
+++ b/po/lt.po
@@ -9196,8 +9196,8 @@ msgstr "        -m, --mbox-type <tipas>      Nutylėtasis pašto dėžutės tipa
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <lygis>    Žurnalo lygis (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <lygis>    Žurnalo lygis (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/lt.po
+++ b/po/lt.po
@@ -9196,8 +9196,8 @@ msgstr "        -m, --mbox-type <tipas>      Nutylėtasis pašto dėžutės tipa
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <lygis>    Žurnalo lygis (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <lygis>    Žurnalo lygis (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -9172,8 +9172,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -9172,8 +9172,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/nl.po
+++ b/po/nl.po
@@ -9424,8 +9424,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/nl.po
+++ b/po/nl.po
@@ -9424,8 +9424,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/pl.po
+++ b/po/pl.po
@@ -9211,8 +9211,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/pl.po
+++ b/po/pl.po
@@ -9211,8 +9211,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -9186,8 +9186,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -9186,8 +9186,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/ru.po
+++ b/po/ru.po
@@ -9345,8 +9345,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/ru.po
+++ b/po/ru.po
@@ -9345,8 +9345,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/sk.po
+++ b/po/sk.po
@@ -9202,8 +9202,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/sk.po
+++ b/po/sk.po
@@ -9202,8 +9202,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/sr.po
+++ b/po/sr.po
@@ -9098,8 +9098,8 @@ msgid "        -m, --mbox-type <type>       Set default mailbox type"
 msgstr "        -m, --mbox-type <врста>      Задаје подразумевану врсту сандучета"
 
 #: usage.c:75
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <ниво>     Задаје ниво бележења у дневник (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <ниво>     Задаје ниво бележења у дневник (0..6)"
 
 #: usage.c:76
 msgid "        -l, --debug-file <file>      Set logging file"

--- a/po/sr.po
+++ b/po/sr.po
@@ -9098,8 +9098,8 @@ msgid "        -m, --mbox-type <type>       Set default mailbox type"
 msgstr "        -m, --mbox-type <врста>      Задаје подразумевану врсту сандучета"
 
 #: usage.c:75
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <ниво>     Задаје ниво бележења у дневник (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <ниво>     Задаје ниво бележења у дневник (%d..%d)\n"
 
 #: usage.c:76
 msgid "        -l, --debug-file <file>      Set logging file"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9374,8 +9374,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/sv.po
+++ b/po/sv.po
@@ -9374,8 +9374,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/tr.po
+++ b/po/tr.po
@@ -9069,8 +9069,8 @@ msgid "        -m, --mbox-type <type>       Set default mailbox type"
 msgstr "        -m, --mbox-type <tür>        Öntanımlı posta kutusu türünü ayarla"
 
 #: usage.c:75
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <düzey>    Günlükleme düzeyini ayarla (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <düzey>    Günlükleme düzeyini ayarla (0..6)"
 
 #: usage.c:76
 msgid "        -l, --debug-file <file>      Set logging file"

--- a/po/tr.po
+++ b/po/tr.po
@@ -9069,8 +9069,8 @@ msgid "        -m, --mbox-type <type>       Set default mailbox type"
 msgstr "        -m, --mbox-type <tür>        Öntanımlı posta kutusu türünü ayarla"
 
 #: usage.c:75
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <düzey>    Günlükleme düzeyini ayarla (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <düzey>    Günlükleme düzeyini ayarla (%d..%d)\n"
 
 #: usage.c:76
 msgid "        -l, --debug-file <file>      Set logging file"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9215,8 +9215,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/uk.po
+++ b/po/uk.po
@@ -9215,8 +9215,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -9170,8 +9170,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -9170,8 +9170,8 @@ msgstr "        -m, --mbox-type <type>       Set default mailbox type"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    Set logging level (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    Set logging level (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -9494,8 +9494,8 @@ msgstr "        -m, --mbox-type <type>       設定預設的信箱類型"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (1..5)"
-msgstr "        -d, --debug-level <level>    設定紀錄/除錯等級 (1..5)"
+msgid "        -d, --debug-level <level>    Set logging level (0..6)"
+msgstr "        -d, --debug-level <level>    設定紀錄/除錯等級 (0..6)"
 
 #: usage.c:76
 #, fuzzy

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -9494,8 +9494,8 @@ msgstr "        -m, --mbox-type <type>       設定預設的信箱類型"
 
 #: usage.c:75
 #, fuzzy
-msgid "        -d, --debug-level <level>    Set logging level (0..6)"
-msgstr "        -d, --debug-level <level>    設定紀錄/除錯等級 (0..6)"
+msgid "        -d, --debug-level <level>    Set logging level (%d..%d)\n"
+msgstr "        -d, --debug-level <level>    設定紀錄/除錯等級 (%d..%d)\n"
 
 #: usage.c:76
 #, fuzzy

--- a/usage.c
+++ b/usage.c
@@ -72,7 +72,7 @@ static void show_cli_overview(bool use_color)
   puts(_("        -F, --config <file>          Use this user config file"));
   puts(_("        -e, --command <command>      Run extra commands"));
   puts(_("        -m, --mbox-type <type>       Set default mailbox type"));
-  puts(_("        -d, --debug-level <level>    Set logging level (0..6)"));
+  printf(_("        -d, --debug-level <level>    Set logging level (%d..%d)\n"), LL_MESSAGE, LL_MAX - 1);
   puts(_("        -l, --debug-file <file>      Set logging file"));
   puts("");
 

--- a/usage.c
+++ b/usage.c
@@ -72,7 +72,7 @@ static void show_cli_overview(bool use_color)
   puts(_("        -F, --config <file>          Use this user config file"));
   puts(_("        -e, --command <command>      Run extra commands"));
   puts(_("        -m, --mbox-type <type>       Set default mailbox type"));
-  puts(_("        -d, --debug-level <level>    Set logging level (1..5)"));
+  puts(_("        -d, --debug-level <level>    Set logging level (0..6)"));
   puts(_("        -l, --debug-file <file>      Set logging file"));
   puts("");
 
@@ -149,7 +149,7 @@ static void show_cli_shared(bool use_color)
 
   puts(_("These logging options override the config:"));
   puts(_("  -d, --debug-level <level>   Set logging level"));
-  puts(_("                              0 (off), 1 (low) .. 5 (high)"));
+  puts(_("                              0 (off), 1 (low) .. 6 (high)"));
   puts(_("  -l, --debug-file <file>     Set logging file"));
   puts(_("                              Default file '~/.neomuttdebug0'"));
   puts("");


### PR DESCRIPTION
* **What does this PR do?**

Update range in description of `--debug-level` and `$debug_level`.
At some point Neomutt learned the log level `LL_NOTIFY` (with a value of 6) but did not update the documentation of `--debug-level` and `$debug_level` accordingly.

Note: This changes the documentation, so the homepage might need a rebuild.

* **You (the maintainer) need to make a choice**

To prevent at least parts of the documentation to go out of sync with the implementation, we can – instead of hardcoding the log level values – use `printf()` to interpolate the actual log level values (`LL_MESSAGE` and `LL_MAX - 1`) in the output of `--help`.  This is done in the last two commits.  Whether that's worth it or not, is your decision to make.

(Obviously this does not prevent the other documentations from bitrotting as they still hardcode the log level values.)