### PR TITLE
mutt_thread: fix crash from dangling Email->thread pointers

### DIFF
--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -808,7 +808,10 @@ void mutt_clear_threads(struct ThreadsContext *tctx)
   {
     struct Email *e = m->emails[i];
     if (!e)
-      break;
+    {
+      // Keep processing, in case there are other holes in the Email array
+      continue;
+    }
 
     /* mailbox may have been only partially read */
     e->thread = NULL;
@@ -1750,8 +1753,14 @@ int mutt_messages_in_thread(struct Mailbox *m, struct Email *e, enum MessageInTh
 
   for (int i = 0; i < (((mit == MIT_POSITION) || !threads[1]) ? 1 : 2); i++)
   {
-    while (!threads[i]->message)
+    /* Descend to the first node that references a real Email.
+     * Guard against a malformed or partially-built tree:
+     * a node with no message and no child would otherwise cause a NULL dereference. */
+    while (threads[i] && !threads[i]->message)
       threads[i] = threads[i]->child;
+
+    if (!threads[i] || !threads[i]->message)
+      return 1;
   }
 
   if (threaded == UT_REVERSE)


### PR DESCRIPTION
`mutt_messages_in_thread()` crashed in the pager while rendering the thread-position expando (`%n`) because `e->thread` pointed at a `MuttThread` node that had already been freed.

Root cause: `mutt_clear_threads()` walked `m->emails[]` but bailed out with 'break' on the first NULL slot before freeing the thread nodes.
A NULL hole in the middle of the array (partial read, or an expunged message) therefore left every following Email with its `->thread` pointer intact while `mutt_hash_free()` freed the nodes underneath them.
Any surviving reference to such an Email (e.g. the pager's shared email) then held a dangling `->thread` pointer.

Fix by clearing every non-NULL Email instead of stopping at the first hole.
Also harden `mutt_messages_in_thread()` to guard its tree-walk loops against NULL nodes/messages and bail out safely rather than dereferencing them.

Fixes: #4924 