### PR TITLE
fix: avoid LOFF_T/long narrowing in text_enriched_handler

### DIFF
--- a/email/enriched.c
+++ b/email/enriched.c
@@ -484,7 +484,7 @@ int text_enriched_handler(struct Body *b_email, struct State *state)
     DONE
   } text_state = TEXT;
 
-  long bytes = b_email->length;
+  LOFF_T bytes = b_email->length;
   struct EnrichedState enriched = { 0 };
   wint_t wc = 0;
   int tag_len = 0;


### PR DESCRIPTION
Fixes #4939

`b_email->length` is `LOFF_T` (`off_t`), copied into a local `long` in `text_enriched_handler`. Both types are 64-bit on every platform NeoMutt currently targets, so this is harmless in practice, but it's not guaranteed by the C standard, and the local variable should match the field it's read from rather than silently narrow it.

One-line fix, no behavioural change on any currently-supported platform. `bytes` is only ever used as a read-countdown in this function (never a buffer size or array index), so even on a hypothetical 32-bit-`long` platform the worst case was a truncated read, not memory corruption.

Coverity CID 535655.

Tests: full suite passes (638/639 — the one unrelated failure, `test_mutt_file_stat_compare`, is a pre-existing artifact of freshly cloning `neomutt-test-files`, whose fixture files all get the same checkout-time mtime; unrelated to this change).

AI disclosure: developed with Claude Code's assistance (investigation, fix, and testing), reviewed and submitted by me.