### PR TITLE
mutt/buffer.c: don't over-allocate if initialized

### DIFF
--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -312,7 +312,10 @@ struct Buffer *buf_new(const char *str)
     buf_addstr_n(buf, str, slen);
   }
   else
+  {
     buf_alloc(buf, 1);
+  }
+
   return buf;
 }
 
@@ -363,8 +366,7 @@ void buf_alloc(struct Buffer *buf, size_t new_size)
 }
 
 /**
- * buf_alloc_exact - Make sure a buffer can store at least new_size bytes,
- * without rounding up.
+ * buf_alloc_exact - Make sure a buffer can store at least new_size bytes, without rounding up
  * @param buf      Buffer to change
  * @param new_size New size
  *

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -375,6 +375,9 @@ void buf_alloc_exact(struct Buffer *buf, size_t new_size)
   if (!buf)
     return;
 
+  if (new_size == 0)
+    new_size = 1;
+
   const bool was_empty = (buf->dptr == NULL);
   const size_t offset = (buf->dptr && buf->data) ? (buf->dptr - buf->data) : 0;
 

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -306,7 +306,11 @@ struct Buffer *buf_new(const char *str)
   struct Buffer *buf = MUTT_MEM_CALLOC(1, struct Buffer);
 
   if (str)
-    buf_addstr(buf, str);
+  {
+    const size_t slen = mutt_str_len(str);
+    buf_alloc_exact(buf, slen + 1);
+    buf_addstr_n(buf, str, slen);
+  }
   else
     buf_alloc(buf, 1);
   return buf;
@@ -355,10 +359,34 @@ void buf_alloc(struct Buffer *buf, size_t new_size)
     // LCOV_EXCL_STOP
   }
 
+  buf_alloc_exact(buf, ROUND_UP(new_size + 1, BufferStepSize));
+}
+
+/**
+ * buf_alloc_exact - Make sure a buffer can store at least new_size bytes,
+ * without rounding up.
+ * @param buf      Buffer to change
+ * @param new_size New size
+ *
+ * @sa buf_alloc
+ */
+void buf_alloc_exact(struct Buffer *buf, size_t new_size)
+{
+  if (!buf)
+    return;
+
   const bool was_empty = (buf->dptr == NULL);
   const size_t offset = (buf->dptr && buf->data) ? (buf->dptr - buf->data) : 0;
 
-  buf->dsize = ROUND_UP(new_size + 1, BufferStepSize);
+  if (buf->data && (new_size <= buf->dsize))
+  {
+    // Extra sanity-checking
+    if (!buf->dptr || (buf->dptr < buf->data) || (buf->dptr > (buf->data + buf->dsize)))
+      buf->dptr = buf->data; // LCOV_EXCL_LINE
+    return;
+  }
+
+  buf->dsize = new_size;
 
   MUTT_MEM_REALLOC(&buf->data, buf->dsize, char);
   buf->dptr = buf->data + offset;

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -42,6 +42,7 @@ struct Buffer
 struct Buffer *buf_new             (const char *str);
 void           buf_free            (struct Buffer **ptr);
 void           buf_alloc           (struct Buffer *buf, size_t size);
+void           buf_alloc_exact     (struct Buffer *buf, size_t size);
 void           buf_dealloc         (struct Buffer *buf);
 void           buf_fix_dptr        (struct Buffer *buf);
 struct Buffer *buf_init            (struct Buffer *buf);

--- a/test/buffer/buf_alloc.c
+++ b/test/buffer/buf_alloc.c
@@ -44,6 +44,17 @@ void test_buf_alloc(void)
   }
 
   {
+    struct Buffer *buf = MUTT_MEM_CALLOC(1, struct Buffer);
+    buf_alloc_exact(buf, 0);
+    TEST_CHECK(buf != NULL);
+    TEST_CHECK(buf->data != NULL);
+    TEST_CHECK(buf->dptr == buf->data);
+    TEST_CHECK(buf->dsize == 1);
+    TEST_CHECK(buf->data[0] == '\0');
+    buf_free(&buf);
+  }
+
+  {
     const int orig_size = 64;
     static int sizes[][2] = {
       { 0, 128 },


### PR DESCRIPTION
parse_address() uses buf_new() to copy addresses into a struct Buffer, but only addr_set_local() and addr_set_intl() would ever modify that buffer.  Rounding every allocation up to the next multiple of 128 bytes wastes a lot of memory.

Loading a mailbox of approximately 1.8 million emails consumed 16.2GB of memory and allocated 7,417,113,344 bytes for Address.mailbox buffers (the sum of mailbox->dsize), of which only 643,359,347 bytes were used (the sum of buf_len(mailbox)).

This commit brings that down to 7.3GB, with only 672,332,445 bytes allocated for those same Address.mailbox buffers.

Fixes: a3b368548f23 ("stuct Address: replace char * uses with struct Buffer")