### PR TITLE
support mailing list action urls

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -704,7 +704,8 @@ $(PWD)/mh:
 ###############################################################################
 # libmlist
 LIBMLIST=	libmlist.a
-LIBMLISTOBJS=	mlist/dlg_mlist.o mlist/functions.o mlist/module.o
+LIBMLISTOBJS=	mlist/config.o mlist/dlg_mlist.o mlist/expando.o \
+		mlist/functions.o mlist/module.o
 CLEANFILES+=	$(LIBMLIST) $(LIBMLISTOBJS)
 ALLOBJS+=	$(LIBMLISTOBJS)
 

--- a/docs/config.c
+++ b/docs/config.c
@@ -5596,6 +5596,16 @@
 ** sorting, though.
 */
 
+{ "url_open_command", D_STRING_COMMAND, 0 },
+/*
+** .pp
+** This specifies the external command used to open URLs from mailing-list
+** \fCList-*\fP headers.
+** .pp
+** The command supports a single \fC%u\fP expando for the URL. If \fC%u\fP is
+** not present, NeoMutt appends the URL to the command.
+*/
+
 { "use_8bit_mime", DT_BOOL, false },
 /*
 ** .pp

--- a/expando/domain.h
+++ b/expando/domain.h
@@ -46,6 +46,7 @@ enum ExpandoDomain
   ED_INDEX,        ///< Index         ED_IND_ #ExpandoDataIndex     @sa StatusFormatDef
   ED_MAILBOX,      ///< Mailbox       ED_MBX_ #ExpandoDataMailbox   @sa IndexFormatDef
   ED_MENU,         ///< Menu          ED_MEN_ #ExpandoDataMenu      @sa StatusFormatDef
+  ED_MLIST,        ///< Mailing List  ED_MLS_ #ExpandoDataMlist     @sa MlistFormatDef
   ED_MSG_ID,       ///< Message Id    ED_MSG_ #ExpandoDataMsgId     @sa MsgIdFormatDef
   ED_NNTP,         ///< Nntp          ED_NTP_ #ExpandoDataNntp      @sa NntpFormatDef
   ED_PATTERN,      ///< Pattern       ED_PAT_ #ExpandoDataPattern   @sa PatternFormatDef

--- a/expando/helpers.c
+++ b/expando/helpers.c
@@ -33,6 +33,8 @@
 #include "mutt/lib.h"
 #include "gui/lib.h"
 #include "helpers.h"
+#include "expando.h"
+#include "node.h"
 #include "render.h"
 
 /**
@@ -114,4 +116,46 @@ void buf_lower_special(struct Buffer *buf)
     *p = mutt_tolower(*p);
     p++;
   }
+}
+
+/**
+ * node_contains - Does the ExpandoNode contain a given ID?
+ * @param node ExpandoNode
+ * @param did  Domain ID, e.g. #ED_ALIAS
+ * @param uid  UID, e.g. #ED_ALI_COMMENT
+ *
+ * Recursively search for an ExpandoNode matching (did,uid).
+ */
+static bool node_contains(const struct ExpandoNode *node, int did, int uid)
+{
+  if (!node)
+    return false;
+
+  if ((node->did == did) && (node->uid == uid))
+    return true;
+
+  struct ExpandoNode **enp = NULL;
+  ARRAY_FOREACH(enp, &node->children)
+  {
+    if (node_contains(*enp, did, uid))
+      return true;
+  }
+
+  return false;
+}
+
+/**
+ * expando_contains - Does the Expando contain a given ID?
+ * @param exp Expando
+ * @param did Domain ID, e.g. #ED_ALIAS
+ * @param uid UID, e.g. #ED_ALI_COMMENT
+ *
+ * Recursively search for an ExpandoNode matching (did,uid).
+ */
+bool expando_contains(const struct Expando *exp, int did, int uid)
+{
+  if (!exp)
+    return false;
+
+  return node_contains(exp->node, did, uid);
 }

--- a/mlist/config.c
+++ b/mlist/config.c
@@ -1,0 +1,58 @@
+/**
+ * @file
+ * Config used by libmlist
+ *
+ * @authors
+ * Copyright (C) 2026 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page mlist_config Config used by libmlist
+ *
+ * Config used by libmlist
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include "config/lib.h"
+#include "expando/lib.h"
+#include "expando.h"
+
+/**
+ * MlistFormatDef - Expando definitions
+ *
+ * Config:
+ * - $url_open_command
+ */
+static const struct ExpandoDefinition MlistFormatDef[] = {
+  // clang-format off
+  { "u", "url", ED_MLIST, ED_MLS_URL, NULL },
+  { NULL, NULL, 0, -1, NULL }
+  // clang-format on
+};
+
+/**
+ * MlistVars - Config definitions for the Mlist library
+ */
+struct ConfigDef MlistVars[] = {
+  // clang-format off
+  { "url_open_command", DT_EXPANDO, 0, IP &MlistFormatDef, NULL,
+    "External command to open a URL from a List-* header"
+  },
+  { NULL },
+  // clang-format on
+};

--- a/mlist/dlg_mlist.c
+++ b/mlist/dlg_mlist.c
@@ -78,9 +78,6 @@ static void mlist_data_add_entries(struct ListData *ld, const struct ListAction 
   struct ListNode *np = NULL;
   STAILQ_FOREACH(np, values, entries)
   {
-    if (!mutt_istr_startswith(np->data, "mailto:"))
-      continue;
-
     const struct ListEntry entry = { action, np->data };
     ARRAY_ADD(&ld->entries, entry);
   }

--- a/mlist/expando.c
+++ b/mlist/expando.c
@@ -1,0 +1,56 @@
+/**
+ * @file
+ * Mlist Expando definitions
+ *
+ * @authors
+ * Copyright (C) 2026 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page mlist_expando Mlist Expando definitions
+ *
+ * Mlist Expando definitions
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include "mutt/lib.h"
+#include "expando.h"
+#include "expando/lib.h"
+
+/**
+ * mlist_url - Mlist: Mailing List URL - Implements ::get_string_t - @ingroup expando_get_string_api
+ */
+static void mlist_url(const struct ExpandoNode *node, void *data,
+                      MuttFormatFlags flags, struct Buffer *buf)
+{
+  struct MlistExpandoData *med = data;
+
+  buf_strcpy(buf, med->url);
+}
+
+/**
+ * MlistRenderCallbacks - Callbacks for Mlist Expandos
+ *
+ * @sa MlistFormatDef, ExpandoDataMlist
+ */
+const struct ExpandoRenderCallback MlistRenderCallbacks[] = {
+  // clang-format off
+  { ED_MLIST, ED_MLS_URL, mlist_url, NULL },
+  { -1, -1, NULL, NULL },
+  // clang-format on
+};

--- a/mlist/expando.h
+++ b/mlist/expando.h
@@ -1,10 +1,9 @@
 /**
  * @file
- * Shared code
+ * Mlist Expando definitions
  *
  * @authors
- * Copyright (C) 2023-2024 Tóth János <gomba007@gmail.com>
- * Copyright (C) 2023-2024 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2026 Richard Russon <rich@flatcap.org>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -21,19 +20,29 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MUTT_EXPANDO_HELPERS_H
-#define MUTT_EXPANDO_HELPERS_H
+#ifndef MUTT_MLIST_EXPANDO_H
+#define MUTT_MLIST_EXPANDO_H
 
-#include <stdbool.h>
+#include "expando/lib.h" // IWYU pragma: keep
 
-struct Buffer;
-struct Expando;
-struct ExpandoRenderCallback;
+/**
+ * struct MlistExpandoData - Data for the Mailing list expando
+ */
+struct MlistExpandoData
+{
+  const char *url;    ///< Mailing list URL
+};
 
-const struct ExpandoRenderCallback *find_get_number(const struct ExpandoRenderCallback *erc, int did, int uid);
-const struct ExpandoRenderCallback *find_get_string(const struct ExpandoRenderCallback *erc, int did, int uid);
+/**
+ * ExpandoDataMlist - Expando UIDs for Mailing Lists
+ *
+ * @sa ED_MLIST, ExpandoDomain
+ */
+enum ExpandoDataMlist
+{
+  ED_MLS_URL = 1,    ///< Mailing List URL
+};
 
-void buf_lower_special(struct Buffer *buf);
-bool expando_contains(const struct Expando *exp, int did, int uid);
+extern const struct ExpandoRenderCallback MlistRenderCallbacks[];
 
-#endif /* MUTT_EXPANDO_HELPERS_H */
+#endif /* MUTT_MLIST_EXPANDO_H */

--- a/mlist/functions.c
+++ b/mlist/functions.c
@@ -31,14 +31,18 @@
 #include <stddef.h>
 #include <stdio.h>
 #include "mutt/lib.h"
+#include "config/lib.h"
 #include "email/lib.h"
 #include "core/lib.h"
 #include "gui/lib.h"
+#include "mutt.h"
 #include "functions.h"
 #include "lib.h"
+#include "expando/lib.h"
 #include "key/lib.h"
 #include "menu/lib.h"
 #include "send/lib.h"
+#include "expando.h"
 #include "module_data.h"
 
 /// Mailing-list actions shown in the dialog
@@ -119,6 +123,55 @@ struct ListHead *mlist_action_value(struct Rfc2369ListHeaders *headers,
 }
 
 /**
+ * mlist_open_url - Open a URL with the configured command
+ * @param url URL to open
+ * @retval true  Command ran successfully
+ * @retval false Command couldn't be run
+ */
+bool mlist_open_url(const char *url)
+{
+  if (!url)
+    return false;
+
+  const struct Expando *c_url_open_command = cs_subset_expando(NeoMutt->sub, "url_open_command");
+  if (!c_url_open_command)
+  {
+    mutt_warning(_("Set the 'url_open_command' option to open URLs"));
+    return false;
+  }
+
+  struct Buffer *cmd = buf_pool_get();
+  struct Buffer *quoted = buf_pool_get();
+
+  buf_quote_filename(quoted, url, true);
+  struct MlistExpandoData med = { buf_string(quoted) };
+
+  expando_filter(c_url_open_command, MlistRenderCallbacks, &med,
+                 MUTT_FORMAT_NONE, -1, NeoMutt->env, cmd);
+
+  if (!expando_contains(c_url_open_command, ED_MLIST, ED_MLS_URL))
+  {
+    buf_addch(cmd, ' ');
+    buf_addstr(cmd, buf_string(quoted));
+  }
+
+  msgwin_clear_text(NULL);
+  mutt_endwin();
+  fflush(stdout);
+
+  const int rc = mutt_system(buf_string(cmd));
+  if (rc == -1)
+    mutt_error(_("Error running \"%s\""), buf_string(cmd));
+
+  const bool c_wait_key = cs_subset_bool(NeoMutt->sub, "wait_key");
+  if ((rc != 0) || c_wait_key)
+    mutt_any_key_to_continue(NULL);
+
+  buf_pool_release(&cmd);
+  return rc == 0;
+}
+
+/**
  * compose_list_action - Compose a message for a mailing-list action
  * @param ld      Dialog state
  * @param entry   Mailing-list entry
@@ -135,7 +188,7 @@ static bool compose_list_action(struct ListData *ld, const struct ListEntry *ent
 
   const char *uri = entry->value;
   if (!mutt_istr_startswith(uri, "mailto:"))
-    return false;
+    return mlist_open_url(uri);
 
   struct Email *e = email_new();
   e->env = mutt_env_new();

--- a/mlist/lib.h
+++ b/mlist/lib.h
@@ -31,12 +31,18 @@
  *
  * | File                | Description                |
  * | :------------------ | :------------------------- |
+ * | mlist/config.c      | @subpage mlist_config      |
  * | mlist/dlg_mlist.c   | @subpage mlist_dlg_mlist   |
+ * | mlist/expando.c     | @subpage mlist_expando     |
+ * | mlist/functions.c   | @subpage mlist_functions   |
  * | mlist/module.c      | @subpage mlist_module      |
  */
 
 #ifndef MUTT_MLIST_LIB_H
 #define MUTT_MLIST_LIB_H
+
+#include "expando.h"
+#include "functions.h" // IWYU pragma: keep
 
 struct Email;
 struct Mailbox;

--- a/mlist/module.c
+++ b/mlist/module.c
@@ -48,6 +48,14 @@ static bool mlist_init(struct NeoMutt *n)
 }
 
 /**
+ * mlist_config_define_variables - Define the Config Variables - Implements Module::config_define_variables()
+ */
+static bool mlist_config_define_variables(struct NeoMutt *n, struct ConfigSet *cs)
+{
+  return cs_register_variables(cs, MlistVars);
+}
+
+/**
  * mlist_cleanup - Clean up a Module - Implements Module::cleanup()
  */
 static bool mlist_cleanup(struct NeoMutt *n, void *data)
@@ -66,7 +74,7 @@ const struct Module ModuleMlist = {
   "mlist",
   mlist_init,
   NULL, // config_define_types
-  NULL, // config_define_variables
+  mlist_config_define_variables,
   NULL, // commands_register
   NULL, // gui_init
   NULL, // gui_cleanup

--- a/send/send.c
+++ b/send/send.c
@@ -65,6 +65,7 @@
 #include "history/lib.h"
 #include "hooks/lib.h"
 #include "index/lib.h"
+#include "mlist/lib.h"
 #include "ncrypt/lib.h"
 #include "pager/lib.h"
 #include "pattern/lib.h"
@@ -2966,6 +2967,9 @@ bool mutt_send_list_subscribe(struct Mailbox *m, struct Email *e)
     return false;
   }
 
+  if (!mutt_istr_startswith(uri, "mailto:"))
+    return mlist_open_url(uri);
+
   struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
   ARRAY_ADD(&ea, e);
   bool rc = send_simple_email(m, &ea, uri, "Subscribe", "subscribe");
@@ -2994,6 +2998,9 @@ bool mutt_send_list_unsubscribe(struct Mailbox *m, struct Email *e)
     mutt_warning(_("No List-Unsubscribe header found"));
     return false;
   }
+
+  if (!mutt_istr_startswith(uri, "mailto:"))
+    return mlist_open_url(uri);
 
   struct EmailArray ea = ARRAY_HEAD_INITIALIZER;
   ARRAY_ADD(&ea, e);

--- a/test/email/mutt_rfc2369_read_headers.c
+++ b/test/email/mutt_rfc2369_read_headers.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <stdio.h>
 #include <string.h>
+#include "mutt/lib.h"
 #include "email/lib.h"
 
 static void check_header(const struct ListHead *actual, const char *expected[], size_t num_expected)

--- a/test/email/mutt_rfc822_parse_line.c
+++ b/test/email/mutt_rfc822_parse_line.c
@@ -27,6 +27,7 @@
 #include "acutest.h"
 #include <stdbool.h>
 #include <string.h>
+#include "mutt/lib.h"
 #include "email/lib.h"
 
 void test_mutt_rfc822_parse_line(void)


### PR DESCRIPTION
- parse every RFC 2369 URI for the list-action dialog
- add `$url_open_command` for non-mailto list actions
- allow subscribe and unsubscribe actions to open URLs

---

An upstream commit added support for [RFC 2369](https://datatracker.ietf.org/doc/html/rfc2369).
It adds functions, e.g. `<list-subscribe>`, `<list-post>` that use the `mailto:` links in the headers.

It also adds a new List Actions Dialog on `<list-action>`.

Commit 14e2a47d2 adds this feature to NeoMutt.

These come from our devel mailing list:
```
List-Id: Teaching an Old Dog New Tricks <neomutt-devel-neomutt.org>
List-Unsubscribe: <https://mailman.neomutt.org/mailman/options/neomutt-devel-neomutt.org>,  <mailto:neomutt-devel-request@neomutt.org?subject=unsubscribe>
List-Archive: <https://mailman.neomutt.org/pipermail/neomutt-devel-neomutt.org/>
List-Post: <mailto:neomutt-devel@neomutt.org>
List-Help: <mailto:neomutt-devel-request@neomutt.org?subject=help>
List-Subscribe: <https://mailman.neomutt.org/mailman/listinfo/neomutt-devel-neomutt.org>,  <mailto:neomutt-devel-request@neomutt.org?subject=subscribe>
```

---

This PR extends the feature to handle URLs.
It adds a new config option `$url_open_command`
This could be set to:
- `xdg-open` -- Any XDG-compatible desktop
- `open` -- MacOS
- `curl`

GitHub notification emails, for Issues, PRs, etc include mailing-list-like headers,
which include URLs, e.g.

```
List-ID: neomutt/neomutt <neomutt.neomutt.github.com>
List-Archive: https://github.com/neomutt/neomutt
List-Post: <mailto:reply+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA@reply.github.com>
List-Unsubscribe: <mailto:unsub+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA@reply.github.com>,
        <https://github.com/notifications/unsubscribe/one-click/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB>
List-Unsubscribe-Post: List-Unsubscribe=One-Click
```

---

**Note:** Currently the GitHub URLs don't work (nothing to do with NeoMutt) -- I've raised an issue.