### PR TITLE
fix: plug Body leak in mutt_decode_save_attachment

### DIFF
--- a/attach/mutt_attach.c
+++ b/attach/mutt_attach.c
@@ -1113,6 +1113,13 @@ int mutt_decode_save_attachment(FILE *fp, struct Body *b, const char *path,
     b->encoding = saved_encoding;
     if (saved_parts)
     {
+      /* For multipart/external-body attachments, mutt_parse_part() above
+       * built a fresh, standalone b->parts tree (b->email stays NULL).
+       * For message/rfc822 attachments, the fresh tree is b->email->body
+       * instead (the two pointers alias), and email_free() below already
+       * frees it - freeing it here too would be a double free. */
+      if (b->parts && (b->parts != saved_parts) && !b->email)
+        mutt_body_free(&b->parts);
       email_free(&b->email);
       b->parts = saved_parts;
       b->email = e_saved;

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -50,6 +50,7 @@ ATTACH_OBJS	= test/attach/mutt_actx_add_attach.o \
 		  test/attach/mutt_actx_entries_free.o \
 		  test/attach/mutt_actx_free.o \
 		  test/attach/mutt_actx_new.o \
+		  test/attach/mutt_decode_save_attachment.o \
 		  test/attach/selection.o
 
 BASE64_OBJS	= test/base64/mutt_b64_buffer_decode.o \

--- a/test/attach/mutt_decode_save_attachment.c
+++ b/test/attach/mutt_decode_save_attachment.c
@@ -1,0 +1,102 @@
+/**
+ * @file
+ * Test code for mutt_decode_save_attachment()
+ *
+ * @authors
+ * Copyright (C) 2026 Chris Andrew <cjhandrew@gmail.com>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stdio.h>
+#include <unistd.h>
+#include "mutt/lib.h"
+#include "email/lib.h"
+#include "attach/lib.h"
+
+/**
+ * test_mutt_decode_save_attachment - CID 557729: repeated compose-menu
+ * decode-save of the same still-unparsed multipart attachment.
+ *
+ * mutt_decode_save_attachment() is called with fp == NULL to decode a
+ * compose-menu attachment that hasn't been parsed yet. On the first call,
+ * b->parts is NULL, so the restore branch (`if (saved_parts)`) is skipped
+ * and the freshly-parsed b->parts tree from mutt_parse_part() is left in
+ * place. Calling it a second time on the *same* Body (e.g. "save
+ * attachment" twice without leaving compose) should exercise the restore
+ * branch, since b->parts is now non-NULL - this is the path traced as a
+ * leak candidate: the second call's freshly re-parsed tree is discarded
+ * without being freed.
+ */
+void test_mutt_decode_save_attachment(void)
+{
+  // int mutt_decode_save_attachment(FILE *fp, struct Body *b, const char *path, StateFlags flags, enum SaveAttach opt);
+
+  char attach_path[] = "/tmp/neomutt-test-attach-XXXXXX";
+  int fd = mkstemp(attach_path);
+  TEST_CHECK(fd >= 0);
+  FILE *fp = fdopen(fd, "w");
+  TEST_CHECK(fp != NULL);
+  fputs("--BOUNDARY\r\n"
+        "Content-Type: text/plain\r\n"
+        "\r\n"
+        "part one\r\n"
+        "--BOUNDARY--\r\n",
+        fp);
+  fclose(fp);
+
+  char out1[] = "/tmp/neomutt-test-out1-XXXXXX";
+  char out2[] = "/tmp/neomutt-test-out2-XXXXXX";
+  TEST_CHECK(mkstemp(out1) >= 0);
+  TEST_CHECK(mkstemp(out2) >= 0);
+
+  struct Body body = { 0 };
+  body.type = TYPE_MULTIPART;
+  body.subtype = mutt_str_dup("mixed");
+  body.filename = mutt_str_dup(attach_path);
+  mutt_param_set(&body.parameter, "boundary", "BOUNDARY");
+
+  int rc1 = mutt_decode_save_attachment(NULL, &body, out1, STATE_DISPLAY, MUTT_SAVE_NONE);
+  TEST_CHECK(rc1 == 0);
+
+  struct Body *parts_after_first_call = body.parts;
+  TEST_CHECK(parts_after_first_call != NULL);
+
+  int rc2 = mutt_decode_save_attachment(NULL, &body, out2, STATE_DISPLAY, MUTT_SAVE_NONE);
+  TEST_CHECK(rc2 == 0);
+
+  // mutt_decode_save_attachment()'s restore branch sets b->parts back to
+  // saved_parts (the pre-call-2 value), so body.parts should be restored
+  // to parts_after_first_call - the traced leak candidate is the second
+  // call's *intermediate* re-parsed tree, which briefly existed as
+  // b->parts during the call but was overwritten by this restore without
+  // ever being freed. That intermediate pointer is never exposed back to
+  // this test (it's purely internal to the function call), so there's no
+  // black-box assertion that can capture it directly - only a leak
+  // detector watching the whole process's heap at exit can confirm it.
+  TEST_CHECK(body.parts == parts_after_first_call);
+
+  mutt_body_free(&body.parts);
+  FREE(&body.subtype);
+  FREE(&body.filename);
+  mutt_param_free(&body.parameter);
+
+  unlink(attach_path);
+  unlink(out1);
+  unlink(out2);
+}

--- a/test/main.c
+++ b/test/main.c
@@ -90,6 +90,7 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_mutt_actx_entries_free)                               \
   NEOMUTT_TEST_ITEM(test_mutt_actx_free)                                       \
   NEOMUTT_TEST_ITEM(test_mutt_actx_new)                                        \
+  NEOMUTT_TEST_ITEM(test_mutt_decode_save_attachment)                          \
                                                                                \
   /* base64 */                                                                 \
   NEOMUTT_TEST_ITEM(test_mutt_b64_buffer_decode)                               \


### PR DESCRIPTION
* **What does this PR do?**

Fixes #4943 — `mutt_decode_save_attachment()`, when called with `fp == NULL` (the compose-menu path), leaked memory on repeated decode/save of the same still-unparsed attachment.

The function re-parses the attachment via `mutt_parse_part()` into `b->parts`, then restores the original `b->parts`/`b->email` afterwards. For multipart and message/`external-body` attachments this re-parse builds a fresh, standalone `b->parts` tree that the restore branch discarded (overwriting the pointer) without ever freeing it — a genuine leak on any repeated "save attachment" without leaving compose. For message/rfc822 attachments the fresh tree is instead `b->email->body` (the two pointers alias), which `email_free()` already frees, so the fix only frees `b->parts` directly when `b->email` is `NULL` and the pointer actually changed — avoiding a double-free on that path.

This was originally filed as Coverity CID 557729 (a use-after-free claim on the same function) — that UAF claim doesn't hold up on inspection and was marked a false positive in Coverity, but tracing it surfaced this separate, real leak, which is what #4943 tracks.

* **Does this PR meet the acceptance criteria?**

  - No new config option, so no `manual.xml.head` change needed
  - Builds clean under ASan, no compiler warnings on the changed file
  - New regression test (`test/attach/mutt_decode_save_attachment.c`) calls the function twice on the same unparsed multipart body; confirmed via `ASAN_OPTIONS=detect_leaks=1` that it leaked 247 bytes across 5 allocations before the fix and is clean after
  - Full unit test suite passes (639/639, `make test`)

* **What are the relevant issue numbers?**

Fixes #4943

* **AI disclosure**

This PR was written primarily by Claude Code, based on the root-cause investigation from the Coverity CID 557729 triage. I've reviewed the diff and reasoning and can explain it.