### PR TITLE
conn: add missing sys/time.h include in raw.c

### DIFF
--- a/conn/raw.c
+++ b/conn/raw.c
@@ -39,6 +39,7 @@
 #include <string.h>
 #include <sys/select.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include "private.h"


### PR DESCRIPTION
Found while scoping #4962 (IWYU CI check proposal) — `raw.c` uses `struct
timeval` directly (`raw.c:115,360`) but only received `sys/time.h`
transitively via `sys/select.h`, so it currently only compiles because of
that side effect.

Confirmed via IWYU itself: clean after this change.

AI disclosure: found and implemented with Claude Code's assistance,
reviewed and sent by me.