### PR TITLE
fix index-format-hook parsing

### DIFF
--- a/hooks/parse.c
+++ b/hooks/parse.c
@@ -1110,7 +1110,7 @@ enum CommandResult parse_index_hook(const struct Command *cmd, struct Buffer *li
   parse_extract_token(fmt, line, TOKEN_NONE);
 
   exp = expando_parse(buf_string(fmt), IndexFormatDef, err);
-  if (!exp)
+  if (!buf_is_empty(err))
     goto out;
 
   if (MoreArgs(line))

--- a/test/command/parse_index_hook.c
+++ b/test/command/parse_index_hook.c
@@ -37,6 +37,7 @@ static const struct Command IndexFormatHook = { "index-format-hook",
 static const struct CommandTest Tests[] = {
   // clang-format off
   { MUTT_CMD_WARNING, "" },
+  { MUTT_CMD_SUCCESS, "date '~d<1d' ''" },
   { MUTT_CMD_SUCCESS, "date '~d<1d' '%[%H:%M]'" },
   { MUTT_CMD_SUCCESS, "date '~d<1m' '%[%a %d]'" },
   { MUTT_CMD_SUCCESS, "date '~d<1y' '%[%b %d]'" },


### PR DESCRIPTION
If the index-format-string format string is empty, there's no Expando.
Check for an error message instead.

Fixes: #4639

**Tests**:

**empty.rc** -- No error, empty string when hook matches
```
set index_format = "%@date@"
index-format-hook  date  "~d<1d"  ""
```

**bad.rc** -- Error message about `%w`
```
set index_format = "%@date@"
index-format-hook  date  "~d<1d"  "%w"
```