### PR TITLE
fix null-pointer dereference in `pattern_exec()`

### DIFF
--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -958,6 +958,8 @@ static bool pattern_exec(struct Pattern *pat, PatternExecFlags flags,
       return pat->pat_not ^ (e->score >= pat->min &&
                              (pat->max == MUTT_MAXRANGE || e->score <= pat->max));
     case MUTT_PAT_SIZE:
+      if (!e->body)
+        return false;
       return pat->pat_not ^ (e->body->length >= pat->min &&
                              (pat->max == MUTT_MAXRANGE || e->body->length <= pat->max));
     case MUTT_PAT_REFERENCE:


### PR DESCRIPTION
This PR attempts to fix [#5014](https://github.com/neomutt/neomutt/issues/5014#issue-5116496493)

## Problem

`pattern_exec()` in `pattern/exec.c` dispatches on `pat->op` and, for the size pattern, dereferences `e->body->length` with no NULL guard:

```c
// pattern/exec.c:960-962
case MUTT_PAT_SIZE:
    return pat->pat_not ^ (e->body->length >= pat->min &&
                           (pat->max == MUTT_MAXRANGE || e->body->length <= pat->max));
```

A NULL `body` is a legal, expected state — `email_new()` zero-initializes it to NULL, `email_get_size()` explicitly handles it (`if (!e || !e->body) return 0;`), and `mutt_rfc822_read_header()` lazily allocates a body only when one is missing (`if (!e->body) { e->body = mutt_body_new(); ... }`). So a freshly-`email_new()`'d Email, or an Email whose headers were read before any body was attached, legitimately has `body == NULL`.

Every sibling leaf in the same `switch` guards its sub-pointer before dereferencing — `MUTT_PAT_SUBJECT` (`:949`), `MUTT_PAT_ID` (`:954`), `MUTT_PAT_REFERENCE` (`:964`), `MUTT_PAT_ADDRESS` (`:969`) all begin with `if (!e->env) return false;`. `MUTT_PAT_SIZE` is the lone case that omits the analogous `if (!e->body) return false;` guard.

## Fix

In the `MUTT_PAT_SIZE` case, add the same style of guard the sibling cases use. When `e->body` is NULL the email has no size to compare against, so it does not match the range:

```c
// pattern/exec.c — MUTT_PAT_SIZE case

// Before
case MUTT_PAT_SIZE:
    return pat->pat_not ^ (e->body->length >= pat->min &&
                           (pat->max == MUTT_MAXRANGE || e->body->length <= pat->max));

// After
case MUTT_PAT_SIZE:
    if (!e->body)
        return false;
    return pat->pat_not ^ (e->body->length >= pat->min &&
                           (pat->max == MUTT_MAXRANGE || e->body->length <= pat->max));
```

The unified diff:

```diff
--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -958,6 +958,8 @@
       return pat->pat_not ^ (e->score >= pat->min &&
                              (pat->max == MUTT_MAXRANGE || e->score <= pat->max));
     case MUTT_PAT_SIZE:
+      if (!e->body)
+        return false;
       return pat->pat_not ^ (e->body->length >= pat->min &&
                              (pat->max == MUTT_MAXRANGE || e->body->length <= pat->max));
     case MUTT_PAT_REFERENCE:
```

`return false` mirrors the `if (!e->env) return false;` clauses already present — a NULL sub-pointer means the leaf cannot match. (An alternative would be to compute the size via `email_get_size(e)`, which returns 0 for a NULL body, making a NULL-body Email behave as size 0 consistently with the rest of neomutt. That is a deeper semantic change — left as a possible follow-up; the minimal guard above is sufficient to kill the crash and keeps `MUTT_PAT_SIZE` consistent with its siblings.)

## Verification

### Sanitizer rebuild

Rebuilt only `pattern/exec.o` with the guard applied (using the exact configured `CFLAGS` from neomutt's `Makefile` — ASan + UBSan), swapped the object into the combined `libneomutt.a` (member `libpattern_exec.o`), and relinked the standalone PoC:

```bash
clang -fsanitize=address,undefined -fno-sanitize=function -fsanitize-address-use-after-scope \
      -g -O0 -fstandalone-debug -fPIC -fno-omit-frame-pointer \
      -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -std=c11 \
      -I. -c pattern/exec.c -o pattern/exec.o
ar r libneomutt.a pattern/exec.o   # member stored as libpattern_exec.o
ranlib libneomutt.a
clang++ -g -O0 -fsanitize=address,undefined -fno-omit-frame-pointer \
      -I. poc.cpp -o poc \
      -Wl,--start-group lib*.a */lib*.a -Wl,--end-group -lncursesw -ltinfo
```

### Before fix:
```
pattern/exec.c:961:39: runtime error: member access within null pointer of type 'struct Body'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior pattern/exec.c:961:39
==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000010
    #0 in pattern_exec /tmp/neomutt_build/pattern/exec.c:961:39
    #1 in mutt_pattern_exec /tmp/neomutt_build/pattern/exec.c:1160:24
    #2 in main poc.cpp:30:13
SUMMARY: AddressSanitizer: SEGV /tmp/neomutt_build/pattern/exec.c:961:39 in pattern_exec
Aborted (exit 1)
```

### After fix:

(clean exit, code 0 — no sanitizer errors)

## Submission Statement
This fix was generated using Claude Code and manually reviewed, tested, and verified by a team member.

Signed-off-by: FuzzAnything [fuzzanything@gmail.com](mailto:fuzzanything@gmail.com)