### PR TITLE
unify browser limit terminology

### DIFF
--- a/browser/config.c
+++ b/browser/config.c
@@ -152,7 +152,7 @@ struct ConfigDef BrowserVars[] = {
   { "mailbox_folder_format", DT_EXPANDO|D_NOT_EMPTY, IP "%2C %<n?%6n&      > %6m %i", IP &FolderFormatDef, NULL,
     "printf-like format string for the browser's display of mailbox folders"
   },
-  { "mask", DT_REGEX|D_REGEX_MATCH_CASE|D_REGEX_ALLOW_NOT|D_REGEX_NOSUB, IP "!^\\.[^.]", 0, NULL,
+  { "browser_limit", DT_REGEX|D_REGEX_MATCH_CASE|D_REGEX_ALLOW_NOT|D_REGEX_NOSUB, IP "!^\\.[^.]", 0, NULL,
     "Only display files/dirs matching this regex in the browser"
   },
   { "show_only_unread", DT_BOOL, false, 0, NULL,
@@ -162,7 +162,8 @@ struct ConfigDef BrowserVars[] = {
     "Group directories before files in the browser"
   },
 
-  { "sort_browser", DT_SYNONYM, IP "browser_sort", IP "2024-11-20" },
+  { "mask",         DT_SYNONYM, IP "browser_limit", IP "2026-07-10" },
+  { "sort_browser", DT_SYNONYM, IP "browser_sort",  IP "2024-11-20" },
 
   { NULL },
   // clang-format on

--- a/browser/dlg_browser.c
+++ b/browser/dlg_browser.c
@@ -112,7 +112,7 @@ static const struct Mapping FolderHelp[] = {
   { N_("Exit"),  OP_EXIT },
   { N_("Chdir"), OP_CHANGE_DIRECTORY },
   { N_("Goto"),  OP_BROWSER_GOTO_FOLDER },
-  { N_("Mask"),  OP_ENTER_MASK },
+  { N_("Limit"), OP_BROWSER_LIMIT },
   { N_("Help"),  OP_HELP },
   { NULL, 0 },
   // clang-format on
@@ -126,7 +126,7 @@ static const struct Mapping FolderNewsHelp[] = {
   { N_("Subscribe"),   OP_BROWSER_SUBSCRIBE },
   { N_("Unsubscribe"), OP_BROWSER_UNSUBSCRIBE },
   { N_("Catchup"),     OP_CATCHUP },
-  { N_("Mask"),        OP_ENTER_MASK },
+  { N_("Limit"),       OP_BROWSER_LIMIT },
   { N_("Help"),        OP_HELP },
   { NULL, 0 },
   // clang-format on
@@ -223,7 +223,7 @@ void init_state(struct BrowserState *state)
 }
 
 /**
- * examine_directory - Get list of all files/newsgroups with mask
+ * examine_directory - Get list of all files/newsgroups matching the browser limit
  * @param m       Mailbox
  * @param menu    Current Menu
  * @param state   State of browser
@@ -244,7 +244,7 @@ int examine_directory(struct Mailbox *m, struct Menu *menu, struct BrowserState 
 
     init_state(state);
 
-    const struct Regex *c_mask = cs_subset_regex(NeoMutt->sub, "mask");
+    const struct Regex *c_browser_limit = cs_subset_regex(NeoMutt->sub, "browser_limit");
     for (unsigned int i = 0; i < adata->groups_num; i++)
     {
       struct NntpMboxData *mdata = adata->groups_list[i];
@@ -252,7 +252,7 @@ int examine_directory(struct Mailbox *m, struct Menu *menu, struct BrowserState 
         continue;
       if (prefix && *prefix && !mutt_str_startswith(mdata->group, prefix))
         continue;
-      if (!mutt_regex_match(c_mask, mdata->group))
+      if (!mutt_regex_match(c_browser_limit, mdata->group))
       {
         continue;
       }
@@ -306,7 +306,7 @@ int examine_directory(struct Mailbox *m, struct Menu *menu, struct BrowserState 
 
     struct MailboxArray ma = neomutt_mailboxes_get(NeoMutt, MUTT_MAILBOX_ANY);
 
-    const struct Regex *c_mask = cs_subset_regex(NeoMutt->sub, "mask");
+    const struct Regex *c_browser_limit = cs_subset_regex(NeoMutt->sub, "browser_limit");
     while ((de = readdir(dir)))
     {
       if (mutt_str_equal(de->d_name, "."))
@@ -316,7 +316,7 @@ int examine_directory(struct Mailbox *m, struct Menu *menu, struct BrowserState 
       {
         continue;
       }
-      if (!mutt_regex_match(c_mask, de->d_name))
+      if (!mutt_regex_match(c_browser_limit, de->d_name))
       {
         continue;
       }
@@ -598,17 +598,17 @@ void init_menu(struct BrowserState *state, struct Menu *menu, struct Mailbox *m,
       struct Buffer *path = buf_pool_get();
       buf_copy(path, &mod_data->last_dir);
       pretty_mailbox(path);
-      const struct Regex *c_mask = cs_subset_regex(NeoMutt->sub, "mask");
+      const struct Regex *c_browser_limit = cs_subset_regex(NeoMutt->sub, "browser_limit");
       const bool c_imap_list_subscribed = cs_subset_bool(NeoMutt->sub, "imap_list_subscribed");
       if (state->imap_browse && c_imap_list_subscribed)
       {
-        snprintf(title, sizeof(title), _("Subscribed [%s], File mask: %s"),
-                 buf_string(path), NONULL(c_mask ? c_mask->pattern : NULL));
+        snprintf(title, sizeof(title), _("Subscribed [%s], Limit: %s"),
+                 buf_string(path), NONULL(c_browser_limit ? c_browser_limit->pattern : NULL));
       }
       else
       {
-        snprintf(title, sizeof(title), _("Directory [%s], File mask: %s"),
-                 buf_string(path), NONULL(c_mask ? c_mask->pattern : NULL));
+        snprintf(title, sizeof(title), _("Directory [%s], Limit: %s"),
+                 buf_string(path), NONULL(c_browser_limit ? c_browser_limit->pattern : NULL));
       }
       buf_pool_release(&path);
     }

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -74,9 +74,9 @@ static const struct MenuFuncOp OpBrowser[] = { /* map: browser */
   { "delete-mailbox",                OP_DELETE_MAILBOX },
   { "descend-directory",             OP_DESCEND_DIRECTORY },
   { "display-filename",              OP_BROWSER_TELL },
-  { "enter-mask",                    OP_ENTER_MASK },
   { "goto-folder",                   OP_BROWSER_GOTO_FOLDER },
   { "goto-parent",                   OP_GOTO_PARENT },
+  { "limit",                         OP_BROWSER_LIMIT },
   { "mailbox-list",                  OP_MAILBOX_LIST },
   { "reload-active",                 OP_LOAD_ACTIVE },
   { "rename-mailbox",                OP_RENAME_MAILBOX },
@@ -91,8 +91,10 @@ static const struct MenuFuncOp OpBrowser[] = { /* map: browser */
   { "unsubscribe",                   OP_BROWSER_UNSUBSCRIBE },
   { "unsubscribe-pattern",           OP_UNSUBSCRIBE_PATTERN },
   { "view-file",                     OP_BROWSER_VIEW_FILE },
+
   // Deprecated
-  { "buffy-list",                    OP_MAILBOX_LIST, MFF_DEPRECATED },
+  { "enter-mask",                    OP_BROWSER_LIMIT, MFF_DEPRECATED },
+  { "buffy-list",                    OP_MAILBOX_LIST,  MFF_DEPRECATED },
   { NULL, 0 },
 };
 
@@ -110,7 +112,7 @@ static const struct MenuOpSeq BrowserDefaultBindings[] = { /* map: browser */
   { OP_CHANGE_DIRECTORY,                   "c" },
   { OP_CREATE_MAILBOX,                     "C" },
   { OP_DELETE_MAILBOX,                     "d" },
-  { OP_ENTER_MASK,                         "m" },
+  { OP_BROWSER_LIMIT,                      "m" },
   { OP_GOTO_PARENT,                        "p" },
   { OP_MAILBOX_LIST,                       "." },
   { OP_RENAME_MAILBOX,                     "r" },
@@ -305,7 +307,7 @@ static int op_browser_subscribe(struct BrowserPrivateData *priv, const struct Ke
 
   if (ARRAY_EMPTY(&priv->state.entry))
   {
-    mutt_error(OptNews ? _("No newsgroups match the mask") : _("There are no mailboxes"));
+    mutt_error(OptNews ? _("No newsgroups match the browser limit") : _("There are no mailboxes"));
     return FR_ERROR;
   }
 
@@ -387,7 +389,7 @@ static int op_browser_view_file(struct BrowserPrivateData *priv, const struct Ke
   struct BrowserModuleData *mod_data = neomutt_get_module_data(NeoMutt, MODULE_ID_BROWSER);
   if (ARRAY_EMPTY(&priv->state.entry))
   {
-    mutt_error(_("No files match the file mask"));
+    mutt_error(_("No files match the browser limit"));
     return FR_ERROR;
   }
 
@@ -783,15 +785,15 @@ static int op_delete_mailbox(struct BrowserPrivateData *priv, const struct KeyEv
 }
 
 /**
- * op_enter_mask - Enter a file mask - Implements ::browser_function_t - @ingroup browser_function_api
+ * op_browser_limit - Limit the browser - Implements ::browser_function_t - @ingroup browser_function_api
  */
-static int op_enter_mask(struct BrowserPrivateData *priv, const struct KeyEvent *event)
+static int op_browser_limit(struct BrowserPrivateData *priv, const struct KeyEvent *event)
 {
   struct BrowserModuleData *mod_data = neomutt_get_module_data(NeoMutt, MODULE_ID_BROWSER);
-  const struct Regex *c_mask = cs_subset_regex(NeoMutt->sub, "mask");
+  const struct Regex *c_browser_limit = cs_subset_regex(NeoMutt->sub, "browser_limit");
   struct Buffer *buf = buf_pool_get();
-  buf_strcpy(buf, c_mask ? c_mask->pattern : NULL);
-  if (mw_get_field(_("File Mask: "), buf, MUTT_COMP_NONE, HC_OTHER, NULL, NULL) != 0)
+  buf_strcpy(buf, c_browser_limit ? c_browser_limit->pattern : NULL);
+  if (mw_get_field(_("Limit: "), buf, MUTT_COMP_NONE, HC_OTHER, NULL, NULL) != 0)
   {
     buf_pool_release(&buf);
     return FR_NO_ACTION;
@@ -805,7 +807,7 @@ static int op_enter_mask(struct BrowserPrivateData *priv, const struct KeyEvent 
     buf_strcpy(buf, ".");
 
   struct Buffer *errmsg = buf_pool_get();
-  int rc = cs_subset_str_string_set(NeoMutt->sub, "mask", buf_string(buf), errmsg);
+  int rc = cs_subset_str_string_set(NeoMutt->sub, "browser_limit", buf_string(buf), errmsg);
   buf_pool_release(&buf);
   if (CSR_RESULT(rc) != CSR_SUCCESS)
   {
@@ -841,7 +843,7 @@ static int op_enter_mask(struct BrowserPrivateData *priv, const struct KeyEvent 
   priv->kill_prefix = false;
   if (ARRAY_EMPTY(&priv->state.entry))
   {
-    mutt_error(_("No files match the file mask"));
+    mutt_error(_("No files match the browser limit"));
     return FR_ERROR;
   }
   return FR_SUCCESS;
@@ -927,7 +929,7 @@ static int op_generic_select_entry(struct BrowserPrivateData *priv, const struct
   struct BrowserModuleData *mod_data = neomutt_get_module_data(NeoMutt, MODULE_ID_BROWSER);
   if (ARRAY_EMPTY(&priv->state.entry))
   {
-    mutt_warning(_("No files match the file mask"));
+    mutt_warning(_("No files match the browser limit"));
     return FR_ERROR;
   }
 
@@ -1402,6 +1404,7 @@ static int op_toggle_mailboxes(struct BrowserPrivateData *priv, const struct Key
 static const struct BrowserFunction BrowserFunctions[] = {
   // clang-format off
   { OP_BROWSER_GOTO_FOLDER,  op_toggle_mailboxes },
+  { OP_BROWSER_LIMIT,        op_browser_limit },
   { OP_BROWSER_NEW_FILE,     op_browser_new_file },
   { OP_BROWSER_SUBSCRIBE,    op_browser_subscribe },
   { OP_BROWSER_TELL,         op_browser_tell },
@@ -1414,7 +1417,6 @@ static const struct BrowserFunction BrowserFunctions[] = {
   { OP_CREATE_MAILBOX,       op_create_mailbox },
   { OP_DELETE_MAILBOX,       op_delete_mailbox },
   { OP_DESCEND_DIRECTORY,    op_generic_select_entry },
-  { OP_ENTER_MASK,           op_enter_mask },
   { OP_EXIT,                 op_quit },
   { OP_GENERIC_SELECT_ENTRY, op_generic_select_entry },
   { OP_GOTO_PARENT,          op_change_directory },

--- a/docs/config.c
+++ b/docs/config.c
@@ -505,18 +505,26 @@
 ** When this variable is \fIset\fP, NeoMutt will abbreviate mailbox
 ** names in the browser mailbox list, using '~' and '='
 ** shortcuts.
+*/
+
+{ "browser_limit", DT_REGEX, "!^\\.[^.]" },
+/*
 ** .pp
-** The default \fC"alpha"\fP setting of $$browser_sort uses
-** locale-based sorting (using \fCstrcoll(3)\fP), which ignores some
-** punctuation.  This can lead to some situations where the order
-** doesn't make intuitive sense.  In those cases, it may be
-** desirable to \fIunset\fP this variable.
+** A regular expression used in the file browser, optionally preceded by
+** the \fInot\fP operator "!".  Only files whose names match this limit
+** will be shown. The match is always case-sensitive.
 */
 
 { "browser_sort", DT_SORT, BROWSER_SORT_ALPHA },
 /*
 ** .pp
 ** Specifies how to sort entries in the file browser.
+** .pp
+** The default \fC"alpha"\fP setting of $$browser_sort uses
+** locale-based sorting (using \fCstrcoll(3)\fP), which ignores some
+** punctuation.  This can lead to some situations where the order
+** doesn't make intuitive sense.  In those cases, it may be
+** desirable to \fIunset\fP this variable.
 ** .dl
 ** .dt \fBValue\fP    .dd \fBSort by\fP
 ** .dt \fCalpha\fP    .dd Name
@@ -2538,14 +2546,6 @@
 ** "+" marker is displayed at the beginning of wrapped lines.
 ** .pp
 ** Also see the $$smart_wrap variable.
-*/
-
-{ "mask", DT_REGEX, "!^\\.[^.]" },
-/*
-** .pp
-** A regular expression used in the file browser, optionally preceded by
-** the \fInot\fP operator "!".  Only files whose names match this mask
-** will be shown. The match is always case-sensitive.
 */
 
 { "mbox", D_STRING_MAILBOX, "~/mbox" },

--- a/gui/opcodes.h
+++ b/gui/opcodes.h
@@ -273,8 +273,8 @@ const char *opcodes_get_name       (int op);
   _fmt(OP_END_COND,                           N_("End of conditional execution (noop)")) \
   /* L10N: Help for Generic function: <enter-command> */ \
   _fmt(OP_ENTER_COMMAND,                      N_("Enter a neomuttrc command")) \
-  /* L10N: Help for Browser function: <enter-mask> */ \
-  _fmt(OP_ENTER_MASK,                         N_("Enter a file mask")) \
+  /* L10N: Help for Browser function: <limit> */ \
+  _fmt(OP_BROWSER_LIMIT,                      N_("Limit the browser to matching files")) \
   /* L10N: Help for Generic function: <exit> */ \
   _fmt(OP_EXIT,                               N_("Exit this menu")) \
   /* L10N: Help for Generic function: <first-entry> */ \

--- a/test/parse/parse_rc.c
+++ b/test/parse/parse_rc.c
@@ -57,7 +57,7 @@ static void test_parse_set(void)
     "net_inc",           // NUMBER
     "signature",         // PATH
     "print",             // QUAD
-    "mask",              // REGEX
+    "browser_limit",     // REGEX
     "sort",              // SORT
     "attribution_intro", // STRING
     "zzz",               // UNKNOWN


### PR DESCRIPTION
The file/dir/maildir Browser has a function:
- `<enter-mask>` -- Enter a file mask

This asks the user for a value which it stores in config option:
- `$mask` -- Only display files/dirs matching this regex in the browser

This filters the entries in the browser to only show matches.

By comparison the Index/Alias/Query dialogs have a function:

- `<limit>` -- Show only messages matching a pattern
  (this function is not backed by a config option)

- Rename the Browser function to `<limit>` keeping `<enter-mask>` as a deprecated synonym.
- Rename `$mask` to `$browser_limit` keeping `$mask` as a synonym