### PR TITLE
bugprone: add default cases for switch-missing-default-case

### DIFF
--- a/alias/functions.c
+++ b/alias/functions.c
@@ -535,6 +535,8 @@ static int op_search(struct AliasFunctionData *fdata, const struct KeyEvent *eve
     case OP_SEARCH_OPPOSITE:
       flags |= SEARCH_OPPOSITE;
       break;
+    default:
+      break;
   }
 
   struct Menu *menu = mdata->menu;
@@ -588,6 +590,10 @@ static int op_sort(struct AliasFunctionData *fdata, const struct KeyEvent *event
 
     case 4: /* (u)nsorted */
       sort = ALIAS_SORT_UNSORTED;
+      break;
+
+    default:
+      resort = false;
       break;
   }
 

--- a/autocrypt/gpgme.c
+++ b/autocrypt/gpgme.c
@@ -305,6 +305,10 @@ int mutt_autocrypt_gpgme_select_or_create_key(struct Address *addr, struct Buffe
 
     case 1: /* create new */
       rc = mutt_autocrypt_gpgme_create_key(addr, keyid, keydata);
+      break;
+
+    default:
+      break;
   }
 
   return rc;

--- a/browser/dlg_browser.c
+++ b/browser/dlg_browser.c
@@ -950,6 +950,9 @@ void dlg_browser(struct Buffer *file, SelectFileFlags flags, struct Mailbox *m,
         case BROWSER_SORT_UNSORTED:
           browser_track = true;
           break;
+
+        default:
+          break;
       }
 
       /* We use mutt_browser_select_dir to initialize the two

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -1262,6 +1262,10 @@ static int op_sort(struct BrowserPrivateData *priv, const struct KeyEvent *event
     case 7: /* do(n)'t sort */
       sort = BROWSER_SORT_UNSORTED;
       break;
+
+    default:
+      resort = false;
+      break;
   }
 
   if (!resort)

--- a/color/ansi.c
+++ b/color/ansi.c
@@ -68,6 +68,8 @@ static void ansi_color_list_add(struct AttrColorList *acl, struct AnsiColor *ans
       case A_UNDERLINE:
         ansi->attr_color = simple_color_get(MT_COLOR_UNDERLINE);
         return;
+      default:
+        break;
     }
   }
 

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -2697,6 +2697,9 @@ static int op_display_headers(struct ComposeFunctionData *fdata, const struct Ke
     case OP_ATTACH_VIEW_TEXT:
       mode = MUTT_VA_AS_TEXT;
       break;
+
+    default:
+      break;
   }
 
   if (mode == MUTT_VA_REGULAR)

--- a/conn/dlg_verifycert.c
+++ b/conn/dlg_verifycert.c
@@ -121,6 +121,8 @@ static int menu_dialog_translate_op(int op)
       return OP_BOTTOM_PAGE;
     case OP_CURRENT_MIDDLE:
       return OP_MIDDLE_PAGE;
+    default:
+      break;
   }
 
   return op;
@@ -275,6 +277,9 @@ int dlg_certificate(const char *title, struct StringArray *carr, bool allow_alwa
       case OP_SEARCH_REVERSE:
         mutt_error(_("Search is not implemented for this menu"));
         continue;
+
+      default:
+        break;
     }
 
     (void) menu_function_dispatcher(menu->win, &event);

--- a/email/handler.c
+++ b/email/handler.c
@@ -270,6 +270,8 @@ static void qp_decode_line(char *dest, char *src, size_t *l, int last)
         soft = true;
         s++;
         break; /* soft line break */
+      default:
+        break;
     }
   }
 

--- a/email/parse.c
+++ b/email/parse.c
@@ -1163,6 +1163,8 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e,
               case 'r':
                 e->replied = true;
                 break;
+              default:
+                break;
             }
             body++;
           }

--- a/envelope/functions.c
+++ b/envelope/functions.c
@@ -93,6 +93,9 @@ static void autocrypt_compose_menu(struct Email *e, const struct ConfigSubset *s
         e->security |= SEC_OPPENCRYPT;
       break;
     }
+
+    default:
+      break;
   }
 }
 #endif

--- a/expando/node_conddate.c
+++ b/expando/node_conddate.c
@@ -107,6 +107,9 @@ time_t cutoff_number(char period, int count)
     case 'M':
       tm.tm_min -= count;
       break;
+
+    default:
+      break;
   }
 
   return mktime(&tm);
@@ -157,6 +160,9 @@ time_t cutoff_this(char period)
       else
         bow = tm.tm_wday - 1; // LCOV_EXCL_LINE
       tm.tm_mday -= bow;
+      break;
+
+    default:
       break;
   }
 

--- a/external.c
+++ b/external.c
@@ -530,6 +530,9 @@ bool mutt_select_sort(bool reverse)
     case 11: /* (l)abel */
       sort = EMAIL_SORT_LABEL;
       break;
+
+    default:
+      return false;
   }
 
   const unsigned char c_use_threads = cs_subset_enum(NeoMutt->sub, "use_threads");
@@ -908,6 +911,7 @@ int mutt_save_message(struct Mailbox *m, struct EmailArray *ea,
         break;
       /* fatal error, abort */
       case -1:
+      default:
         goto errcleanup;
     }
   }

--- a/imap/message.c
+++ b/imap/message.c
@@ -1243,6 +1243,8 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
           continue;
         case -2:
           goto bail;
+        default:
+          continue;
       }
 
       if (!ftello(fp))

--- a/imap/search.c
+++ b/imap/search.c
@@ -188,6 +188,8 @@ static bool compile_search_self(const struct ImapAccountData *adata,
       imap_quote_string(term, sizeof(term), pat->p.str, false);
       buf_addstr(buf, term);
       break;
+    default:
+      return false;
   }
   return true;
 }

--- a/index/functions.c
+++ b/index/functions.c
@@ -2983,6 +2983,9 @@ static int op_search(struct IndexFunctionData *fdata, const struct KeyEvent *eve
     case OP_SEARCH_OPPOSITE:
       flags |= SEARCH_OPPOSITE;
       break;
+
+    default:
+      break;
   }
 
   // Initiating a search can happen on an empty mailbox, but
@@ -3820,6 +3823,9 @@ static int op_main_windowed_vfolder(struct IndexFunctionData *fdata,
       break;
     case OP_MAIN_WINDOWED_VFOLDER_RESET:
       nm_query_window_reset();
+      break;
+
+    default:
       break;
   }
 

--- a/main.c
+++ b/main.c
@@ -1591,6 +1591,8 @@ int main(int argc, char *argv[], char *envp[])
         case 1:
           mutt_error(_("Mailbox is empty"));
           goto done; // TEST42: neomutt -z -f /dev/null
+        default:
+          break;
       }
     }
 

--- a/menu/draw.c
+++ b/menu/draw.c
@@ -243,6 +243,8 @@ static void print_enriched_string(struct MuttWindow *win, int index,
           case MUTT_TREE_MISSING:
             mutt_window_addch(win, '?');
             break;
+          default:
+            break;
         }
         s++;
         n--;

--- a/mutt_signal.c
+++ b/mutt_signal.c
@@ -83,6 +83,9 @@ static void curses_signal_handler(int sig)
     case SIGINT:
       SigInt = true;
       break;
+
+    default:
+      break;
   }
   errno = save_errno;
 }

--- a/muttlib.c
+++ b/muttlib.c
@@ -383,6 +383,9 @@ bool mutt_needs_mailcap(struct Body *b)
     case TYPE_MULTIPART:
     case TYPE_MESSAGE:
       return false;
+
+    default:
+      break;
   }
 
   return true;
@@ -554,6 +557,9 @@ int mutt_check_overwrite(const char *attname, const char *path, struct Buffer *f
         case 2: /* no */
           FREE(directory);
           return 1;
+        default:
+          FREE(directory);
+          return -1;
       }
     }
     /* L10N: Means "The path you specified as the destination file is a directory."
@@ -593,6 +599,8 @@ int mutt_check_overwrite(const char *attname, const char *path, struct Buffer *f
         break;
       case 1: /* overwrite */
         break;
+      default:
+        return -1;
     }
   }
   return 0;

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -1348,6 +1348,8 @@ static void show_one_sig_validity(gpgme_ctx_t ctx, int idx, struct State *state)
     case GPGME_VALIDITY_ULTIMATE:
       txt = NULL;
       break;
+    default:
+      break;
   }
   if (txt)
     state_puts(state, txt);
@@ -4077,6 +4079,9 @@ static SecurityFlags gpgme_send_menu(struct Email *e, bool is_smime)
       case 's': /* (s)ign */
         e->security &= ~SEC_ENCRYPT;
         e->security |= SEC_SIGN;
+        break;
+
+      default:
         break;
     }
   }

--- a/ncrypt/functions_pgp.c
+++ b/ncrypt/functions_pgp.c
@@ -92,6 +92,7 @@ static int op_generic_select_entry(struct PgpData *pd, const struct KeyEvent *ev
       switch ((*pkey)->trust & 0x03)
       {
         case 0:
+        default:
           str = _("ID has undefined validity. Do you really want to use the key?");
           break;
         case 1:

--- a/ncrypt/functions_smime.c
+++ b/ncrypt/functions_smime.c
@@ -70,6 +70,7 @@ static int op_generic_select_entry(struct SmimeData *sd, const struct KeyEvent *
         s = _("ID is expired/disabled/revoked. Do you really want to use the key?");
         break;
       case 'u':
+      default:
         s = _("ID has undefined validity. Do you really want to use the key?");
         break;
       case 'v':

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -224,6 +224,8 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
           case 'u':
             trust = 3;
             break;
+          default:
+            break;
         }
 
         if (!is_uid && !(*is_subkey && c_pgp_ignore_subkeys))
@@ -370,6 +372,9 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
 
             case 's':
               flags |= KEYFLAG_CANSIGN;
+              break;
+
+            default:
               break;
           }
         }

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -2101,6 +2101,9 @@ SecurityFlags pgp_class_send_menu(struct Email *e)
         e->security &= ~SEC_ENCRYPT;
         e->security |= SEC_SIGN;
         break;
+
+      default:
+        break;
     }
   }
 

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -298,8 +298,14 @@ static struct SmimeKey *smime_parse_key(char *buf)
             case 's':
               key->flags |= KEYFLAG_CANSIGN;
               break;
+
+            default:
+              break;
           }
         }
+        break;
+
+      default:
         break;
     }
   }
@@ -2173,6 +2179,8 @@ SecurityFlags smime_class_send_menu(struct Email *e)
                   rc = cs_subset_str_string_set(NeoMutt->sub, "smime_encrypt_with",
                                                 "des3", errmsg);
                   break;
+                default:
+                  break;
               }
               break;
 
@@ -2192,6 +2200,8 @@ SecurityFlags smime_class_send_menu(struct Email *e)
                 case 3:
                   rc = cs_subset_str_string_set(NeoMutt->sub, "smime_encrypt_with",
                                                 "rc2-128", errmsg);
+                  break;
+                default:
                   break;
               }
               break;
@@ -2213,6 +2223,8 @@ SecurityFlags smime_class_send_menu(struct Email *e)
                   rc = cs_subset_str_string_set(NeoMutt->sub, "smime_encrypt_with",
                                                 "aes256", errmsg);
                   break;
+                default:
+                  break;
               }
               break;
 
@@ -2224,6 +2236,9 @@ SecurityFlags smime_class_send_menu(struct Email *e)
             case -1: /* Ctrl-G or Enter */
               choice = 0;
               break;
+
+            default:
+              break;
           }
 
           if ((CSR_RESULT(rc) != CSR_SUCCESS) && !buf_is_empty(errmsg))
@@ -2233,6 +2248,9 @@ SecurityFlags smime_class_send_menu(struct Email *e)
         } while (choice == -1);
         break;
       }
+
+      default:
+        break;
     }
   }
 

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -1129,6 +1129,9 @@ static bool pattern_exec(struct Pattern *pat, PatternExecFlags flags,
       if (!e->env)
         return false;
       return pat->pat_not ^ (e->env->newsgroups && patmatch(pat, e->env->newsgroups));
+
+    default:
+      break;
   }
   mutt_error(_("error: unknown op %d (report this error)"), pat->op);
   return false;
@@ -1201,6 +1204,9 @@ bool mutt_pattern_alias_exec(struct Pattern *pat, PatternExecFlags flags,
       return pat->pat_not ^ (perform_alias_and(pat->child, flags, av, cache) > 0);
     case MUTT_PAT_OR:
       return pat->pat_not ^ (perform_alias_or(pat->child, flags, av, cache) > 0);
+
+    default:
+      break;
   }
 
   return false;

--- a/pattern/message.c
+++ b/pattern/message.c
@@ -316,6 +316,9 @@ bool eat_message_range(struct Pattern *pat, PatternCompFlags flags,
           s->dptr++;
         SKIPWS(s->dptr);
         return true;
+
+      default:
+        break;
     }
   }
   return false;

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -409,6 +409,9 @@ int mutt_pattern_func(struct MailboxView *mv, int op, char *prompt)
           case MUTT_UNTAG:
             mutt_set_flag(m, e, MUTT_TAG, (op == MUTT_TAG), true);
             break;
+
+          default:
+            break;
         }
       }
     }

--- a/pop/auth.c
+++ b/pop/auth.c
@@ -378,6 +378,8 @@ static enum PopAuthRes pop_auth_apop(struct PopAccountData *adata, const char *m
       return POP_A_SUCCESS;
     case -1:
       return POP_A_SOCKET;
+    default:
+      break;
   }
 
   // L10N: %s is the method name, e.g. Anonymous, CRAM-MD5, GSSAPI, SASL
@@ -437,6 +439,8 @@ static enum PopAuthRes pop_auth_user(struct PopAccountData *adata, const char *m
       return POP_A_SUCCESS;
     case -1:
       return POP_A_SOCKET;
+    default:
+      break;
   }
 
   mutt_error("%s %s", _("Login failed"), adata->err_msg);
@@ -480,6 +484,8 @@ static enum PopAuthRes pop_auth_oauth(struct PopAccountData *adata, const char *
       return POP_A_SUCCESS;
     case -1:
       return POP_A_SOCKET;
+    default:
+      break;
   }
 
   /* The error response was a SASL continuation, so "continue" it.
@@ -587,6 +593,9 @@ int pop_authenticate(struct PopAccountData *adata)
               }
               case -2:
                 rc = POP_A_FAILURE;
+                break;
+              default:
+                break;
             }
           }
 
@@ -622,6 +631,9 @@ int pop_authenticate(struct PopAccountData *adata)
           }
           case -2:
             rc = POP_A_FAILURE;
+            break;
+          default:
+            break;
         }
       }
 
@@ -647,6 +659,10 @@ int pop_authenticate(struct PopAccountData *adata)
     case POP_A_UNAVAIL:
       if (attempts == 0)
         mutt_error(_("No authenticators available"));
+      break;
+
+    default:
+      break;
   }
 
   return -2;

--- a/pop/lib.c
+++ b/pop/lib.c
@@ -233,6 +233,7 @@ static int pop_capabilities(struct PopAccountData *adata, int mode)
         break;
       }
       case -1:
+      default:
         return -1;
     }
   }

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -193,6 +193,7 @@ static int pop_read_header(struct PopAccountData *adata, struct Email *e)
       break;
     }
     case -3:
+    default:
     {
       mutt_error(_("Can't write header to temporary file"));
       break;

--- a/postpone/functions.c
+++ b/postpone/functions.c
@@ -248,6 +248,9 @@ static int op_search(struct PostponeData *pd, const struct KeyEvent *event)
     case OP_SEARCH_OPPOSITE:
       flags |= SEARCH_OPPOSITE;
       break;
+
+    default:
+      break;
   }
 
   int index = menu_get_index(pd->menu);

--- a/send/send.c
+++ b/send/send.c
@@ -1808,6 +1808,10 @@ full_fcc:
         case 3:  /* (s)kip */
           rc = 0;
           break;
+
+        default:
+          rc = 0;
+          break;
       }
     }
   }

--- a/version.c
+++ b/version.c
@@ -571,6 +571,8 @@ static void print_compile_options(const struct CompileOption *co, FILE *fp, bool
         else
           fmt = "%s ";
         break;
+      default:
+        break;
     }
     fprintf(fp, fmt, co[i].name);
   }


### PR DESCRIPTION
The second of the three categories flatcap flagged as good candidates on #4970 (the clang-tidy CI PR) — `bugprone-switch-missing-default-case`, 55 sites across 34 files, matching his count exactly.

Each switch was read in full to determine the semantically correct default, not just silenced mechanically:

- Most are op/command dispatchers or menu-choice switches (`event->op`, `mw_multi_choice()` results, single-letter responses) where the existing code already has an implicit fallback after the switch (a later `return`, or falling through to shared code) — these get `default: break;` to make that explicit without changing behaviour.
- A few (`external.c`, `muttlib.c`, `send/send.c`) explicitly mirror the existing "abort" case's behaviour, since leaving the loop/function state unchanged on an impossible value would otherwise risk an infinite loop or a silently-wrong return.
- `pattern/exec.c`'s two large op-table dispatchers already had an explicit "unknown op" error path after the switch; the new default falls through to it, matching the existing intent exactly.
- A handful (`pop/auth.c`, `pop/lib.c`, `pop/pop.c`) switch on documented function return codes; checked each callee's own `@retval` doc comment to confirm every case was genuinely covered, and matched the default to whichever existing case already represents "no specific outcome" for that function.

No case does more than reproduce behaviour the code already had implicitly — this is a defensiveness/documentation change, not a behaviour change.

**Verification**: `clang-tidy -p . <file> --checks='-*,bugprone-switch-missing-default-case'` now reports 0 warnings across all 55 sites (was 55). Full clean build, `make test` passes (all suites), `clang-format --dry-run -Werror` clean on every changed file (one pre-existing, unrelated violation in `autocrypt/gpgme.c` confirmed via `git stash` before and after — not introduced by this change).

**AI assistance**: the mechanical location of all 55 sites and the semantic analysis of each switch (tracing callee return contracts, existing fallback behaviour, and loop-safety implications) was done by Claude Code; I reviewed the reasoning and diff before this went up.