### PR TITLE
fix: avoid short overflow of row count in calc_address()

### DIFF
--- a/envelope/window.c
+++ b/envelope/window.c
@@ -219,7 +219,7 @@ static int calc_address(struct AddressList *al, short cols, short *srows)
   struct ListHead slist = STAILQ_HEAD_INITIALIZER(slist);
   mutt_addrlist_write_list(al, &slist);
 
-  short rows = 1;
+  int rows = 1;
   int addr_len;
   int width_left = cols;
   struct ListNode *next = NULL;


### PR DESCRIPTION
Fixes #4942

`rows` in `calc_address()` was declared `short`, but is only ever bounded by the number of addresses in a single To/Cc header — a maliciously crafted email with 32768+ recipients in one header would overflow it (UB in C, likely wraps negative on real compilers). Needs an extreme address count to trigger, so practical severity is low, but it's genuine UB reachable from attacker-controlled input.

Fix: widen the internal loop variable to `int`; `*srows` (the `short` output) is still only ever assigned `MIN(rows, MAX_ADDR_ROWS)`, and `MAX_ADDR_ROWS` is 5, so the narrowing at that point is always safe regardless of how large `rows` gets internally.

Coverity CID 392740.

Tests: full suite passes (638/639 — the one unrelated failure, `test_mutt_file_stat_compare`, is a pre-existing artifact of freshly cloning `neomutt-test-files`, whose fixture files all get the same checkout-time mtime; unrelated to this change).

AI disclosure: developed with Claude Code's assistance (investigation, fix, and testing), reviewed and submitted by me.