### PR TITLE
menu: fix repaint

### DIFF
--- a/menu/window.c
+++ b/menu/window.c
@@ -97,6 +97,7 @@ static int menu_repaint(struct MuttWindow *win)
     return 0;
 
   struct Menu *menu = win->wdata;
+  menu->redraw |= MENU_REDRAW_FULL;
   menu_redraw(menu);
   menu->redraw = MENU_REDRAW_NONE;
 


### PR DESCRIPTION
A stray deletion caused menu repainting to fail.

Fixes: #4913