### PR TITLE
gui: migrate the remaining 5 raw emails[] call sites

### DIFF
--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -1223,7 +1223,7 @@ struct Mailbox *dlg_index(struct MuttWindow *dlg, struct Mailbox *m_init)
         {
           for (size_t i = 0; i < shared->mailbox->msg_count; i++)
           {
-            const struct Email *e = shared->mailbox->emails[i];
+            const struct Email *e = mview_email_at(shared->mailbox_view, i);
             if (e && !e->read && !e->old)
             {
               mutt_message(_("New mail in this mailbox"));

--- a/index/functions.c
+++ b/index/functions.c
@@ -2886,7 +2886,7 @@ static int op_resend(struct IndexFunctionData *fdata, const struct KeyEvent *eve
     struct Mailbox *m = shared->mailbox;
     for (size_t i = 0; i < m->msg_count; i++)
     {
-      struct Email *e = m->emails[i];
+      struct Email *e = mview_email_at(shared->mailbox_view, i);
       if (!e)
         break;
       if (message_is_tagged(e))
@@ -3036,7 +3036,7 @@ static int op_tag(struct IndexFunctionData *fdata, const struct KeyEvent *event)
     struct Mailbox *m = shared->mailbox;
     for (size_t i = 0; i < m->msg_count; i++)
     {
-      struct Email *e = m->emails[i];
+      struct Email *e = mview_email_at(shared->mailbox_view, i);
       if (!e)
         continue;
       if (e->visible)

--- a/index/index.c
+++ b/index/index.c
@@ -292,7 +292,7 @@ static int index_color_observer(struct NotifyCallback *nc)
   // Force re-caching of index colours
   for (int i = 0; i < m->msg_count; i++)
   {
-    struct Email *e = m->emails[i];
+    struct Email *e = mview_email_at(shared->mailbox_view, i);
     if (!e)
       break;
     e->attr_color = NULL;
@@ -516,7 +516,7 @@ static int index_score_observer(struct NotifyCallback *nc)
 
   for (int i = 0; i < m->msg_count; i++)
   {
-    struct Email *e = m->emails[i];
+    struct Email *e = mview_email_at(shared->mailbox_view, i);
     if (!e)
       break;
 


### PR DESCRIPTION
Follow-up to #5003's 7 sites, which deliberately left these 5 out pending a specific check: whether `shared->mailbox_view` and the `Mailbox *` already in scope at each site are guaranteed to refer to the same mailbox.

Confirmed via `index_shared_data_set_mview()` (`index/shared_data.c`): it's the only place `shared->mailbox_view` is ever assigned, and it always sets `shared->mailbox = mview_mailbox(mv)` atomically in the same call. No other code path assigns either field independently. So `shared->mailbox_view->mailbox` and `shared->mailbox` are guaranteed to agree by construction at every point `shared` is valid.

Migrated: `op_resend()`, `op_tag()` (functions.c); the colour re-cache loop and one more `IndexSharedData`-driven loop (index.c); the new-mail notification loop inside `dlg_index()`'s main loop (dlg_index.c). All five substitute `mview_email_at(shared->mailbox_view, i)` for the raw `m->emails[i]`/`shared->mailbox->emails[i]` they already used.

This completes the raw-`emails[]` GUI call-site migration queued on #4977 — all 12 originally-identified sites are now on `mview_email_at()`.

Verified: full clean build, zero new warnings; `test/neomutt-test` 641/641 passes.

AI assistance: implementation, codebase research, and verification done by Claude Code; reviewed by chrisdebian before commit.