### PR TITLE
compose: honour unlink flag when detaching files

### DIFF
--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1290,9 +1290,6 @@ static int op_attach_detach(struct ComposeFunctionData *fdata, const struct KeyE
         continue;
       struct AttachPtr *ap = *app;
 
-      if (ap->unowned)
-        ap->body->unlink = false;
-
       const int index = body_index(actx, ap->body);
       if ((index >= 0) && (delete_attachment(actx, index, fdata->n->sub) == 0))
         rc = FR_SUCCESS;
@@ -1313,10 +1310,6 @@ static int op_attach_detach(struct ComposeFunctionData *fdata, const struct KeyE
   }
   else
   {
-    struct AttachPtr *cur_att = current_attachment(actx, menu);
-    if (cur_att->unowned)
-      cur_att->body->unlink = false;
-
     const int index = menu_get_index(menu);
     if (delete_attachment(actx, index, fdata->n->sub) == -1)
     {


### PR DESCRIPTION
The compose detach handler cleared `Body::unlink` for attachments backed by user-owned files immediately before freeing the body.
This defeated an explicit `<toggle-unlink>` request and also affected files copied by `<get-attachment>`.

Leave the unlink decision to `mutt_body_free()`, which already removes files only when `Body::unlink` is set.
The separate compose-abort path still clears unlink for unowned attachments, so abandoning a draft continues to preserve the original user files.

Fixes #4980
