### PR TITLE
fix: don't hide postponed message subject unless the draft is actually encrypted

### DIFF
--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -1082,13 +1082,21 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid, bool po
 
   const bool c_crypt_protected_headers_read = cs_subset_bool(sub, "crypt_protected_headers_read");
 
-  /* post == 1 => postpone message.
-   * post == 0 => Normal mode.  */
+  /* When postponing, the real Subject is only recoverable if the postponed
+   * copy is itself encrypted (postpone_message() embeds it as a protected
+   * header inside the encrypted body via mutt_protect()). If $postpone_encrypt
+   * is unset, the postponed copy stays in plain text, so hiding the Subject
+   * header here would discard the only copy of it - see #3256. */
+  const bool c_postpone_encrypt = cs_subset_bool(sub, "postpone_encrypt");
+  bool hide_protected_subject = c_crypt_protected_headers_read &&
+                                mutt_should_hide_protected_subject(e) &&
+                                (!post || c_postpone_encrypt);
+
+  // post == true  => postpone message
+  // post == false => normal mode
   mutt_rfc822_write_header(msg->fp, e->env, e->body,
-                           post ? MUTT_WRITE_HEADER_POSTPONE : MUTT_WRITE_HEADER_FCC, false,
-                           c_crypt_protected_headers_read &&
-                               mutt_should_hide_protected_subject(e),
-                           sub);
+                           post ? MUTT_WRITE_HEADER_POSTPONE : MUTT_WRITE_HEADER_FCC,
+                           false, hide_protected_subject, sub);
 
   /* (postponement) if this was a reply of some sort, <msgid> contains the
    * Message-ID: of message replied to.  Save it using a special X-Mutt-


### PR DESCRIPTION
* **What does this PR do?**

Fixes #3256 — when a message is postponed with `$crypt_protected_headers_write` set, NeoMutt hides the Subject header with the `$crypt_protected_headers_subject` placeholder even when the postponed copy is saved in plain text (the default, since `$postpone_encrypt` is off by default). That destroys the real subject with no way to recover it on recall.

The fix only hides the Subject when the postponed copy is actually going to be encrypted (`$postpone_encrypt` set) — in that case `postpone_message()` already embeds the real subject as a protected header inside the encrypted body via `mutt_protect()`, so it's genuinely recoverable on recall. When `$postpone_encrypt` is unset, the real subject is now kept in the plain-text postponed copy — matching the behaviour @flatcap described as correct on the issue thread.

* **Does this PR meet the acceptance criteria?**

  - No new config option, so no `manual.xml.head` change needed
  - Builds clean, no compiler warnings on the changed file
  - Full unit test suite passes (639/639, `make test`)

* **What are the relevant issue numbers?**

Fixes #3256

* **AI disclosure**

This PR was written primarily by Claude Code, based on the root-cause investigation I posted on the issue thread. I've reviewed the diff and reasoning and can explain it.