### PR TITLE
expando: Return `Expando` struct when parsing an empty string

### DIFF
--- a/expando/expando.c
+++ b/expando/expando.c
@@ -73,15 +73,16 @@ void expando_free(struct Expando **ptr)
 
 /**
  * expando_parse - Parse an Expando string
- * @param str  String to parse
- * @param defs Data defining Expando
+ * @param str  String to parse; must be non-NULL
+ * @param defs Data defining Expando; must be non-NULL
  * @param err  Buffer for error messages
  * @retval ptr New Expando
+ * @retval NULL Error
  */
 struct Expando *expando_parse(const char *str, const struct ExpandoDefinition *defs,
                               struct Buffer *err)
 {
-  if (!str || (*str == '\0') || !defs)
+  if (!str || !defs)
     return NULL;
 
   struct Expando *exp = expando_new(str);

--- a/test/command/parse_index_hook.c
+++ b/test/command/parse_index_hook.c
@@ -37,6 +37,7 @@ static const struct Command IndexFormatHook = { "index-format-hook",
 static const struct CommandTest Tests[] = {
   // clang-format off
   { MUTT_CMD_WARNING, "" },
+  { MUTT_CMD_SUCCESS, "date '~d<1d' ''" },
   { MUTT_CMD_SUCCESS, "date '~d<1d' '%[%H:%M]'" },
   { MUTT_CMD_SUCCESS, "date '~d<1m' '%[%a %d]'" },
   { MUTT_CMD_SUCCESS, "date '~d<1y' '%[%b %d]'" },

--- a/test/expando/expando.c
+++ b/test/expando/expando.c
@@ -83,6 +83,7 @@ void test_expando_expando(void)
     };
     const char *str_good = "%a";
     const char *str_bad = "%z";
+    const char *str_empty = "";
 
     struct Buffer *err = buf_pool_get();
     struct Expando *exp = NULL;
@@ -91,15 +92,20 @@ void test_expando_expando(void)
     TEST_CHECK(exp == NULL);
     exp = expando_parse(str_good, NULL, err);
     TEST_CHECK(exp == NULL);
+    exp = expando_parse(str_empty, NULL, err);
+    TEST_CHECK(exp == NULL);
 
     exp = expando_parse(str_bad, TestFormatDef, err);
     TEST_CHECK(exp == NULL);
 
     exp = expando_parse(str_good, TestFormatDef, err);
     TEST_CHECK(exp != NULL);
+    expando_free(&exp);
+    exp = expando_parse(str_empty, TestFormatDef, err);
+    TEST_CHECK(exp != NULL);
+    expando_free(&exp);
 
     buf_pool_release(&err);
-    expando_free(&exp);
   }
 
   // int expando_render(const struct Expando *exp, const struct ExpandoRenderCallback *rdata, void *data, MuttFormatFlags flags, int cols, struct Buffer *buf);
@@ -139,6 +145,28 @@ void test_expando_expando(void)
 
       rc = expando_render(exp, TestRenderCallback, NULL, MUTT_FORMAT_NONE, -1, buf);
       TEST_CHECK_NUM_EQ(rc, 5);
+
+      buf_pool_release(&buf);
+      buf_pool_release(&err);
+      expando_free(&exp);
+    }
+
+    {
+      const char *str = "";
+
+      struct Buffer *err = buf_pool_get();
+      struct Expando *exp = NULL;
+
+      exp = expando_parse(str, TestFormatDef, err);
+      TEST_CHECK(exp != NULL);
+
+      int rc;
+
+      struct Buffer *buf = buf_pool_get();
+
+      rc = expando_render(exp, TestRenderCallback, NULL, MUTT_FORMAT_NONE, -1, buf);
+      TEST_CHECK_NUM_EQ(rc, 0);
+      TEST_CHECK_STR_EQ(buf_string(buf), "");
 
       buf_pool_release(&buf);
       buf_pool_release(&err);


### PR DESCRIPTION
@flatcap I have no clue whether changing the return value for the empty string breaks some (implicit) assumptions in other parts of the code.  @gahr at the time was also not familiar with it (https://github.com/neomutt/neomutt/issues/4639#issuecomment-3023295845). So we need some code-hero with expertise to verify this commit doesn't have unwanted side effects.

---

Let `expando_parse` return an `Expando` struct for the empty string "" instead of NULL.

Code paths using `expando_parse` often treat the return value of NULL as an error condition.  As a result parsing the empty string "" via the expando mechanism results in an error.  For example when the user configures the following index-format-hook:

  index-format-hook date "~d<1d" ""

History:

`expando_parse` returning NULL for an empty string was introduced in commit 58c167e6067b4b28e59c6b80789a28f2b01face3 "expando: use ARRAYs".

Fixes: #4639

---

Totally Offtopic:

@flatcap I wonder why you choose to treat the the empty string "" specially by representing it as `NULL` increasing the code complexity and introducing additional code paths.  The config system does the same:

https://github.com/neomutt/neomutt/blob/e756936d099a6cfdb9c3ebb5d08c200dc132f3e2/config/string.c#L63-L65

What is/was your motivation? Is it all about saving 1 byte?

