### PR TITLE
ci: add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"


### PR DESCRIPTION
No automated dependency-update tooling exists for the github-actions ecosystem -- confirmed via `find .github -iname dependabot*`, nothing found. Every action reference (`actions/checkout@v7`, `codeql-action@v4`, etc.) is a static, hand-picked version that never gets an update PR.

Weekly schedule matches the existing CI cadence (most scheduled workflows already run Mondays). `github-actions` ecosystem only, since that's the specific gap found -- not proposing anything for the C toolchain itself.

AI disclosure: found and implemented with Claude Code's assistance while reviewing the CI setup, reviewed and sent by me.