### PR TITLE
ci: exclude bugprone-assignment-in-if-condition from clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,7 @@ Checks: >
   clang-analyzer-*,
   -bugprone-multi-level-implicit-pointer-conversion,
   -bugprone-easily-swappable-parameters,
+  -bugprone-assignment-in-if-condition,
   -clang-analyzer-security.insecureAPI.*
 # bugprone-multi-level-implicit-pointer-conversion: fires on every call to
 # the codebase's own FREE()/ARRAY_FREE() macros, which take a `void *` via an
@@ -18,6 +19,18 @@ Checks: >
 # adjacent same-typed pointer parameters (e.g. any (haystack, needle)-style
 # string function) -- too subjective/noisy to be useful as a default-on
 # check.
+#
+# bugprone-assignment-in-if-condition: sampled all 192 findings on a full
+# build -- every single one is either this codebase's own established
+# `if ((x = foo()))` / `if (!(x = foo()))` idiom (already parenthesized to
+# signal the assignment is intentional, not a typo for `==`), or a
+# macro-expansion artifact (TAILQ_INSERT_HEAD/STAILQ_REMOVE*/MOVE_ADDRESSLIST
+# etc., whose BSD-style queue.h internals perform the flagged assignment, not
+# the call site clang-tidy points at -- MOVE_ADDRESSLIST's own body contains
+# no assignment at all). Zero genuine unintended-assignment bugs found across
+# the full sample -- same false-positive-against-an-established-idiom shape
+# as bugprone-multi-level-implicit-pointer-conversion above, not a real
+# defect class here.
 #
 # clang-analyzer-security.insecureAPI.*: suggests C11 Annex K bounds-checked
 # functions (memcpy_s, snprintf_s, etc.) that glibc doesn't implement and


### PR DESCRIPTION
Picked up from #5004's standing invitation to scope a category. This one and
bugprone-narrowing-conversions were the two largest by count (207 and 458 in
#5004's original snapshot); checked both before picking either.

bugprone-narrowing-conversions turned out to be a genuine, if large, category
(size_t/int/long -> narrower signed type, mostly implementation-defined
truncation risk) -- not what this PR touches, flagging for a possible future
pass of its own.

bugprone-assignment-in-if-condition is a different story: sampled all 192
findings on a full build (`CC=clang ./configure --autocrypt --fmemopen --gdbm
--gnutls --gpgme --gss --lmdb --lua --lz4 --notmuch --pcre2 --rocksdb --sasl
--tdb --with-lock=fcntl --zlib --zstd --compile-commands --disable-doc`,
matching clang-tidy.yml). Every single one is either:

- this codebase's own established `if ((x = foo()))` / `if (!(x = foo()))`
  idiom, already parenthesized to signal the assignment is intentional and
  not a typo for `==`, or
- a macro-expansion artifact -- TAILQ_INSERT_HEAD/STAILQ_REMOVE*/
  MOVE_ADDRESSLIST and similar BSD-style queue.h macros, where clang-tidy
  flags the call site but the actual assignment happens inside the macro's
  own internals. MOVE_ADDRESSLIST is the clearest example: its body
  (`email/envelope.c`) contains no assignment operator at all.

Zero genuine unintended-assignment bugs turned up across the full sample.
Same shape as the existing bugprone-multi-level-implicit-pointer-conversion
exclusion just above this one in the file -- a real, established idiom this
check doesn't have a way to recognize, not an actual defect class here.

AI disclosure: drafted with Claude Code assistance; reasoning and diff
reviewed before opening.