### PR TITLE
notmuch: allow <entire-thread> from any mailbox type

### DIFF
--- a/index/functions.c
+++ b/index/functions.c
@@ -3686,8 +3686,7 @@ static int op_main_entire_thread(struct IndexFunctionData *fdata, const struct K
   struct IndexPrivateData *priv = fdata->priv;
   if (shared->mailbox->type != MUTT_NOTMUCH)
   {
-    if (((shared->mailbox->type != MUTT_MH) && (shared->mailbox->type != MUTT_MAILDIR)) ||
-        (!shared->email || !shared->email->env || !shared->email->env->message_id))
+    if (!shared->email || !shared->email->env || !shared->email->env->message_id)
     {
       mutt_message(_("No virtual folder and no Message-ID, aborting"));
       return FR_ERROR;


### PR DESCRIPTION
Previously <entire-thread> only worked in notmuch virtual folders, or from Maildir/MH mailboxes (via an on-the-fly notmuch query).
Drop the restriction to Maildir/MH so any mailbox type (IMAP, POP, MBOX, NNTP, compressed, ...)
can also use <entire-thread>, as long as the selected message has a Message-ID and notmuch has indexed it.

Fixes: #105 (maybe)

Someone posted a workaround to Issue #105, but it vanished almost immediately.

I still don't use notmuch, myself, but I had a quick hack.
I'm not _really_ sure how `<entire-thread>` is _meant_ to work, but this may help.