### PR TITLE
compose: make spelling command configurable

### DIFF
--- a/compose/config.c
+++ b/compose/config.c
@@ -36,10 +36,6 @@
 #include "expando/lib.h"
 #include "shared_data.h"
 
-#ifndef ISPELL
-#define ISPELL "ispell"
-#endif
-
 /**
  * ComposeFormatDef - Expando definitions
  *
@@ -55,6 +51,19 @@ static const struct ExpandoDefinition ComposeFormatDef[] = {
   { "h", "hostname",     ED_GLOBAL,  ED_GLO_HOSTNAME,     NULL },
   { "l", "attach-size",  ED_COMPOSE, ED_COM_ATTACH_SIZE,  NULL },
   { "v", "version",      ED_GLOBAL,  ED_GLO_VERSION,      NULL },
+  { NULL, NULL, 0, -1, NULL }
+  // clang-format on
+};
+
+/**
+ * SpellingCommandFormatDef - Expando definitions
+ *
+ * Config:
+ * - $spelling_command
+ */
+static const struct ExpandoDefinition SpellingCommandFormatDef[] = {
+  // clang-format off
+  { "f", "file", ED_COMPOSE, ED_COM_SPELLING_FILE, NULL },
   { NULL, NULL, 0, -1, NULL }
   // clang-format on
 };
@@ -89,14 +98,15 @@ struct ConfigDef ComposeVars[] = {
   { "edit_headers", DT_BOOL, false, 0, NULL,
     "Let the user edit the email headers whilst editing an email"
   },
-  { "ispell", DT_STRING|D_STRING_COMMAND, IP ISPELL, 0, NULL,
+  { "spelling_command", DT_EXPANDO|D_STRING_COMMAND, IP "ispell -x %f", IP &SpellingCommandFormatDef, NULL,
     "External command to perform spell-checking"
   },
   { "postpone", DT_QUAD, MUTT_ASKYES, 0, NULL,
     "Save messages to the `$postponed` folder"
   },
 
-  { "edit_hdrs", DT_SYNONYM, IP "edit_headers", IP "2021-03-21" },
+  { "edit_hdrs", DT_SYNONYM, IP "edit_headers",     IP "2021-03-21" },
+  { "ispell",    DT_SYNONYM, IP "spelling_command", IP "2026-07-14" },
   { NULL },
   // clang-format on
 };

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -47,6 +47,7 @@
 #include "attach/lib.h"
 #include "browser/lib.h"
 #include "editor/lib.h"
+#include "expando/lib.h"
 #include "history/lib.h"
 #include "hooks/lib.h"
 #include "imap/lib.h"
@@ -110,7 +111,7 @@ static const struct MenuFuncOp OpCompose[] = { /* map: compose */
   { "group-alternatives",            OP_ATTACH_GROUP_ALTS },
   { "group-multilingual",            OP_ATTACH_GROUP_LINGUAL },
   { "group-related",                 OP_ATTACH_GROUP_RELATED },
-  { "ispell",                        OP_COMPOSE_ISPELL },
+  { "ispell",                        OP_COMPOSE_CHECK_SPELLING },
   { "move-down",                     OP_ATTACH_MOVE_DOWN },
   { "move-up",                       OP_ATTACH_MOVE_UP },
   { "new-mime",                      OP_ATTACH_NEW_MIME },
@@ -182,7 +183,7 @@ static const struct MenuOpSeq ComposeDefaultBindings[] = { /* map: compose */
 #endif
   { OP_COMPOSE_EDIT_FILE,                  "\033e" },          // <Alt-e>
   { OP_COMPOSE_EDIT_MESSAGE,               "e" },
-  { OP_COMPOSE_ISPELL,                     "i" },
+  { OP_COMPOSE_CHECK_SPELLING,             "i" },
   { OP_COMPOSE_PGP_MENU,                   "p" },
   { OP_COMPOSE_POSTPONE_MESSAGE,           "P" },
   { OP_COMPOSE_RENAME_FILE,                "R" },
@@ -2470,18 +2471,50 @@ static int op_compose_edit_message(struct ComposeFunctionData *fdata,
 }
 
 /**
- * op_compose_ispell - Run ispell on the message - Implements ::compose_function_t - @ingroup compose_function_api
+ * struct SpellingCommandData - Data for the spelling command
  */
-static int op_compose_ispell(struct ComposeFunctionData *fdata, const struct KeyEvent *event)
+struct SpellingCommandData
+{
+  const char *filename; ///< Filename of the message being composed
+};
+
+/**
+ * spelling_command_file - Spelling command: Filename - Implements ::get_string_t - @ingroup expando_get_string_api
+ */
+static void spelling_command_file(const struct ExpandoNode *node, void *data,
+                                  MuttFormatFlags flags, struct Buffer *buf)
+{
+  struct SpellingCommandData *scd = data;
+
+  buf_quote_filename(buf, scd->filename, true);
+}
+
+/**
+ * op_compose_check_spelling - Check the spelling of the message - Implements ::compose_function_t - @ingroup compose_function_api
+ */
+static int op_compose_check_spelling(struct ComposeFunctionData *fdata,
+                                     const struct KeyEvent *event)
 {
   struct ComposeSharedData *shared = fdata->shared;
   endwin();
-  const char *const c_ispell = cs_subset_string(shared->sub, "ispell");
+  const struct Expando *c_spelling_command = cs_subset_expando(shared->sub, "spelling_command");
   struct Buffer *cmd = buf_pool_get();
-  struct Buffer *quoted = buf_pool_get();
-  buf_quote_filename(quoted, shared->email->body->filename, true);
-  buf_printf(cmd, "%s -x %s", NONULL(c_ispell), buf_string(quoted));
-  buf_pool_release(&quoted);
+  struct SpellingCommandData scd = { shared->email->body->filename };
+  const struct ExpandoRenderCallback spelling_command_render_callbacks[] = {
+    { ED_COMPOSE, ED_COM_SPELLING_FILE, spelling_command_file, NULL },
+    { -1, -1, NULL, NULL },
+  };
+  expando_render(c_spelling_command, spelling_command_render_callbacks, &scd,
+                 MUTT_FORMAT_NONE, -1, cmd);
+  if (!expando_find_node(c_spelling_command, ED_COMPOSE, ED_COM_SPELLING_FILE))
+  {
+    if (!buf_is_empty(cmd))
+      buf_addch(cmd, ' ');
+    struct Buffer *quoted = buf_pool_get();
+    buf_quote_filename(quoted, scd.filename, true);
+    buf_addstr(cmd, buf_string(quoted));
+    buf_pool_release(&quoted);
+  }
   if (mutt_system(buf_string(cmd)) == -1)
   {
     mutt_error(_("Error running \"%s\""), buf_string(cmd));
@@ -2761,7 +2794,7 @@ static const struct ComposeFunction ComposeFunctions[] = {
   { OP_ATTACH_VIEW_TEXT,           op_display_headers           },
   { OP_COMPOSE_EDIT_FILE,          op_compose_edit_file         },
   { OP_COMPOSE_EDIT_MESSAGE,       op_compose_edit_message      },
-  { OP_COMPOSE_ISPELL,             op_compose_ispell            },
+  { OP_COMPOSE_CHECK_SPELLING,     op_compose_check_spelling    },
   { OP_COMPOSE_POSTPONE_MESSAGE,   op_compose_postpone_message  },
   { OP_COMPOSE_RENAME_FILE,        op_compose_rename_file       },
   { OP_COMPOSE_SEND_MESSAGE,       op_compose_send_message      },

--- a/compose/shared_data.h
+++ b/compose/shared_data.h
@@ -56,6 +56,7 @@ enum ExpandoDataCompose
 {
   ED_COM_ATTACH_COUNT = 1,     ///< ComposeAttachData, num_attachments()
   ED_COM_ATTACH_SIZE,          ///< ComposeAttachData, cum_attachs_size()
+  ED_COM_SPELLING_FILE,        ///< Spelling command's filename
 };
 
 void compose_shared_data_free(struct MuttWindow *win, void **ptr);

--- a/debug/names_expando.c
+++ b/debug/names_expando.c
@@ -208,6 +208,7 @@ const char *name_expando_uid_compose(int uid)
   {
     DEBUG_NAME(ED_COM_ATTACH_COUNT);
     DEBUG_NAME(ED_COM_ATTACH_SIZE);
+    DEBUG_NAME(ED_COM_SPELLING_FILE);
     DEBUG_DEFAULT;
   }
 }

--- a/docs/config.c
+++ b/docs/config.c
@@ -1,9 +1,5 @@
 #include "config.h"
 
-#ifndef ISPELL
-#define ISPELL "ispell"
-#endif
-
 /*++*/
 // clang-format off
 { "abort_backspace", DT_BOOL, true },
@@ -2339,10 +2335,17 @@
 ** .te
 */
 
-{ "ispell", D_STRING_COMMAND, ISPELL },
+{ "spelling_command", D_STRING_COMMAND, "ispell -x %f" },
 /*
 ** .pp
-** How to invoke ispell (GNU's spell-checking software).
+** External command to perform spell-checking.  The following printf-style
+** sequence is understood:
+** .dl
+** .dt %f .dd %{file} .dd Filename of the message
+** .de
+** .pp
+** If the command does not contain the sequence, the filename will be appended
+** to the command.
 */
 
 { "keep_flagged", DT_BOOL, false },

--- a/gui/opcodes.h
+++ b/gui/opcodes.h
@@ -172,7 +172,7 @@ const char *opcodes_get_name       (int op);
   /* L10N: Help for Compose function: <edit-message> */ \
   _fmt(OP_COMPOSE_EDIT_MESSAGE,               N_("Edit the message")) \
   /* L10N: Help for Compose function: <ispell> */ \
-  _fmt(OP_COMPOSE_ISPELL,                     N_("Run ispell on the message")) \
+  _fmt(OP_COMPOSE_CHECK_SPELLING,             N_("Check the spelling of the message")) \
   /* L10N: Help for Compose function: <postpone-message> */ \
   _fmt(OP_COMPOSE_POSTPONE_MESSAGE,           N_("Save this message to send later")) \
   /* L10N: Help for Compose function: <rename-file> */ \

--- a/test/parse/parse_rc.c
+++ b/test/parse/parse_rc.c
@@ -51,7 +51,7 @@ static void test_parse_set(void)
   const char *vars[] = {
     "from",              // ADDRESS
     "beep",              // BOOL
-    "ispell",            // COMMAND
+    "spelling_command",  // COMMAND
     "mbox_type",         // ENUM
     "to_chars",          // MBTABLE
     "net_inc",           // NUMBER


### PR DESCRIPTION
Rename the config option from `$ispell` to `$spelling_command` while retaining `$ispell` as a synonym.

Upgrade the option to `DT_EXPANDO` and add `%f` / `%{file}` for the shell-quoted message filename.
Move ispell's `-x` argument into the default value, leaving alternate spelling programs free to define their own command line.

Track whether the filename expando was rendered and append the quoted filename when it was omitted.
This preserves the convenient behaviour of legacy command values without duplicating filenames in expando-aware commands.