### PR TITLE
conn: fix two size_t/int truncation issues found while scoping #4940

### DIFF
--- a/conn/gnutls.c
+++ b/conn/gnutls.c
@@ -1127,7 +1127,14 @@ static int tls_socket_write(struct Connection *conn, const char *buf, size_t cou
     sent += rc;
   } while (sent < count);
 
-  return sent;
+  // sent is a size_t accumulator narrowed into this function's int return
+  // type, mandated by the shared Connection::write() interface -- the same
+  // pattern flagged by Coverity CID 392753/392751 in raw.c/tunnel.c, though
+  // not currently flagged here. The sole caller of conn->write(),
+  // mutt_socket_write_d(), already takes an int len, so count is bounded to
+  // INT_MAX before it ever reaches here -- see #4940 for the full
+  // call-graph trace. Explicit cast documents the narrowing is safe.
+  return (int) sent;
 }
 
 /**

--- a/conn/gnutls.c
+++ b/conn/gnutls.c
@@ -1127,13 +1127,7 @@ static int tls_socket_write(struct Connection *conn, const char *buf, size_t cou
     sent += rc;
   } while (sent < count);
 
-  // sent is a size_t accumulator narrowed into this function's int return
-  // type, mandated by the shared Connection::write() interface -- the same
-  // pattern flagged by Coverity CID 392753/392751 in raw.c/tunnel.c, though
-  // not currently flagged here. The sole caller of conn->write(),
-  // mutt_socket_write_d(), already takes an int len, so count is bounded to
-  // INT_MAX before it ever reaches here -- see #4940 for the full
-  // call-graph trace. Explicit cast documents the narrowing is safe.
+  // Narrowed to int for the Connection::write() interface; see #4940.
   return (int) sent;
 }
 

--- a/conn/zstrm.c
+++ b/conn/zstrm.c
@@ -29,6 +29,7 @@
  */
 
 #include "config.h"
+#include <limits.h>
 #include <stdbool.h>
 #include <string.h>
 #include <time.h>
@@ -282,8 +283,19 @@ static int zstrm_write(struct Connection *conn, const char *buf, size_t count)
     }
   } while (true);
 
-  rc = (int) count;
-  return (rc <= 0) ? 1 : rc; /* avoid wrong behaviour due to overflow */
+  // count is the number of (uncompressed) bytes accepted by this layer, all
+  // of which are always consumed by the deflate loop above before this
+  // point is reached. Narrowing it into this function's int return can only
+  // go wrong if count itself overflows INT_MAX, in which case the previous
+  // `(rc <= 0) ? 1 : rc` fallback silently reported a false "1 byte
+  // written" instead of surfacing the failure -- see #4940. Report the
+  // overflow as an error instead of masking it.
+  if (count > INT_MAX)
+  {
+    mutt_debug(LL_DEBUG1, "zstrm_write: count %zu exceeds INT_MAX\n", count);
+    return -1;
+  }
+  return (int) count;
 }
 
 /**

--- a/conn/zstrm.c
+++ b/conn/zstrm.c
@@ -283,13 +283,7 @@ static int zstrm_write(struct Connection *conn, const char *buf, size_t count)
     }
   } while (true);
 
-  // count is the number of (uncompressed) bytes accepted by this layer, all
-  // of which are always consumed by the deflate loop above before this
-  // point is reached. Narrowing it into this function's int return can only
-  // go wrong if count itself overflows INT_MAX, in which case the previous
-  // `(rc <= 0) ? 1 : rc` fallback silently reported a false "1 byte
-  // written" instead of surfacing the failure -- see #4940. Report the
-  // overflow as an error instead of masking it.
+  // Guard overflow when narrowing to int for Connection::write(); see #4940.
   if (count > INT_MAX)
   {
     mutt_debug(LL_DEBUG1, "zstrm_write: count %zu exceeds INT_MAX\n", count);


### PR DESCRIPTION
Two small, independent fixes flagged in the #4940 investigation (comment
from 2026-07-21) — separate from the larger `Connection::write()` interface
question, which that comment concluded isn't worth pursuing (the sole
caller already bounds `count` to `INT_MAX`).

- **`gnutls.c` (`tls_socket_write`)**: same size_t-into-int narrowing
  pattern as Coverity CID 392753/392751 (`raw.c`/`tunnel.c`), though not
  itself Coverity-flagged. Adds an explicit `(int)` cast with a comment
  documenting why the narrowing is safe.
- **`zstrm.c` (`zstrm_write`)**: a distinct, non-CID bug — the old
  `(rc <= 0) ? 1 : rc` clamp silently reported a false "1 byte written" if
  `count` ever overflowed `INT_MAX`, instead of surfacing the failure.
  Replaced with an explicit overflow check that returns -1.

Both build-verified clean (`make conn/gnutls.o conn/zstrm.o`, `-Wall`,
zero warnings).

AI disclosure: implemented with Claude Code's assistance, following up on
the investigation already posted to #4940.