### PR TITLE
bugprone: parenthesize macro arguments/replacement lists

### DIFF
--- a/color/color.h
+++ b/color/color.h
@@ -99,7 +99,7 @@ enum ColorId
 
 extern const struct Mapping ColorFields[];
 
-#define COLOR_DEFAULT -1
+#define COLOR_DEFAULT (-1)
 
 struct ColorModuleData;
 

--- a/compress/private.h
+++ b/compress/private.h
@@ -26,8 +26,8 @@
 #define COMPRESS_OPS(_name, _min_level, _max_level) \
   const struct ComprOps compr_##_name##_ops = {     \
     .name       = #_name,                           \
-    .min_level  = _min_level,                       \
-    .max_level  = _max_level,                       \
+    .min_level  = (_min_level),                     \
+    .max_level  = (_max_level),                     \
     .open       = compr_##_name##_open,             \
     .compress   = compr_##_name##_compress,         \
     .decompress = compr_##_name##_decompress,       \

--- a/config/types.h
+++ b/config/types.h
@@ -119,7 +119,7 @@ enum ConfigTypeField
 #define D_SORT_LAST                D_CUSTOM_BIT_0                      ///< Sort flag for -last prefix
 #define D_SORT_REVERSE             D_CUSTOM_BIT_1                      ///< Sort flag for -reverse prefix
 
-#define IS_MAILBOX(flags)   ((CONFIG_TYPE(flags) == DT_STRING) && (flags & D_STRING_MAILBOX))
-#define IS_COMMAND(flags)   ((CONFIG_TYPE(flags) == DT_STRING) && (flags & D_STRING_COMMAND))
+#define IS_MAILBOX(flags)   ((CONFIG_TYPE(flags) == DT_STRING) && ((flags) & D_STRING_MAILBOX))
+#define IS_COMMAND(flags)   ((CONFIG_TYPE(flags) == DT_STRING) && ((flags) & D_STRING_COMMAND))
 
 #endif /* MUTT_CONFIG_TYPES_H */

--- a/email/mime.h
+++ b/email/mime.h
@@ -91,7 +91,8 @@ extern const char MimeSpecials[];
 
 /// Get the type name of a body part
 #define BODY_TYPE(body)                                                        \
-  ((body->type == TYPE_OTHER) && body->xtype ? body->xtype : BodyTypes[(body->type)])
+  (((body)->type == TYPE_OTHER) && (body)->xtype ? (body)->xtype :             \
+                                                   BodyTypes[((body)->type)])
 
 /// Get the encoding name for an encoding type
 #define ENCODING(x) BodyEncodings[(x)]

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -49,7 +49,7 @@ enum MuttWindowSize
   MUTT_WIN_SIZE_MINIMISE,  ///< Window size depends on its children
 };
 
-#define MUTT_WIN_SIZE_UNLIMITED -1 ///< Use as much space as possible
+#define MUTT_WIN_SIZE_UNLIMITED (-1) ///< Use as much space as possible
 
 /**
  * struct WindowState - The current, or old, state of a Window

--- a/gui/opcodes.h
+++ b/gui/opcodes.h
@@ -31,9 +31,9 @@
 const char *opcodes_get_description(int op);
 const char *opcodes_get_name       (int op);
 
-#define OP_REPAINT     -3 ///< Repaint is needed
-#define OP_TIMEOUT     -2 ///< 1 second with no events
-#define OP_ABORT       -1 ///< $abort_key pressed (Ctrl-G)
+#define OP_REPAINT     (-3) ///< Repaint is needed
+#define OP_TIMEOUT     (-2) ///< 1 second with no events
+#define OP_ABORT       (-1) ///< $abort_key pressed (Ctrl-G)
 
 // clang-format off
 #define OPS_ATTACH(_fmt) \

--- a/hcache/lib.h
+++ b/hcache/lib.h
@@ -165,7 +165,7 @@ struct HCacheEntry hcache_fetch_email(struct HeaderCache *hc, const char *key, s
 
 char *hcache_fetch_raw_str(struct HeaderCache *hc, const char *key, size_t keylen);
 bool  hcache_fetch_raw_obj_full(struct HeaderCache *hc, const char *key, size_t keylen, void *dst, size_t dstlen);
-#define hcache_fetch_raw_obj(hc, key, keylen, dst) hcache_fetch_raw_obj_full(hc, key, keylen, dst, sizeof(*dst))
+#define hcache_fetch_raw_obj(hc, key, keylen, dst) hcache_fetch_raw_obj_full(hc, key, keylen, dst, sizeof(*(dst)))
 
 int hcache_store_raw(struct HeaderCache *hc, const char *key, size_t keylen,
                           void *data, size_t dlen);

--- a/imap/private.h
+++ b/imap/private.h
@@ -49,12 +49,12 @@ struct Progress;
 #define IMAP_LOG_PASS  5   ///< Log passwords (dangerous!)
 
 /* IMAP command responses. Used in ImapCommand.state too */
-#define IMAP_RES_NO       -2  ///< `<tag> NO ...`
-#define IMAP_RES_BAD      -1  ///< `<tag> BAD ...`
-#define IMAP_RES_OK        0  ///< `<tag> OK ...`
-#define IMAP_RES_CONTINUE  1  ///< `* ...`
-#define IMAP_RES_RESPOND   2  ///< `+`
-#define IMAP_RES_NEW       3  ///< ImapCommand.state additions
+#define IMAP_RES_NO       (-2)  ///< `<tag> NO ...`
+#define IMAP_RES_BAD      (-1)  ///< `<tag> BAD ...`
+#define IMAP_RES_OK         0   ///< `<tag> OK ...`
+#define IMAP_RES_CONTINUE   1   ///< `* ...`
+#define IMAP_RES_RESPOND    2   ///< `+`
+#define IMAP_RES_NEW        3   ///< ImapCommand.state additions
 
 /// Length of IMAP sequence buffer
 #define SEQ_LEN 16

--- a/mutt/array.h
+++ b/mutt/array.h
@@ -107,7 +107,7 @@
  *       explicitly set. In that case, the memory returned is all zeroes.
  */
 #define ARRAY_GET(head, idx)                                                   \
-  ((idx >= 0) && ((head)->size > (idx)) ? &(head)->entries[(idx)] : NULL)
+  (((idx) >= 0) && ((head)->size > (idx)) ? &(head)->entries[(idx)] : NULL)
 
 /**
  * ARRAY_SET - Set an element in the array
@@ -261,7 +261,7 @@
 #define ARRAY_FOREACH_FROM_TO(elem, head, from, to)                            \
   for (int ARRAY_FOREACH_IDX_##elem = (from);                                  \
        (ARRAY_FOREACH_IDX_##elem < (to)) &&                                    \
-       (elem = ARRAY_GET(head, ARRAY_FOREACH_IDX_##elem));                     \
+       ((elem) = ARRAY_GET(head, ARRAY_FOREACH_IDX_##elem));                   \
        ARRAY_FOREACH_IDX_##elem++)
 
 /**
@@ -312,7 +312,7 @@
 #define ARRAY_FOREACH_REVERSE_FROM_TO(elem, head, from, to)                    \
   for (int ARRAY_FOREACH_IDX_##elem = (from) - 1;                              \
        (ARRAY_FOREACH_IDX_##elem >= (to)) &&                                   \
-       (elem = ARRAY_GET(head, ARRAY_FOREACH_IDX_##elem));                     \
+       ((elem) = ARRAY_GET(head, ARRAY_FOREACH_IDX_##elem));                   \
        ARRAY_FOREACH_IDX_##elem--)
 
 /**
@@ -322,7 +322,7 @@
  * @retval n   The index of element in the array
  */
 #define ARRAY_IDX(head, elem)                                                  \
-  (elem - (head)->entries)
+  ((elem) - (head)->entries)
 
 /**
  * ARRAY_INSERT - Insert an element into the, shifting up the subsequent entries

--- a/mutt/mbyte.h
+++ b/mutt/mbyte.h
@@ -34,12 +34,12 @@ extern bool OptLocales;
 
 #ifdef LOCALES_HACK
 #define IsPrint(ch) (isprint((unsigned char) (ch)) || ((unsigned char) (ch) >= 0xa0))
-#define IsWPrint(wc) (iswprint(wc) || wc >= 0xa0)
+#define IsWPrint(wc) (iswprint(wc) || (wc) >= 0xa0)
 #else
 #define IsPrint(ch) (isprint((unsigned char) (ch)) || (OptLocales ? 0 : ((unsigned char) (ch) >= 0xa0)))
-#define IsWPrint(wc) (iswprint(wc) || (OptLocales ? 0 : (wc >= 0xa0)))
+#define IsWPrint(wc) (iswprint(wc) || (OptLocales ? 0 : ((wc) >= 0xa0)))
 #endif
-#define IsBOM(wc) (wc == L'\xfeff')
+#define IsBOM(wc) ((wc) == L'\xfeff')
 
 int    mutt_mb_charlen(const char *s, int *width);
 int    mutt_mb_filter_unprintable(char **s);

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -51,7 +51,7 @@ void string_array_clear(struct StringArray *arr);
  * on some systems */
 #define SKIPWS(ch)                                                             \
   while (*(ch) && mutt_isspace(*(ch)))                              \
-    ch++;
+    (ch)++;
 
 #define terminate_string(str, strlen, buflen)                                  \
   (str)[MIN((strlen), (buflen))] = '\0'

--- a/notmuch/private.h
+++ b/notmuch/private.h
@@ -50,8 +50,8 @@ struct Mailbox;
  * - libnotmuch 5.1 released with notmuch 0.26. notmuch 0.26.1 fixed version.
  */
 #define LIBNOTMUCH_CHECK_VERSION(major, minor, micro)                              \
-  (major == 5 && minor == 4 && HAVE_NOTMUCH_DATABASE_OPEN_WITH_CONFIG)          || \
-  (major == 5 && minor == 1 && HAVE_NOTMUCH_DATABASE_INDEX_FILE)                || \
+  ((major) == 5 && (minor) == 4 && HAVE_NOTMUCH_DATABASE_OPEN_WITH_CONFIG)      || \
+  ((major) == 5 && (minor) == 1 && HAVE_NOTMUCH_DATABASE_INDEX_FILE)            || \
   ((LIBNOTMUCH_MAJOR_VERSION > (major) ||                                          \
    (LIBNOTMUCH_MAJOR_VERSION == (major) && LIBNOTMUCH_MINOR_VERSION > (minor))  || \
    (LIBNOTMUCH_MAJOR_VERSION == (major) &&                                         \

--- a/pattern/private.h
+++ b/pattern/private.h
@@ -146,7 +146,7 @@ static inline int email_msgno(struct Email *e)
   return e->msgno + 1;
 }
 
-#define MUTT_MAXRANGE -1
+#define MUTT_MAXRANGE (-1)
 
 extern const struct PatternFlags Flags[];
 


### PR DESCRIPTION
The last of the three categories flatcap flagged as good candidates on #4970 — `bugprone-macro-parentheses`. 28 sites across 13 files fixed; 7 confirmed as genuine false positives and deliberately left untouched (see below).

Every site was checked against its actual call sites for a live bug, not just mechanically wrapped:

- Simple negative-constant macros (`COLOR_DEFAULT`, `MUTT_WIN_SIZE_UNLIMITED`, `OP_REPAINT`/`TIMEOUT`/`ABORT`, `IMAP_RES_NO`/`BAD`, `MUTT_MAXRANGE`) get their replacement list wrapped.
- Value-expression arguments used unparenthesized next to an operator (`config/types.h`'s `IS_MAILBOX`/`IS_COMMAND`, `mutt/array.h`'s `ARRAY_GET`, `mutt/mbyte.h`'s `IsWPrint`/`IsBOM`, `notmuch/private.h`'s `LIBNOTMUCH_CHECK_VERSION`) get the argument wrapped — no live caller currently passes a compound expression, but this is exactly the class of bug that bites the next caller who does.
- `mutt/string2.h`'s `SKIPWS` and `mutt/array.h`'s `ARRAY_FOREACH_(REVERSE_)FROM_TO` wrap the argument even though it's used as an assignment/increment target, since `(x)++`/`(x) = ...` are equivalent to the unparenthesized form for any valid lvalue — harmless, satisfies the check.

Three false-positive patterns confirmed and left alone, since parenthesizing would either not compile or change meaning:

- `mutt/atoi.h:39` and `mutt/memory.h:57`: the macro argument is a **type name** (a function parameter's type, and a `_Generic` type-association respectively), not a value expression — wrapping a type name in parens isn't valid there.
- `mutt/array.h:52`: same class — `T` is the array element's type name in a struct member declaration.
- `mutt/queue.h:437`/`632`/`887`/`896` (all four remaining sites in that file): `field` is passed as a **member-designator** into `__containerof()` (built on `offsetof()`), not a value expression. Verified empirically with a standalone test file: parenthesizing a member-designator argument to `offsetof()` is a genuine compile error ("expected identifier"), not just a style question.

**Verification**: `clang-tidy -p . <file> --checks='-*,bugprone-macro-parentheses' --header-filter='.*'` now reports only the 7 confirmed-false-positive sites above (was 28 fixable + 7 false positives = 35 total unique locations). Full clean build, `make test` passes (all suites), `clang-format --dry-run -Werror` shows no *new* violations in any changed file (checked differentially against each file's pre-existing state, since several of these headers already had unrelated formatting drift).

**AI assistance**: the mechanical location of all sites, the call-site tracing to distinguish live risk from defensive-only fixes, and the identification + empirical verification of the false positives was done by Claude Code; I reviewed the reasoning and diff, including the compile-error test for the `offsetof()` case, before this went up.