### PR TITLE
openssl: stop retrying without data

### DIFF
--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -1359,7 +1359,7 @@ retry:
   else if (BIO_should_retry(SSL_get_rbio(data->ssl)))
   {
     // Temporary failure, e.g. signal received
-    if (raw_socket_poll(conn, 0) >= 0)
+    if (raw_socket_poll(conn, 0) > 0)
     {
       goto retry;
     }


### PR DESCRIPTION
* **What does this PR do?**

Fix an infinite OpenSSL read retry after a socket timeout.

When `SSL_read()` reaches `SO_RCVTIMEO`, OpenSSL reports a retryable
operation. `raw_socket_poll(conn, 0)` returns `0` when no data is readable,
but the current `>= 0` test treats that result as success and starts another
blocking `SSL_read()`. The cycle can then repeat indefinitely.

Require a positive poll result so the read is retried only when the socket is
actually readable.

`raw_socket_poll()` is a readiness check, not a connection-health check, and
`SSL_read()` has already waited for the configured socket timeout before this
zero-timeout poll.

* **Screenshots (if relevant)**

Not applicable.

* **Does this PR meet the acceptance criteria?**

  - Documentation is unchanged because this corrects existing timeout
    behavior.
  - The OpenSSL build and full unit-test suite pass.
  - `conn/openssl.c` passes the CI-pinned `clang-format 22.1.8` check.
  - The current unit-test framework does not provide a TLS socket integration
    fixture. A deterministic local integration test is described below.

* **What are the relevant issue numbers?**

Related to #4197.

Follow-up to #4738.

## Validation

Tested on arm64 Darwin 25.6 with OpenSSL 3.6.3.

The integration harness starts a local TLS server that completes the TLS
handshake but deliberately withholds the IMAP greeting. NeoMutt is configured
with `socket_timeout=2` and run under an independent seven-second cutoff.

```text
baseline rc=124 elapsed=7s outer-timeout=yes
patched  rc=1   elapsed=2s outer-timeout=no
```

The baseline must be killed by the outer timeout. The patched build returns
when its configured socket timeout expires.

## AI assistance disclosure

OpenAI Codex assisted with inspecting the existing implementation, diagnosing
the retry condition, preparing the one-character source change, running the
build and validation workflow, and drafting the commit and pull-request text.
The author reviewed the relevant OpenSSL and socket control flow and personally
validated the diagnosis and fix.
