### PR TITLE
gui: migrate 7 more raw emails[] GUI call sites to mview_email_at

### DIFF
--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -441,7 +441,7 @@ static void update_index_threaded(struct MailboxView *mv, enum MxStatus check, i
   {
     save_new = MUTT_MEM_MALLOC(num_new, struct Email *);
     for (int i = oldcount; i < m->msg_count; i++)
-      save_new[i - oldcount] = m->emails[i];
+      save_new[i - oldcount] = mview_email_at(mv, i);
   }
 
   /* Sort first to thread the new messages, because some patterns
@@ -454,7 +454,7 @@ static void update_index_threaded(struct MailboxView *mv, enum MxStatus check, i
   {
     for (int i = 0; i < m->msg_count; i++)
     {
-      struct Email *e = m->emails[i];
+      struct Email *e = mview_email_at(mv, i);
       if (!e)
         continue;
 
@@ -521,7 +521,7 @@ static void update_index_unthreaded(struct MailboxView *mv, enum MxStatus check)
     mv->mailbox->vcount = mv->vsize = 0;
     for (int i = 0; i < mv->mailbox->msg_count; i++)
     {
-      struct Email *e = mv->mailbox->emails[i];
+      struct Email *e = mview_email_at(mv, i);
       if (!e)
         break;
 

--- a/index/functions.c
+++ b/index/functions.c
@@ -597,7 +597,7 @@ static int ea_add_selection_threads(struct EmailArray *ea,
   struct Mailbox *m = mv->mailbox;
   for (int i = 0; i < m->msg_count; i++)
   {
-    struct Email *et = m->emails[i];
+    struct Email *et = mview_email_at(mv, i);
     if (!et)
       break;
     if (!message_is_tagged(et))
@@ -3424,7 +3424,7 @@ static int op_get_children(struct IndexFunctionData *fdata, const struct KeyEven
       /* try to restore old position */
       for (int i = 0; i < m->msg_count; i++)
       {
-        e2 = m->emails[i];
+        e2 = mview_email_at(mv, i);
         if (!e2)
           break;
         if (e2->index == oldindex)
@@ -3511,8 +3511,8 @@ static int op_get_message(struct IndexFunctionData *fdata, const struct KeyEvent
     int rc2 = nntp_check_msgid(m, buf_string(buf));
     if (rc2 == 0)
     {
-      e = m->emails[m->msg_count - 1];
       struct MailboxView *mv = shared->mailbox_view;
+      e = mview_email_at(mv, m->msg_count - 1);
       mutt_sort_headers(mv, false);
       menu_set_index(priv->menu, e->vnum);
       menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);

--- a/index/index.c
+++ b/index/index.c
@@ -202,7 +202,7 @@ static int config_reply_regex(struct MailboxView *mv)
 
   for (int i = 0; i < m->msg_count; i++)
   {
-    struct Email *e = m->emails[i];
+    struct Email *e = mview_email_at(mv, i);
     if (!e)
       break;
     struct Envelope *env = e->env;


### PR DESCRIPTION
Follow-up to `mview_email_at()`/`mview_email_count()` (this branch's initial commit) -- continuing the raw-`emails[]` GUI call-site migration per your "yes please" on #4977.

## What's here

12 candidate raw-`emails[]` sites exist across `index/dlg_index.c`, `index/index.c` and `index/functions.c`. This PR covers the 7 where a `struct MailboxView *` was already directly available in scope -- either as a function parameter or a local variable already declared before the loop -- so each change is a pure 1:1 swap with no new plumbing:

- `ea_add_selection_threads()` (functions.c) -- `mv` is a parameter
- `op_get_children()` (functions.c) -- `mv` already local, above the loop
- `op_get_message()` (functions.c) -- `mv`'s declaration moved 2 lines earlier so it exists before its first use; no behaviour change
- `config_reply_regex()` (index.c) -- `mv` is a parameter
- `update_index_threaded()`, two sites (dlg_index.c) -- `mv` is a parameter
- `update_index_unthreaded()` (dlg_index.c) -- `mv` is a parameter

## What's deliberately left out

The remaining 5 sites (`op_resend()`, `op_tag()` in functions.c; two sites in index.c; one in `dlg_index()`'s main loop) only have a `Mailbox *` or `IndexSharedData *` directly in scope, not a `MailboxView *`. Using them would mean pulling in `shared->mailbox_view` instead of the `mv` already threaded through the functions above -- that deserves its own look at whether `shared->mailbox_view` and the `Mailbox *` in scope are guaranteed to agree at each of those specific points, rather than assuming so. Left for a separate follow-up PR.

## Verification

- Full clean build, zero new warnings.
- `test/neomutt-test` suite passes, 640/640, unchanged from baseline.
- `mview_email_at()`'s own documented contract (`mv->mailbox->emails[num]`, the exact expression each of these seven sites already used, plus a bounds check none of these bounded loops can trip) makes this a mechanical, behaviour-preserving substitution rather than a new code path needing fresh interactive verification.

AI assistance: implementation, codebase research, and verification done by Claude Code; reviewed by me before opening this PR.