### PR TITLE
fix: free tempfile string on send_msg()'s outer fork() failure

### DIFF
--- a/send/sendmail.c
+++ b/send/sendmail.c
@@ -109,7 +109,11 @@ static int send_msg(const char *path, struct StringArray *args, const char *msg,
   }
 
   pid_t pid = fork();
-  if (pid == 0)
+  if (pid == -1)
+  {
+    FREE(tempfile);
+  }
+  else if (pid == 0)
   {
     struct sigaction act = { 0 };
     struct sigaction oldalrm = { 0 };


### PR DESCRIPTION
Fixes #4941

If the outer `fork()` in `send_msg()` fails (`pid == -1`), execution fell straight past the `if (pid == 0) {...}` child-only block — which is where every other failure path frees the tempfile string allocated just before the fork — so the string leaked. `fork()` only fails under severe resource exhaustion, so this is narrow and low-severity, but it's a real, confirmed leak (CID open since 2016).

Fix: handle `pid == -1` explicitly and free `*tempfile` there, matching the cleanup already done on the inner fork's failure path.

Coverity CID 76964.

Tests: full suite passes (638/639 — the one unrelated failure, `test_mutt_file_stat_compare`, is a pre-existing artifact of freshly cloning `neomutt-test-files`, whose fixture files all get the same checkout-time mtime; unrelated to this change).

AI disclosure: developed with Claude Code's assistance (investigation, fix, and testing), reviewed and submitted by me.