### PR TITLE
flags: check for NULL email and thread in mutt_thread_set_flag()

### DIFF
--- a/flags.c
+++ b/flags.c
@@ -382,8 +382,8 @@ void mutt_emails_set_flag(struct Mailbox *m, struct EmailArray *ea,
 int mutt_thread_set_flag(struct Mailbox *m, struct Email *e,
                          enum MessageType flag, bool bf, bool subthread)
 {
-  struct MuttThread *start = NULL;
-  struct MuttThread *cur = e->thread;
+  if (!e)
+    return -1;
 
   if (!mutt_using_threads())
   {
@@ -391,11 +391,16 @@ int mutt_thread_set_flag(struct Mailbox *m, struct Email *e,
     return -1;
   }
 
+  struct MuttThread *cur = e->thread;
+
+  if (!cur)
+    return -1;
+
   if (!subthread)
     while (cur->parent)
       cur = cur->parent;
 
-  start = cur;
+  struct MuttThread *start = cur;
 
   if (cur->message && (cur != e->thread))
     mutt_set_flag(m, cur->message, flag, bf, true);


### PR DESCRIPTION
Prevent a SIGSEGV in mutt_thread_set_flag() by adding validation for the Email pointer and its associated MuttThread.

Some callers in index/functions.c, such as op_main_read_thread() and op_undelete_thread(), do not guard against shared->email being NULL (which occurs when the mailbox is empty). If triggered, they pass a NULL Email pointer to mutt_thread_set_flag(), causing a crash when attempting to access the thread.

Additionally, even if the Email pointer is valid, its thread association (e->thread) can be NULL. This happens when threading is disabled, but can also occur when threading is enabled if the thread tree has been cleared (e.g., via mutt_clear_threads() during a rebuild, or mview_free() during teardown) and not yet rebuilt. If mutt_thread_set_flag() is called in this transient state, attempting to traverse the thread results in a SIGSEGV.

To address this, we now return early if the Email pointer is NULL, verify that threading is enabled (preserving the "Threading is not enabled" error message), and return early if the MuttThread pointer itself is NULL.