### PR TITLE
fix invalid-shift(UBSan) in `mutt_decode_base64()`

### DIFF
--- a/email/handler.c
+++ b/email/handler.c
@@ -1601,7 +1601,11 @@ void mutt_decode_base64(struct State *state, size_t len, bool istext, iconv_t cd
     }
 
     const int c1 = base64val(buf[0]);
+    if (c1 == -1) /* '=' (or any non-base64 char) at slot 0: stop */
+      break;
     const int c2 = base64val(buf[1]);
+    if (c2 == -1) /* '=' at slot 1: invalid padding, stop */
+      break;
 
     /* first char */
     ch = (c1 << 2) | (c2 >> 4);


### PR DESCRIPTION
This PR attempts to fix [#5008](https://github.com/neomutt/neomutt/issues/5008#issue-5106624064)

## Problem

`mutt_decode_base64()` (`email/handler.c`) decodes base64 in 4-character quads. Its fill loop admits the `=` padding character at **any** buffer slot via the clause `(base64val(ch) != -1) || (ch == '=')` (`handler.c:1589`), but the decode logic only special-cases `=` at slots 2 (`:1617`) and 3 (`:1633`). At slots 0 and 1 the code calls `base64val('=')` directly, which returns the sentinel `-1` (`Index64[61] == -1`, `mutt/base64.c`), and then evaluates:

```c
const int c1 = base64val(buf[0]);   // '=' -> -1
const int c2 = base64val(buf[1]);
ch = (c1 << 2) | (c2 >> 4);         // :1604 — (-1) << 2 == UB
```

Left-shifting a negative signed value is undefined behavior (C11 §6.5.7). Under `-fsanitize=undefined` this is reported as `left shift of negative value` and aborts; on a non-sanitized two's-complement build it wraps without trapping and the function silently emits wrong decoded bytes from malformed padding.

The trigger is any base64 body with `=` padding at an invalid (leading) position (e.g. the 4-byte input `"=utf"`), reachable through the core MIME base64 decode path with no privileges required. 
## Fix

Extend the existing `=` guard (already present at slots 2 and 3) to slots 0 and 1, so a `=` (or any non-base64 byte) at a leading position stops decoding instead of being shifted. This mirrors the guarded standalone decoder in `mutt/base64.c`, which validates `base64val(d) == BAD` before every shift.

```diff
--- a/email/handler.c
+++ b/email/handler.c
@@ -1601,7 +1601,11 @@ void mutt_decode_base64(struct State *state, size_t len, bool istext, iconv_t cd)

     const int c1 = base64val(buf[0]);
+    if (c1 == -1)          /* '=' / non-base64 at slot 0: stop */
+      break;
     const int c2 = base64val(buf[1]);
+    if (c2 == -1)          /* '=' at slot 1: invalid padding, stop */
+      break;

     /* first char */
     ch = (c1 << 2) | (c2 >> 4);
```

`=` at slot 0 or 1 is structurally malformed under RFC 4648 (a single leading data char carries only 6 bits and cannot yield an output byte, and interior padding is forbidden), so `break` — the same action the decoder already takes for valid tail padding at slots 2/3 and for a short final quad (`if (i != 4) break;`, `:1592`) — is the spec-correct response. No signature or return-value change is needed (`mutt_decode_base64` returns `void`), and the guards never fire on well-formed input, so `XXXX` / `XXX=` / `XX==` all decode unchanged.

## Verification

1. **Reproduce (pre-fix):** build NeoMutt with `-fsanitize=address,undefined`, compile `poc.cpp` against `lib*.a` (`-lncursesw -ltinfo`), run `./poc` → UBSan reports `left shift of negative value -1` at `handler.c:1604`.
2. **Fixed:** apply the patch, rebuild, recompile, re-run `./poc` → clean exit, no UBSan report (3/3 deterministic clean runs). The PoC now hits `if (c1 == -1) break;` on the first quad and returns without shifting.
3. **Regression — valid base64:** feed `SGVsbG8=` (`Hello`) and a full quad (`dGVzdA==`, `test`) through the same harness; decoded output is byte-identical to the pre-fix build (the new guards never fire on well-formed input).
4. **Regression — tail padding:** confirm `XX==` and `XXX=` still yield 1 and 2 output bytes respectively (the existing `:1617`/`:1633` breaks are untouched).

## Submission Statement

This fix was generated using Claude Code and manually reviewed, tested, and verified by a team member.

Signed-off-by: FuzzAnything <fuzzanything@gmail.com>