### PR TITLE
gui: add mview_email_at/mview_email_count accessors

### DIFF
--- a/gui/mview.c
+++ b/gui/mview.c
@@ -366,6 +366,46 @@ bool message_is_tagged(struct Email *e)
 }
 
 /**
+ * mview_email_count - Number of Emails in a MailboxView
+ * @param mv MailboxView
+ * @retval num Number of Emails
+ *
+ * This safely gets the result of the following:
+ * - `mv->mailbox->msg_count`
+ */
+int mview_email_count(const struct MailboxView *mv)
+{
+  if (!mv || !mv->mailbox)
+    return 0;
+
+  return mv->mailbox->msg_count;
+}
+
+/**
+ * mview_email_at - Get an Email by physical (insertion-order) index
+ * @param mv  MailboxView
+ * @param num Physical index number (0-based; matches Email::msgno)
+ * @retval ptr  Email
+ * @retval NULL No Email selected, or bad index values
+ *
+ * This safely gets the result of the following:
+ * - `mv->mailbox->emails[num]`
+ *
+ * @note This is physical/insertion order, NOT display/sort order.
+ *       For display (vnum) order, see mutt_get_virt_email().
+ */
+struct Email *mview_email_at(const struct MailboxView *mv, int num)
+{
+  if (!mv || !mv->mailbox || !mv->mailbox->emails)
+    return NULL;
+
+  if ((num < 0) || (num >= mv->mailbox->msg_count))
+    return NULL;
+
+  return mv->mailbox->emails[num];
+}
+
+/**
  * mutt_get_virt_email - Get a virtual Email
  * @param m    Mailbox
  * @param vnum Virtual index number

--- a/gui/mview.h
+++ b/gui/mview.h
@@ -78,6 +78,8 @@ struct MailboxView *mview_new             (struct Mailbox *m, struct Notify *par
 void                mview_update          (struct MailboxView *mv);
 bool                mview_has_limit       (const struct MailboxView *mv);
 struct Mailbox *    mview_mailbox         (struct MailboxView *mv);
+int                 mview_email_count     (const struct MailboxView *mv);
+struct Email *      mview_email_at        (const struct MailboxView *mv, int num);
 
 bool message_is_tagged(struct Email *e);
 struct Email *mutt_get_virt_email(struct Mailbox *m, int vnum);

--- a/index/functions.c
+++ b/index/functions.c
@@ -1292,18 +1292,18 @@ static int op_jump(struct IndexFunctionData *fdata, const struct KeyEvent *event
     }
   }
 
-  if ((num < 1) || (num > shared->mailbox->msg_count))
+  if ((num < 1) || (num > mview_email_count(shared->mailbox_view)))
   {
     mutt_warning(_("Invalid message number"));
   }
-  else if (!shared->mailbox->emails[num - 1] ||
-           !shared->mailbox->emails[num - 1]->visible)
+  else if (!mview_email_at(shared->mailbox_view, num - 1) ||
+           !mview_email_at(shared->mailbox_view, num - 1)->visible)
   {
     mutt_warning(_("That message is not visible"));
   }
   else
   {
-    struct Email *e = shared->mailbox->emails[num - 1];
+    struct Email *e = mview_email_at(shared->mailbox_view, num - 1);
 
     if (mutt_messages_in_thread(shared->mailbox, e, MIT_POSITION) > 1)
     {

--- a/index/subjectrx.c
+++ b/index/subjectrx.c
@@ -172,11 +172,9 @@ void subjectrx_clear_mods(struct MailboxView *mv)
   if (!mv || !mv->mailbox)
     return;
 
-  struct Mailbox *m = mv->mailbox;
-
-  for (int i = 0; i < m->msg_count; i++)
+  for (int i = 0; i < mview_email_count(mv); i++)
   {
-    struct Email *e = m->emails[i];
+    struct Email *e = mview_email_at(mv, i);
     if (!e || !e->env)
       continue;
     FREE(&e->env->disp_subj);

--- a/test/common.c
+++ b/test/common.c
@@ -490,6 +490,16 @@ int mutt_thread_set_flag(struct Mailbox *m, struct Email *e,
   return 0;
 }
 
+struct Email *mview_email_at(const struct MailboxView *mv, int num)
+{
+  return NULL;
+}
+
+int mview_email_count(const struct MailboxView *mv)
+{
+  return 0;
+}
+
 void mview_free(struct MailboxView **ptr)
 {
 }


### PR DESCRIPTION
Small PR with the accessor + 2 migrated call sites as the initial prototype for step 1 of the Branch-by-Abstraction plan from #4977 -- happy to follow up with the rest of the `index/` call sites in separate PRs once you've had a look at the pattern.

## What's here

- `mview_email_count()` / `mview_email_at()` in `gui/mview.c`/`gui/mview.h`, mirroring `mutt_get_virt_email()`'s existing NULL/bounds-check style exactly.
- Two call sites migrated as the proof of the pattern: `subjectrx_clear_mods()` (a plain loop) and `op_jump()` (a single-index lookup) -- the simplest example of each shape, deliberately not a full migration.

## A build-system wrinkle found along the way

Migrating even these two sites forces the real `gui/mview.o` into `test/neomutt-test`'s link for the first time, since `test/common.c`/`test/pattern/dummy.c` stub every other public `mview.c` function specifically so the real object (which pulls in imap/ncrypt/pattern/mx) never needs linking. Added matching stubs for the two new functions to `test/common.c` -- without them, `make test` fails to link. No new unit tests for the two functions themselves in this PR, since exercising the real (non-stubbed) implementation would reintroduce the same conflict; flagging that as a separate decision about the stub/dummy test architecture rather than folding it in here.

## Verification

- Full clean build, zero new warnings.
- `test/neomutt-test` links cleanly (confirmed it doesn't without the `test/common.c` addition above).
- Manually exercised both migrated call sites against a scratch Maildir and confirmed byte-for-byte identical behaviour against an unmodified `main` build with the same setup.

AI assistance: implementation, codebase research, and verification done by Claude Code; reviewed by me before opening this PR.
