### PR TITLE
fix: check serial_restore return values in hcache_fetch_email

### DIFF
--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -604,8 +604,11 @@ struct HCacheEntry hcache_fetch_email(struct HeaderCache *hc, const char *key,
     goto end;
   }
   int off = 0;
-  serial_restore_uint32_t(&hce.uidvalidity, data, &off, dlen);
-  serial_restore_int(&hce.crc, data, &off, dlen);
+  if (!serial_restore_uint32_t(&hce.uidvalidity, data, &off, dlen) ||
+      !serial_restore_int(&hce.crc, data, &off, dlen))
+  {
+    goto end;
+  }
   ASSERT((size_t) off == hlen);
   if ((hce.crc != hc->crc) || ((uidvalidity != 0) && (uidvalidity != hce.uidvalidity)))
   {


### PR DESCRIPTION
## Summary

Coverity CID 561614: `hcache_fetch_email()` (`hcache/hcache.c`) discarded the `bool` returns from `serial_restore_uint32_t()` and `serial_restore_int()`.

Not currently reachable — the preceding `if (hlen > dlen) goto end;` guard already guarantees enough bytes for both fixed-size reads (`header_size() == sizeof(int) + sizeof(uint32_t)` matches exactly what the two calls consume), so the immediately-following `ASSERT((size_t) off == hlen)` can't actually fire today. But every other call site of `serial_restore_int()`/`serial_restore_uint32_t()` in this file checks the return (see `hcache/serialize.c`), and if that invariant ever breaks under a future header-cache format change, this path would hit the `ASSERT` (abort) instead of failing gracefully via the existing `goto end`, matching how the rest of the file already handles a bad restore.

## Test plan

- [x] `make` — clean build, no new warnings on the changed file
- [x] `make test` — 638/639 pass; the sole failure (`test_mutt_file_stat_compare`) is a pre-existing fixture-mtime artifact of a fresh `neomutt-test-files` checkout, unrelated to this change
- [x] Manual trace confirming the guard is currently unreachable in practice, and that `goto end` on failure returns the same zero-initialized `HCacheEntry` already used by every other early-exit path in the function

## AI disclosure

This PR was written primarily by Claude Code.