### PR TITLE
Remove four unreferenced functions

### DIFF
--- a/color/regex.c
+++ b/color/regex.c
@@ -147,22 +147,6 @@ struct RegexColor *regex_color_new(void)
 }
 
 /**
- * regex_color_list_new - Create a new RegexColorList
- * @retval ptr New RegexColorList
- */
-struct RegexColorList *regex_color_list_new(void)
-{
-  struct RegexColorList *rcl = MUTT_MEM_CALLOC(1, struct RegexColorList);
-
-  STAILQ_INIT(rcl);
-
-  struct RegexColor *rcol = regex_color_new();
-  STAILQ_INSERT_TAIL(rcl, rcol, entries);
-
-  return rcl;
-}
-
-/**
  * regex_color_list_clear - Free the contents of a RegexColorList
  * @param rcl List to clear
  *

--- a/color/regex4.h
+++ b/color/regex4.h
@@ -58,7 +58,6 @@ struct RegexColor *    regex_color_new  (void);
 struct RegexColorList *regex_colors_get_list(enum ColorId cid);
 
 void                   regex_color_list_clear(struct RegexColorList *rcl);
-struct RegexColorList *regex_color_list_new(void);
 
 bool regex_colors_parse_color_list (enum ColorId cid, const char *pat, struct AttrColor *ac, int *rc, struct Buffer *err);
 int  regex_colors_parse_status_list(enum ColorId cid, const char *pat, struct AttrColor *ac, int match, struct Buffer *err);

--- a/ncrypt/pgplib.c
+++ b/ncrypt/pgplib.c
@@ -61,44 +61,6 @@ const char *pgp_pkalgbytype(unsigned char type)
 }
 
 /**
- * pgp_canencrypt - Does this algorithm ID support encryption?
- * @param type Algorithm ID
- * @retval true Algorithm does support encryption
- */
-bool pgp_canencrypt(unsigned char type)
-{
-  switch (type)
-  {
-    case 1:
-    case 2:
-    case 16:
-    case 20:
-      return true;
-    default:
-      return false;
-  }
-}
-
-/**
- * pgp_cansign - Does this algorithm ID support signing?
- * @param type Algorithm ID
- * @retval true Algorithm does support signing
- */
-bool pgp_cansign(unsigned char type)
-{
-  switch (type)
-  {
-    case 1:
-    case 3:
-    case 17:
-    case 20:
-      return true;
-    default:
-      return false;
-  }
-}
-
-/**
  * pgp_uid_free - Free a PGP UID
  * @param[out] upp PGP UID to free
  */

--- a/ncrypt/pgplib.h
+++ b/ncrypt/pgplib.h
@@ -86,9 +86,6 @@ const char *pgp_pkalgbytype(unsigned char type);
 
 struct PgpUid *pgp_copy_uids(struct PgpUid *up, struct PgpKeyInfo *parent);
 
-bool pgp_canencrypt(unsigned char type);
-bool pgp_cansign(unsigned char type);
-
 void pgp_key_free(struct PgpKeyInfo **kpp);
 
 struct PgpKeyInfo *pgp_remove_key(struct PgpKeyInfo **klist, struct PgpKeyInfo *key);

--- a/progress/lib.h
+++ b/progress/lib.h
@@ -90,6 +90,5 @@ struct Progress *progress_new        (enum ProgressType type, size_t size);
 bool             progress_update     (struct Progress *progress, size_t pos, int percent);
 void             progress_set_message(struct Progress *progress, const char *fmt, ...)
                                       __attribute__((__format__(__printf__, 2, 3)));
-void             progress_set_size   (struct Progress *progress, size_t size);
 
 #endif /* MUTT_PROGRESS_LIB_H */

--- a/progress/progress.c
+++ b/progress/progress.c
@@ -186,14 +186,3 @@ void progress_set_message(struct Progress *progress, const char *fmt, ...)
 
   va_end(ap);
 }
-
-/**
- * progress_set_size - Set the progress size
- */
-void progress_set_size(struct Progress *progress, size_t size)
-{
-  // Decloak an opaque pointer
-  struct MuttWindow *win = (struct MuttWindow *) progress;
-
-  progress_window_set_size(win, size);
-}


### PR DESCRIPTION
## What

Four functions with no callers anywhere in the tree:

- `pgp_canencrypt()` / `pgp_cansign()` (`ncrypt/pgplib.c`) -- superseded by the `KEYFLAG_CANENCRYPT`/`KEYFLAG_CANSIGN` bitflag system used throughout `ncrypt/` (`gnupgparse.c`, `smime.c`, `pgp.c`, `crypt_gpgme.c`, and others).
- `progress_set_size()` (`progress/progress.c`) -- a one-line wrapper around `progress_window_set_size()` with no callers of its own.
- `regex_color_list_new()` (`color/regex.c`) -- constructor for `RegexColorList` with no callers anywhere.

## How this was found

`cppcheck --enable=unusedFunction` over the whole project, cross-checked against a `-ffunction-sections`/`--gc-sections` linker build (which sees through function-pointer dispatch tables correctly, unlike the static analyzer alone -- two early candidates, `alias_dialog()` and `query_index()`, were false positives from exactly that pattern and are excluded here).

The remaining candidates were then verified by hand against the whole source tree with a plain text search, not just what compiles in one configuration -- a couple of others turned out to be reachable only through optional subsystems this local build doesn't have enabled (SSL/TLS, autocrypt+GPGME) and are correctly *not* included in this PR. The four here have no call site under any configuration.

## Verification

Clean build (clang, zero new warnings), 641/641 tests passing (`test/neomutt-test`, using `NEOMUTT_TEST_DIR`).

## Unrelated aside, FYI only

While working in this area I noticed `.github/workflows/clang-format.yml` only checks `*.c` files (`git ls-files ... '*.c'`), never headers -- and the three headers touched here weren't clang-format-22.1.8-clean even before this PR (pristine `main` included). Left them exactly as they were beyond the one-line removal each, since two of them use hand-aligned column formatting that clang-format's automatic reflow doesn't reproduce, so this may well be deliberate rather than an oversight. Flagging in case it's useful, not proposing a change.

This PR was written primarily by Claude Code, based on findings I reviewed and independently verified before opening it.