### PR TITLE
color: fix index_tags pattern matching

### DIFF
--- a/menu/draw.c
+++ b/menu/draw.c
@@ -86,19 +86,6 @@ static const struct AttrColor *get_color(int index, unsigned char *s)
     goto done;
   }
 
-  // %g %{tags} / %J %{thread-tags} - Plain message tags
-  if (type == MT_COLOR_INDEX_TAGS)
-  {
-    STAILQ_FOREACH(np, rcl, entries)
-    {
-      if (strstr(buf_string(buf), np->pattern))
-      {
-        ac_merge = merged_color_overlay(ac_merge, &np->attr_color);
-      }
-    }
-    goto done;
-  }
-
   STAILQ_FOREACH(np, rcl, entries)
   {
     if (mutt_pattern_exec(SLIST_FIRST(np->color_pattern),


### PR DESCRIPTION
Commit d86195a51 changed `MT_COLOR_INDEX_TAGS` to match the configured
argument as a literal substring against the rendered tag text.

This was wrong, so revert that bit of the change.

Evaluate the argument as a NeoMutt pattern against the Email via mutt_pattern_exec().
