### PR TITLE
date: bound tm_mon in mutt_date_make_time

### DIFF
--- a/mutt/date.c
+++ b/mutt/date.c
@@ -257,6 +257,8 @@ time_t mutt_date_make_time(struct tm *t, bool local)
 
   if ((t->tm_mday < 1) || (t->tm_mday > 31))
     return TIME_T_MIN;
+  if ((t->tm_mon < 0) || (t->tm_mon > 11))
+    return TIME_T_MIN;
   if ((t->tm_hour < 0) || (t->tm_hour > 23) || (t->tm_min < 0) ||
       (t->tm_min > 59) || (t->tm_sec < 0) || (t->tm_sec > 60))
   {

--- a/test/date/mutt_date_make_time.c
+++ b/test/date/mutt_date_make_time.c
@@ -54,6 +54,8 @@ void test_mutt_date_make_time(void)
     { { 0,  0,  24, 1,  0,  100,   0 }, TIME_T_MIN },
     { { 0,  0,  0,  0,  0,  100,   0 }, TIME_T_MIN },
     { { 0,  0,  0,  32, 0,  100,   0 }, TIME_T_MIN },
+    { { 0,  0,  0,  1,  -1, 100,   0 }, TIME_T_MIN },
+    { { 0,  0,  0,  1,  12, 100,   0 }, TIME_T_MIN },
     { { 0,  0,  0,  1,  0,  10001, 0 }, TIME_T_MAX },
     { { 0,  0,  0,  1,  0, -10001, 0 }, TIME_T_MIN },
   };


### PR DESCRIPTION
mutt_date_make_time() range-checks every struct tm field except tm_mon:
- a negative tm_mon indexes the static AccumDaysPerMonth[] out of bounds (e.g. tm_mon == -1)
- a value >= 12 slips through the % 12 and returns a bogus time_t instead of the TIME_T_MIN every other out-of-range field gets

Reject out-of-range tm_mon like the sibling fields. Added the two cases to the existing test.