### PR TITLE
hcache: bound deserialization reads against the cache entry length

### DIFF
--- a/compress/lib.h
+++ b/compress/lib.h
@@ -100,16 +100,17 @@ struct ComprOps
    * @ingroup compress_api
    *
    * decompress - Decompress header cache data
-   * @param[in] handle Compression handle
-   * @param[in] cbuf   Data to be decompressed
-   * @param[in] clen   Length of the compressed input data
+   * @param[in]  handle Compression handle
+   * @param[in]  cbuf   Data to be decompressed
+   * @param[in]  clen   Length of the compressed input data
+   * @param[out] dlen   Length of the decompressed output data
    * @retval ptr  Success, pointer to decompressed data
    * @retval NULL Otherwise
    *
    * @note This function returns a pointer to data, which will be freed by the
    *       close() function.
    */
-  void *(*decompress)(ComprHandle *handle, const char *cbuf, size_t clen);
+  void *(*decompress)(ComprHandle *handle, const char *cbuf, size_t clen, size_t *dlen);
 
   /**
    * @defgroup compress_close close()

--- a/compress/lz4.c
+++ b/compress/lz4.c
@@ -135,7 +135,8 @@ static void *compr_lz4_compress(ComprHandle *handle, const char *data,
 /**
  * compr_lz4_decompress - Decompress header cache data - Implements ComprOps::decompress() - @ingroup compress_decompress
  */
-static void *compr_lz4_decompress(ComprHandle *handle, const char *cbuf, size_t clen)
+static void *compr_lz4_decompress(ComprHandle *handle, const char *cbuf,
+                                  size_t clen, size_t *dlen)
 {
   if (!handle)
     return NULL;
@@ -153,7 +154,11 @@ static void *compr_lz4_decompress(ComprHandle *handle, const char *cbuf, size_t 
   if (ulen > INT_MAX)
     return NULL; // LCOV_EXCL_LINE
   if (ulen == 0)
+  {
+    if (dlen)
+      *dlen = 0;
     return (void *) cbuf;
+  }
 
   mutt_mem_realloc(&cdata->buf, ulen);
   void *ubuf = cdata->buf;
@@ -161,6 +166,9 @@ static void *compr_lz4_decompress(ComprHandle *handle, const char *cbuf, size_t 
   int rc = LZ4_decompress_safe(data + 4, ubuf, clen - 4, ulen);
   if (rc < 0)
     return NULL;
+
+  if (dlen)
+    *dlen = rc;
 
   return ubuf;
 }

--- a/compress/zlib.c
+++ b/compress/zlib.c
@@ -133,7 +133,8 @@ static void *compr_zlib_compress(ComprHandle *handle, const char *data,
 /**
  * compr_zlib_decompress - Decompress header cache data - Implements ComprOps::decompress() - @ingroup compress_decompress
  */
-static void *compr_zlib_decompress(ComprHandle *handle, const char *cbuf, size_t clen)
+static void *compr_zlib_decompress(ComprHandle *handle, const char *cbuf,
+                                   size_t clen, size_t *dlen)
 {
   if (!handle)
     return NULL;
@@ -155,6 +156,9 @@ static void *compr_zlib_decompress(ComprHandle *handle, const char *cbuf, size_t
   int rc = uncompress(ubuf, &ulen, cs + 4, clen - 4);
   if (rc != Z_OK)
     return NULL;
+
+  if (dlen)
+    *dlen = ulen;
 
   return ubuf;
 }

--- a/compress/zstd.c
+++ b/compress/zstd.c
@@ -136,7 +136,8 @@ static void *compr_zstd_compress(ComprHandle *handle, const char *data,
 /**
  * compr_zstd_decompress - Decompress header cache data - Implements ComprOps::decompress() - @ingroup compress_decompress
  */
-static void *compr_zstd_decompress(ComprHandle *handle, const char *cbuf, size_t clen)
+static void *compr_zstd_decompress(ComprHandle *handle, const char *cbuf,
+                                   size_t clen, size_t *dlen)
 {
   if (!handle)
     return NULL;
@@ -156,6 +157,9 @@ static void *compr_zstd_decompress(ComprHandle *handle, const char *cbuf, size_t
   size_t rc = ZSTD_decompressDCtx(cdata->dctx, cdata->buf, len, cbuf, clen);
   if (ZSTD_isError(rc))
     return NULL; // LCOV_EXCL_LINE
+
+  if (dlen)
+    *dlen = rc;
 
   return cdata->buf;
 }

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -261,49 +261,64 @@ static void *dump_email(struct HeaderCache *hc, const struct Email *e, int *off,
 
 /**
  * restore_email - Restore an Email from data retrieved from the cache
- * @param d Data retrieved using hcache_fetch_email()
- * @retval ptr Success, the restored header (can't be NULL)
+ * @param d    Data retrieved using hcache_fetch_email()
+ * @param dlen Length of the retrieved data
+ * @retval ptr  Success, the restored header
+ * @retval NULL The entry was truncated or corrupt
  *
  * @note The returned Email must be free'd by caller code with
  *       email_free()
  */
-static struct Email *restore_email(const unsigned char *d)
+static struct Email *restore_email(const unsigned char *d, size_t dlen)
 {
   int off = 0;
   struct Email *e = email_new();
   bool convert = !CharsetIsUtf8;
+  uint32_t packed = 0;
+  uint64_t big = 0;
+  unsigned int num = 0;
 
   off += sizeof(uint32_t);     // skip validate
   off += sizeof(unsigned int); // skip crc
 
-  uint32_t packed = 0;
-  serial_restore_uint32_t(&packed, d, &off);
+  if (!serial_restore_uint32_t(&packed, d, &off, dlen))
+    goto fail;
   email_unpack_flags(e, packed);
 
   packed = 0;
-  serial_restore_uint32_t(&packed, d, &off);
+  if (!serial_restore_uint32_t(&packed, d, &off, dlen))
+    goto fail;
   email_unpack_timezone(e, packed);
 
-  uint64_t big = 0;
-  serial_restore_uint64_t(&big, d, &off);
+  if (!serial_restore_uint64_t(&big, d, &off, dlen))
+    goto fail;
   e->date_sent = big;
 
   big = 0;
-  serial_restore_uint64_t(&big, d, &off);
+  if (!serial_restore_uint64_t(&big, d, &off, dlen))
+    goto fail;
   e->received = big;
 
-  unsigned int num = 0;
-  serial_restore_int(&num, d, &off);
+  if (!serial_restore_int(&num, d, &off, dlen))
+    goto fail;
   e->lines = num;
 
   e->env = mutt_env_new();
-  serial_restore_envelope(e->env, d, &off, convert);
+  if (!serial_restore_envelope(e->env, d, &off, dlen, convert))
+    goto fail;
 
   e->body = mutt_body_new();
-  serial_restore_body(e->body, d, &off, convert);
-  serial_restore_tags(&e->tags, d, &off);
+  if (!serial_restore_body(e->body, d, &off, dlen, convert))
+    goto fail;
+
+  if (!serial_restore_tags(&e->tags, d, &off, dlen))
+    goto fail;
 
   return e;
+
+fail:
+  email_free(&e);
+  return NULL;
 }
 
 /**
@@ -589,8 +604,8 @@ struct HCacheEntry hcache_fetch_email(struct HeaderCache *hc, const char *key,
     goto end;
   }
   int off = 0;
-  serial_restore_uint32_t(&hce.uidvalidity, data, &off);
-  serial_restore_int(&hce.crc, data, &off);
+  serial_restore_uint32_t(&hce.uidvalidity, data, &off, dlen);
+  serial_restore_int(&hce.crc, data, &off, dlen);
   ASSERT((size_t) off == hlen);
   if ((hce.crc != hc->crc) || ((uidvalidity != 0) && (uidvalidity != hce.uidvalidity)))
   {
@@ -600,17 +615,19 @@ struct HCacheEntry hcache_fetch_email(struct HeaderCache *hc, const char *key,
 #ifdef USE_HCACHE_COMPRESSION
   if (hc->compr_ops)
   {
-    void *dblob = hc->compr_ops->decompress(hc->compr_handle,
-                                            (char *) data + hlen, dlen - hlen);
+    size_t ulen = 0;
+    void *dblob = hc->compr_ops->decompress(hc->compr_handle, (char *) data + hlen,
+                                            dlen - hlen, &ulen);
     if (!dblob)
     {
       goto end;
     }
     data = (char *) dblob - hlen; /* restore skips uidvalidity and crc */
+    dlen = hlen + ulen;
   }
 #endif
 
-  hce.email = restore_email(data);
+  hce.email = restore_email(data, dlen);
 
 end:
   free_raw(hc, &to_free);

--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -48,6 +48,22 @@
 #define SERIAL_MAX_LIST_COUNT 1024
 
 /**
+ * serial_in_bounds - Does a read stay within the serialized blob?
+ * @param off  Current offset into the blob
+ * @param need Number of bytes about to be read
+ * @param dlen Total length of the blob
+ * @retval true The read is fully contained in the blob
+ *
+ * The restore helpers walk a blob whose length is only known to the caller.
+ * A truncated or crafted cache entry can claim fields that extend past the
+ * end of the fetched data, so every read is checked against @a dlen first.
+ */
+static bool serial_in_bounds(int off, size_t need, size_t dlen)
+{
+  return (off >= 0) && (need <= dlen) && ((size_t) off <= (dlen - need));
+}
+
+/**
  * lazy_realloc - Reallocate some memory
  * @param[in] ptr Pointer to resize
  * @param[in] size Minimum size
@@ -114,38 +130,59 @@ unsigned char *serial_dump_uint64_t(const uint64_t s, unsigned char *d, int *off
 
 /**
  * serial_restore_int - Unpack an integer from a binary blob
- * @param[in]     i   Integer to write to
- * @param[in]     d   Binary blob to read from
- * @param[in,out] off Offset into the blob
+ * @param[in]     i    Integer to write to
+ * @param[in]     d    Binary blob to read from
+ * @param[in,out] off  Offset into the blob
+ * @param[in]     dlen Length of the binary blob
+ * @retval true  The integer was read
+ * @retval false The read would leave the blob
  */
-void serial_restore_int(unsigned int *i, const unsigned char *d, int *off)
+bool serial_restore_int(unsigned int *i, const unsigned char *d, int *off, size_t dlen)
 {
+  if (!serial_in_bounds(*off, sizeof(int), dlen))
+    return false;
+
   memcpy(i, d + *off, sizeof(int));
   (*off) += sizeof(int);
+  return true;
 }
 
 /**
  * serial_restore_uint32_t - Unpack an uint32_t from a binary blob
- * @param[in]     s   uint32_t to write to
- * @param[in]     d   Binary blob to read from
- * @param[in,out] off Offset into the blob
+ * @param[in]     s    uint32_t to write to
+ * @param[in]     d    Binary blob to read from
+ * @param[in,out] off  Offset into the blob
+ * @param[in]     dlen Length of the binary blob
+ * @retval true  The uint32_t was read
+ * @retval false The read would leave the blob
  */
-void serial_restore_uint32_t(uint32_t *s, const unsigned char *d, int *off)
+bool serial_restore_uint32_t(uint32_t *s, const unsigned char *d, int *off, size_t dlen)
 {
+  if (!serial_in_bounds(*off, sizeof(uint32_t), dlen))
+    return false;
+
   memcpy(s, d + *off, sizeof(uint32_t));
   (*off) += sizeof(uint32_t);
+  return true;
 }
 
 /**
  * serial_restore_uint64_t - Unpack an uint64_t from a binary blob
- * @param[in]     s   uint64_t to write to
- * @param[in]     d   Binary blob to read from
- * @param[in,out] off Offset into the blob
+ * @param[in]     s    uint64_t to write to
+ * @param[in]     d    Binary blob to read from
+ * @param[in,out] off  Offset into the blob
+ * @param[in]     dlen Length of the binary blob
+ * @retval true  The uint64_t was read
+ * @retval false The read would leave the blob
  */
-void serial_restore_uint64_t(uint64_t *s, const unsigned char *d, int *off)
+bool serial_restore_uint64_t(uint64_t *s, const unsigned char *d, int *off, size_t dlen)
 {
+  if (!serial_in_bounds(*off, sizeof(uint64_t), dlen))
+    return false;
+
   memcpy(s, d + *off, sizeof(uint64_t));
   (*off) += sizeof(uint64_t);
+  return true;
 }
 
 /**
@@ -204,18 +241,24 @@ unsigned char *serial_dump_char(const char *c, unsigned char *d, int *off, bool 
  * @param[out]    c       Store the unpacked string here
  * @param[in]     d       Binary blob to read from
  * @param[in,out] off     Offset into the blob
+ * @param[in]     dlen    Length of the binary blob
  * @param[in]     convert If true, the strings will be converted to utf-8
+ * @retval true  The string was read (an empty string yields a NULL @a c)
+ * @retval false The read would leave the blob
  */
-void serial_restore_char(char **c, const unsigned char *d, int *off, bool convert)
+bool serial_restore_char(char **c, const unsigned char *d, int *off, size_t dlen, bool convert)
 {
-  unsigned int size = 0;
-  serial_restore_int(&size, d, off);
+  *c = NULL;
 
-  if ((size == 0) || (size > SERIAL_MAX_CHAR_SIZE))
-  {
-    *c = NULL;
-    return;
-  }
+  unsigned int size = 0;
+  if (!serial_restore_int(&size, d, off, dlen))
+    return false;
+
+  if (size == 0)
+    return true;
+
+  if ((size > SERIAL_MAX_CHAR_SIZE) || !serial_in_bounds(*off, size, dlen))
+    return false;
 
   *c = MUTT_MEM_MALLOC(size, char);
   memcpy(*c, d + *off, size);
@@ -233,6 +276,7 @@ void serial_restore_char(char **c, const unsigned char *d, int *off, bool conver
     }
   }
   *off += size;
+  return true;
 }
 
 /**
@@ -270,42 +314,51 @@ unsigned char *serial_dump_address(const struct AddressList *al,
  * @param[out]    al      Store the unpacked AddressList here
  * @param[in]     d       Binary blob to read from
  * @param[in,out] off     Offset into the blob
+ * @param[in]     dlen    Length of the binary blob
  * @param[in]     convert If true, the strings will be converted from utf-8
+ * @retval true  The AddressList was read
+ * @retval false A read would leave the blob, or the count is out of range
  */
-void serial_restore_address(struct AddressList *al, const unsigned char *d,
-                            int *off, bool convert)
+bool serial_restore_address(struct AddressList *al, const unsigned char *d,
+                            int *off, size_t dlen, bool convert)
 {
   unsigned int counter = 0;
   unsigned int g = 0;
 
-  serial_restore_int(&counter, d, off);
+  if (!serial_restore_int(&counter, d, off, dlen))
+    return false;
 
   if (counter > SERIAL_MAX_LIST_COUNT)
-    return;
+    return false;
 
   while (counter > 0)
   {
     struct Address *a = mutt_addr_new();
+    mutt_addrlist_append(al, a);
 
     a->personal = buf_new(NULL);
-    serial_restore_buffer(a->personal, d, off, convert);
+    if (!serial_restore_buffer(a->personal, d, off, dlen, convert))
+      return false;
     if (buf_is_empty(a->personal))
     {
       buf_free(&a->personal);
     }
 
     a->mailbox = buf_new(NULL);
-    serial_restore_buffer(a->mailbox, d, off, false);
+    if (!serial_restore_buffer(a->mailbox, d, off, dlen, false))
+      return false;
     if (buf_is_empty(a->mailbox))
     {
       buf_free(&a->mailbox);
     }
 
-    serial_restore_int(&g, d, off);
+    if (!serial_restore_int(&g, d, off, dlen))
+      return false;
     a->group = !!g;
-    mutt_addrlist_append(al, a);
     counter--;
   }
+
+  return true;
 }
 
 /**
@@ -341,24 +394,32 @@ unsigned char *serial_dump_stailq(const struct ListHead *l, unsigned char *d,
  * @param[in]     l       List to add to
  * @param[in]     d       Binary blob to read from
  * @param[in,out] off     Offset into the blob
+ * @param[in]     dlen    Length of the binary blob
  * @param[in]     convert If true, the strings will be converted from utf-8
+ * @retval true  The list was read
+ * @retval false A read would leave the blob, or the count is out of range
  */
-void serial_restore_stailq(struct ListHead *l, const unsigned char *d, int *off, bool convert)
+bool serial_restore_stailq(struct ListHead *l, const unsigned char *d, int *off,
+                           size_t dlen, bool convert)
 {
   unsigned int counter = 0;
 
-  serial_restore_int(&counter, d, off);
+  if (!serial_restore_int(&counter, d, off, dlen))
+    return false;
 
   if (counter > SERIAL_MAX_LIST_COUNT)
-    return;
+    return false;
 
   struct ListNode *np = NULL;
   while (counter > 0)
   {
     np = mutt_list_insert_tail(l, NULL);
-    serial_restore_char(&np->data, d, off, convert);
+    if (!serial_restore_char(&np->data, d, off, dlen, convert))
+      return false;
     counter--;
   }
+
+  return true;
 }
 
 /**
@@ -390,22 +451,29 @@ unsigned char *serial_dump_buffer(const struct Buffer *buf, unsigned char *d,
  * @param[out]    buf     Store the unpacked Buffer here
  * @param[in]     d       Binary blob to read from
  * @param[in,out] off     Offset into the blob
+ * @param[in]     dlen    Length of the binary blob
  * @param[in]     convert If true, the strings will be converted from utf-8
+ * @retval true  The Buffer was read
+ * @retval false A read would leave the blob
  */
-void serial_restore_buffer(struct Buffer *buf, const unsigned char *d, int *off, bool convert)
+bool serial_restore_buffer(struct Buffer *buf, const unsigned char *d, int *off,
+                           size_t dlen, bool convert)
 {
   buf_alloc(buf, 1);
 
   unsigned int used = 0;
-  serial_restore_int(&used, d, off);
+  if (!serial_restore_int(&used, d, off, dlen))
+    return false;
   if (used == 0)
-    return;
+    return true;
 
   char *str = NULL;
-  serial_restore_char(&str, d, off, convert);
+  if (!serial_restore_char(&str, d, off, dlen, convert))
+    return false;
 
   buf_addstr(buf, str);
   FREE(&str);
+  return true;
 }
 
 /**
@@ -442,27 +510,35 @@ unsigned char *serial_dump_parameter(const struct ParameterList *pl,
  * @param[in]     pl      Store the unpacked Parameter here
  * @param[in]     d       Binary blob to read from
  * @param[in,out] off     Offset into the blob
+ * @param[in]     dlen    Length of the binary blob
  * @param[in]     convert If true, the strings will be converted from utf-8
+ * @retval true  The Parameter was read
+ * @retval false A read would leave the blob, or the count is out of range
  */
-void serial_restore_parameter(struct ParameterList *pl, const unsigned char *d,
-                              int *off, bool convert)
+bool serial_restore_parameter(struct ParameterList *pl, const unsigned char *d,
+                              int *off, size_t dlen, bool convert)
 {
   unsigned int counter = 0;
 
-  serial_restore_int(&counter, d, off);
+  if (!serial_restore_int(&counter, d, off, dlen))
+    return false;
 
   if (counter > SERIAL_MAX_LIST_COUNT)
-    return;
+    return false;
 
   struct Parameter *np = NULL;
   while (counter > 0)
   {
     np = mutt_param_new();
-    serial_restore_char(&np->attribute, d, off, false);
-    serial_restore_char(&np->value, d, off, convert);
     TAILQ_INSERT_TAIL(pl, np, entries);
+    if (!serial_restore_char(&np->attribute, d, off, dlen, false))
+      return false;
+    if (!serial_restore_char(&np->value, d, off, dlen, convert))
+      return false;
     counter--;
   }
+
+  return true;
 }
 
 /**
@@ -562,33 +638,50 @@ unsigned char *serial_dump_body(const struct Body *b, unsigned char *d, int *off
  * @param[in]     b       Store the unpacked Body here
  * @param[in]     d       Binary blob to read from
  * @param[in,out] off     Offset into the blob
+ * @param[in]     dlen    Length of the binary blob
  * @param[in]     convert If true, the strings will be converted from utf-8
+ * @retval true  The Body was read
+ * @retval false A read would leave the blob
  */
-void serial_restore_body(struct Body *b, const unsigned char *d, int *off, bool convert)
+bool serial_restore_body(struct Body *b, const unsigned char *d, int *off,
+                         size_t dlen, bool convert)
 {
   uint32_t packed = 0;
-  serial_restore_uint32_t(&packed, d, off);
+  if (!serial_restore_uint32_t(&packed, d, off, dlen))
+    return false;
   body_unpack_flags(b, packed);
 
   uint64_t big = 0;
-  serial_restore_uint64_t(&big, d, off);
+  if (!serial_restore_uint64_t(&big, d, off, dlen))
+    return false;
   b->offset = big;
 
   big = 0;
-  serial_restore_uint64_t(&big, d, off);
+  if (!serial_restore_uint64_t(&big, d, off, dlen))
+    return false;
   b->length = big;
 
-  serial_restore_char(&b->xtype, d, off, false);
-  serial_restore_char(&b->subtype, d, off, false);
+  if (!serial_restore_char(&b->xtype, d, off, dlen, false))
+    return false;
+  if (!serial_restore_char(&b->subtype, d, off, dlen, false))
+    return false;
 
   TAILQ_INIT(&b->parameter);
-  serial_restore_parameter(&b->parameter, d, off, convert);
+  if (!serial_restore_parameter(&b->parameter, d, off, dlen, convert))
+    return false;
 
-  serial_restore_char(&b->description, d, off, convert);
-  serial_restore_char(&b->content_id, d, off, convert);
-  serial_restore_char(&b->form_name, d, off, convert);
-  serial_restore_char(&b->filename, d, off, convert);
-  serial_restore_char(&b->d_filename, d, off, convert);
+  if (!serial_restore_char(&b->description, d, off, dlen, convert))
+    return false;
+  if (!serial_restore_char(&b->content_id, d, off, dlen, convert))
+    return false;
+  if (!serial_restore_char(&b->form_name, d, off, dlen, convert))
+    return false;
+  if (!serial_restore_char(&b->filename, d, off, dlen, convert))
+    return false;
+  if (!serial_restore_char(&b->d_filename, d, off, dlen, convert))
+    return false;
+
+  return true;
 }
 
 /**
@@ -645,31 +738,43 @@ unsigned char *serial_dump_envelope(const struct Envelope *env,
  * @param[in]     env     Store the unpacked Envelope here
  * @param[in]     d       Binary blob to read from
  * @param[in,out] off     Offset into the blob
+ * @param[in]     dlen    Length of the binary blob
  * @param[in]     convert If true, the strings will be converted from utf-8
+ * @retval true  The Envelope was read
+ * @retval false A read would leave the blob
  */
-void serial_restore_envelope(struct Envelope *env, const unsigned char *d, int *off, bool convert)
+bool serial_restore_envelope(struct Envelope *env, const unsigned char *d,
+                             int *off, size_t dlen, bool convert)
 {
   int real_subj_off = 0;
 
-  serial_restore_address(&env->return_path, d, off, convert);
-  serial_restore_address(&env->from, d, off, convert);
-  serial_restore_address(&env->to, d, off, convert);
-  serial_restore_address(&env->cc, d, off, convert);
-  serial_restore_address(&env->bcc, d, off, convert);
-  serial_restore_address(&env->sender, d, off, convert);
-  serial_restore_address(&env->reply_to, d, off, convert);
-  serial_restore_address(&env->mail_followup_to, d, off, convert);
+  if (!serial_restore_address(&env->return_path, d, off, dlen, convert) ||
+      !serial_restore_address(&env->from, d, off, dlen, convert) ||
+      !serial_restore_address(&env->to, d, off, dlen, convert) ||
+      !serial_restore_address(&env->cc, d, off, dlen, convert) ||
+      !serial_restore_address(&env->bcc, d, off, dlen, convert) ||
+      !serial_restore_address(&env->sender, d, off, dlen, convert) ||
+      !serial_restore_address(&env->reply_to, d, off, dlen, convert) ||
+      !serial_restore_address(&env->mail_followup_to, d, off, dlen, convert))
+  {
+    return false;
+  }
 
-  serial_restore_char(&env->list_post, d, off, convert);
-  serial_restore_char(&env->list_subscribe, d, off, convert);
-  serial_restore_char(&env->list_unsubscribe, d, off, convert);
+  if (!serial_restore_char(&env->list_post, d, off, dlen, convert) ||
+      !serial_restore_char(&env->list_subscribe, d, off, dlen, convert) ||
+      !serial_restore_char(&env->list_unsubscribe, d, off, dlen, convert))
+  {
+    return false;
+  }
 
   const bool c_auto_subscribe = cs_subset_bool(NeoMutt->sub, "auto_subscribe");
   if (c_auto_subscribe)
     mutt_auto_subscribe(env->list_post);
 
-  serial_restore_char((char **) &env->subject, d, off, convert);
-  serial_restore_int((unsigned int *) (&real_subj_off), d, off);
+  if (!serial_restore_char((char **) &env->subject, d, off, dlen, convert))
+    return false;
+  if (!serial_restore_int((unsigned int *) (&real_subj_off), d, off, dlen))
+    return false;
 
   size_t len = mutt_str_len(env->subject);
   if ((real_subj_off < 0) || (real_subj_off >= len))
@@ -677,21 +782,33 @@ void serial_restore_envelope(struct Envelope *env, const unsigned char *d, int *
   else
     *(char **) &env->real_subj = env->subject + real_subj_off;
 
-  serial_restore_char(&env->message_id, d, off, false);
-  serial_restore_char(&env->supersedes, d, off, false);
-  serial_restore_char(&env->date, d, off, false);
-  serial_restore_char(&env->x_label, d, off, convert);
-  serial_restore_char(&env->organization, d, off, convert);
+  if (!serial_restore_char(&env->message_id, d, off, dlen, false) ||
+      !serial_restore_char(&env->supersedes, d, off, dlen, false) ||
+      !serial_restore_char(&env->date, d, off, dlen, false) ||
+      !serial_restore_char(&env->x_label, d, off, dlen, convert) ||
+      !serial_restore_char(&env->organization, d, off, dlen, convert))
+  {
+    return false;
+  }
 
-  serial_restore_buffer(&env->spam, d, off, convert);
+  if (!serial_restore_buffer(&env->spam, d, off, dlen, convert))
+    return false;
 
-  serial_restore_stailq(&env->references, d, off, false);
-  serial_restore_stailq(&env->in_reply_to, d, off, false);
-  serial_restore_stailq(&env->userhdrs, d, off, convert);
+  if (!serial_restore_stailq(&env->references, d, off, dlen, false) ||
+      !serial_restore_stailq(&env->in_reply_to, d, off, dlen, false) ||
+      !serial_restore_stailq(&env->userhdrs, d, off, dlen, convert))
+  {
+    return false;
+  }
 
-  serial_restore_char(&env->xref, d, off, false);
-  serial_restore_char(&env->followup_to, d, off, false);
-  serial_restore_char(&env->x_comment_to, d, off, convert);
+  if (!serial_restore_char(&env->xref, d, off, dlen, false) ||
+      !serial_restore_char(&env->followup_to, d, off, dlen, false) ||
+      !serial_restore_char(&env->x_comment_to, d, off, dlen, convert))
+  {
+    return false;
+  }
+
+  return true;
 }
 
 /**
@@ -725,21 +842,28 @@ unsigned char *serial_dump_tags(const struct TagList *tl, unsigned char *d, int 
  * @param[in]     tl   TagList to unpack
  * @param[in]     d    Binary blob to add to
  * @param[in,out] off  Offset into the blob
+ * @param[in]     dlen Length of the binary blob
+ * @retval true  The TagList was read
+ * @retval false A read would leave the blob, or the count is out of range
  */
-void serial_restore_tags(struct TagList *tl, const unsigned char *d, int *off)
+bool serial_restore_tags(struct TagList *tl, const unsigned char *d, int *off, size_t dlen)
 {
   unsigned int counter = 0;
 
-  serial_restore_int(&counter, d, off);
+  if (!serial_restore_int(&counter, d, off, dlen))
+    return false;
 
   if (counter > SERIAL_MAX_LIST_COUNT)
-    return;
+    return false;
 
   while (counter > 0)
   {
     char *name = NULL;
-    serial_restore_char(&name, d, off, false);
+    if (!serial_restore_char(&name, d, off, dlen, false))
+      return false;
     driver_tags_add(tl, name);
     counter--;
   }
+
+  return true;
 }

--- a/hcache/serialize.h
+++ b/hcache/serialize.h
@@ -50,17 +50,17 @@ unsigned char *serial_dump_uint64_t (const uint64_t s,               unsigned ch
 unsigned char *serial_dump_parameter(const struct ParameterList *pl, unsigned char *d, int *off, bool convert);
 unsigned char *serial_dump_stailq   (const struct ListHead *l,       unsigned char *d, int *off, bool convert);
 
-void serial_restore_address  (struct AddressList *al,   const unsigned char *d, int *off, bool convert);
-void serial_restore_body     (struct Body *b,           const unsigned char *d, int *off, bool convert);
-void serial_restore_tags     (struct TagList *tl,       const unsigned char *d, int *off);
-void serial_restore_buffer   (struct Buffer *buf,       const unsigned char *d, int *off, bool convert);
-void serial_restore_char     (char **c,                 const unsigned char *d, int *off, bool convert);
-void serial_restore_envelope (struct Envelope *env,     const unsigned char *d, int *off, bool convert);
-void serial_restore_int      (unsigned int *i,          const unsigned char *d, int *off);
-void serial_restore_uint32_t (uint32_t *s,              const unsigned char *d, int *off);
-void serial_restore_uint64_t (uint64_t *s,              const unsigned char *d, int *off);
-void serial_restore_parameter(struct ParameterList *pl, const unsigned char *d, int *off, bool convert);
-void serial_restore_stailq   (struct ListHead *l,       const unsigned char *d, int *off, bool convert);
+bool serial_restore_address  (struct AddressList *al,   const unsigned char *d, int *off, size_t dlen, bool convert);
+bool serial_restore_body     (struct Body *b,           const unsigned char *d, int *off, size_t dlen, bool convert);
+bool serial_restore_tags     (struct TagList *tl,       const unsigned char *d, int *off, size_t dlen);
+bool serial_restore_buffer   (struct Buffer *buf,       const unsigned char *d, int *off, size_t dlen, bool convert);
+bool serial_restore_char     (char **c,                 const unsigned char *d, int *off, size_t dlen, bool convert);
+bool serial_restore_envelope (struct Envelope *env,     const unsigned char *d, int *off, size_t dlen, bool convert);
+bool serial_restore_int      (unsigned int *i,          const unsigned char *d, int *off, size_t dlen);
+bool serial_restore_uint32_t (uint32_t *s,              const unsigned char *d, int *off, size_t dlen);
+bool serial_restore_uint64_t (uint64_t *s,              const unsigned char *d, int *off, size_t dlen);
+bool serial_restore_parameter(struct ParameterList *pl, const unsigned char *d, int *off, size_t dlen, bool convert);
+bool serial_restore_stailq   (struct ListHead *l,       const unsigned char *d, int *off, size_t dlen, bool convert);
 
 void lazy_realloc(void *ptr, size_t size);
 

--- a/test/compress/common.c
+++ b/test/compress/common.c
@@ -122,10 +122,14 @@ static void one_test(const struct ComprOps *compr_ops, short level, size_t size)
   void *copy = MUTT_MEM_MALLOC(clen, char);
   memcpy(copy, cdata, clen);
 
-  void *ddata = compr_ops->decompress(compr_handle, copy, clen);
+  size_t dlen = 0;
+  void *ddata = compr_ops->decompress(compr_handle, copy, clen, &dlen);
   FREE(&copy);
 
   if (!TEST_CHECK(ddata != NULL))
+    return;
+
+  if (!TEST_CHECK(dlen == size))
     return;
 
   if (!TEST_CHECK(memcmp(compress_test_data, ddata, size) == 0))

--- a/test/compress/lz4.c
+++ b/test/compress/lz4.c
@@ -38,7 +38,7 @@ void test_compress_lz4(void)
 {
   // ComprHandle *open(short level);
   // void *compress(ComprHandle *handle, const char *data, size_t dlen, size_t *clen);
-  // void *decompress(ComprHandle *handle, const char *cbuf, size_t clen);
+  // void *decompress(ComprHandle *handle, const char *cbuf, size_t clen, size_t *dlen);
   // void close(ComprHandle **ptr);
 
   const struct ComprOps *compr_ops = compress_get_ops("lz4");
@@ -48,7 +48,7 @@ void test_compress_lz4(void)
   {
     // Degenerate tests
     TEST_CHECK(compr_ops->compress(NULL, NULL, 0, NULL) == NULL);
-    TEST_CHECK(compr_ops->decompress(NULL, NULL, 0) == NULL);
+    TEST_CHECK(compr_ops->decompress(NULL, NULL, 0, NULL) == NULL);
     ComprHandle *compr_handle = NULL;
     compr_ops->close(NULL);
     TEST_CHECK_(1, "compr_ops->close(NULL)");
@@ -84,15 +84,15 @@ void test_compress_lz4(void)
     const char zeroes[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
-    void *result = compr_ops->decompress(compr_handle, zeroes, 0);
+    void *result = compr_ops->decompress(compr_handle, zeroes, 0, NULL);
     TEST_CHECK(result == NULL);
 
-    result = compr_ops->decompress(compr_handle, zeroes, sizeof(zeroes));
+    result = compr_ops->decompress(compr_handle, zeroes, sizeof(zeroes), NULL);
     TEST_CHECK(result == zeroes);
 
     const char ones[] = { 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
                           0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01 };
-    result = compr_ops->decompress(compr_handle, ones, sizeof(ones));
+    result = compr_ops->decompress(compr_handle, ones, sizeof(ones), NULL);
     TEST_CHECK(result == NULL);
 
     compr_ops->close(&compr_handle);

--- a/test/compress/zlib.c
+++ b/test/compress/zlib.c
@@ -38,7 +38,7 @@ void test_compress_zlib(void)
 {
   // ComprHandle *open(short level);
   // void *compress(ComprHandle *handle, const char *data, size_t dlen, size_t *clen);
-  // void *decompress(ComprHandle *handle, const char *cbuf, size_t clen);
+  // void *decompress(ComprHandle *handle, const char *cbuf, size_t clen, size_t *dlen);
   // void close(ComprHandle **ptr);
 
   const struct ComprOps *compr_ops = compress_get_ops("zlib");
@@ -48,7 +48,7 @@ void test_compress_zlib(void)
   {
     // Degenerate tests
     TEST_CHECK(compr_ops->compress(NULL, NULL, 0, NULL) == NULL);
-    TEST_CHECK(compr_ops->decompress(NULL, NULL, 0) == NULL);
+    TEST_CHECK(compr_ops->decompress(NULL, NULL, 0, NULL) == NULL);
     ComprHandle *compr_handle = NULL;
     compr_ops->close(NULL);
     TEST_CHECK_(1, "compr_ops->close(NULL)");
@@ -84,15 +84,15 @@ void test_compress_zlib(void)
     const char zeroes[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
-    void *result = compr_ops->decompress(compr_handle, zeroes, 0);
+    void *result = compr_ops->decompress(compr_handle, zeroes, 0, NULL);
     TEST_CHECK(result == NULL);
 
-    result = compr_ops->decompress(compr_handle, zeroes, sizeof(zeroes));
+    result = compr_ops->decompress(compr_handle, zeroes, sizeof(zeroes), NULL);
     TEST_CHECK(result == NULL);
 
     const char ones[] = { 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
                           0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01 };
-    result = compr_ops->decompress(compr_handle, ones, sizeof(ones));
+    result = compr_ops->decompress(compr_handle, ones, sizeof(ones), NULL);
     TEST_CHECK(result == NULL);
 
     compr_ops->close(&compr_handle);

--- a/test/compress/zstd.c
+++ b/test/compress/zstd.c
@@ -38,7 +38,7 @@ void test_compress_zstd(void)
 {
   // ComprHandle *open(short level);
   // void *compress(ComprHandle *handle, const char *data, size_t dlen, size_t *clen);
-  // void *decompress(ComprHandle *handle, const char *cbuf, size_t clen);
+  // void *decompress(ComprHandle *handle, const char *cbuf, size_t clen, size_t *dlen);
   // void close(ComprHandle **ptr);
 
   const struct ComprOps *compr_ops = compress_get_ops("zstd");
@@ -48,7 +48,7 @@ void test_compress_zstd(void)
   {
     // Degenerate tests
     TEST_CHECK(compr_ops->compress(NULL, NULL, 0, NULL) == NULL);
-    TEST_CHECK(compr_ops->decompress(NULL, NULL, 0) == NULL);
+    TEST_CHECK(compr_ops->decompress(NULL, NULL, 0, NULL) == NULL);
     ComprHandle *compr_handle = NULL;
     compr_ops->close(NULL);
     TEST_CHECK_(1, "compr_ops->close(NULL)");
@@ -83,7 +83,7 @@ void test_compress_zstd(void)
 
     const char zeroes[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    void *result = compr_ops->decompress(compr_handle, zeroes, sizeof(zeroes));
+    void *result = compr_ops->decompress(compr_handle, zeroes, sizeof(zeroes), NULL);
     TEST_CHECK(result == NULL);
 
     compr_ops->close(&compr_handle);


### PR DESCRIPTION
* **What does this PR do?**

Bounds-checks the header cache deserialiser, which walks a fetched entry without ever knowing its length.

- `restore_email()` and the `serial_restore_*` helpers advance an offset and `memcpy()` fixed fields plus a length-prefixed string (up to `SERIAL_MAX_CHAR_SIZE`) with no check that the read stays inside the entry; only the 8-byte uidvalidity/crc header is range-checked.
- A truncated or corrupt entry then reads past the end of the heap allocation, the worst case being the attacker-sized `size` copied in `serial_restore_char()`.
- Threads the fetched length through the restore helpers and rejects any read that would leave the blob via a new `serial_in_bounds()` helper.
- `decompress()` now also reports the inflated length, so the same bound covers lz4/zlib/zstd entries.

* **Does this PR meet the acceptance criteria?**

   - Doxygen comments updated for the new parameter
   - Code follows the style guide
   - Builds and the `compress` unit tests pass

* **What are the relevant issue numbers?**

None.
