### PR TITLE
fix: null-pointer dereference in mutt_replacelist_match()

### DIFF
--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -273,7 +273,7 @@ int mutt_regexlist_remove(struct RegexList *rl, const char *str)
 int mutt_replacelist_add(struct ReplaceList *rl, const char *pat,
                          const char *templ, struct Buffer *err)
 {
-  if (!rl || !pat || (*pat == '\0') || !templ || (*templ == '\0'))
+  if (!rl || !pat || (*pat == '\0') || !templ)
     return 0;
 
   struct Regex *rx = mutt_regex_compile(pat, REG_ICASE);

--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -273,7 +273,7 @@ int mutt_regexlist_remove(struct RegexList *rl, const char *str)
 int mutt_replacelist_add(struct ReplaceList *rl, const char *pat,
                          const char *templ, struct Buffer *err)
 {
-  if (!rl || !pat || (*pat == '\0') || !templ)
+  if (!rl || !pat || (*pat == '\0') || !templ || (*templ == '\0'))
     return 0;
 
   struct Regex *rx = mutt_regex_compile(pat, REG_ICASE);
@@ -505,33 +505,36 @@ bool mutt_replacelist_match(struct ReplaceList *rl, char *buf, size_t buflen, co
       mutt_debug(LL_DEBUG5, "%d subs\n", (int) np->regex->regex->re_nsub);
 
       /* Copy template into buf, with substitutions. */
-      for (p = np->templ; *p && (tlen < (buflen - 1));)
+      if (np->templ)
       {
-        /* backreference to pattern match substring, eg. %1, %2, etc) */
-        if (*p == '%')
+        for (p = np->templ; *p && (tlen < (buflen - 1));)
         {
-          char *e = NULL; /* used as pointer to end of integer backreference in strtol() call */
-
-          p++; /* skip over % char */
-          long n = strtol(p, &e, 10);
-          /* Ensure that the integer conversion succeeded (e!=p) and bounds check.  The upper bound check
-           * should not strictly be necessary since add_to_spam_list() finds the largest value, and
-           * the static array above is always large enough based on that value. */
-          if ((e != p) && (n >= 0) && (n < np->nmatch) && (pmatch[n].rm_so != -1))
+          /* backreference to pattern match substring, eg. %1, %2, etc) */
+          if (*p == '%')
           {
-            /* copy as much of the substring match as will fit in the output buffer, saving space for
-             * the terminating nul char */
-            for (int idx = pmatch[n].rm_so;
-                 (idx < pmatch[n].rm_eo) && (tlen < (buflen - 1)); idx++)
+            char *e = NULL; /* used as pointer to end of integer backreference in strtol() call */
+
+            p++; /* skip over % char */
+            long n = strtol(p, &e, 10);
+            /* Ensure that the integer conversion succeeded (e!=p) and bounds check.  The upper bound check
+             * should not strictly be necessary since add_to_spam_list() finds the largest value, and
+             * the static array above is always large enough based on that value. */
+            if ((e != p) && (n >= 0) && (n < np->nmatch) && (pmatch[n].rm_so != -1))
             {
-              buf[tlen++] = str[idx];
+              /* copy as much of the substring match as will fit in the output buffer, saving space for
+               * the terminating nul char */
+              for (int idx = pmatch[n].rm_so;
+                   (idx < pmatch[n].rm_eo) && (tlen < (buflen - 1)); idx++)
+              {
+                buf[tlen++] = str[idx];
+              }
             }
+            p = e; /* skip over the parsed integer */
           }
-          p = e; /* skip over the parsed integer */
-        }
-        else
-        {
-          buf[tlen++] = *p++;
+          else
+          {
+            buf[tlen++] = *p++;
+          }
         }
       }
       /* tlen should always be less than buflen except when buflen<=0


### PR DESCRIPTION
This PR attempts to fix [#5010](https://github.com/neomutt/neomutt/issues/5010#issue-5107254173)

## Problem

`mutt_replacelist_add()` only NULL-checks its `templ` argument, never testing for the empty string:

```c
if (!rl || !pat || (*pat == '\0') || !templ)
  return 0;
...
np->templ = mutt_str_dup(templ);
```

`mutt_str_dup()` is documented to return `NULL` for an empty string (`mutt/string.c`: *"str was NULL or empty"*). So a non-NULL but empty template `""` leaves `np->templ == NULL` on a node that is still inserted into the list. `mutt_replacelist_match()` then dereferences it with no guard as soon as the regex matches:

```c
for (p = np->templ; *p && (tlen < (buflen - 1));)   /* mutt/regex.c:508 — *p reads NULL */
```

This is a deterministic null-pointer dereference (UBSan null load + ASan SEGV). The sibling function `mutt_replacelist_apply()` already guards the identical loop with `if (np->templ)` at `mutt/regex.c:400` — `match` is simply missing the check `apply` has, so the two are inconsistent.

The `ReplaceList` mechanism backs NeoMutt's `subjectrx`/`spam` commands, so an empty configured replacement template is a realistic, user-reachable trigger rather than an artificial input.

## Fix

Two complementary, defense-in-depth changes to `mutt/regex.c`. Either alone prevents the crash; together they restore the invariant (`np->templ != NULL` for every list node) *and* make `match` as robust as `apply`.

### 1. Reject empty templates at construction (`mutt_replacelist_add`)

Before:

```c
if (!rl || !pat || (*pat == '\0') || !templ)
  return 0;
```

After:

```c
if (!rl || !pat || (*pat == '\0') || !templ || (*templ == '\0'))
  return 0;
```

### 2. Guard `np->templ` in the consumer (`mutt_replacelist_match`)

Before:

```c
/* Copy template into buf, with substitutions. */
for (p = np->templ; *p && (tlen < (buflen - 1));)
{
  /* ... substitution loop body ... */
}
```

After:

```c
/* Copy template into buf, with substitutions.
 * Guard np->templ like mutt_replacelist_apply() does. */
if (np->templ)
{
  for (p = np->templ; *p && (tlen < (buflen - 1));)
  {
    /* ... substitution loop body, unchanged ... */
  }
}
```

## Verification

Reproduced deterministically against commit `fb8e54b69cff6c7257d348122d19459cba5539bc ` with an ASan+UBSan static build of `libneomutt.a` and a standalone PoC that calls the public API:

```c
mutt_replacelist_add(&repl, "a", "", err);                 // empty template
mutt_replacelist_match(&repl, buf, sizeof(buf), "a");      // match → deref NULL
```

**Before the fix**

```
regex.c:508:27: runtime error: load of null pointer of type 'char'
SUMMARY: UndefinedBehaviorSanitizer: null-pointer-use mutt/regex.c:508:27
==NNN==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000
    #0 mutt_replacelist_match .../mutt/regex.c:508:27
AddressSanitizer: deadly signal (ABRT)            [ exit 6 ]
```

**After the fix**

Clean exit, no sanitizer output.

## Submission Statement

This fix was generated using Claude Code and manually reviewed, tested, and verified by a team member.

Signed-off-by: FuzzAnything <fuzzanything@gmail.com>