### PR TITLE
auth_cram: fix out-of-bounds read of cram-md5 challenge

### DIFF
--- a/imap/auth_cram.c
+++ b/imap/auth_cram.c
@@ -131,11 +131,14 @@ enum ImapAuthRes imap_auth_cram_md5(struct ImapAccountData *adata, const char *m
     goto bail;
   }
 
-  if (mutt_b64_decode(adata->buf + 2, obuf->data, obuf->dsize) == -1)
+  int dlen = mutt_b64_decode(adata->buf + 2, obuf->data, obuf->dsize - 1);
+  if (dlen == -1)
   {
     mutt_debug(LL_DEBUG1, "Error decoding base64 response\n");
     goto bail;
   }
+  obuf->data[dlen] = '\0';
+  buf_fix_dptr(obuf);
 
   mutt_debug(LL_DEBUG2, "CRAM challenge: %s\n", buf_string(obuf));
 


### PR DESCRIPTION
imap_auth_cram_md5() decodes the server cram-md5 challenge with the full obuf->dsize as the output limit:
- mutt_b64_decode() returns raw bytes and never terminates, so a challenge that decodes to obuf->dsize (1024) fills the buffer with no NUL
- adata->buf grows unbounded, so a hostile or MITM server controls that length
- the buffer is then read as a C string by buf_string()/hmac_md5() -> strlen(), over-reading past the allocation

Decode into obuf->dsize - 1 and terminate at the returned length, like pop/auth.c already does.