### PR TITLE
ci: add concurrency groups to the 3 workflows that run on every push/PR

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -9,6 +9,10 @@ on:
       - 'copilot/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ASAN Build

--- a/.github/workflows/build-and-test-freebsd.yml
+++ b/.github/workflows/build-and-test-freebsd.yml
@@ -10,7 +10,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,10 @@ on:
       - 'copilot/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,10 @@ on:
     - cron: "46 1 * * 1"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
asan.yml, build-and-test.yml and codeql.yml (via its push+pull_request triggers) all run on every push to a PR branch, with no concurrency control -- pushing several commits in quick succession queues up a full run for each one instead of the superseded runs being cancelled.

The one workflow that already had a concurrency group (build-and-test-freebsd.yml) had it configured incorrectly: `group: ${{ github.workflow }}` with no `${{ github.ref }}` means every branch and PR shares a single global queue, so unrelated PRs would serialize behind each other -- and with no `cancel-in-progress: true` set, superseded runs weren't actually being cancelled either, just queued, so it wasn't saving any CI time.

Every other workflow (coverity.yml, coveralls.yml, debian.yml, debug.yml, doxygen.yml, fedora.yml, macos.yml, xunused.yml) only runs on a weekly schedule or workflow_dispatch, not on every push, so this doesn't apply to them.

AI disclosure: found and implemented with Claude Code's assistance while reviewing the CI setup, reviewed and sent by me.