### PR TITLE
actions: use checkout action to deploy

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -10,7 +10,7 @@ jobs:
   doxygen:
     name: Update Code Docs
     runs-on: ubuntu-latest
-    container: ghcr.io/neomutt/fedora:42
+    container: ghcr.io/neomutt/fedora:44
     permissions:
       contents: read
 
@@ -42,8 +42,7 @@ jobs:
       with:
         repository: neomutt/code
         path: code
-        persist-credentials: false
-        # otherwise GITHUB_TOKEN will be used, rather than the Personal Access Token
+        token: ${{ secrets.DOXYGEN_DEPLOY_KEY }}
 
     - name: Generate Docs
       run: |
@@ -57,10 +56,5 @@ jobs:
         action-doxygen/bin/commit.sh neomutt/html code
 
     - name: Push to Code Docs
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.DOXYGEN_DEPLOY_KEY }}
-        branch: main
-        directory: code
-        repository: neomutt/code
-
+      run: git push origin main
+      working-directory: code

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -40,8 +40,7 @@ jobs:
       with:
         repository: neomutt/neomutt.github.io
         path: website
-        persist-credentials: false
-        # otherwise GITHUB_TOKEN will be used, rather than the Personal Access Token
+        token: ${{ secrets.TRANSLATE_DEPLOY_KEY }}
 
     - name: Set Up Git
       run: |
@@ -63,10 +62,5 @@ jobs:
         scripts/commit.sh neomutt website translate.html
 
     - name: Push to Website
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.TRANSLATE_DEPLOY_KEY }}
-        branch: main
-        directory: website
-        repository: neomutt/neomutt.github.io
-
+      run: git push origin main
+      working-directory: website


### PR DESCRIPTION
Drop 'ad-m/github-push-action' in favour of 'actions/checkout' for deploying translations and doxygen code docs.

Bump container version to Fedora 44.