### PR TITLE
parse: always expand $var inside backticks

### DIFF
--- a/commands/source.c
+++ b/commands/source.c
@@ -241,7 +241,7 @@ enum CommandResult parse_source(const struct Command *cmd, struct Buffer *line,
 
   do
   {
-    if (parse_extract_token(token, line, TOKEN_BACKTICK_VARS) != 0)
+    if (parse_extract_token(token, line, TOKEN_NONE) != 0)
     {
       buf_printf(err, _("source: error at %s"), line->dptr);
       goto done;

--- a/parse/extract.c
+++ b/parse/extract.c
@@ -182,16 +182,15 @@ int parse_extract_token(struct Buffer *dest, struct Buffer *line, TokenFlags fla
       }
       struct Buffer *cmd = buf_pool_get();
       *pc = '\0';
-      if (flags & TOKEN_BACKTICK_VARS)
+      /* Recursively extract tokens to interpolate NeoMutt variables.
+       * TOKEN_NOSHELL leaves unknown/env variables for the shell to expand. */
+      if (parse_extract_token(cmd, line,
+                              TOKEN_QUOTE | TOKEN_SPACE | TOKEN_COMMENT |
+                                  TOKEN_SEMICOLON | TOKEN_NOSHELL) != 0)
       {
-        /* recursively extract tokens to interpolate variables */
-        parse_extract_token(cmd, line,
-                            TOKEN_QUOTE | TOKEN_SPACE | TOKEN_COMMENT |
-                                TOKEN_SEMICOLON | TOKEN_NOSHELL);
-      }
-      else
-      {
-        buf_strcpy(cmd, line->dptr);
+        *pc = '`';
+        buf_pool_release(&cmd);
+        return -1;
       }
       *pc = '`';
       pid = filter_create(buf_string(cmd), NULL, &fp, NULL, NeoMutt->env);

--- a/parse/extract.h
+++ b/parse/extract.h
@@ -54,11 +54,10 @@ enum TokenFlag
   TOKEN_PATTERN       = 1U <<  4,  ///< ~%=!| are terms (for patterns)
   TOKEN_COMMENT       = 1U <<  5,  ///< Don't reap comments
   TOKEN_SEMICOLON     = 1U <<  6,  ///< Don't treat ; as special
-  TOKEN_BACKTICK_VARS = 1U <<  7,  ///< Expand variables within backticks
-  TOKEN_NOSHELL       = 1U <<  8,  ///< Don't expand environment variables
-  TOKEN_QUESTION      = 1U <<  9,  ///< Treat '?' as a special
-  TOKEN_PLUS          = 1U << 10,  ///< Treat '+' as a special
-  TOKEN_MINUS         = 1U << 11,  ///< Treat '-' as a special
+  TOKEN_NOSHELL       = 1U <<  7,  ///< Don't expand environment variables
+  TOKEN_QUESTION      = 1U <<  8,  ///< Treat '?' as a special
+  TOKEN_PLUS          = 1U <<  9,  ///< Treat '+' as a special
+  TOKEN_MINUS         = 1U << 10,  ///< Treat '-' as a special
 };
 typedef uint16_t TokenFlags;
 

--- a/parse/set.c
+++ b/parse/set.c
@@ -676,7 +676,7 @@ enum CommandResult parse_set(const struct Command *cmd, struct Buffer *line,
       // implies 'equals', we can group them in this single case guarded by
       // 'equals'.
       struct Buffer *value = buf_pool_get();
-      parse_extract_token(value, line, TOKEN_BACKTICK_VARS);
+      parse_extract_token(value, line, TOKEN_NONE);
       if (increment)
         rc = command_set_increment(token, value, err);
       else if (decrement)

--- a/sidebar/commands.c
+++ b/sidebar/commands.c
@@ -58,7 +58,7 @@ enum CommandResult parse_sidebar_pin(const struct Command *cmd, struct Buffer *l
 
   do
   {
-    parse_extract_token(path, line, TOKEN_BACKTICK_VARS);
+    parse_extract_token(path, line, TOKEN_NONE);
     expand_path(path, false);
     add_to_stailq(&mod_data->sidebar_pinned, buf_string(path));
   } while (MoreArgs(line));
@@ -89,7 +89,7 @@ enum CommandResult parse_sidebar_unpin(const struct Command *cmd, struct Buffer 
 
   do
   {
-    parse_extract_token(path, line, TOKEN_BACKTICK_VARS);
+    parse_extract_token(path, line, TOKEN_NONE);
     /* Check for deletion of entire list */
     if (mutt_str_equal(buf_string(path), "*"))
     {


### PR DESCRIPTION
Variable interpolation inside backticks was gated behind the opt-in `TOKEN_BACKTICK_VARS` flag, which only 'set', 'source' and 'sidebar' passed.
Other commands (macro, alias, ...) therefore did not expand NeoMutt variables inside backticks, giving inconsistent behaviour.

Make the recursive token extraction the default in parse_extract_token() so all commands expand $var inside backticks consistently.
`TOKEN_NOSHELL` recursion semantics are preserved, leaving unknown/env variables for the shell.
The now-unused `TOKEN_BACKTICK_VARS` flag is removed.

Fixes: #4895 