### PR TITLE
auth_gss: fix out-of-bounds read of gss security token

### DIFF
--- a/imap/auth_gss.c
+++ b/imap/auth_gss.c
@@ -286,7 +286,7 @@ enum ImapAuthRes imap_auth_gss(struct ImapAccountData *adata, const char *method
 
   /* we don't care about buffer size if we don't wrap content. But here it is */
   ((char *) send_token.value)[0] = '\0';
-  buf_size = ntohl(*((long *) send_token.value));
+  buf_size = ntohl(*((uint32_t *) send_token.value));
   gss_release_buffer(&min_stat, &send_token);
   mutt_debug(LL_DEBUG2, "Unwrapped security level flags: %c%c%c\n",
              (server_conf_flags & GSS_AUTH_P_NONE) ? 'N' : '-',


### PR DESCRIPTION
* **What does this PR do?**

  the gss security-level token comes from the server, and the `length < 4`
  guard only covers 4 bytes:

  - `ntohl(*((long *) send_token.value))` dereferences a `long`, so it reads
    8 bytes on 64-bit builds, 4 past a minimal 4-byte unwrapped token
  - a malicious or proxied server can return a token sized to exactly 4
    bytes, putting the trailing read off the end of the heap allocation
  - read it as `uint32_t` so the access matches both the guard and the
    32-bit `ntohl`, keeping the same buffer-size value

  asan reports a heap-buffer-overflow read of size 8 on the old code; the
  `uint32_t` read is clean.

* **What are the relevant issue numbers?**

  none
