### PR TITLE
gui: migrate 17 more raw emails[] call sites to mview_email_at

### DIFF
--- a/alias/alternates.c
+++ b/alias/alternates.c
@@ -52,7 +52,7 @@ void mutt_alternates_reset(struct MailboxView *mv)
 
   for (int i = 0; i < m->msg_count; i++)
   {
-    struct Email *e = m->emails[i];
+    struct Email *e = mview_email_at(mv, i);
     if (!e)
       break;
     e->recip_valid = false;

--- a/attach/commands.c
+++ b/attach/commands.c
@@ -273,7 +273,7 @@ void mutt_attachments_reset(struct MailboxView *mv)
 
   for (int i = 0; i < m->msg_count; i++)
   {
-    struct Email *e = m->emails[i];
+    struct Email *e = mview_email_at(mv, i);
     if (!e)
       break;
     e->attach_valid = false;

--- a/email/sort.c
+++ b/email/sort.c
@@ -361,7 +361,7 @@ void mutt_sort_headers(struct MailboxView *mv, bool init)
     return;
 
   struct Mailbox *m = mv->mailbox;
-  if (!m || !m->emails[0])
+  if (!m || !mview_email_at(mv, 0))
     return;
 
   OptNeedResort = false;
@@ -385,7 +385,7 @@ void mutt_sort_headers(struct MailboxView *mv, bool init)
   {
     for (int i = 0; i < m->msg_count; i++)
     {
-      struct Email *e = m->emails[i];
+      struct Email *e = mview_email_at(mv, i);
       if (!e)
         break;
       mutt_score_message(m, e, true);
@@ -421,7 +421,7 @@ void mutt_sort_headers(struct MailboxView *mv, bool init)
   m->vcount = 0;
   for (int i = 0; i < m->msg_count; i++)
   {
-    struct Email *e_cur = m->emails[i];
+    struct Email *e_cur = mview_email_at(mv, i);
     if (!e_cur)
       break;
 

--- a/gui/selection.c
+++ b/gui/selection.c
@@ -135,7 +135,7 @@ int ea_add_tagged(struct EmailArray *ea, struct MailboxView *mv, struct Email *e
     struct Mailbox *m = mv->mailbox;
     for (int i = 0; i < m->msg_count; i++)
     {
-      e = m->emails[i];
+      e = mview_email_at(mv, i);
       if (!e)
         break;
       if (!message_is_tagged(e))

--- a/gui/thread.c
+++ b/gui/thread.c
@@ -822,7 +822,7 @@ void mutt_clear_threads(struct ThreadsContext *tctx)
 
   for (int i = 0; i < m->msg_count; i++)
   {
-    struct Email *e = m->emails[i];
+    struct Email *e = mview_email_at(mv, i);
     if (!e)
     {
       // Keep processing, in case there are other holes in the Email array
@@ -1083,7 +1083,7 @@ static void check_subjects(struct MailboxView *mv, bool init)
   struct Mailbox *m = mv->mailbox;
   for (int i = 0; i < m->msg_count; i++)
   {
-    struct Email *e = m->emails[i];
+    struct Email *e = mview_email_at(mv, i);
     if (!e || !e->thread)
       continue;
 
@@ -1172,7 +1172,7 @@ void mutt_sort_threads(struct ThreadsContext *tctx, bool init)
   const bool c_duplicate_threads = cs_subset_bool(NeoMutt->sub, "duplicate_threads");
   for (i = 0; i < m->msg_count; i++)
   {
-    e = m->emails[i];
+    e = mview_email_at(mv, i);
     if (!e)
       continue;
 
@@ -1266,7 +1266,7 @@ void mutt_sort_threads(struct ThreadsContext *tctx, bool init)
   /* thread by references */
   for (i = 0; i < m->msg_count; i++)
   {
-    e = m->emails[i];
+    e = mview_email_at(mv, i);
     if (!e)
       break;
 

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -427,7 +427,7 @@ int dlg_pager(struct PagerView *pview)
         {
           for (size_t i = oldcount; i < shared->mailbox->msg_count; i++)
           {
-            struct Email *e = shared->mailbox->emails[i];
+            struct Email *e = mview_email_at(shared->mailbox_view, i);
 
             if (e && !e->read)
             {

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -349,7 +349,7 @@ int mutt_pattern_func(struct MailboxView *mv, int op, char *prompt)
 
     for (int i = 0; i < m->msg_count; i++)
     {
-      struct Email *e = m->emails[i];
+      struct Email *e = mview_email_at(mv, i);
       if (!e)
         break;
 
@@ -518,7 +518,7 @@ int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur,
   if (pattern_changed)
   {
     for (int i = 0; i < m->msg_count; i++)
-      m->emails[i]->searched = false;
+      mview_email_at(mv, i)->searched = false;
     if ((m->type == MUTT_IMAP) && (!imap_search(m, state->pattern)))
       return -1;
   }

--- a/postpone/dlg_postpone.c
+++ b/postpone/dlg_postpone.c
@@ -116,7 +116,7 @@ static int post_make_entry(struct Menu *menu, int line, int max_cols, struct Buf
   }
 
   const struct Expando *c_index_format = cs_subset_expando(NeoMutt->sub, "index_format");
-  return mutt_make_string(buf, max_cols, c_index_format, m, -1, m->emails[line],
+  return mutt_make_string(buf, max_cols, c_index_format, m, -1, mview_email_at(mv, line),
                           MUTT_FORMAT_INDEX | MUTT_FORMAT_ARROWCURSOR, NULL);
 }
 
@@ -188,7 +188,7 @@ static int post_tag(struct Menu *menu, int sel, int act)
   {
     for (size_t i = 0; i < m->msg_count; i++)
     {
-      struct Email *e = m->emails[i];
+      struct Email *e = mview_email_at(mv, i);
       if (!e)
         break;
       mutt_set_flag(m, e, MUTT_TAG, false, true);
@@ -198,7 +198,7 @@ static int post_tag(struct Menu *menu, int sel, int act)
   }
 
   int index = menu_get_index(menu);
-  struct Email *e = m->emails[index];
+  struct Email *e = mview_email_at(mv, index);
   if (!e)
     return FR_NO_ACTION;
 

--- a/postpone/functions.c
+++ b/postpone/functions.c
@@ -215,8 +215,7 @@ static int op_generic_select_entry(struct PostponeData *pd, const struct KeyEven
 {
   int index = menu_get_index(pd->menu);
   struct MailboxView *mv = pd->mailbox_view;
-  struct Mailbox *m = mv->mailbox;
-  pd->email = m->emails[index];
+  pd->email = mview_email_at(mv, index);
   pd->done = true;
   return FR_SUCCESS;
 }


### PR DESCRIPTION
Continues the raw-`emails[]` GUI call-site migration on this branch (`mview_email_at()`/`mview_email_count()`, PR #4985; 7 sites in PR #5003; 5 sites in PR #5012, completing the original 12 from Discussion #4977). You'd separately flagged a broader tail of remaining `->emails[]` accesses beyond those 12 — a full audit found ~42 sites across 15 files (excluding `mview.c`, tests, and the mail-backend directories, which have their own reasons to touch `Mailbox` directly).

This PR covers the **17 where a `struct MailboxView *` was already directly available in scope** — as a function parameter, or via an existing struct field (`PostponeData::mailbox_view`, `IndexSharedData::mailbox_view`, `ThreadsContext::mailbox_view`) — so each change is a pure 1:1 swap with no new plumbing, same bar the previous two PRs in this series held to:

- `postpone/dlg_postpone.c` (3) — `post_make_entry()`, `post_tag()` (×2) — `pd->mailbox_view` already declared in each function
- `postpone/functions.c` (1) — `op_generic_select_entry()` — same `PostponeData` pattern
- `email/sort.c` (3) — `mutt_sort_headers()` — `mv` is the parameter
- `pattern/pattern.c` (2) — `mutt_pattern_func()`, `mutt_search_command()` — both take `mv` directly
- `pager/dlg_pager.c` (1) — `dlg_pager()`'s new-mail check — via `shared->mailbox_view` (`IndexSharedData`)
- `gui/selection.c` (1) — `ea_add_tagged()` — `mv` is the parameter
- `attach/commands.c` (1) — `mutt_attachments_reset()` — `mv` is the parameter
- `alias/alternates.c` (1) — `mutt_alternates_reset()` — `mv` is the parameter
- `gui/thread.c` (4 of its 7) — `mutt_clear_threads()`, `mutt_sort_threads()` (×2) via `tctx->mailbox_view`; `check_subjects()` via its own `mv` param

**What's deliberately left out**, and why: two sites in `postpone/functions.c`'s `postpone_add_selection()` take a `Mailbox *` rather than a `MailboxView *` — migrating those would mean changing that helper's own signature, not a pure swap, so they're left for a separate follow-up along with `gui/thread.c`'s remaining 3 sites (`make_subj_hash()`, `mutt_set_vnum()`, `mutt_make_id_hash()` — all public, multi-caller functions taking `Mailbox *` only, needing each call chain checked before threading `mv` through). Two more apparent matches, in `index/shared_data.c` and `debug/notify.c`, turned out on inspection to be `EventEmail::emails[]` — an unrelated struct that happens to share the field name, not `Mailbox::emails[]` at all — so they were never really part of this tail.

Verified: full clean build with zero new warnings; full unit test suite passes (641/641, unchanged from baseline). `mview_email_at()`'s documented contract (`mv->mailbox->emails[num]`, the exact expression every one of these seventeen sites already used, plus a bounds check none of the loops here can trip) makes this a mechanical, behaviour-preserving substitution.

AI assistance: implementation, codebase research, and verification done by Claude Code; reviewed by chrisdebian before commit.