### PR TITLE
openssl: honor socket timeout during handshake

### DIFF
--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -1176,12 +1176,24 @@ static int ssl_negotiate(struct Connection *conn, struct SslSockData *ssldata)
   ERR_clear_error();
 
 retry:
+  errno = 0;
   err = SSL_connect(ssldata->ssl);
+  const int saved_errno = errno;
   if (err != 1)
   {
-    // Temporary failure, e.g. signal received
     if (BIO_should_retry(SSL_get_rbio(ssldata->ssl)))
     {
+      // An interrupted read need not have any data ready yet.
+      if (saved_errno == EINTR)
+      {
+        if (SigInt)
+        {
+          mutt_error(_("Connection to %s has been aborted"), conn->account.host);
+          return -1;
+        }
+        goto retry;
+      }
+
       if (!BIO_should_read(SSL_get_rbio(ssldata->ssl)))
         goto retry;
 

--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -1181,7 +1181,19 @@ retry:
   {
     // Temporary failure, e.g. signal received
     if (BIO_should_retry(SSL_get_rbio(ssldata->ssl)))
-      goto retry;
+    {
+      if (!BIO_should_read(SSL_get_rbio(ssldata->ssl)))
+        goto retry;
+
+      const int poll_rc = raw_socket_poll(conn, 0);
+      if (poll_rc > 0)
+        goto retry;
+      if (poll_rc == 0)
+      {
+        mutt_error(_("Connection to %s timed out"), conn->account.host);
+        return -1;
+      }
+    }
 
     switch (SSL_get_error(ssldata->ssl, err))
     {

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -239,7 +239,9 @@ CONFIG_OBJS	= test/config/account.o \
 		  test/config/variable.o
 
 @if USE_SSL_OPENSSL
-CONN_OBJS	+= test/conn/ssl_socket_read_timeout.o
+CONN_OBJS	+= test/conn/ssl_timeout_common.o \
+		  test/conn/ssl_negotiate_timeout.o \
+		  test/conn/ssl_socket_read_timeout.o
 @endif
 
 CONVERT_OBJS	= test/convert/mutt_convert_file_from_to.o \

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -238,6 +238,10 @@ CONFIG_OBJS	= test/config/account.o \
 		  test/config/synonym.o \
 		  test/config/variable.o
 
+@if USE_SSL_OPENSSL
+CONN_OBJS	+= test/conn/ssl_socket_read_timeout.o
+@endif
+
 CONVERT_OBJS	= test/convert/mutt_convert_file_from_to.o \
 		  test/convert/mutt_convert_file_to.o \
 		  test/convert/mutt_get_content_info.o \
@@ -735,7 +739,8 @@ BUILD_DIRS	= $(PWD)/test/account $(PWD)/test/address $(PWD)/test/array \
 		  $(PWD)/test/atoi $(PWD)/test/attach $(PWD)/test/base64 \
 		  $(PWD)/test/body $(PWD)/test/buffer $(PWD)/test/charset \
 		  $(PWD)/test/cli $(PWD)/test/color $(PWD)/test/command \
-		  $(PWD)/test/compress $(PWD)/test/config $(PWD)/test/convert \
+		  $(PWD)/test/compress $(PWD)/test/config $(PWD)/test/conn \
+		  $(PWD)/test/convert \
 		  $(PWD)/test/core $(PWD)/test/date $(PWD)/test/editor \
 		  $(PWD)/test/email $(PWD)/test/envelope $(PWD)/test/envlist \
 		  $(PWD)/test/eqi $(PWD)/test/expando $(PWD)/test/file \
@@ -770,6 +775,7 @@ TEST_OBJS	= test/common.o test/main.o test/module.o \
 		  $(COMMAND_OBJS) \
 		  $(COMPRESS_OBJS) \
 		  $(CONFIG_OBJS) \
+		  $(CONN_OBJS) \
 		  $(CONVERT_OBJS) \
 		  $(CORE_OBJS) \
 		  $(DATE_OBJS) \

--- a/test/conn/ssl_negotiate_timeout.c
+++ b/test/conn/ssl_negotiate_timeout.c
@@ -24,6 +24,9 @@
 #include "config.h"
 #include "acutest.h"
 #ifdef USE_SSL_OPENSSL
+#include <errno.h>
+#include <openssl/ssl.h>
+#include <signal.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -31,36 +34,97 @@
 #include "mutt/lib.h"
 #include "core/lib.h"
 #include "conn/lib.h"
+#include "conn/private.h"
 #include "ssl_timeout_common.h"
 #include "test_common.h" // IWYU pragma: keep
 
-static void run_silent_peer(int listener, pid_t parent_pid)
+static volatile sig_atomic_t ReceivedSignal = 0;
+
+static void record_signal(int sig)
+{
+  const int saved_errno = errno;
+  ReceivedSignal = sig;
+  if (sig == SIGINT)
+    SigInt = 1;
+  errno = saved_errno;
+}
+
+static void run_peer(int listener, SSL_CTX *server_ctx, int sig, pid_t opener_pid, pid_t parent_pid)
 {
   int client = accept(listener, NULL, NULL);
   close(listener);
   if (client < 0)
     _exit(2);
 
-  // Keep TCP open without sending a TLS response while the client negotiates.
+  SSL *ssl = NULL;
+  if (server_ctx || sig)
+  {
+    // Wait for ClientHello without consuming it, then let the client block.
+    char byte = 0;
+    if (recv(client, &byte, 1, MSG_PEEK) != 1)
+      _exit(2);
+    usleep(300000);
+    if (sig && (kill(opener_pid, sig) != 0))
+      _exit(2);
+  }
+
+  if (server_ctx)
+  {
+    // Readability must not be required immediately after the signal.
+    usleep(300000);
+    ssl = SSL_new(server_ctx);
+    if (!ssl || (SSL_set_fd(ssl, client) != 1) || (SSL_accept(ssl) != 1))
+      _exit(2);
+    if (SSL_write(ssl, "x", 1) != 1)
+      _exit(2);
+  }
+
+  // Keep the peer open so its closure cannot explain the client's result.
   for (int i = 0; (i < 100) && (getppid() == parent_pid); i++)
     usleep(100000);
 
+  SSL_free(ssl);
   close(client);
   _exit(0);
 }
 
-static void run_opener(unsigned short port, int result_fd)
+static void run_opener(unsigned short port, int result_fd, int sig)
 {
   struct Connection *conn = test_ssl_timeout_new_connection(port);
   if (!conn)
     _exit(2);
 
+  if (sig)
+  {
+    if (raw_socket_open(conn) != 0)
+      _exit(2);
+
+    // Connect changes SIGINT handling. Install non-restarting handlers after it
+    // and exercise the same negotiation function through STARTTLS.
+    struct sigaction action = { 0 };
+    action.sa_handler = record_signal;
+    sigemptyset(&action.sa_mask);
+    if (sigaction(sig, &action, NULL) != 0)
+      _exit(2);
+    SigInt = 0;
+    ReceivedSignal = 0;
+  }
+
   struct SslTimeoutResult result = { 0 };
   uint64_t start = mutt_date_now_ms();
-  result.rc = mutt_socket_open(conn);
+  result.rc = sig ? mutt_ssl_starttls(conn) : mutt_socket_open(conn);
   result.elapsed = mutt_date_now_ms() - start;
 
+  if (sig && (ReceivedSignal != sig))
+    _exit(2);
   if (result.rc == 0)
+  {
+    // Do not close while the server is still finishing the TLS handshake.
+    char byte = 0;
+    if ((mutt_socket_read(conn, &byte, 1) != 1) || (byte != 'x'))
+      _exit(2);
+  }
+  if (sig || (result.rc == 0))
     mutt_socket_close(conn);
   FREE(&conn);
 
@@ -70,14 +134,7 @@ static void run_opener(unsigned short port, int result_fd)
   _exit(0);
 }
 
-/**
- * test_ssl_negotiate_timeout - Test that OpenSSL negotiation honors socket_timeout
- *
- * Regression test for #5005.  The loopback peer accepts TCP but does not send a
- * TLS response.  Negotiation must return after the socket timeout instead of
- * immediately retrying another blocking SSL_connect().
- */
-void test_ssl_negotiate_timeout(void)
+static void check_handshake(SSL_CTX *server_ctx, int sig)
 {
   int listener = -1;
   pid_t peer_pid = -1;
@@ -85,23 +142,11 @@ void test_ssl_negotiate_timeout(void)
   int result_fds[2] = { -1, -1 };
   unsigned short port = 0;
 
-  if (!test_ssl_timeout_configure_client(NULL))
-    goto done;
-
   listener = test_ssl_timeout_create_listener(&port);
   if (listener < 0)
     goto done;
 
   pid_t parent_pid = getpid();
-  peer_pid = fork();
-  if (!TEST_CHECK(peer_pid >= 0))
-    goto done;
-  if (peer_pid == 0)
-    run_silent_peer(listener, parent_pid);
-
-  close(listener);
-  listener = -1;
-
   if (!TEST_CHECK(pipe(result_fds) == 0))
     goto done;
   opener_pid = fork();
@@ -109,11 +154,23 @@ void test_ssl_negotiate_timeout(void)
     goto done;
   if (opener_pid == 0)
   {
+    close(listener);
     close(result_fds[0]);
-    run_opener(port, result_fds[1]);
+    run_opener(port, result_fds[1], sig);
   }
   close(result_fds[1]);
   result_fds[1] = -1;
+
+  peer_pid = fork();
+  if (!TEST_CHECK(peer_pid >= 0))
+    goto done;
+  if (peer_pid == 0)
+  {
+    close(result_fds[0]);
+    run_peer(listener, server_ctx, sig, opener_pid, parent_pid);
+  }
+  close(listener);
+  listener = -1;
 
   int opener_status = 0;
   if (!TEST_CHECK(test_ssl_timeout_wait(&opener_pid, &opener_status)))
@@ -125,11 +182,17 @@ void test_ssl_negotiate_timeout(void)
   if (!TEST_CHECK(test_ssl_timeout_read_result(result_fds[0], &result)))
     goto done;
   TEST_MSG("open rc=%d elapsed=%llu ms", result.rc, (unsigned long long) result.elapsed);
-  TEST_CHECK(result.rc < 0);
-  TEST_CHECK(result.elapsed >= 1000);
+  if (server_ctx)
+    TEST_CHECK(result.rc == 0);
+  else
+    TEST_CHECK(result.rc < 0);
+  if (sig == SIGINT)
+    TEST_CHECK(result.elapsed < 1800);
+  else if (!server_ctx)
+    TEST_CHECK(result.elapsed >= 1000);
   TEST_CHECK(result.elapsed <= 5000);
 
-  // Prove that negotiation ended from the client timeout, not peer closure.
+  // Prove that negotiation ended without waiting for peer closure.
   int status = 0;
   pid_t peer_state = waitpid(peer_pid, &status, WNOHANG);
   TEST_CHECK(peer_state == 0);
@@ -145,5 +208,49 @@ done:
   test_ssl_timeout_stop_child(&peer_pid);
   if (listener >= 0)
     close(listener);
+}
+
+/**
+ * test_ssl_negotiate_timeout - Test that OpenSSL negotiation honors socket_timeout
+ *
+ * Regression test for #5005. The loopback peer accepts TCP but sends no TLS
+ * response. Negotiation must not renew the socket timeout indefinitely.
+ */
+void test_ssl_negotiate_timeout(void)
+{
+  if (test_ssl_timeout_configure_client(NULL))
+    check_handshake(NULL, 0);
+}
+
+/**
+ * test_ssl_negotiate_retry - Distinguish interrupted negotiation from a timeout
+ *
+ * A delayed healthy peer must still succeed after a harmless signal, whereas a
+ * silent peer must still time out. SIGINT must cancel rather than restart the
+ * operation. Each client runs in a child so signal handlers stay isolated.
+ */
+void test_ssl_negotiate_retry(void)
+{
+  SSL_CTX *server_ctx = NULL;
+  char cert_path[128] = { 0 };
+
+  if (!test_ssl_timeout_create_server_context(&server_ctx, cert_path, sizeof(cert_path)))
+    goto done;
+  if (!test_ssl_timeout_configure_client(cert_path))
+    goto done;
+
+  TEST_CASE("delayed successful handshake");
+  check_handshake(server_ctx, 0);
+  TEST_CASE("successful handshake after SIGWINCH");
+  check_handshake(server_ctx, SIGWINCH);
+  TEST_CASE("silent peer after SIGWINCH");
+  check_handshake(NULL, SIGWINCH);
+  TEST_CASE("cancellation by SIGINT");
+  check_handshake(NULL, SIGINT);
+
+done:
+  SSL_CTX_free(server_ctx);
+  if (cert_path[0])
+    unlink(cert_path);
 }
 #endif

--- a/test/conn/ssl_negotiate_timeout.c
+++ b/test/conn/ssl_negotiate_timeout.c
@@ -1,0 +1,149 @@
+/**
+ * @file
+ * Test the OpenSSL handshake timeout
+ *
+ * @authors
+ * Copyright (C) 2026 Todd A. Gibson <tgibson@augustcouncil.com>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#ifdef USE_SSL_OPENSSL
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "conn/lib.h"
+#include "ssl_timeout_common.h"
+#include "test_common.h" // IWYU pragma: keep
+
+static void run_silent_peer(int listener, pid_t parent_pid)
+{
+  int client = accept(listener, NULL, NULL);
+  close(listener);
+  if (client < 0)
+    _exit(2);
+
+  // Keep TCP open without sending a TLS response while the client negotiates.
+  for (int i = 0; (i < 100) && (getppid() == parent_pid); i++)
+    usleep(100000);
+
+  close(client);
+  _exit(0);
+}
+
+static void run_opener(unsigned short port, int result_fd)
+{
+  struct Connection *conn = test_ssl_timeout_new_connection(port);
+  if (!conn)
+    _exit(2);
+
+  struct SslTimeoutResult result = { 0 };
+  uint64_t start = mutt_date_now_ms();
+  result.rc = mutt_socket_open(conn);
+  result.elapsed = mutt_date_now_ms() - start;
+
+  if (result.rc == 0)
+    mutt_socket_close(conn);
+  FREE(&conn);
+
+  if (!test_ssl_timeout_write_result(result_fd, &result))
+    _exit(2);
+  close(result_fd);
+  _exit(0);
+}
+
+/**
+ * test_ssl_negotiate_timeout - Test that OpenSSL negotiation honors socket_timeout
+ *
+ * Regression test for #5005.  The loopback peer accepts TCP but does not send a
+ * TLS response.  Negotiation must return after the socket timeout instead of
+ * immediately retrying another blocking SSL_connect().
+ */
+void test_ssl_negotiate_timeout(void)
+{
+  int listener = -1;
+  pid_t peer_pid = -1;
+  pid_t opener_pid = -1;
+  int result_fds[2] = { -1, -1 };
+  unsigned short port = 0;
+
+  if (!test_ssl_timeout_configure_client(NULL))
+    goto done;
+
+  listener = test_ssl_timeout_create_listener(&port);
+  if (listener < 0)
+    goto done;
+
+  pid_t parent_pid = getpid();
+  peer_pid = fork();
+  if (!TEST_CHECK(peer_pid >= 0))
+    goto done;
+  if (peer_pid == 0)
+    run_silent_peer(listener, parent_pid);
+
+  close(listener);
+  listener = -1;
+
+  if (!TEST_CHECK(pipe(result_fds) == 0))
+    goto done;
+  opener_pid = fork();
+  if (!TEST_CHECK(opener_pid >= 0))
+    goto done;
+  if (opener_pid == 0)
+  {
+    close(result_fds[0]);
+    run_opener(port, result_fds[1]);
+  }
+  close(result_fds[1]);
+  result_fds[1] = -1;
+
+  int opener_status = 0;
+  if (!TEST_CHECK(test_ssl_timeout_wait(&opener_pid, &opener_status)))
+    goto done;
+  if (!TEST_CHECK(WIFEXITED(opener_status) && (WEXITSTATUS(opener_status) == 0)))
+    goto done;
+
+  struct SslTimeoutResult result = { 0 };
+  if (!TEST_CHECK(test_ssl_timeout_read_result(result_fds[0], &result)))
+    goto done;
+  TEST_MSG("open rc=%d elapsed=%llu ms", result.rc, (unsigned long long) result.elapsed);
+  TEST_CHECK(result.rc < 0);
+  TEST_CHECK(result.elapsed >= 1000);
+  TEST_CHECK(result.elapsed <= 5000);
+
+  // Prove that negotiation ended from the client timeout, not peer closure.
+  int status = 0;
+  pid_t peer_state = waitpid(peer_pid, &status, WNOHANG);
+  TEST_CHECK(peer_state == 0);
+  if (peer_state == peer_pid)
+    peer_pid = -1;
+
+done:
+  test_ssl_timeout_stop_child(&opener_pid);
+  if (result_fds[0] >= 0)
+    close(result_fds[0]);
+  if (result_fds[1] >= 0)
+    close(result_fds[1]);
+  test_ssl_timeout_stop_child(&peer_pid);
+  if (listener >= 0)
+    close(listener);
+}
+#endif

--- a/test/conn/ssl_socket_read_timeout.c
+++ b/test/conn/ssl_socket_read_timeout.c
@@ -24,278 +24,28 @@
 #include "config.h"
 #include "acutest.h"
 #ifdef USE_SSL_OPENSSL
-#include <arpa/inet.h>
-#include <errno.h>
-#include <netinet/in.h>
-#include <openssl/evp.h>
-#include <openssl/pem.h>
-#include <openssl/rsa.h>
-#include <openssl/ssl.h>
-#include <openssl/x509.h>
-#include <signal.h>
 #include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include "mutt/lib.h"
-#include "config/lib.h"
 #include "core/lib.h"
 #include "conn/lib.h"
+#include "ssl_timeout_common.h"
 #include "test_common.h" // IWYU pragma: keep
-
-/**
- * create_server_context - Create a self-contained TLS identity for the fixture
- * @param[out] server_ctx   OpenSSL server context
- * @param[out] cert_path    Path to the temporary certificate
- * @param[in]  cert_path_len Size of the certificate path buffer
- * @retval true  Success
- * @retval false Error
- *
- * Generate an ephemeral RSA key and self-signed X.509 certificate at runtime.
- * Writing the certificate to a temporary file lets NeoMutt trust the loopback
- * server without relying on an external certificate or network service.
- */
-static bool create_server_context(SSL_CTX **server_ctx, char *cert_path, size_t cert_path_len)
-{
-  EVP_PKEY_CTX *key_ctx = NULL;
-  EVP_PKEY *key = NULL;
-  X509 *cert = NULL;
-  SSL_CTX *ctx = NULL;
-  FILE *fp = NULL;
-  int fd = -1;
-  bool result = false;
-
-  key_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
-  if (!TEST_CHECK(key_ctx != NULL))
-    goto done;
-  if (!TEST_CHECK(EVP_PKEY_keygen_init(key_ctx) > 0))
-    goto done;
-  if (!TEST_CHECK(EVP_PKEY_CTX_set_rsa_keygen_bits(key_ctx, 2048) > 0))
-    goto done;
-  if (!TEST_CHECK(EVP_PKEY_keygen(key_ctx, &key) > 0))
-    goto done;
-
-  cert = X509_new();
-  if (!TEST_CHECK(cert != NULL))
-    goto done;
-  if (!TEST_CHECK(X509_set_version(cert, 2) == 1))
-    goto done;
-  if (!TEST_CHECK(ASN1_INTEGER_set(X509_get_serialNumber(cert), 1) == 1))
-    goto done;
-  if (!TEST_CHECK(X509_gmtime_adj(X509_get_notBefore(cert), -60) != NULL))
-    goto done;
-  if (!TEST_CHECK(X509_gmtime_adj(X509_get_notAfter(cert), 86400) != NULL))
-    goto done;
-  if (!TEST_CHECK(X509_set_pubkey(cert, key) == 1))
-    goto done;
-
-  X509_NAME *name = X509_get_subject_name(cert);
-  if (!TEST_CHECK(name != NULL))
-    goto done;
-  if (!TEST_CHECK(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
-                                             (const unsigned char *) "localhost",
-                                             -1, -1, 0) == 1))
-  {
-    goto done;
-  }
-  if (!TEST_CHECK(X509_set_issuer_name(cert, name) == 1))
-    goto done;
-  if (!TEST_CHECK(X509_sign(cert, key, EVP_sha256()) > 0))
-    goto done;
-
-  ctx = SSL_CTX_new(SSLv23_server_method());
-  if (!TEST_CHECK(ctx != NULL))
-    goto done;
-  if (!TEST_CHECK(SSL_CTX_use_certificate(ctx, cert) == 1))
-    goto done;
-  if (!TEST_CHECK(SSL_CTX_use_PrivateKey(ctx, key) == 1))
-    goto done;
-  if (!TEST_CHECK(SSL_CTX_check_private_key(ctx) == 1))
-    goto done;
-
-  snprintf(cert_path, cert_path_len, "/tmp/neomutt-test-cert-XXXXXX");
-  fd = mkstemp(cert_path);
-  if (!TEST_CHECK(fd >= 0))
-    goto done;
-  fp = fdopen(fd, "w");
-  if (!TEST_CHECK(fp != NULL))
-    goto done;
-  fd = -1;
-  if (!TEST_CHECK(PEM_write_X509(fp, cert) == 1))
-    goto done;
-  if (!TEST_CHECK(fclose(fp) == 0))
-  {
-    fp = NULL;
-    goto done;
-  }
-  fp = NULL;
-
-  *server_ctx = ctx;
-  ctx = NULL;
-  result = true;
-
-done:
-  if (fp)
-    fclose(fp);
-  if (fd >= 0)
-    close(fd);
-  if (!result && cert_path[0])
-    unlink(cert_path);
-  SSL_CTX_free(ctx);
-  X509_free(cert);
-  EVP_PKEY_free(key);
-  EVP_PKEY_CTX_free(key_ctx);
-  return result;
-}
-
-/**
- * create_listener - Open an IPv4 loopback listener on an ephemeral port
- * @param[out] port Assigned port
- * @retval num Listener file descriptor
- * @retval -1  Error
- *
- * Binding port zero asks the kernel to choose an available port, avoiding a
- * fixed-port dependency and conflicts with concurrent test runs.
- */
-static int create_listener(unsigned short *port)
-{
-  int listener = socket(AF_INET, SOCK_STREAM, 0);
-  if (!TEST_CHECK(listener >= 0))
-    return -1;
-
-  struct sockaddr_in address = { 0 };
-  address.sin_family = AF_INET;
-  address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-  address.sin_port = 0;
-
-  if (!TEST_CHECK(bind(listener, (struct sockaddr *) &address, sizeof(address)) == 0))
-    goto fail;
-  if (!TEST_CHECK(listen(listener, 1) == 0))
-    goto fail;
-
-  socklen_t address_len = sizeof(address);
-  if (!TEST_CHECK(getsockname(listener, (struct sockaddr *) &address, &address_len) == 0))
-    goto fail;
-
-  *port = ntohs(address.sin_port);
-  return listener;
-
-fail:
-  close(listener);
-  return -1;
-}
-
-static void run_server(int listener, SSL_CTX *server_ctx, pid_t parent_pid)
-{
-  int client = accept(listener, NULL, NULL);
-  close(listener);
-  if (client < 0)
-    _exit(2);
-
-  SSL *ssl = SSL_new(server_ctx);
-  if (!ssl)
-    _exit(2);
-  SSL_set_fd(ssl, client);
-  if (SSL_accept(ssl) != 1)
-    _exit(2);
-
-  // Complete TLS, then withhold application data while the parent reads.
-  for (int i = 0; (i < 100) && (getppid() == parent_pid); i++)
-    usleep(100000);
-
-  SSL_free(ssl);
-  SSL_CTX_free(server_ctx);
-  close(client);
-  _exit(0);
-}
-
-/**
- * configure_client - Configure NeoMutt for the private TLS fixture
- * @param[in] cert_path Path to the fixture's temporary certificate
- * @retval true  Success
- * @retval false Error
- *
- * Use a two-second socket timeout and trust only the generated certificate.
- * Host verification is disabled because the fixture connects to its private
- * loopback address rather than the certificate's hostname.
- */
-static bool configure_client(const char *cert_path)
-{
-  int rc = cs_subset_str_native_set(NeoMutt->sub, "socket_timeout", 2, NULL);
-  if (!TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS))
-    return false;
-
-  rc = cs_subset_str_native_set(NeoMutt->sub, "ssl_use_system_certs", false, NULL);
-  if (!TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS))
-    return false;
-
-  rc = cs_subset_str_native_set(NeoMutt->sub, "ssl_verify_host", false, NULL);
-  if (!TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS))
-    return false;
-
-  rc = cs_subset_str_string_set(NeoMutt->sub, "certificate_file", cert_path, NULL);
-  if (!TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS))
-    return false;
-
-#ifdef HAVE_GETADDRINFO
-  rc = cs_subset_str_native_set(NeoMutt->sub, "use_ipv6", false, NULL);
-  if (!TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS))
-    return false;
-#endif
-
-  return true;
-}
-
-struct ReadResult
-{
-  int rc;
-  uint64_t elapsed;
-};
 
 static void run_reader(struct Connection *conn, int result_fd)
 {
-  struct ReadResult result = { 0 };
+  struct SslTimeoutResult result = { 0 };
   char buf[16] = { 0 };
   uint64_t start = mutt_date_now_ms();
   result.rc = mutt_socket_read(conn, buf, sizeof(buf));
   result.elapsed = mutt_date_now_ms() - start;
 
-  const char *data = (const char *) &result;
-  size_t remaining = sizeof(result);
-  while (remaining > 0)
-  {
-    ssize_t written = write(result_fd, data, remaining);
-    if ((written < 0) && (errno == EINTR))
-      continue;
-    if (written <= 0)
-      _exit(2);
-    data += written;
-    remaining -= written;
-  }
-
+  if (!test_ssl_timeout_write_result(result_fd, &result))
+    _exit(2);
   close(result_fd);
   _exit(0);
-}
-
-static bool read_result(int fd, struct ReadResult *result)
-{
-  char *data = (char *) result;
-  size_t remaining = sizeof(*result);
-  while (remaining > 0)
-  {
-    ssize_t received = read(fd, data, remaining);
-    if ((received < 0) && (errno == EINTR))
-      continue;
-    if (received <= 0)
-      return false;
-    data += received;
-    remaining -= received;
-  }
-
-  return true;
 }
 
 /**
@@ -317,15 +67,12 @@ void test_ssl_socket_read_timeout(void)
   char cert_path[64] = { 0 };
   unsigned short port = 0;
 
-  conn = mutt_socket_new(MUTT_CONNECTION_SSL);
-  if (!TEST_CHECK(conn != NULL))
+  if (!test_ssl_timeout_create_server_context(&server_ctx, cert_path, sizeof(cert_path)))
     goto done;
-  if (!create_server_context(&server_ctx, cert_path, sizeof(cert_path)))
-    goto done;
-  if (!configure_client(cert_path))
+  if (!test_ssl_timeout_configure_client(cert_path))
     goto done;
 
-  listener = create_listener(&port);
+  listener = test_ssl_timeout_create_listener(&port);
   if (listener < 0)
     goto done;
 
@@ -334,16 +81,16 @@ void test_ssl_socket_read_timeout(void)
   if (!TEST_CHECK(server_pid >= 0))
     goto done;
   if (server_pid == 0)
-    run_server(listener, server_ctx, parent_pid);
+    test_ssl_timeout_run_idle_server(listener, server_ctx, parent_pid);
 
   close(listener);
   listener = -1;
   SSL_CTX_free(server_ctx);
   server_ctx = NULL;
 
-  mutt_str_copy(conn->account.host, "127.0.0.1", sizeof(conn->account.host));
-  conn->account.port = port;
-  conn->account.flags = MUTT_ACCT_PORT | MUTT_ACCT_SSL;
+  conn = test_ssl_timeout_new_connection(port);
+  if (!TEST_CHECK(conn != NULL))
+    goto done;
 
   if (!TEST_CHECK(mutt_socket_open(conn) == 0))
     goto done;
@@ -365,30 +112,13 @@ void test_ssl_socket_read_timeout(void)
   result_fds[1] = -1;
 
   int reader_status = 0;
-  bool reader_finished = false;
-  // Allow scheduling margin around socket_timeout=2, but independently bound
-  // the operation at seven seconds if the read retry loop regresses.
-  for (int i = 0; i < 70; i++)
-  {
-    pid_t state = waitpid(reader_pid, &reader_status, WNOHANG);
-    if (state == reader_pid)
-    {
-      reader_finished = true;
-      reader_pid = -1;
-      break;
-    }
-    if ((state < 0) && (errno != EINTR))
-      break;
-    usleep(100000);
-  }
-
-  if (!TEST_CHECK(reader_finished))
+  if (!TEST_CHECK(test_ssl_timeout_wait(&reader_pid, &reader_status)))
     goto done;
   if (!TEST_CHECK(WIFEXITED(reader_status) && (WEXITSTATUS(reader_status) == 0)))
     goto done;
 
-  struct ReadResult result = { 0 };
-  if (!TEST_CHECK(read_result(result_fds[0], &result)))
+  struct SslTimeoutResult result = { 0 };
+  if (!TEST_CHECK(test_ssl_timeout_read_result(result_fds[0], &result)))
     goto done;
   TEST_MSG("read rc=%d elapsed=%llu ms", result.rc, (unsigned long long) result.elapsed);
   TEST_CHECK(result.rc < 0);
@@ -403,13 +133,7 @@ void test_ssl_socket_read_timeout(void)
     server_pid = -1;
 
 done:
-  if (reader_pid > 0)
-  {
-    kill(reader_pid, SIGTERM);
-    while ((waitpid(reader_pid, NULL, 0) < 0) && (errno == EINTR))
-    {
-    }
-  }
+  test_ssl_timeout_stop_child(&reader_pid);
   if (result_fds[0] >= 0)
     close(result_fds[0]);
   if (result_fds[1] >= 0)
@@ -417,13 +141,7 @@ done:
   if (connection_open)
     mutt_socket_close(conn);
   FREE(&conn);
-  if (server_pid > 0)
-  {
-    kill(server_pid, SIGTERM);
-    while ((waitpid(server_pid, NULL, 0) < 0) && (errno == EINTR))
-    {
-    }
-  }
+  test_ssl_timeout_stop_child(&server_pid);
   if (listener >= 0)
     close(listener);
   SSL_CTX_free(server_ctx);

--- a/test/conn/ssl_socket_read_timeout.c
+++ b/test/conn/ssl_socket_read_timeout.c
@@ -1,0 +1,433 @@
+/**
+ * @file
+ * Test the OpenSSL read timeout
+ *
+ * @authors
+ * Copyright (C) 2026 Todd A. Gibson <tgibson@augustcouncil.com>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#ifdef USE_SSL_OPENSSL
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/rsa.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include "mutt/lib.h"
+#include "config/lib.h"
+#include "core/lib.h"
+#include "conn/lib.h"
+#include "test_common.h" // IWYU pragma: keep
+
+/**
+ * create_server_context - Create a self-contained TLS identity for the fixture
+ * @param[out] server_ctx   OpenSSL server context
+ * @param[out] cert_path    Path to the temporary certificate
+ * @param[in]  cert_path_len Size of the certificate path buffer
+ * @retval true  Success
+ * @retval false Error
+ *
+ * Generate an ephemeral RSA key and self-signed X.509 certificate at runtime.
+ * Writing the certificate to a temporary file lets NeoMutt trust the loopback
+ * server without relying on an external certificate or network service.
+ */
+static bool create_server_context(SSL_CTX **server_ctx, char *cert_path, size_t cert_path_len)
+{
+  EVP_PKEY_CTX *key_ctx = NULL;
+  EVP_PKEY *key = NULL;
+  X509 *cert = NULL;
+  SSL_CTX *ctx = NULL;
+  FILE *fp = NULL;
+  int fd = -1;
+  bool result = false;
+
+  key_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+  if (!TEST_CHECK(key_ctx != NULL))
+    goto done;
+  if (!TEST_CHECK(EVP_PKEY_keygen_init(key_ctx) > 0))
+    goto done;
+  if (!TEST_CHECK(EVP_PKEY_CTX_set_rsa_keygen_bits(key_ctx, 2048) > 0))
+    goto done;
+  if (!TEST_CHECK(EVP_PKEY_keygen(key_ctx, &key) > 0))
+    goto done;
+
+  cert = X509_new();
+  if (!TEST_CHECK(cert != NULL))
+    goto done;
+  if (!TEST_CHECK(X509_set_version(cert, 2) == 1))
+    goto done;
+  if (!TEST_CHECK(ASN1_INTEGER_set(X509_get_serialNumber(cert), 1) == 1))
+    goto done;
+  if (!TEST_CHECK(X509_gmtime_adj(X509_get_notBefore(cert), -60) != NULL))
+    goto done;
+  if (!TEST_CHECK(X509_gmtime_adj(X509_get_notAfter(cert), 86400) != NULL))
+    goto done;
+  if (!TEST_CHECK(X509_set_pubkey(cert, key) == 1))
+    goto done;
+
+  X509_NAME *name = X509_get_subject_name(cert);
+  if (!TEST_CHECK(name != NULL))
+    goto done;
+  if (!TEST_CHECK(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                                             (const unsigned char *) "localhost",
+                                             -1, -1, 0) == 1))
+  {
+    goto done;
+  }
+  if (!TEST_CHECK(X509_set_issuer_name(cert, name) == 1))
+    goto done;
+  if (!TEST_CHECK(X509_sign(cert, key, EVP_sha256()) > 0))
+    goto done;
+
+  ctx = SSL_CTX_new(SSLv23_server_method());
+  if (!TEST_CHECK(ctx != NULL))
+    goto done;
+  if (!TEST_CHECK(SSL_CTX_use_certificate(ctx, cert) == 1))
+    goto done;
+  if (!TEST_CHECK(SSL_CTX_use_PrivateKey(ctx, key) == 1))
+    goto done;
+  if (!TEST_CHECK(SSL_CTX_check_private_key(ctx) == 1))
+    goto done;
+
+  snprintf(cert_path, cert_path_len, "/tmp/neomutt-test-cert-XXXXXX");
+  fd = mkstemp(cert_path);
+  if (!TEST_CHECK(fd >= 0))
+    goto done;
+  fp = fdopen(fd, "w");
+  if (!TEST_CHECK(fp != NULL))
+    goto done;
+  fd = -1;
+  if (!TEST_CHECK(PEM_write_X509(fp, cert) == 1))
+    goto done;
+  if (!TEST_CHECK(fclose(fp) == 0))
+  {
+    fp = NULL;
+    goto done;
+  }
+  fp = NULL;
+
+  *server_ctx = ctx;
+  ctx = NULL;
+  result = true;
+
+done:
+  if (fp)
+    fclose(fp);
+  if (fd >= 0)
+    close(fd);
+  if (!result && cert_path[0])
+    unlink(cert_path);
+  SSL_CTX_free(ctx);
+  X509_free(cert);
+  EVP_PKEY_free(key);
+  EVP_PKEY_CTX_free(key_ctx);
+  return result;
+}
+
+/**
+ * create_listener - Open an IPv4 loopback listener on an ephemeral port
+ * @param[out] port Assigned port
+ * @retval num Listener file descriptor
+ * @retval -1  Error
+ *
+ * Binding port zero asks the kernel to choose an available port, avoiding a
+ * fixed-port dependency and conflicts with concurrent test runs.
+ */
+static int create_listener(unsigned short *port)
+{
+  int listener = socket(AF_INET, SOCK_STREAM, 0);
+  if (!TEST_CHECK(listener >= 0))
+    return -1;
+
+  struct sockaddr_in address = { 0 };
+  address.sin_family = AF_INET;
+  address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  address.sin_port = 0;
+
+  if (!TEST_CHECK(bind(listener, (struct sockaddr *) &address, sizeof(address)) == 0))
+    goto fail;
+  if (!TEST_CHECK(listen(listener, 1) == 0))
+    goto fail;
+
+  socklen_t address_len = sizeof(address);
+  if (!TEST_CHECK(getsockname(listener, (struct sockaddr *) &address, &address_len) == 0))
+    goto fail;
+
+  *port = ntohs(address.sin_port);
+  return listener;
+
+fail:
+  close(listener);
+  return -1;
+}
+
+static void run_server(int listener, SSL_CTX *server_ctx, pid_t parent_pid)
+{
+  int client = accept(listener, NULL, NULL);
+  close(listener);
+  if (client < 0)
+    _exit(2);
+
+  SSL *ssl = SSL_new(server_ctx);
+  if (!ssl)
+    _exit(2);
+  SSL_set_fd(ssl, client);
+  if (SSL_accept(ssl) != 1)
+    _exit(2);
+
+  // Complete TLS, then withhold application data while the parent reads.
+  for (int i = 0; (i < 100) && (getppid() == parent_pid); i++)
+    usleep(100000);
+
+  SSL_free(ssl);
+  SSL_CTX_free(server_ctx);
+  close(client);
+  _exit(0);
+}
+
+/**
+ * configure_client - Configure NeoMutt for the private TLS fixture
+ * @param[in] cert_path Path to the fixture's temporary certificate
+ * @retval true  Success
+ * @retval false Error
+ *
+ * Use a two-second socket timeout and trust only the generated certificate.
+ * Host verification is disabled because the fixture connects to its private
+ * loopback address rather than the certificate's hostname.
+ */
+static bool configure_client(const char *cert_path)
+{
+  int rc = cs_subset_str_native_set(NeoMutt->sub, "socket_timeout", 2, NULL);
+  if (!TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS))
+    return false;
+
+  rc = cs_subset_str_native_set(NeoMutt->sub, "ssl_use_system_certs", false, NULL);
+  if (!TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS))
+    return false;
+
+  rc = cs_subset_str_native_set(NeoMutt->sub, "ssl_verify_host", false, NULL);
+  if (!TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS))
+    return false;
+
+  rc = cs_subset_str_string_set(NeoMutt->sub, "certificate_file", cert_path, NULL);
+  if (!TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS))
+    return false;
+
+#ifdef HAVE_GETADDRINFO
+  rc = cs_subset_str_native_set(NeoMutt->sub, "use_ipv6", false, NULL);
+  if (!TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS))
+    return false;
+#endif
+
+  return true;
+}
+
+struct ReadResult
+{
+  int rc;
+  uint64_t elapsed;
+};
+
+static void run_reader(struct Connection *conn, int result_fd)
+{
+  struct ReadResult result = { 0 };
+  char buf[16] = { 0 };
+  uint64_t start = mutt_date_now_ms();
+  result.rc = mutt_socket_read(conn, buf, sizeof(buf));
+  result.elapsed = mutt_date_now_ms() - start;
+
+  const char *data = (const char *) &result;
+  size_t remaining = sizeof(result);
+  while (remaining > 0)
+  {
+    ssize_t written = write(result_fd, data, remaining);
+    if ((written < 0) && (errno == EINTR))
+      continue;
+    if (written <= 0)
+      _exit(2);
+    data += written;
+    remaining -= written;
+  }
+
+  close(result_fd);
+  _exit(0);
+}
+
+static bool read_result(int fd, struct ReadResult *result)
+{
+  char *data = (char *) result;
+  size_t remaining = sizeof(*result);
+  while (remaining > 0)
+  {
+    ssize_t received = read(fd, data, remaining);
+    if ((received < 0) && (errno == EINTR))
+      continue;
+    if (received <= 0)
+      return false;
+    data += received;
+    remaining -= received;
+  }
+
+  return true;
+}
+
+/**
+ * test_ssl_socket_read_timeout - Test that OpenSSL read retries honor socket_timeout
+ *
+ * Regression test for #4995.  The loopback TLS server completes the handshake,
+ * but does not send application data.  The read must return after the socket
+ * timeout instead of immediately retrying another blocking SSL_read().
+ */
+void test_ssl_socket_read_timeout(void)
+{
+  SSL_CTX *server_ctx = NULL;
+  struct Connection *conn = NULL;
+  int listener = -1;
+  pid_t server_pid = -1;
+  pid_t reader_pid = -1;
+  int result_fds[2] = { -1, -1 };
+  bool connection_open = false;
+  char cert_path[64] = { 0 };
+  unsigned short port = 0;
+
+  conn = mutt_socket_new(MUTT_CONNECTION_SSL);
+  if (!TEST_CHECK(conn != NULL))
+    goto done;
+  if (!create_server_context(&server_ctx, cert_path, sizeof(cert_path)))
+    goto done;
+  if (!configure_client(cert_path))
+    goto done;
+
+  listener = create_listener(&port);
+  if (listener < 0)
+    goto done;
+
+  pid_t parent_pid = getpid();
+  server_pid = fork();
+  if (!TEST_CHECK(server_pid >= 0))
+    goto done;
+  if (server_pid == 0)
+    run_server(listener, server_ctx, parent_pid);
+
+  close(listener);
+  listener = -1;
+  SSL_CTX_free(server_ctx);
+  server_ctx = NULL;
+
+  mutt_str_copy(conn->account.host, "127.0.0.1", sizeof(conn->account.host));
+  conn->account.port = port;
+  conn->account.flags = MUTT_ACCT_PORT | MUTT_ACCT_SSL;
+
+  if (!TEST_CHECK(mutt_socket_open(conn) == 0))
+    goto done;
+  connection_open = true;
+
+  // Isolate the potentially unbounded read so a regression cannot hang the
+  // entire Acutest process; the pipe carries its result back to the parent.
+  if (!TEST_CHECK(pipe(result_fds) == 0))
+    goto done;
+  reader_pid = fork();
+  if (!TEST_CHECK(reader_pid >= 0))
+    goto done;
+  if (reader_pid == 0)
+  {
+    close(result_fds[0]);
+    run_reader(conn, result_fds[1]);
+  }
+  close(result_fds[1]);
+  result_fds[1] = -1;
+
+  int reader_status = 0;
+  bool reader_finished = false;
+  // Allow scheduling margin around socket_timeout=2, but independently bound
+  // the operation at seven seconds if the read retry loop regresses.
+  for (int i = 0; i < 70; i++)
+  {
+    pid_t state = waitpid(reader_pid, &reader_status, WNOHANG);
+    if (state == reader_pid)
+    {
+      reader_finished = true;
+      reader_pid = -1;
+      break;
+    }
+    if ((state < 0) && (errno != EINTR))
+      break;
+    usleep(100000);
+  }
+
+  if (!TEST_CHECK(reader_finished))
+    goto done;
+  if (!TEST_CHECK(WIFEXITED(reader_status) && (WEXITSTATUS(reader_status) == 0)))
+    goto done;
+
+  struct ReadResult result = { 0 };
+  if (!TEST_CHECK(read_result(result_fds[0], &result)))
+    goto done;
+  TEST_MSG("read rc=%d elapsed=%llu ms", result.rc, (unsigned long long) result.elapsed);
+  TEST_CHECK(result.rc < 0);
+  TEST_CHECK(result.elapsed >= 1000);
+  TEST_CHECK(result.elapsed <= 5000);
+
+  // Prove that the read ended from the client timeout, not peer closure.
+  int status = 0;
+  pid_t server_state = waitpid(server_pid, &status, WNOHANG);
+  TEST_CHECK(server_state == 0);
+  if (server_state == server_pid)
+    server_pid = -1;
+
+done:
+  if (reader_pid > 0)
+  {
+    kill(reader_pid, SIGTERM);
+    while ((waitpid(reader_pid, NULL, 0) < 0) && (errno == EINTR))
+    {
+    }
+  }
+  if (result_fds[0] >= 0)
+    close(result_fds[0]);
+  if (result_fds[1] >= 0)
+    close(result_fds[1]);
+  if (connection_open)
+    mutt_socket_close(conn);
+  FREE(&conn);
+  if (server_pid > 0)
+  {
+    kill(server_pid, SIGTERM);
+    while ((waitpid(server_pid, NULL, 0) < 0) && (errno == EINTR))
+    {
+    }
+  }
+  if (listener >= 0)
+    close(listener);
+  SSL_CTX_free(server_ctx);
+  if (cert_path[0])
+    unlink(cert_path);
+}
+#endif

--- a/test/conn/ssl_timeout_common.c
+++ b/test/conn/ssl_timeout_common.c
@@ -1,0 +1,373 @@
+/**
+ * @file
+ * Shared fixture for OpenSSL socket-timeout tests
+ *
+ * @authors
+ * Copyright (C) 2026 Todd A. Gibson <tgibson@augustcouncil.com>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#ifdef USE_SSL_OPENSSL
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/rsa.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include "mutt/lib.h"
+#include "config/lib.h"
+#include "core/lib.h"
+#include "conn/lib.h"
+#include "ssl_timeout_common.h"
+#include "test_common.h" // IWYU pragma: keep
+
+/**
+ * test_ssl_timeout_create_server_context - Create a private TLS identity
+ * @param[out] server_ctx    OpenSSL server context
+ * @param[out] cert_path     Path to the temporary certificate
+ * @param[in]  cert_path_len Size of the certificate path buffer
+ * @retval true  Success
+ * @retval false Error
+ *
+ * Generate an ephemeral RSA key and self-signed X.509 certificate at runtime.
+ * Writing the certificate to a temporary file lets NeoMutt trust the loopback
+ * server without relying on an external certificate or network service.
+ */
+bool test_ssl_timeout_create_server_context(SSL_CTX **server_ctx, char *cert_path, size_t cert_path_len)
+{
+  EVP_PKEY_CTX *key_ctx = NULL;
+  EVP_PKEY *key = NULL;
+  X509 *cert = NULL;
+  SSL_CTX *ctx = NULL;
+  FILE *fp = NULL;
+  int fd = -1;
+  bool result = false;
+
+  key_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+  if (!TEST_CHECK(key_ctx != NULL))
+    goto done;
+  if (!TEST_CHECK(EVP_PKEY_keygen_init(key_ctx) > 0))
+    goto done;
+  if (!TEST_CHECK(EVP_PKEY_CTX_set_rsa_keygen_bits(key_ctx, 2048) > 0))
+    goto done;
+  if (!TEST_CHECK(EVP_PKEY_keygen(key_ctx, &key) > 0))
+    goto done;
+
+  cert = X509_new();
+  if (!TEST_CHECK(cert != NULL))
+    goto done;
+  if (!TEST_CHECK(X509_set_version(cert, 2) == 1))
+    goto done;
+  if (!TEST_CHECK(ASN1_INTEGER_set(X509_get_serialNumber(cert), 1) == 1))
+    goto done;
+  if (!TEST_CHECK(X509_gmtime_adj(X509_get_notBefore(cert), -60) != NULL))
+    goto done;
+  if (!TEST_CHECK(X509_gmtime_adj(X509_get_notAfter(cert), 86400) != NULL))
+    goto done;
+  if (!TEST_CHECK(X509_set_pubkey(cert, key) == 1))
+    goto done;
+
+  X509_NAME *name = X509_get_subject_name(cert);
+  if (!TEST_CHECK(name != NULL))
+    goto done;
+  if (!TEST_CHECK(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                                             (const unsigned char *) "localhost",
+                                             -1, -1, 0) == 1))
+  {
+    goto done;
+  }
+  if (!TEST_CHECK(X509_set_issuer_name(cert, name) == 1))
+    goto done;
+  if (!TEST_CHECK(X509_sign(cert, key, EVP_sha256()) > 0))
+    goto done;
+
+  ctx = SSL_CTX_new(SSLv23_server_method());
+  if (!TEST_CHECK(ctx != NULL))
+    goto done;
+  if (!TEST_CHECK(SSL_CTX_use_certificate(ctx, cert) == 1))
+    goto done;
+  if (!TEST_CHECK(SSL_CTX_use_PrivateKey(ctx, key) == 1))
+    goto done;
+  if (!TEST_CHECK(SSL_CTX_check_private_key(ctx) == 1))
+    goto done;
+
+  snprintf(cert_path, cert_path_len, "/tmp/neomutt-test-cert-XXXXXX");
+  fd = mkstemp(cert_path);
+  if (!TEST_CHECK(fd >= 0))
+    goto done;
+  fp = fdopen(fd, "w");
+  if (!TEST_CHECK(fp != NULL))
+    goto done;
+  fd = -1;
+  if (!TEST_CHECK(PEM_write_X509(fp, cert) == 1))
+    goto done;
+  if (!TEST_CHECK(fclose(fp) == 0))
+  {
+    fp = NULL;
+    goto done;
+  }
+  fp = NULL;
+
+  *server_ctx = ctx;
+  ctx = NULL;
+  result = true;
+
+done:
+  if (fp)
+    fclose(fp);
+  if (fd >= 0)
+    close(fd);
+  if (!result && cert_path[0])
+    unlink(cert_path);
+  SSL_CTX_free(ctx);
+  X509_free(cert);
+  EVP_PKEY_free(key);
+  EVP_PKEY_CTX_free(key_ctx);
+  return result;
+}
+
+/**
+ * test_ssl_timeout_create_listener - Open a private loopback listener
+ * @param[out] port Assigned port
+ * @retval num Listener file descriptor
+ * @retval -1  Error
+ *
+ * Binding port zero asks the kernel to choose an available port, avoiding a
+ * fixed-port dependency and conflicts with concurrent test runs.
+ */
+int test_ssl_timeout_create_listener(unsigned short *port)
+{
+  int listener = socket(AF_INET, SOCK_STREAM, 0);
+  if (!TEST_CHECK(listener >= 0))
+    return -1;
+
+  struct sockaddr_in address = { 0 };
+  address.sin_family = AF_INET;
+  address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  address.sin_port = 0;
+
+  if (!TEST_CHECK(bind(listener, (struct sockaddr *) &address, sizeof(address)) == 0))
+    goto fail;
+  if (!TEST_CHECK(listen(listener, 1) == 0))
+    goto fail;
+
+  socklen_t address_len = sizeof(address);
+  if (!TEST_CHECK(getsockname(listener, (struct sockaddr *) &address, &address_len) == 0))
+    goto fail;
+
+  *port = ntohs(address.sin_port);
+  return listener;
+
+fail:
+  close(listener);
+  return -1;
+}
+
+/**
+ * test_ssl_timeout_configure_client - Configure a private TLS client
+ * @param[in] cert_path Trusted fixture certificate, or NULL before negotiation
+ * @retval true  Success
+ * @retval false Error
+ */
+bool test_ssl_timeout_configure_client(const char *cert_path)
+{
+  int rc = cs_subset_str_native_set(NeoMutt->sub, "socket_timeout", 2, NULL);
+  if (!TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS))
+    return false;
+
+  rc = cs_subset_str_native_set(NeoMutt->sub, "ssl_use_system_certs", false, NULL);
+  if (!TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS))
+    return false;
+
+  if (cert_path)
+  {
+    rc = cs_subset_str_native_set(NeoMutt->sub, "ssl_verify_host", false, NULL);
+    if (!TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS))
+      return false;
+
+    rc = cs_subset_str_string_set(NeoMutt->sub, "certificate_file", cert_path, NULL);
+    if (!TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS))
+      return false;
+  }
+
+#ifdef HAVE_GETADDRINFO
+  rc = cs_subset_str_native_set(NeoMutt->sub, "use_ipv6", false, NULL);
+  if (!TEST_CHECK_NUM_EQ(CSR_RESULT(rc), CSR_SUCCESS))
+    return false;
+#endif
+
+  return true;
+}
+
+/**
+ * test_ssl_timeout_new_connection - Create a TLS connection to the loopback fixture
+ * @param[in] port Fixture port
+ * @retval ptr New connection
+ * @retval NULL Error
+ */
+struct Connection *test_ssl_timeout_new_connection(unsigned short port)
+{
+  struct Connection *conn = mutt_socket_new(MUTT_CONNECTION_SSL);
+  if (!conn)
+    return NULL;
+
+  mutt_str_copy(conn->account.host, "127.0.0.1", sizeof(conn->account.host));
+  conn->account.port = port;
+  conn->account.flags = MUTT_ACCT_PORT | MUTT_ACCT_SSL;
+  return conn;
+}
+
+/**
+ * test_ssl_timeout_run_idle_server - Complete TLS, then perform no application I/O
+ * @param[in] listener   Listening socket
+ * @param[in] server_ctx OpenSSL server context
+ * @param[in] parent_pid Parent test process
+ *
+ * After the handshake, keep the connection open without sending or consuming
+ * application data.
+ */
+void test_ssl_timeout_run_idle_server(int listener, SSL_CTX *server_ctx, pid_t parent_pid)
+{
+  int client = accept(listener, NULL, NULL);
+  close(listener);
+  if (client < 0)
+    _exit(2);
+
+  SSL *ssl = SSL_new(server_ctx);
+  if (!ssl)
+    _exit(2);
+  SSL_set_fd(ssl, client);
+  if (SSL_accept(ssl) != 1)
+    _exit(2);
+
+  for (int i = 0; (i < 100) && (getppid() == parent_pid); i++)
+    usleep(100000);
+
+  SSL_free(ssl);
+  SSL_CTX_free(server_ctx);
+  close(client);
+  _exit(0);
+}
+
+/**
+ * test_ssl_timeout_write_result - Send a child operation result through a pipe
+ * @param[in] fd     Pipe file descriptor
+ * @param[in] result Result to send
+ * @retval true  Success
+ * @retval false Error
+ */
+bool test_ssl_timeout_write_result(int fd, const struct SslTimeoutResult *result)
+{
+  const char *data = (const char *) result;
+  size_t remaining = sizeof(*result);
+
+  while (remaining > 0)
+  {
+    ssize_t written = write(fd, data, remaining);
+    if ((written < 0) && (errno == EINTR))
+      continue;
+    if (written <= 0)
+      return false;
+    data += written;
+    remaining -= written;
+  }
+
+  return true;
+}
+
+/**
+ * test_ssl_timeout_read_result - Receive a child operation result from a pipe
+ * @param[in]  fd     Pipe file descriptor
+ * @param[out] result Received result
+ * @retval true  Success
+ * @retval false Error
+ */
+bool test_ssl_timeout_read_result(int fd, struct SslTimeoutResult *result)
+{
+  char *data = (char *) result;
+  size_t remaining = sizeof(*result);
+
+  while (remaining > 0)
+  {
+    ssize_t received = read(fd, data, remaining);
+    if ((received < 0) && (errno == EINTR))
+      continue;
+    if (received <= 0)
+      return false;
+    data += received;
+    remaining -= received;
+  }
+
+  return true;
+}
+
+/**
+ * test_ssl_timeout_wait - Wait up to seven seconds for an operation child
+ * @param[in,out] child_pid Child process, set to -1 after it is reaped
+ * @param[out]    status    Child wait status
+ * @retval true  Child finished
+ * @retval false Watchdog expired or wait failed
+ */
+bool test_ssl_timeout_wait(pid_t *child_pid, int *status)
+{
+  for (int i = 0; i < 70; i++)
+  {
+    pid_t state = waitpid(*child_pid, status, WNOHANG);
+    if (state == *child_pid)
+    {
+      *child_pid = -1;
+      return true;
+    }
+    if (state < 0)
+    {
+      if (errno == EINTR)
+        continue;
+      return false;
+    }
+    usleep(100000);
+  }
+
+  return false;
+}
+
+/**
+ * test_ssl_timeout_stop_child - Terminate and reap a fixture child
+ * @param[in,out] child_pid Child process, set to -1 after cleanup
+ */
+void test_ssl_timeout_stop_child(pid_t *child_pid)
+{
+  if (!child_pid || (*child_pid <= 0))
+    return;
+
+  kill(*child_pid, SIGTERM);
+  while ((waitpid(*child_pid, NULL, 0) < 0) && (errno == EINTR))
+  {
+  }
+  *child_pid = -1;
+}
+#endif

--- a/test/conn/ssl_timeout_common.h
+++ b/test/conn/ssl_timeout_common.h
@@ -1,0 +1,52 @@
+/**
+ * @file
+ * Shared fixture for OpenSSL socket-timeout tests
+ *
+ * @authors
+ * Copyright (C) 2026 Todd A. Gibson <tgibson@augustcouncil.com>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_TEST_CONN_SSL_TIMEOUT_COMMON_H
+#define MUTT_TEST_CONN_SSL_TIMEOUT_COMMON_H
+
+#include <openssl/ssl.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+struct Connection;
+
+/** Result returned by an isolated socket operation. */
+struct SslTimeoutResult
+{
+  int rc;
+  uint64_t elapsed;
+};
+
+bool test_ssl_timeout_configure_client(const char *cert_path);
+bool test_ssl_timeout_create_server_context(SSL_CTX **server_ctx, char *cert_path,
+                                            size_t cert_path_len);
+int test_ssl_timeout_create_listener(unsigned short *port);
+struct Connection *test_ssl_timeout_new_connection(unsigned short port);
+void test_ssl_timeout_run_idle_server(int listener, SSL_CTX *server_ctx, pid_t parent_pid);
+bool test_ssl_timeout_write_result(int fd, const struct SslTimeoutResult *result);
+bool test_ssl_timeout_read_result(int fd, struct SslTimeoutResult *result);
+bool test_ssl_timeout_wait(pid_t *child_pid, int *status);
+void test_ssl_timeout_stop_child(pid_t *child_pid);
+
+#endif /* MUTT_TEST_CONN_SSL_TIMEOUT_COMMON_H */

--- a/test/main.c
+++ b/test/main.c
@@ -37,7 +37,9 @@ void test_fini(void);
 #include "acutest.h"
 
 #ifdef USE_SSL_OPENSSL
-#define NEOMUTT_OPENSSL_TESTS NEOMUTT_TEST_ITEM(test_ssl_socket_read_timeout)
+#define NEOMUTT_OPENSSL_TESTS                                                  \
+  NEOMUTT_TEST_ITEM(test_ssl_negotiate_timeout)                                \
+  NEOMUTT_TEST_ITEM(test_ssl_socket_read_timeout)
 #else
 #define NEOMUTT_OPENSSL_TESTS
 #endif

--- a/test/main.c
+++ b/test/main.c
@@ -36,6 +36,12 @@ void test_fini(void);
 #define TEST_FINI test_fini()
 #include "acutest.h"
 
+#ifdef USE_SSL_OPENSSL
+#define NEOMUTT_OPENSSL_TESTS NEOMUTT_TEST_ITEM(test_ssl_socket_read_timeout)
+#else
+#define NEOMUTT_OPENSSL_TESTS
+#endif
+
 /******************************************************************************
  * Add your test cases to this list.
  *****************************************************************************/
@@ -271,6 +277,9 @@ void test_fini(void);
   NEOMUTT_TEST_ITEM(test_config_subset)                                        \
   NEOMUTT_TEST_ITEM(test_config_synonym)                                       \
   NEOMUTT_TEST_ITEM(test_config_variable)                                      \
+                                                                               \
+  /* conn */                                                                   \
+  NEOMUTT_OPENSSL_TESTS                                                        \
                                                                                \
   /* convert */                                                                \
   NEOMUTT_TEST_ITEM(test_mutt_convert_file_to)                                 \

--- a/test/main.c
+++ b/test/main.c
@@ -38,6 +38,7 @@ void test_fini(void);
 
 #ifdef USE_SSL_OPENSSL
 #define NEOMUTT_OPENSSL_TESTS                                                  \
+  NEOMUTT_TEST_ITEM(test_ssl_negotiate_retry)                                  \
   NEOMUTT_TEST_ITEM(test_ssl_negotiate_timeout)                                \
   NEOMUTT_TEST_ITEM(test_ssl_socket_read_timeout)
 #else


### PR DESCRIPTION
* **What does this PR do?**

Depends on #5007. The first commit is that PR; the handshake-specific changes
begin with the second commit.

Make the OpenSSL TLS handshake honor `socket_timeout` when a peer accepts TCP
but does not send a TLS response.

`SSL_connect()` can return a retryable read condition after the underlying
socket timeout. The old loop immediately called `SSL_connect()` again, allowing
each retry to consume another full timeout indefinitely. The new handling:

- retries harmless `EINTR` interruptions without requiring immediate readability;
- reports cancellation when `SIGINT` interrupts negotiation;
- otherwise preserves existing non-read retry behavior and retries a read
  condition only when the socket has become readable;
- reports the existing translated timeout error when no data is available.

Add an OpenSSL-only loopback regression. A silent peer accepts TCP while
`mutt_socket_open()` runs in a child process with `socket_timeout=2`; the parent
enforces an independent seven-second deadline. The old loop fails at that
deadline, while corrected negotiation returns after about two seconds. The
test also verifies that the peer is still open.

Extend that fixture with a delayed successful handshake, successful negotiation
after `SIGWINCH`, a silent peer that still times out after `SIGWINCH`, and prompt
cancellation after `SIGINT`. The signal cases use the same negotiation function
through STARTTLS, with non-restarting handlers installed after TCP connection
setup. A one-byte acknowledgment keeps successful clients connected until the
server finishes its handshake.

Factor the existing OpenSSL timeout fixture into shared helpers for loopback
setup, ephemeral TLS credentials, an idle post-handshake peer, child result
transport, watchdog waiting, and cleanup. The existing read-timeout regression
now uses the same fixture without changing its scenario.

* **Screenshots (if relevant)**

Not applicable.

* **Does this PR meet the acceptance criteria?**

- User documentation is unchanged; a handshake waiting for a TLS response now
  honors the existing `socket_timeout` setting.
- The new test and helpers include Doxygen documentation.
- Local OpenSSL focused and full test suites pass.
- The repository Ubuntu CI container passes default, OpenSSL, and
  all-features/GnuTLS matrices, including docs, full tests, and
  install/uninstall cleanup.
- OpenSSL-only tests are omitted from non-OpenSSL configurations.
- Changed C and header sources pass pinned `clang-format` 22.1.8 and
  `git diff --check`.

* **What are the relevant issue numbers?**

Second focused step in #5005.

Extends and factors the OpenSSL loopback regression introduced by #5007.

## Validation

Tested on arm64 Darwin 25.6 with OpenSSL 3.6.4 and on x86_64 Linux with
OpenSSL 3.0.13.

```text
unfixed handshake: 3/3 runs failed at the seven-second watchdog
corrected handshake and signal cases: 3/3 focused runs passed
interruption correction removed: new regression failed as expected
cancellation handling removed: SIGINT case failed as expected
existing read timeout regression: passed
local full OpenSSL suite: passed (644 tests)
Ubuntu CI image: default, OpenSSL, and all-features/GnuTLS matrices passed
```

## AI assistance disclosure

OpenAI Codex assisted with converting the reproducer into the loopback test
fixture, implementing and validating the focused retry correction and signal
regressions, running the build matrix, factoring the shared test fixture, and
drafting the commit and pull-request text. The author reviewed the original
OpenSSL and socket control flow and test implementation, and personally
validated the original passing and deliberately regressed behavior.
