### PR TITLE
parse: fix out-of-bounds read in parse_references

### DIFF
--- a/email/parse.c
+++ b/email/parse.c
@@ -280,6 +280,43 @@ static void parse_content_disposition(const char *s, struct Body *b)
 }
 
 /**
+ * extract_message_id - Find a message-id in a string
+ * @param[in]  s   String to parse
+ * @param[out] len Number of bytes of s parsed (optional)
+ * @retval ptr  Message id found
+ * @retval NULL No more message ids
+ *
+ * @a len is an offset into @a s, so the caller may advance @a s by it to find
+ * the next message-id.  The string is scanned verbatim; decoding, if any, is
+ * the caller's responsibility.
+ *
+ * @note Caller must free returned string
+ */
+static char *extract_message_id(const char *s, size_t *len)
+{
+  if (!s)
+    return NULL;
+
+  for (const char *p = s, *beg = NULL; *p; p++)
+  {
+    if (*p == '<')
+    {
+      beg = p;
+      continue;
+    }
+
+    if (beg && (*p == '>'))
+    {
+      if (len)
+        *len = p - s + 1;
+      return mutt_strn_dup(beg, (p + 1) - beg);
+    }
+  }
+
+  return NULL;
+}
+
+/**
  * parse_references - Parse references from an email header
  * @param head List to receive the references
  * @param s    String to parse
@@ -289,11 +326,21 @@ static void parse_references(struct ListHead *head, const char *s)
   if (!head)
     return;
 
+  /* Decode once: mutt_extract_message_id() returns an offset into the decoded
+   * text, so the search and the advance must happen on the same string.
+   * Decoding can lengthen the text (e.g. a single-byte charset expanding to
+   * UTF-8), so applying that offset to the raw header would run off the end. */
+  char *decoded = mutt_str_dup(s);
+  rfc2047_decode(&decoded);
+
   char *m = NULL;
-  for (size_t off = 0; (m = mutt_extract_message_id(s, &off)); s += off)
+  const char *p = decoded;
+  for (size_t off = 0; (m = extract_message_id(p, &off)); p += off)
   {
     mutt_list_insert_head(head, m);
   }
+
+  FREE(&decoded);
 }
 
 /**
@@ -361,9 +408,11 @@ enum ContentType mutt_check_mime_type(const char *s)
 /**
  * mutt_extract_message_id - Find a Message-ID
  * @param[in]  s String to parse
- * @param[out] len Number of bytes of s parsed
+ * @param[out] len Number of bytes of s parsed (optional)
  * @retval ptr  Message id found
  * @retval NULL No more message ids
+ *
+ * @note Caller must free returned string
  */
 char *mutt_extract_message_id(const char *s, size_t *len)
 {
@@ -373,24 +422,7 @@ char *mutt_extract_message_id(const char *s, size_t *len)
   char *decoded = mutt_str_dup(s);
   rfc2047_decode(&decoded);
 
-  char *res = NULL;
-
-  for (const char *p = decoded, *beg = NULL; *p; p++)
-  {
-    if (*p == '<')
-    {
-      beg = p;
-      continue;
-    }
-
-    if (beg && (*p == '>'))
-    {
-      if (len)
-        *len = p - decoded + 1;
-      res = mutt_strn_dup(beg, (p + 1) - beg);
-      break;
-    }
-  }
+  char *res = extract_message_id(decoded, len);
 
   FREE(&decoded);
   return res;

--- a/test/email/mutt_rfc822_read_header.c
+++ b/test/email/mutt_rfc822_read_header.c
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
+#include "mutt/lib.h"
 #include "email/lib.h"
 #include "test_common.h"
 
@@ -69,5 +70,62 @@ void test_mutt_rfc822_read_header(void)
     mutt_env_free(&env);
     mutt_body_free(&e.body);
     fclose(fp);
+  }
+
+  {
+    // Two message-ids inside a single RFC2047 encoded-word.  The ids only
+    // appear after decoding, so parse_references() must decode before scanning.
+    // The old code advanced the raw header by an offset measured in the decoded
+    // copy, which dropped the second id.
+    char *hdr = NULL;
+    const char *ids = "<id1@example.com> <id2@example.com>";
+    char enc[128] = { 0 };
+    mutt_b64_encode(ids, strlen(ids), enc, sizeof(enc));
+    mutt_str_asprintf(&hdr, "References: =?utf-8?B?%s?=\n\n", enc);
+
+    FILE *fp = test_make_file_with_contents(hdr, strlen(hdr));
+    if (TEST_CHECK(fp != NULL))
+    {
+      struct Envelope *env = mutt_rfc822_read_header(fp, NULL, false, false);
+      TEST_CHECK(env != NULL);
+      // references are stored in reverse order
+      struct ListNode *np = STAILQ_FIRST(&env->references);
+      if (TEST_CHECK(np != NULL))
+      {
+        TEST_CHECK_STR_EQ(np->data, "<id2@example.com>");
+        np = STAILQ_NEXT(np, entries);
+        if (TEST_CHECK(np != NULL))
+          TEST_CHECK_STR_EQ(np->data, "<id1@example.com>");
+      }
+      mutt_env_free(&env);
+      fclose(fp);
+    }
+    FREE(&hdr);
+  }
+
+  {
+    // An In-Reply-To whose RFC2047 encoded-word decodes to a longer string than
+    // the raw header (single-byte charset -> UTF-8).  The header value is
+    // strdup'd into a tight buffer, so the old decoded-offset advance read past
+    // its end.
+    char raw[300];
+    char enc[512] = { 0 };
+    memset(raw, 0xE9, sizeof(raw)); // Latin-1 'e' acute -> 2 UTF-8 bytes each
+    mutt_b64_encode(raw, sizeof(raw), enc, sizeof(enc));
+
+    char *hdr = NULL;
+    mutt_str_asprintf(&hdr, "In-Reply-To: =?iso-8859-1?B?%s?= <id@example.com>\n\n", enc);
+
+    FILE *fp = test_make_file_with_contents(hdr, strlen(hdr));
+    if (TEST_CHECK(fp != NULL))
+    {
+      struct Envelope *env = mutt_rfc822_read_header(fp, NULL, false, false);
+      TEST_CHECK(env != NULL);
+      TEST_CHECK(!STAILQ_EMPTY(&env->in_reply_to));
+      TEST_CHECK_STR_EQ(STAILQ_FIRST(&env->in_reply_to)->data, "<id@example.com>");
+      mutt_env_free(&env);
+      fclose(fp);
+    }
+    FREE(&hdr);
   }
 }


### PR DESCRIPTION
* **What does this PR do?**

Out-of-bounds read parsing `References:` / `In-Reply-To:` headers:

- `mutt_extract_message_id()` rfc2047-decodes a copy of the header and reports the message-id offset within that decoded copy
- `parse_references()` advances the raw header by that offset (`s += off`)
- an encoded-word in a charset that expands to UTF-8 (e.g. `=?iso-8859-1?B?...?=`) makes the decoded text longer than the raw header, so the offset overruns the buffer and the next read walks off the end (`In-Reply-To` uses a tight `strdup`'d value, so ASAN flags it directly)

`parse_references()` now decodes the header once and iterates over that single copy, so the scan and the advance use the same string. The `<...>` scan moves into a small `extract_message_id()` helper; `mutt_extract_message_id()` is unchanged for its other (NULL-len) callers.

Regression added to `test/email/mutt_rfc822_read_header.c`: it feeds an encoded `References` with two ids (both now recovered) and an expanding `In-Reply-To`; the latter fails under ASAN before the change.

* **What are the relevant issue numbers?**

None.
