### PR TITLE
bcache: sanitize mailbox names that escape the cache dir

### DIFF
--- a/bcache/bcache.c
+++ b/bcache/bcache.c
@@ -87,7 +87,23 @@ static int bcache_path(struct ConnAccount *account, const char *mailbox, struct 
   }
   buf_fix_dptr(host);
 
-  buf_addstr(host, mailbox);
+  /* A server-supplied mailbox name with '..' components would let the cache
+   * path escape $message_cache_dir.  Replace them with '__' so the path stays
+   * inside the cache directory.  imap_hcache_open() rejects these names for
+   * the header cache. */
+  for (const char *p = mailbox; p && *p;)
+  {
+    const char *slash = strchr(p, '/');
+    const size_t len = slash ? (size_t) (slash - p) : strlen(p);
+    if ((len == 2) && (p[0] == '.') && (p[1] == '.'))
+      buf_addstr(host, "__");
+    else
+      buf_addstr_n(host, p, len);
+    if (!slash)
+      break;
+    buf_addch(host, '/');
+    p = slash + 1;
+  }
 
   struct Buffer *path = buf_pool_get();
   struct Buffer *dst = buf_pool_get();


### PR DESCRIPTION
* **What does this PR do?**

  the body cache builds its on-disk path from the server-supplied mailbox
  name, so a name containing `..` components escapes `$message_cache_dir`.

  - replace each `..` path component of the mailbox name with `__` before
    building the cache path, so it stays inside the cache directory and
    caching keeps working for such names
  - components that merely contain dots (`a..b`, `..foo`) are untouched
  - covers both the imap and nntp body caches (the group name is reused as
    the path)

* **What are the relevant issue numbers?**

  none
