### PR TITLE
ci: enable UBSan alongside ASan (with a real bug found along the way)

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -23,7 +23,8 @@ jobs:
 
     env:
       ASAN_OPTIONS: detect_leaks=1:color=never:log_path=asan:print_legend=false:print_summary=false
-      CONFIGURE_OPTIONS: --asan --autocrypt --gdbm --gnutls --gpgme --gss --lmdb --lua --lz4 --notmuch --sasl --tdb --with-lock=fcntl --zlib --zstd
+      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1:log_path=ubsan
+      CONFIGURE_OPTIONS: --asan --ubsan --autocrypt --gdbm --gnutls --gpgme --gss --lmdb --lua --lz4 --notmuch --sasl --tdb --with-lock=fcntl --zlib --zstd
       # Force Node 24 until github-actions-cpu-cores gets a new release
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -66,6 +67,7 @@ jobs:
     - name: Run Tests
       run: |
         export ASAN_OPTIONS="$ASAN_OPTIONS"
+        export UBSAN_OPTIONS="$UBSAN_OPTIONS"
         export NEOMUTT_TEST_DIR="$GITHUB_WORKSPACE/test-files"
         make test
 
@@ -75,6 +77,15 @@ jobs:
       with:
         name: asan-log
         path: ${{ github.workspace }}/asan.*
+        retention-days: 10
+        if-no-files-found: ignore
+
+    - name: Upload UBSAN Log
+      uses: actions/upload-artifact@v7
+      if: failure()
+      with:
+        name: ubsan-log
+        path: ${{ github.workspace }}/ubsan.*
         retention-days: 10
         if-no-files-found: ignore
 

--- a/attach/commands.c
+++ b/attach/commands.c
@@ -60,15 +60,16 @@ struct AttachMatch
  * @note We don't free minor because it is either a pointer into major,
  *       or a static string.
  */
-void attachmatch_free(struct AttachMatch **ptr)
+void attachmatch_free(void **ptr)
 {
   if (!ptr || !*ptr)
     return;
 
-  struct AttachMatch *am = *ptr;
+  struct AttachMatch **am_ptr = (struct AttachMatch **) ptr;
+  struct AttachMatch *am = *am_ptr;
   regfree(&am->minor_regex);
   FREE(&am->major);
-  FREE(ptr);
+  FREE(am_ptr);
 }
 
 /**
@@ -576,10 +577,10 @@ enum CommandResult parse_unattachments(const struct Command *cmd, struct Buffer 
 
   if (op == '*')
   {
-    mutt_list_free_type(&mod_data->attach_allow, (list_free_t) attachmatch_free);
-    mutt_list_free_type(&mod_data->attach_exclude, (list_free_t) attachmatch_free);
-    mutt_list_free_type(&mod_data->inline_allow, (list_free_t) attachmatch_free);
-    mutt_list_free_type(&mod_data->inline_exclude, (list_free_t) attachmatch_free);
+    mutt_list_free_type(&mod_data->attach_allow, attachmatch_free);
+    mutt_list_free_type(&mod_data->attach_exclude, attachmatch_free);
+    mutt_list_free_type(&mod_data->inline_allow, attachmatch_free);
+    mutt_list_free_type(&mod_data->inline_exclude, attachmatch_free);
 
     mutt_debug(LL_NOTIFY, "NT_ATTACH_DELETE_ALL\n");
     notify_send(mod_data->attachments_notify, NT_ATTACH, NT_ATTACH_DELETE_ALL, NULL);

--- a/attach/commands.h
+++ b/attach/commands.h
@@ -51,7 +51,7 @@ int  mutt_count_body_parts  (struct Email *e, FILE *fp);
 void mutt_parse_mime_message(struct Email *e, FILE *fp);
 
 struct AttachMatch *attachmatch_new (void);
-void                attachmatch_free(struct AttachMatch **ptr);
+void                attachmatch_free(void **ptr);
 
 enum CommandResult parse_mime_lookup  (const struct Command *cmd, struct Buffer *line, const struct ParseContext *pc, struct ParseError *pe);
 enum CommandResult parse_unmime_lookup(const struct Command *cmd, struct Buffer *line, const struct ParseContext *pc, struct ParseError *pe);

--- a/attach/module.c
+++ b/attach/module.c
@@ -92,10 +92,10 @@ static bool attach_cleanup(struct NeoMutt *n, void *data)
   notify_free(&mod_data->attachments_notify);
 
   /* Lists of AttachMatch */
-  mutt_list_free_type(&mod_data->attach_allow, (list_free_t) attachmatch_free);
-  mutt_list_free_type(&mod_data->attach_exclude, (list_free_t) attachmatch_free);
-  mutt_list_free_type(&mod_data->inline_allow, (list_free_t) attachmatch_free);
-  mutt_list_free_type(&mod_data->inline_exclude, (list_free_t) attachmatch_free);
+  mutt_list_free_type(&mod_data->attach_allow, attachmatch_free);
+  mutt_list_free_type(&mod_data->attach_exclude, attachmatch_free);
+  mutt_list_free_type(&mod_data->inline_allow, attachmatch_free);
+  mutt_list_free_type(&mod_data->inline_exclude, attachmatch_free);
 
   mutt_list_free(&mod_data->mime_lookup);
 


### PR DESCRIPTION
ASan already runs in CI (`asan.yml`), but UBSan never did, despite `auto.def` supporting it (`--ubsan`). Tested locally first rather than just flipping the flag on — that surfaced a real, if practically harmless, undefined-behaviour bug (first commit): `attachmatch_free()` was declared as `void(struct AttachMatch **)` but called everywhere through a `(list_free_t)` cast to `void(void **)`. Calling through an incompatible function-pointer type is UB per the C standard — works fine on this ABI (both are just pointer-to-pointer), which is exactly why nobody had noticed. Fixed by giving it the generic `void **` signature `list_free_t` actually expects, matching the pattern the codebase's own test (`test_list_free` in `test/list/mutt_list_free_type.c`) already uses, and casting internally instead of at each of the 8 call sites.

Second commit adds `--ubsan` to the existing configure invocation, `UBSAN_OPTIONS` with `halt_on_error=1` so a real violation fails the job rather than just logging, and a log artifact upload matching the existing ASan one.

**Being upfront about one thing I couldn't fully verify**: testing locally (a git worktree, ASan+UBSan both on) also hit 17 test failures unrelated to either sanitizer — `mkstemp`/`chmod`/`stat` calls failing in ways that look specific to my local sandbox's filesystem restrictions rather than real bugs (they don't reproduce without the sanitizers active, but they're not proper UBSan/ASan reports either — no violation logged for any of them, just quiet permission-shaped failures). I couldn't rule out whether the actual CI container behaves the same way. If this run fails for reasons unrelated to the `attachmatch_free` fix, that's most likely what's happening — happy to help dig further if so.

AI assistance: Claude Code investigated the UBSan finding, wrote both commits and this description. I reviewed the diff, the reasoning for the fix, and reproduced the before/after locally before submitting.