### PR TITLE
docs: add Repology packaging status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Code build](https://github.com/neomutt/neomutt/actions/workflows/build-and-test.yml/badge.svg?branch=main&event=push)](https://github.com/neomutt/neomutt/actions/workflows/build-and-test.yml "Latest Automatic Code Build")
 [![Coverity Scan](https://img.shields.io/coverity/scan/8495.svg)](https://scan.coverity.com/projects/neomutt-neomutt "Latest Code Static Analysis")
 [![Website build](https://github.com/neomutt/neomutt.github.io/actions/workflows/pages/pages-build-deployment/badge.svg)](https://neomutt.org/ "Website Build")
+[![Packaging status](https://repology.org/badge/tiny-repos/neomutt.svg)](https://repology.org/project/neomutt/versions "Packaging status across distros")
 
 ## What is NeoMutt?
 


### PR DESCRIPTION
No packaging status indicator existed in the README badge row, unlike the website (distro.md), which already has one.

Confirmed before opening: the live README (fetched fresh via the GitHub API) has no existing mention of Repology or packaging status, and no prior open or closed PR/issue on this repo ever proposed one. Also confirmed the `neomutt` slug on Repology resolves correctly.

Used the `tiny-repos` badge variant rather than `vertical-allrepos` (the one used on the website's distro.md) since this README's badge row is a single line of small shields.io-style badges -- the tall vertical variant would break that layout.