### PR TITLE
ci: add explicit permissions: contents: read to all workflows

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -18,6 +18,8 @@ jobs:
     name: ASAN Build
     runs-on: ubuntu-latest
     container: ghcr.io/neomutt/ubuntu
+    permissions:
+      contents: read
 
     env:
       ASAN_OPTIONS: detect_leaks=1:color=never:log_path=asan:print_legend=false:print_summary=false

--- a/.github/workflows/build-and-test-freebsd.yml
+++ b/.github/workflows/build-and-test-freebsd.yml
@@ -18,6 +18,8 @@ jobs:
     if: github.event.pull_request.draft == false
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     env:
       # Force Node 24 until github-actions-cpu-cores gets a new release

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,6 +19,8 @@ jobs:
     name: Build-${{ matrix.cfg.name }}
     runs-on: ubuntu-latest
     container: ghcr.io/neomutt/ubuntu
+    permissions:
+      contents: read
 
     strategy:
       # Limit jobs to one at a time so that ccache really helps later builds

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -9,6 +9,8 @@ jobs:
   Fuzzing:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -11,6 +11,8 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     container: ghcr.io/neomutt/ubuntu
+    permissions:
+      contents: read
 
     env:
       OPTIONS: --coverage --autocrypt --gdbm --gnutls --gpgme --gss --lmdb --lua --lz4 --notmuch --sasl --tdb --with-lock=fcntl --zlib --zstd

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -11,6 +11,8 @@ jobs:
     name: Coverity
     runs-on: ubuntu-latest
     container: ghcr.io/neomutt/ubuntu
+    permissions:
+      contents: read
 
     env:
       TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -28,6 +28,8 @@ jobs:
     name: Debian ${{ matrix.distro.version }} - ${{ matrix.config.name }}
     runs-on: ubuntu-latest
     container: ghcr.io/neomutt/debian:${{ matrix.distro.version }}
+    permissions:
+      contents: read
 
     env:
       # Force Node 24 until github-actions-cpu-cores gets a new release

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -11,6 +11,8 @@ jobs:
     name: ${{ matrix.cfg.name }}
     runs-on: ubuntu-latest
     container: ghcr.io/neomutt/ubuntu
+    permissions:
+      contents: read
 
     env:
       CONFIGURE_OPTIONS: --autocrypt --fmemopen --gdbm --gnutls --gpgme --gss --lmdb --lua --lz4 --notmuch --pcre2 --rocksdb --sasl --tdb --with-lock=fcntl --zlib --zstd

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -11,6 +11,8 @@ jobs:
     name: Update Code Docs
     runs-on: ubuntu-latest
     container: ghcr.io/neomutt/fedora:42
+    permissions:
+      contents: read
 
     steps:
     - name: Check Secret

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -27,6 +27,8 @@ jobs:
     name: Fedora ${{ matrix.distro.version }} - ${{ matrix.config.name }}
     runs-on: ubuntu-latest
     container: ghcr.io/neomutt/fedora:${{ matrix.distro.version }}
+    permissions:
+      contents: read
 
     env:
       # Force Node 24 until github-actions-cpu-cores gets a new release

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     name: Build on macOS
     runs-on: macos-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Get number of CPU cores

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -10,6 +10,8 @@ jobs:
   leaderboard:
     name: Update Leaderboard
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Check secret

--- a/.github/workflows/xunused.yml
+++ b/.github/workflows/xunused.yml
@@ -12,6 +12,8 @@ jobs:
     name: Check for unused functions
     runs-on: ubuntu-latest
     container: ghcr.io/neomutt/ubuntu
+    permissions:
+      contents: read
 
     env:
       CONFIGURE_OPTIONS: --autocrypt --compile-commands --disable-doc --gdbm --gnutls --gpgme --gss --lmdb --lua --lz4 --notmuch --sasl --tdb --with-lock=fcntl --zlib --zstd


### PR DESCRIPTION
Only `codeql.yml` declared an explicit `permissions` block; the other 13 ran with whatever the org's default `GITHUB_TOKEN` scope is, un-auditable from the workflow file alone.

None of these workflows need write access via `GITHUB_TOKEN` — the two that do write somewhere (`translate.yml`, `doxygen.yml`) both authenticate with a dedicated deploy-key secret passed explicitly to a separate push action, not `GITHUB_TOKEN` itself, so `contents: read` is correct for all 13, not just the read-only build/test ones.

AI disclosure: found and implemented with Claude Code's assistance while reviewing the CI setup, reviewed and sent by me.