### PR TITLE
key: fix unbind all menus with key

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -4346,6 +4346,9 @@ set alias_file=~/.mail_aliases
         </group>
         <group choice="opt">
           <arg choice="plain">
+            <replaceable class="parameter">*</replaceable>
+          </arg>
+          <arg choice="plain">
             <replaceable class="parameter">key</replaceable>
           </arg>
         </group>
@@ -4723,6 +4726,9 @@ set alias_file=~/.mail_aliases
           </group>
           <group choice="opt">
             <arg choice="plain">
+              <replaceable class="parameter">*</replaceable>
+            </arg>
+            <arg choice="plain">
               <replaceable class="parameter">key</replaceable>
             </arg>
           </group>
@@ -4737,11 +4743,55 @@ set alias_file=~/.mail_aliases
         </para>
         <para>
           <emphasis>key</emphasis> is the key or key sequence to be unbound.
-          It may be omitted in which case all keybindings in the given menus
-          are removed.  To prevent NeoMutt from becoming unusable some fallback
-          key bindings are added afterwards.  The fallback keybindings added
-          depend on the menu, they are listed in <xref linkend="tab-fallback-key-bindings" />.
+          It may be omitted, or given as <literal>*</literal>, in which case
+          every keybinding in the given menus is removed.  If
+          <emphasis>key</emphasis> is omitted, <literal>unbind</literal>
+          restores a small set of fallback bindings afterwards to prevent
+          NeoMutt from becoming unusable.  If <emphasis>key</emphasis> is
+          explicitly given as <literal>*</literal>, no fallback bindings are
+          restored.  The fallback keybindings added depend on the menu, they
+          are listed in <xref linkend="tab-fallback-key-bindings" />.
         </para>
+        <para>
+          <literal>unbind</literal> removes only regular bindings; key
+          <link linkend="macro">macros</link> are left untouched.  Use
+          <link linkend="unmacro"><literal>unmacro</literal></link> to remove
+          macros.
+        </para>
+        <para>
+          The two wildcard forms behave differently:
+        </para>
+        <variablelist>
+          <varlistentry>
+            <term><literal>unbind *</literal></term>
+            <listitem>
+              <para>
+                Removes every binding from every menu, then restores the
+                fallback bindings listed in
+                <xref linkend="tab-fallback-key-bindings" /> so that NeoMutt
+                remains usable.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term><literal>unbind * *</literal></term>
+            <listitem>
+              <para>
+                Removes every binding from every menu and does
+                <emphasis>not</emphasis> restore any fallback bindings.
+              </para>
+              <warning>
+                <para>
+                  After <literal>unbind * *</literal> NeoMutt has no key
+                  bindings at all and is effectively unusable until further
+                  <literal>bind</literal> commands are issued (for example
+                  from a config file sourced afterwards).  Use this form only
+                  if you intend to install a completely custom key map.
+                </para>
+              </warning>
+            </listitem>
+          </varlistentry>
+        </variablelist>
         <table id="tab-fallback-key-bindings">
           <title>Fallback key bindings</title>
           <tgroup cols="3">
@@ -5085,13 +5135,18 @@ folder-hook work "set sort=threads"
             <replaceable class="parameter">*</replaceable>
           </arg>
           <arg choice="plain">
-            <replaceable class="parameter">map</replaceable>
-          </arg>
-          <arg choice="opt" rep="repeat">
-            <replaceable class="parameter">,map</replaceable>
+            <arg choice="plain">
+              <replaceable class="parameter">map</replaceable>
+            </arg>
+            <arg choice="opt" rep="repeat">
+              <replaceable class="parameter">,map</replaceable>
+            </arg>
           </arg>
         </group>
         <group choice="opt">
+          <arg choice="plain">
+            <replaceable class="parameter">*</replaceable>
+          </arg>
           <arg choice="plain">
             <replaceable class="parameter">key</replaceable>
           </arg>
@@ -5178,18 +5233,27 @@ folder-hook work "set sort=threads"
         </para>
         <cmdsynopsis>
           <command>unmacro</command>
-          <arg choice="plain">
-            <replaceable class="parameter">map</replaceable>
-          </arg>
-          <arg choice="opt" rep="repeat">
-            <replaceable class="parameter">,map</replaceable>
-          </arg>
-          <arg choice="plain">
-            <replaceable class="parameter">key</replaceable>
-          </arg>
-          <arg choice="plain">
-            <replaceable class="parameter">sequence</replaceable>
-         </arg>
+          <group choice="req">
+            <arg choice="plain">
+              <replaceable class="parameter">*</replaceable>
+            </arg>
+            <arg choice="plain">
+              <arg choice="plain">
+                <replaceable class="parameter">map</replaceable>
+              </arg>
+              <arg choice="opt" rep="repeat">
+                <replaceable class="parameter">,map</replaceable>
+              </arg>
+            </arg>
+          </group>
+          <group choice="opt">
+            <arg choice="plain">
+              <replaceable class="parameter">*</replaceable>
+            </arg>
+            <arg choice="plain">
+              <replaceable class="parameter">key</replaceable>
+            </arg>
+          </group>
         </cmdsynopsis>
         <para>
           <emphasis>map</emphasis> specifies from which menus the macro
@@ -5200,14 +5264,22 @@ folder-hook work "set sort=threads"
           <link linkend="maps">in the <literal>bind</literal> section</link>.
         </para>
         <para>
-          <emphasis>key</emphasis> is the key or key sequence to be unbound.
-          It may be omitted in which case all macros in the given menus
-          are removed.
+          <emphasis>key</emphasis> is the key or key sequence to be removed.
+          It may be omitted, or given as <literal>*</literal>, in which case
+          all macros in the given menus are removed.
+          <literal>unmacro *</literal> removes every macro from every menu.
         </para>
         <note>
           <para>
-            Missing key sequence in unmacro command means unmacro all macros in menus
-            given in <emphasis>map</emphasis>.
+            <literal>unmacro</literal> only removes
+            <link linkend="macro">macros</link>; regular key
+            <link linkend="bind">bindings</link> are left untouched (use
+            <link linkend="unbind"><literal>unbind</literal></link> for
+            those).  Because of this, the <literal>* *</literal> wildcard
+            form has no special meaning for <literal>unmacro</literal>:
+            <literal>unmacro *</literal> and <literal>unmacro * *</literal>
+            both simply remove every macro from every menu, and no fallback
+            bindings need to be restored.
           </para>
         </note>
       </sect2>
@@ -20631,6 +20703,9 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             </group>
             <group choice="opt">
               <arg choice="plain">
+                <replaceable class="parameter">*</replaceable>
+              </arg>
+              <arg choice="plain">
                 <replaceable class="parameter">key</replaceable>
               </arg>
             </group>
@@ -21089,6 +21164,9 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               </arg>
             </group>
             <group choice="opt">
+              <arg choice="plain">
+                <replaceable class="parameter">*</replaceable>
+              </arg>
               <arg choice="plain">
                 <replaceable class="parameter">key</replaceable>
               </arg>

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -208,7 +208,7 @@ A \fImime-subtype\fP of \(lq\fB*\fP\(rq matches any
 .PP
 .nf
 \fBbind\fP \fImap\fP[\fB,\fP\fImap\fP ... ] \fIkey\fP \fIfunction\fP
-\fBunbind\fP { \fB*\fP | \fImap\fP | [\fB,\fP\fImap\fP...]} [ \fIkey\fP ]
+\fBunbind\fP { \fB*\fP | \fImap\fP[\fB,\fP\fImap\fP...] } [ { \fB*\fP | \fIkey\fP } ]
 .fi
 .IP
 This command allows you to change the default or define additional key bindings
@@ -237,8 +237,21 @@ can also be referred to by their symbolic names:
 \fIfunction\fP specifies which action to take when key is pressed. Note that
 the function name is to be specified without angle brackets.
 .IP
-A missing key sequence in the \fBunbind\fP command means unbind all bindings
-in the menus given in \fImap\fP.
+If \fIkey\fP is omitted (or specified as \fB*\fP) when \fImap\fP names one or
+more specific menus, all bindings in those menus are removed and a small set
+of safe fallback bindings is restored so the menus remain usable.
+.IP
+\fBunbind\fP only removes regular bindings; key macros are left untouched
+(use \fBunmacro\fP for those).
+.IP
+\fBunbind *\fP removes every binding from every menu and then restores a small
+set of safe fallback bindings, so NeoMutt remains usable.
+.IP
+\fBunbind * *\fP removes every binding from every menu without restoring any
+fallbacks.
+.B Warning:
+after this command NeoMutt has no key bindings at all and is effectively
+unusable until further \fBbind\fP commands are issued.
 .IP
 For more information on keys and functions, please consult the NeoMutt manual.
 .
@@ -561,7 +574,7 @@ These commands allow you to run Lua scripts within NeoMutt.
 .PP
 .nf
 \fBmacro\fP \fImenu\fP[\fB,\fP\fImenu\fP ... ] \fIkey\fP \fIsequence\fP [ \fIdescription\fP ]
-\fBunmacro\fP { \fB*\fP | \fImenu\fP | [\fB,\fP\fImenu\fP...]} [ \fIkey\fP ]
+\fBunmacro\fP { \fB*\fP | \fImenu\fP[\fB,\fP\fImenu\fP...] } [ { \fB*\fP | \fIkey\fP } ]
 .fi
 .IP
 This command binds the given \fIsequence\fP of keys to the given \fIkey\fP in
@@ -571,8 +584,12 @@ command above. To specify multiple menus, put only a comma between the menus.
 Optionally you can specify a descriptive text after \fIsequence\fP, which is
 shown in the help screens if they contain a \fIdescription\fP.
 .IP
-Missing key sequence in \fBunmacro\fP command means unmacro all macros in menus
-given in \fImenu\fP.
+If \fIkey\fP is omitted (or specified as \fB*\fP), all macros in the given
+\fImenu\fPs are removed.  \fBunmacro *\fP removes every macro from every menu.
+.IP
+\fBunmacro\fP only removes macros; regular key bindings are left untouched
+(use \fBunbind\fP for those).  \fBunmacro *\fP and \fBunmacro * *\fP therefore
+behave identically.
 .
 .PP
 .nf

--- a/key/commands.c
+++ b/key/commands.c
@@ -54,6 +54,7 @@ struct ParseUnbind
   struct MenuDefinitionArray mda; ///< Menus to work on
   bool all_menus;                 ///< Command affects all Menus
   bool all_keys;                  ///< Command affects all key bindings
+  bool restore_defaults;          ///< Restore fallback bindings after unbind
   const char *key;                ///< Key string to be removed
 };
 
@@ -480,20 +481,31 @@ bool parse_unbind_args(const struct Command *cmd, struct Buffer *line,
       // `unbind * key`
       // `unmacro * key`
       parse_extract_token(token, line, TOKEN_NONE);
-      args->key = buf_strdup(token);
+      if (mutt_str_equal(buf_string(token), "*"))
+        args->all_keys = true;
+      else
+        args->key = buf_strdup(token);
     }
     else
     {
       // `unbind *`
       // `unmacro *`
       args->all_keys = true;
+      args->restore_defaults = (cmd->id == CMD_UNBIND);
     }
   }
   else
   {
-    parse_menu(&args->mda, buf_string(token), err);
-    if (!buf_is_empty(err))
-      goto done;
+    if (mutt_str_equal(buf_string(token), "*"))
+    {
+      args->all_menus = true;
+    }
+    else
+    {
+      parse_menu(&args->mda, buf_string(token), err);
+      if (!buf_is_empty(err))
+        goto done;
+    }
 
     if (MoreArgs(line))
     {
@@ -516,6 +528,7 @@ bool parse_unbind_args(const struct Command *cmd, struct Buffer *line,
       // `unbind  menu`
       // `unmacro menu`
       args->all_keys = true;
+      args->restore_defaults = (cmd->id == CMD_UNBIND);
     }
   }
 
@@ -540,8 +553,7 @@ done:
  * @retval true Success
  *
  * The user is trying to remove a binding or a macro.
- * We choose *not* to distinguish the two, since a key can only be bound to one or the other.
- * i.e. `unbind` will also clear macros, `unmacro` will also clear bindings
+ * `unbind` only removes regular bindings; `unmacro` only removes macros.
  */
 bool parse_unbind_exec(const struct Command *cmd, struct ParseUnbind *args, struct Buffer *err)
 {
@@ -565,6 +577,7 @@ bool parse_unbind_exec(const struct Command *cmd, struct ParseUnbind *args, stru
   ARRAY_FOREACH(mdp, &mod_data->menu_defs)
   {
     struct MenuDefinition *md = *mdp;
+    bool menu_success = false;
 
     if (!args->all_menus)
     {
@@ -592,12 +605,19 @@ bool parse_unbind_exec(const struct Command *cmd, struct ParseUnbind *args, stru
     struct Keymap *km_tmp = NULL;
     STAILQ_FOREACH_SAFE(km, &sm->keymaps, entries, km_tmp)
     {
-      if (args->all_keys ||
-          ((key_len == km->len) && (memcmp(km->keys, key_bytes, km->len) == 0)))
+      bool match = args->all_keys || ((key_len == km->len) &&
+                                      (memcmp(km->keys, key_bytes, km->len) == 0));
+      if ((cmd->id == CMD_UNMACRO) && (km->op != OP_MACRO))
+        match = false;
+      if ((cmd->id == CMD_UNBIND) && (km->op == OP_MACRO))
+        match = false;
+
+      if (match)
       {
         STAILQ_REMOVE(&sm->keymaps, km, Keymap, entries);
         keymap_free(&km);
         success = true;
+        menu_success = true;
 
         if (!args->all_keys && !args->all_menus)
         {
@@ -612,32 +632,38 @@ bool parse_unbind_exec(const struct Command *cmd, struct ParseUnbind *args, stru
       }
     }
 
-    if (args->all_keys && !args->all_menus && success)
+    if (args->all_keys && !args->all_menus)
     {
-      buf_reset(keystr);
-      keymap_expand_string(args->key, keystr);
-      mutt_debug(LL_NOTIFY, "%s: %s %s\n", notify_binding_name(nb), md->name,
-                 buf_string(keystr));
+      if (menu_success)
+      {
+        buf_reset(keystr);
+        keymap_expand_string(args->key, keystr);
+        mutt_debug(LL_NOTIFY, "%s: %s %s\n", notify_binding_name(nb), md->name,
+                   buf_string(keystr));
 
-      struct EventBinding ev_b = { md, args->key, OP_NULL };
-      notify_send(NeoMutt->notify, NT_BINDING, nb, &ev_b);
+        struct EventBinding ev_b = { md, args->key, OP_NULL };
+        notify_send(NeoMutt->notify, NT_BINDING, nb, &ev_b);
+      }
 
-      // restore some bindings for this menu
-      set_default_bindings(md);
+      if (args->restore_defaults)
+        set_default_bindings(md);
     }
   }
 
-  if (args->all_menus && success)
+  if (args->all_menus && args->all_keys)
   {
-    buf_reset(keystr);
-    keymap_expand_string(args->key, keystr);
-    mutt_debug(LL_NOTIFY, "%s: ALL %s\n", notify_binding_name(nb), buf_string(keystr));
+    if (success)
+    {
+      buf_reset(keystr);
+      keymap_expand_string(args->key, keystr);
+      mutt_debug(LL_NOTIFY, "%s: ALL %s\n", notify_binding_name(nb), buf_string(keystr));
 
-    struct EventBinding ev_b = { NULL, args->key, OP_NULL };
-    notify_send(NeoMutt->notify, NT_BINDING, nb, &ev_b);
+      struct EventBinding ev_b = { NULL, args->key, OP_NULL };
+      notify_send(NeoMutt->notify, NT_BINDING, nb, &ev_b);
+    }
 
-    // restore some bindings for all menus
-    set_default_bindings(NULL);
+    if (args->restore_defaults)
+      set_default_bindings(NULL);
   }
 
   buf_pool_release(&keystr);

--- a/test/command/parse_unbind.c
+++ b/test/command/parse_unbind.c
@@ -24,6 +24,7 @@
 #include "config.h"
 #include "acutest.h"
 #include <stddef.h>
+#include <string.h>
 #include "mutt/lib.h"
 #include "core/lib.h"
 #include "gui/lib.h"
@@ -46,6 +47,7 @@ static const struct CommandTest UnBindTests[] = {
   // clang-format off
   // unbind { * | <map>[,<map> ... ] } [ <key> ]
   { MUTT_CMD_SUCCESS, "*" },
+  { MUTT_CMD_SUCCESS, "* *" },
   { MUTT_CMD_SUCCESS, "* d" },
   { MUTT_CMD_SUCCESS, "* missing" },
   { MUTT_CMD_SUCCESS, "index" },
@@ -70,9 +72,25 @@ static const struct CommandTest UnBindTests[] = {
 static const struct CommandTest UnMacroTests[] = {
   // clang-format off
   // unmacro { * | <map>[,<map> ... ] } [ <key> ]
+  { MUTT_CMD_SUCCESS, "*" },
+  { MUTT_CMD_SUCCESS, "* *" },
+  { MUTT_CMD_SUCCESS, "* d" },
+  { MUTT_CMD_SUCCESS, "* missing" },
+  { MUTT_CMD_SUCCESS, "index" },
+  { MUTT_CMD_SUCCESS, "index,pager" },
+  { MUTT_CMD_SUCCESS, "index *" },
+  { MUTT_CMD_SUCCESS, "index,pager *" },
+  { MUTT_CMD_SUCCESS, "index d" },
+  { MUTT_CMD_SUCCESS, "index missing" },
+  { MUTT_CMD_SUCCESS, "index,pager d" },
+  { MUTT_CMD_SUCCESS, "index,pager missing" },
   { MUTT_CMD_WARNING, "" },
-  { MUTT_CMD_SUCCESS, "index eee" },
-  { MUTT_CMD_SUCCESS, "index nn" },
+  { MUTT_CMD_WARNING, "bad" },
+  { MUTT_CMD_WARNING, "bad,index" },
+  { MUTT_CMD_WARNING, "index,bad" },
+  { MUTT_CMD_WARNING, "index d extra" },
+  { MUTT_CMD_WARNING, "index,pager d extra" },
+  { MUTT_CMD_WARNING, "* d extra" },
   { MUTT_CMD_ERROR,   NULL },
   // clang-format on
 };
@@ -85,6 +103,42 @@ static void init_menus(void)
   sidebar_init_keys(NeoMutt, sm_generic);
   index_init_keys(NeoMutt, sm_generic);
   pager_init_keys(NeoMutt, sm_generic);
+}
+
+static bool has_binding(const char *menu, int op)
+{
+  return km_find_func(menu_find_by_name(menu), op) != NULL;
+}
+
+static bool has_keymap(const char *menu, const char *key, int op)
+{
+  struct MenuDefinition *md = menu_find_by_name(menu);
+  struct SubMenu **smp = ARRAY_GET(&md->submenus, 0);
+  struct SubMenu *sm = *smp;
+  keycode_t key_bytes[KEY_SEQ_MAX_LEN] = { 0 };
+  int key_len = parse_keys(key, key_bytes, KEY_SEQ_MAX_LEN);
+
+  struct Keymap *km = NULL;
+  STAILQ_FOREACH(km, &sm->keymaps, entries)
+  {
+    if ((km->op == op) && (km->len == key_len) &&
+        (memcmp(km->keys, key_bytes, key_len) == 0))
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+static void run_unbind_command(const struct Command *cmd, struct Buffer *line,
+                               const struct ParseContext *pc,
+                               struct ParseError *pe, const char *command)
+{
+  parse_error_reset(pe);
+  buf_strcpy(line, command);
+  buf_seek(line, 0);
+  TEST_CHECK_NUM_EQ(parse_unbind(cmd, line, pc, pe), MUTT_CMD_SUCCESS);
 }
 
 static void test_parse_unbind2(void)
@@ -119,7 +173,6 @@ static void test_parse_unmacro(void)
 {
   // enum CommandResult parse_unbind(const struct Command *cmd, struct Buffer *line, const struct ParseContext *pc, struct ParseError *pe)
 
-  init_menus();
   struct Buffer *line = buf_pool_get();
   struct ParseContext *pc = parse_context_new();
   struct ParseError *pe = parse_error_new();
@@ -127,22 +180,274 @@ static void test_parse_unmacro(void)
 
   for (int i = 0; UnMacroTests[i].line; i++)
   {
+    init_menus();
+    km_bind(menu_find_by_name("index"), "x", OP_MACRO, "<exit>", NULL, NULL);
+    km_bind(menu_find_by_name("pager"), "x", OP_MACRO, "<exit>", NULL, NULL);
+    km_bind(menu_find_by_name("index"), "y", OP_MACRO, "<exit>", NULL, NULL);
+
     TEST_CASE(UnMacroTests[i].line);
     parse_error_reset(pe);
     buf_strcpy(line, UnMacroTests[i].line);
     buf_seek(line, 0);
     rc = parse_unbind(&UnMacro, line, pc, pe);
     TEST_CHECK_NUM_EQ(rc, UnMacroTests[i].rc);
+
+    km_cleanup(neomutt_get_module_data(NeoMutt, MODULE_ID_KEY));
+  }
+
+  const char *commands[] = {
+    "index x", "* x", "index", "index *", "*", "* *",
+  };
+  for (size_t i = 0; i < (sizeof(commands) / sizeof(commands[0])); i++)
+  {
+    init_menus();
+    km_bind(menu_find_by_name("index"), "x", OP_MACRO, "<exit>", NULL, NULL);
+    km_bind(menu_find_by_name("pager"), "x", OP_MACRO, "<exit>", NULL, NULL);
+    km_bind(menu_find_by_name("index"), "y", OP_MACRO, "<exit>", NULL, NULL);
+
+    TEST_CASE(commands[i]);
+    TEST_CHECK(has_keymap("index", "x", OP_MACRO));
+    TEST_CHECK(has_keymap("pager", "x", OP_MACRO));
+    TEST_CHECK(has_keymap("index", "y", OP_MACRO));
+    TEST_CHECK(has_binding("index", OP_DISPLAY_MESSAGE));
+
+    parse_error_reset(pe);
+    buf_strcpy(line, commands[i]);
+    buf_seek(line, 0);
+    rc = parse_unbind(&UnMacro, line, pc, pe);
+    TEST_CHECK_NUM_EQ(rc, MUTT_CMD_SUCCESS);
+
+    if (mutt_str_equal(commands[i], "index x"))
+    {
+      TEST_CHECK(!has_keymap("index", "x", OP_MACRO));
+      TEST_CHECK(has_keymap("pager", "x", OP_MACRO));
+      TEST_CHECK(has_keymap("index", "y", OP_MACRO));
+    }
+    else if (mutt_str_equal(commands[i], "* x"))
+    {
+      TEST_CHECK(!has_keymap("index", "x", OP_MACRO));
+      TEST_CHECK(!has_keymap("pager", "x", OP_MACRO));
+      TEST_CHECK(has_keymap("index", "y", OP_MACRO));
+    }
+    else
+    {
+      TEST_CHECK(!has_keymap("index", "x", OP_MACRO));
+      TEST_CHECK(!has_keymap("index", "y", OP_MACRO));
+      if (mutt_str_equal(commands[i], "index") || mutt_str_equal(commands[i], "index *"))
+        TEST_CHECK(has_keymap("pager", "x", OP_MACRO));
+      else
+        TEST_CHECK(!has_keymap("pager", "x", OP_MACRO));
+    }
+
+    TEST_CHECK(has_binding("index", OP_DISPLAY_MESSAGE));
+    km_cleanup(neomutt_get_module_data(NeoMutt, MODULE_ID_KEY));
   }
 
   parse_context_free(&pc);
   parse_error_free(&pe);
   buf_pool_release(&line);
+}
+
+static void test_parse_unbind_behaviour(void)
+{
+  struct Buffer *line = buf_pool_get();
+  struct ParseContext *pc = parse_context_new();
+  struct ParseError *pe = parse_error_new();
+
+  TEST_CASE("unbind index y removes one regular binding from one menu");
+  init_menus();
+  km_bind(menu_find_by_name("index"), "y", OP_DISPLAY_MESSAGE, NULL, NULL, NULL);
+  km_bind(menu_find_by_name("pager"), "y", OP_EXIT, NULL, NULL, NULL);
+  km_bind(menu_find_by_name("index"), "x", OP_MACRO, "<exit>", NULL, NULL);
+  TEST_CHECK(has_keymap("index", "y", OP_DISPLAY_MESSAGE));
+  TEST_CHECK(has_keymap("pager", "y", OP_EXIT));
+  TEST_CHECK(has_keymap("index", "x", OP_MACRO));
+  TEST_CHECK(has_binding("index", OP_MAIN_NEXT_UNDELETED));
+  run_unbind_command(&UnBind, line, pc, pe, "index y");
+  TEST_CHECK(!has_keymap("index", "y", OP_DISPLAY_MESSAGE));
+  TEST_CHECK(has_keymap("pager", "y", OP_EXIT));
+  TEST_CHECK(has_keymap("index", "x", OP_MACRO));
+  TEST_CHECK(has_binding("index", OP_MAIN_NEXT_UNDELETED));
   km_cleanup(neomutt_get_module_data(NeoMutt, MODULE_ID_KEY));
+
+  TEST_CASE("unbind index removes all regular bindings and restores fallbacks");
+  init_menus();
+  km_bind(menu_find_by_name("index"), "y", OP_DISPLAY_MESSAGE, NULL, NULL, NULL);
+  km_bind(menu_find_by_name("pager"), "y", OP_EXIT, NULL, NULL, NULL);
+  TEST_CHECK(has_keymap("index", "y", OP_DISPLAY_MESSAGE));
+  TEST_CHECK(has_keymap("pager", "y", OP_EXIT));
+  TEST_CHECK(has_binding("index", OP_MAIN_NEXT_UNDELETED));
+  run_unbind_command(&UnBind, line, pc, pe, "index");
+  TEST_CHECK(!has_keymap("index", "y", OP_DISPLAY_MESSAGE));
+  TEST_CHECK(has_keymap("pager", "y", OP_EXIT));
+  TEST_CHECK(has_binding("index", OP_DISPLAY_MESSAGE));
+  TEST_CHECK(!has_binding("index", OP_MAIN_NEXT_UNDELETED));
+  km_cleanup(neomutt_get_module_data(NeoMutt, MODULE_ID_KEY));
+
+  TEST_CASE("unbind * y removes one regular binding from all menus");
+  init_menus();
+  km_bind(menu_find_by_name("generic"), "y", OP_HELP, NULL, NULL, NULL);
+  km_bind(menu_find_by_name("index"), "y", OP_DISPLAY_MESSAGE, NULL, NULL, NULL);
+  km_bind(menu_find_by_name("pager"), "y", OP_EXIT, NULL, NULL, NULL);
+  km_bind(menu_find_by_name("index"), "x", OP_MACRO, "<exit>", NULL, NULL);
+  km_bind(menu_find_by_name("pager"), "x", OP_MACRO, "<exit>", NULL, NULL);
+  TEST_CHECK(has_keymap("generic", "y", OP_HELP));
+  TEST_CHECK(has_keymap("index", "y", OP_DISPLAY_MESSAGE));
+  TEST_CHECK(has_keymap("pager", "y", OP_EXIT));
+  TEST_CHECK(has_keymap("index", "x", OP_MACRO));
+  TEST_CHECK(has_keymap("pager", "x", OP_MACRO));
+  run_unbind_command(&UnBind, line, pc, pe, "* y");
+  TEST_CHECK(!has_keymap("generic", "y", OP_HELP));
+  TEST_CHECK(!has_keymap("index", "y", OP_DISPLAY_MESSAGE));
+  TEST_CHECK(!has_keymap("pager", "y", OP_EXIT));
+  TEST_CHECK(has_keymap("index", "x", OP_MACRO));
+  TEST_CHECK(has_keymap("pager", "x", OP_MACRO));
+  TEST_CHECK(has_binding("generic", OP_HELP));
+  km_cleanup(neomutt_get_module_data(NeoMutt, MODULE_ID_KEY));
+
+  parse_context_free(&pc);
+  parse_error_free(&pe);
+  buf_pool_release(&line);
+}
+
+static void test_parse_unbind_restore_defaults(void)
+{
+  struct Buffer *line = buf_pool_get();
+  struct ParseContext *pc = parse_context_new();
+  struct ParseError *pe = parse_error_new();
+
+  TEST_CASE("unbind * restores fallback bindings");
+  init_menus();
+  TEST_CHECK(has_binding("generic", OP_HELP));
+  TEST_CHECK(has_binding("index", OP_MAIN_NEXT_UNDELETED));
+  parse_error_reset(pe);
+  buf_strcpy(line, "*");
+  buf_seek(line, 0);
+  TEST_CHECK_NUM_EQ(parse_unbind(&UnBind, line, pc, pe), MUTT_CMD_SUCCESS);
+  TEST_CHECK(has_binding("generic", OP_HELP));
+  TEST_CHECK(has_binding("index", OP_DISPLAY_MESSAGE));
+  TEST_CHECK(!has_binding("index", OP_MAIN_NEXT_UNDELETED));
+  km_cleanup(neomutt_get_module_data(NeoMutt, MODULE_ID_KEY));
+
+  TEST_CASE("unbind * * removes fallback bindings too");
+  init_menus();
+  TEST_CHECK(has_binding("generic", OP_HELP));
+  parse_error_reset(pe);
+  buf_strcpy(line, "* *");
+  buf_seek(line, 0);
+  TEST_CHECK_NUM_EQ(parse_unbind(&UnBind, line, pc, pe), MUTT_CMD_SUCCESS);
+  TEST_CHECK(!has_binding("generic", OP_HELP));
+  TEST_CHECK(!has_binding("index", OP_DISPLAY_MESSAGE));
+  km_cleanup(neomutt_get_module_data(NeoMutt, MODULE_ID_KEY));
+
+  TEST_CASE("unmacro * does not remove bindings");
+  init_menus();
+  TEST_CHECK(has_binding("generic", OP_HELP));
+  parse_error_reset(pe);
+  buf_strcpy(line, "*");
+  buf_seek(line, 0);
+  TEST_CHECK_NUM_EQ(parse_unbind(&UnMacro, line, pc, pe), MUTT_CMD_SUCCESS);
+  TEST_CHECK(has_binding("generic", OP_HELP));
+  TEST_CHECK(has_binding("index", OP_DISPLAY_MESSAGE));
+  km_cleanup(neomutt_get_module_data(NeoMutt, MODULE_ID_KEY));
+
+  TEST_CASE("unbind * * does not remove macros");
+  init_menus();
+  km_bind(menu_find_by_name("index"), "x", OP_MACRO, "<exit>", NULL, NULL);
+  TEST_CHECK(has_keymap("index", "x", OP_MACRO));
+  parse_error_reset(pe);
+  buf_strcpy(line, "* *");
+  buf_seek(line, 0);
+  TEST_CHECK_NUM_EQ(parse_unbind(&UnBind, line, pc, pe), MUTT_CMD_SUCCESS);
+  TEST_CHECK(has_keymap("index", "x", OP_MACRO));
+  TEST_CHECK(!has_binding("index", OP_DISPLAY_MESSAGE));
+  km_cleanup(neomutt_get_module_data(NeoMutt, MODULE_ID_KEY));
+
+  TEST_CASE("unbind * restores fallback bindings after unbind * *");
+  init_menus();
+  parse_error_reset(pe);
+  buf_strcpy(line, "* *");
+  buf_seek(line, 0);
+  TEST_CHECK_NUM_EQ(parse_unbind(&UnBind, line, pc, pe), MUTT_CMD_SUCCESS);
+  TEST_CHECK(!has_binding("generic", OP_HELP));
+  TEST_CHECK(!has_binding("index", OP_DISPLAY_MESSAGE));
+  parse_error_reset(pe);
+  buf_strcpy(line, "*");
+  buf_seek(line, 0);
+  TEST_CHECK_NUM_EQ(parse_unbind(&UnBind, line, pc, pe), MUTT_CMD_SUCCESS);
+  TEST_CHECK(has_binding("generic", OP_HELP));
+  TEST_CHECK(has_binding("index", OP_DISPLAY_MESSAGE));
+  km_cleanup(neomutt_get_module_data(NeoMutt, MODULE_ID_KEY));
+
+  TEST_CASE("unbind index * does not restore fallback bindings for one menu");
+  init_menus();
+  parse_error_reset(pe);
+  buf_strcpy(line, "* *");
+  buf_seek(line, 0);
+  TEST_CHECK_NUM_EQ(parse_unbind(&UnBind, line, pc, pe), MUTT_CMD_SUCCESS);
+  TEST_CHECK(!has_binding("index", OP_DISPLAY_MESSAGE));
+  TEST_CHECK(!has_binding("pager", OP_EXIT));
+  parse_error_reset(pe);
+  buf_strcpy(line, "index *");
+  buf_seek(line, 0);
+  TEST_CHECK_NUM_EQ(parse_unbind(&UnBind, line, pc, pe), MUTT_CMD_SUCCESS);
+  TEST_CHECK(!has_binding("index", OP_DISPLAY_MESSAGE));
+  TEST_CHECK(!has_binding("pager", OP_EXIT));
+  km_cleanup(neomutt_get_module_data(NeoMutt, MODULE_ID_KEY));
+
+  TEST_CASE("unbind index restores fallback bindings for one menu");
+  init_menus();
+  parse_error_reset(pe);
+  buf_strcpy(line, "* *");
+  buf_seek(line, 0);
+  TEST_CHECK_NUM_EQ(parse_unbind(&UnBind, line, pc, pe), MUTT_CMD_SUCCESS);
+  TEST_CHECK(!has_binding("index", OP_DISPLAY_MESSAGE));
+  TEST_CHECK(!has_binding("pager", OP_EXIT));
+  parse_error_reset(pe);
+  buf_strcpy(line, "index");
+  buf_seek(line, 0);
+  TEST_CHECK_NUM_EQ(parse_unbind(&UnBind, line, pc, pe), MUTT_CMD_SUCCESS);
+  TEST_CHECK(has_binding("index", OP_DISPLAY_MESSAGE));
+  TEST_CHECK(!has_binding("pager", OP_EXIT));
+  km_cleanup(neomutt_get_module_data(NeoMutt, MODULE_ID_KEY));
+
+  TEST_CASE("unmacro index * does not restore fallback bindings");
+  init_menus();
+  km_bind(menu_find_by_name("index"), "x", OP_MACRO, "<exit>", NULL, NULL);
+  parse_error_reset(pe);
+  buf_strcpy(line, "* *");
+  buf_seek(line, 0);
+  TEST_CHECK_NUM_EQ(parse_unbind(&UnBind, line, pc, pe), MUTT_CMD_SUCCESS);
+  TEST_CHECK(has_keymap("index", "x", OP_MACRO));
+  TEST_CHECK(!has_binding("index", OP_DISPLAY_MESSAGE));
+  parse_error_reset(pe);
+  buf_strcpy(line, "index *");
+  buf_seek(line, 0);
+  TEST_CHECK_NUM_EQ(parse_unbind(&UnMacro, line, pc, pe), MUTT_CMD_SUCCESS);
+  TEST_CHECK(!has_keymap("index", "x", OP_MACRO));
+  TEST_CHECK(!has_binding("index", OP_DISPLAY_MESSAGE));
+  km_cleanup(neomutt_get_module_data(NeoMutt, MODULE_ID_KEY));
+
+  TEST_CASE("unbind index x does not remove macro x");
+  init_menus();
+  km_bind(menu_find_by_name("index"), "x", OP_MACRO, "<exit>", NULL, NULL);
+  TEST_CHECK(has_keymap("index", "x", OP_MACRO));
+  parse_error_reset(pe);
+  buf_strcpy(line, "index x");
+  buf_seek(line, 0);
+  TEST_CHECK_NUM_EQ(parse_unbind(&UnBind, line, pc, pe), MUTT_CMD_SUCCESS);
+  TEST_CHECK(has_keymap("index", "x", OP_MACRO));
+  km_cleanup(neomutt_get_module_data(NeoMutt, MODULE_ID_KEY));
+
+  parse_context_free(&pc);
+  parse_error_free(&pe);
+  buf_pool_release(&line);
 }
 
 void test_parse_unbind(void)
 {
   test_parse_unbind2();
+  test_parse_unbind_behaviour();
+  test_parse_unbind_restore_defaults();
   test_parse_unmacro();
 }


### PR DESCRIPTION
**unbind** / **unmacro** syntax:

| Command           | Remove          | From      | Notes                         |
| :---------------  | :-------------- | :-------- | :---------------------------- |
| `unbind index q`  | One keybinding  | One menu  |                               |
| `unbind index`    | All keybindings | One menu  | Some default bindings are set |
| `unbind index *`  | All keybindings | One menu  |                               |
| `unbind * q`      | One keybinding  | All menus |                               |
| `unbind *`        | All keybindings | All menus | Some default bindings are set |
| `unbind * *`      | All keybindings | All menus | Only Ctrl-C is possible       |

| Command           | Remove          | From      |
| :---------------  | :-------------- | :-------- |
| `unmacro index q` | One macro       | One menu  |
| `unmacro index`   | All macros      | One menu  |
| `unmacro index *` | All macros      | One menu  |
| `unmacro * q`     | One macro       | All menus |
| `unmacro *`       | All macros      | All menus |
| `unmacro * *`     | All macros      | All menus |

This PR fixes the behaviour and introduces the nuclear option `unbind * *` (with clear warnings).