### PR TITLE
fix: fall back to hil_index -1 when sb_prev() finds nothing on removal

### DIFF
--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -163,7 +163,8 @@ void sb_remove_mailbox(struct SidebarWindowData *wdata, const struct Mailbox *m)
       if (!sbep_cur)
       {
         // The last entry was deleted, so backtrack
-        sb_prev(wdata);
+        if (!sb_prev(wdata))
+          wdata->hil_index = -1;
       }
       else if ((*sbep_cur)->is_hidden)
       {

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -630,6 +630,8 @@ RFC2047_OBJS	= test/rfc2047/common.o \
 RFC2231_OBJS	= test/rfc2231/rfc2231_decode_parameters.o \
 		  test/rfc2231/rfc2231_encode_string.o
 
+SIDEBAR_OBJS	= test/sidebar/sb_remove_mailbox.o
+
 SIGNAL_OBJS	= test/signal/mutt_sig_allow_interrupt.o \
 		  test/signal/mutt_sig_block.o \
 		  test/signal/mutt_sig_block_system.o \
@@ -746,7 +748,8 @@ BUILD_DIRS	= $(PWD)/test/account $(PWD)/test/address $(PWD)/test/array \
 		  $(PWD)/test/notmuch $(PWD)/test/parameter $(PWD)/test/parse \
 		  $(PWD)/test/path $(PWD)/test/pattern $(PWD)/test/pool \
 		  $(PWD)/test/prex $(PWD)/test/random $(PWD)/test/regex \
-		  $(PWD)/test/rfc2047 $(PWD)/test/rfc2231 $(PWD)/test/signal \
+		  $(PWD)/test/rfc2047 $(PWD)/test/rfc2231 $(PWD)/test/sidebar \
+		  $(PWD)/test/signal \
 		  $(PWD)/test/slist $(PWD)/test/sort $(PWD)/test/store \
 		  $(PWD)/test/string $(PWD)/test/tags $(PWD)/test/thread \
 		  $(PWD)/test/url
@@ -806,6 +809,7 @@ TEST_OBJS	= test/common.o test/main.o test/module.o \
 		  $(REGEX_OBJS) \
 		  $(RFC2047_OBJS) \
 		  $(RFC2231_OBJS) \
+		  $(SIDEBAR_OBJS) \
 		  $(SIGNAL_OBJS) \
 		  $(SLIST_OBJS) \
 		  $(SORT_OBJS) \

--- a/test/main.c
+++ b/test/main.c
@@ -704,6 +704,9 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_rfc2231_decode_parameters)                            \
   NEOMUTT_TEST_ITEM(test_rfc2231_encode_string)                                \
                                                                                \
+  /* sidebar */                                                                \
+  NEOMUTT_TEST_ITEM(test_sb_remove_mailbox)                                    \
+                                                                               \
   /* signal */                                                                 \
   NEOMUTT_TEST_ITEM(test_mutt_sig_allow_interrupt)                             \
   NEOMUTT_TEST_ITEM(test_mutt_sig_block)                                       \

--- a/test/sidebar/sb_remove_mailbox.c
+++ b/test/sidebar/sb_remove_mailbox.c
@@ -1,0 +1,79 @@
+/**
+ * @file
+ * Test code for sb_remove_mailbox()
+ *
+ * @authors
+ * Copyright (C) 2026 Chris Andrew <cjhandrew@gmail.com>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "sidebar/private.h"
+#include "test_common.h"
+
+/**
+ * test_sb_remove_mailbox - CID 561613: hil_index left dangling when the
+ * highlighted, last-in-array entry is deleted and no previous unhidden
+ * entry exists to backtrack to.
+ *
+ * sb_remove_mailbox() removes the highlighted, last entry in the array.
+ * The "last entry was deleted, so backtrack" branch calls sb_prev() but
+ * didn't check its return value - if every remaining entry is hidden,
+ * sb_prev() returns false and hil_index is left at its old value, which
+ * is now one past the end of the (shrunk) array, instead of falling back
+ * to -1 the way the sibling is_hidden branch a few lines below already
+ * does in its own equivalent failure case.
+ */
+void test_sb_remove_mailbox(void)
+{
+  // void sb_remove_mailbox(struct SidebarWindowData *wdata, const struct Mailbox *m);
+
+  struct Mailbox mailbox_a = { 0 };
+  struct Mailbox mailbox_b = { 0 };
+
+  struct SidebarWindowData wdata = { 0 };
+
+  struct SbEntry *entry_a = MUTT_MEM_CALLOC(1, struct SbEntry);
+  entry_a->mailbox = &mailbox_a;
+  entry_a->is_hidden = true; // No unhidden entry left for sb_prev() to backtrack to
+  ARRAY_ADD(&wdata.entries, entry_a);
+
+  struct SbEntry *entry_b = MUTT_MEM_CALLOC(1, struct SbEntry);
+  entry_b->mailbox = &mailbox_b;
+  entry_b->is_hidden = false;
+  ARRAY_ADD(&wdata.entries, entry_b);
+
+  wdata.top_index = 0;
+  wdata.bot_index = 1;
+  wdata.opn_index = -1;
+  wdata.hil_index = 1; // Highlighting the last entry, about to be removed
+
+  sb_remove_mailbox(&wdata, &mailbox_b);
+
+  TEST_CHECK_NUM_EQ(ARRAY_SIZE(&wdata.entries), 1);
+  TEST_CHECK_NUM_EQ(wdata.hil_index, -1);
+
+  struct SbEntry **sbep = NULL;
+  ARRAY_FOREACH(sbep, &wdata.entries)
+  {
+    FREE(sbep);
+  }
+  ARRAY_FREE(&wdata.entries);
+}


### PR DESCRIPTION
* **What does this PR do?**

`sb_remove_mailbox()` keeps the sidebar highlight in place when possible after a mailbox is removed. When the highlighted entry was the last one in the array and got deleted, it calls `sb_prev()` to backtrack to the previous unhidden entry, but never checked whether that succeeded.

If every remaining entry is hidden, `sb_prev()` returns false and `hil_index` is left at its old value — now one past the end of the shrunk array, since the entry it used to point to no longer exists. The sibling `is_hidden` branch a few lines below already falls back to `hil_index = -1` in its own equivalent failure case; this branch didn't.

Not memory-unsafe on its own: every `hil_index` reader goes through `ARRAY_GET()`, which bounds-checks and returns `NULL` out of range. But it leaves the sidebar in a state the many `hil_index < 0` "nothing highlighted" checks elsewhere in the file won't detect.

Fixed by checking `sb_prev()`'s return value and falling back to `-1`, matching the sibling branch.

Found via Coverity CID 561613 (Unchecked return value). Per your note on #4939-#4943 that simple fixes can skip the Issues step, this went straight to a PR.

* **Does this PR meet the acceptance criteria?**

  - No new config option, so no `manual.xml.head` change needed
  - Builds clean under ASan, no compiler warnings on the changed file
  - New regression test (`test/sidebar/sb_remove_mailbox.c`) confirmed to fail without the fix (`hil_index` stuck at the stale out-of-bounds value) and pass with it
  - Full unit test suite passes (all tests, `make test`)

* **AI disclosure**

This PR was written primarily by Claude Code, based on the Coverity CID 561613 triage. I've reviewed the diff and reasoning and can explain it.