### PR TITLE
Add typeas() and RVALUE() to make macros more robust

### DIFF
--- a/mutt/memory.h
+++ b/mutt/memory.h
@@ -52,9 +52,10 @@
 #define MUTT_MEM_CALLOC(n, type)  ((type *) mutt_mem_calloc(n, sizeof(type)))
 #define MUTT_MEM_MALLOC(n, type)  ((type *) mutt_mem_mallocarray(n, sizeof(type)))
 
-#define MUTT_MEM_REALLOC(pptr, n, type)                                       \
-(                                                                             \
-  _Generic(*(pptr), type *: mutt_mem_reallocarray(pptr, n, sizeof(type)))     \
+#define MUTT_MEM_REALLOC(pptr, n, T)                                  \
+(                                                                     \
+  _Generic(*(pptr), T *: (void)0),                                    \
+  mutt_mem_reallocarray(pptr, n, sizeof(T))                           \
 )
 
 void *mutt_mem_calloc(size_t nmemb, size_t size);

--- a/mutt/memory.h
+++ b/mutt/memory.h
@@ -63,12 +63,12 @@
 # define typeas(T)  __typeof__(*(__typeof__(T) *){_Generic(0, T: NULL, default: NULL)})
 #endif
 
-#define MUTT_MEM_CALLOC(n, type)  ((type *) mutt_mem_calloc(n, sizeof(type)))
-#define MUTT_MEM_MALLOC(n, type)  ((type *) mutt_mem_mallocarray(n, sizeof(type)))
+#define MUTT_MEM_CALLOC(n, T)  ((typeas(T) *) mutt_mem_calloc(n, sizeof(T)))
+#define MUTT_MEM_MALLOC(n, T)  ((typeas(T) *) mutt_mem_mallocarray(n, sizeof(T)))
 
 #define MUTT_MEM_REALLOC(pptr, n, T)                                  \
 (                                                                     \
-  _Generic(*(pptr), T *: (void)0),                                    \
+  _Generic(*(pptr), typeas(T) *: (void)0),                            \
   mutt_mem_reallocarray(pptr, n, sizeof(T))                           \
 )
 

--- a/mutt/memory.h
+++ b/mutt/memory.h
@@ -63,6 +63,8 @@
 # define typeas(T)  __typeof__(*(__typeof__(T) *){_Generic(0, T: NULL, default: NULL)})
 #endif
 
+#define RVALUE(lv)  ((void)0, (lv))
+
 #define MUTT_MEM_CALLOC(n, T)  ((typeas(T) *) mutt_mem_calloc(n, sizeof(T)))
 #define MUTT_MEM_MALLOC(n, T)  ((typeas(T) *) mutt_mem_mallocarray(n, sizeof(T)))
 

--- a/mutt/memory.h
+++ b/mutt/memory.h
@@ -65,8 +65,15 @@
 
 #define RVALUE(lv)  ((void)0, (lv))
 
-#define MUTT_MEM_CALLOC(n, T)  ((typeas(T) *) mutt_mem_calloc(n, sizeof(T)))
-#define MUTT_MEM_MALLOC(n, T)  ((typeas(T) *) mutt_mem_mallocarray(n, sizeof(T)))
+#define MUTT_MEM_CALLOC(n, T)                                         \
+(                                                                     \
+  RVALUE((typeas(T) *){mutt_mem_calloc(n, sizeof(T))})                \
+)
+
+#define MUTT_MEM_MALLOC(n, T)                                         \
+(                                                                     \
+  RVALUE((typeas(T) *){mutt_mem_mallocarray(n, sizeof(T))})           \
+)
 
 #define MUTT_MEM_REALLOC(pptr, n, T)                                  \
 (                                                                     \

--- a/mutt/memory.h
+++ b/mutt/memory.h
@@ -49,6 +49,20 @@
 # define countof(x)  (sizeof(x) / sizeof((x)[0]))
 #endif
 
+#if !defined(typeas)
+/**
+ * typeas - type as
+ * @param T Type name
+ * @retval T Type name
+ *
+ * typeas(T) is equivalent to typeof(T), except it requires that the
+ * parameter T is a type name (typeof() accepts expressions).  For
+ * example, typeof(6) is equivalent to typeof(int), but typeas(6)
+ * results in a compile-time error.
+ */
+# define typeas(T)  __typeof__(*(__typeof__(T) *){_Generic(0, T: NULL, default: NULL)})
+#endif
+
 #define MUTT_MEM_CALLOC(n, type)  ((type *) mutt_mem_calloc(n, sizeof(type)))
 #define MUTT_MEM_MALLOC(n, type)  ((type *) mutt_mem_mallocarray(n, sizeof(type)))
 


### PR DESCRIPTION
-  This is a subset of <https://github.com/neomutt/neomutt/pull/4756>, without renaming existing macros, as requested by @gahr .

Cc: @flatcap 

---

Revisions:

<details>
<summary>v1b</summary>

-  Clarify in the commit message why we use this complex implementation of typeas().

```
$ git range-diff main neomutt/alx/t alx/t
1:  d34b5828dbd9 = 1:  d34b5828dbd9 mutt/memory.h: MUTT_MEM_REALLOC(): Refactor for readability
2:  c5ee24421e3b ! 2:  f8440c9b9124 mutt/memory.h: typeas(): Add macro
    @@ Commit message
         This macro is like typeof(), but guarantees that the argument is a type
         name.  It rejects an expression as argument.
     
    +    A simpler implementation of typeas() would be:
    +
    +            #define typeas(T)  __typeof__((T){})
    +
    +    However, that implementation wouldn't work with function types or void.
    +    That's because you can't create a compound literal of type void or of
    +    function type (or of incomplete type).
    +
    +    The implementation we've used supports more types, by creating a pointer
    +    compount literal instead.  In this case, the way to verify that T is a
    +    type is by using it in a _Generic(3) selector, which is required to be
    +    a type.
    +
         Link: <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3634.txt>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
3:  d97b26fca6db = 3:  acb971a257da mutt/memory.h: Use typeas() to make these macros more robust
4:  7097560db0db = 4:  e7c14013ee22 mutt/memory.h: RVALUE(): Add macro for performing lvalue conversion
5:  89c6bb04f308 = 5:  fe7fca5eddd5 mutt/memory.h: Use compound literals instead of casts
```
</details>

<details>
<summary>v1c</summary>

-  Add a complete explanation of how typeas() works.

```
$ git range-diff main neomutt/alx/t alx/t 
1:  d34b5828dbd9 = 1:  d34b5828dbd9 mutt/memory.h: MUTT_MEM_REALLOC(): Refactor for readability
2:  f8440c9b9124 ! 2:  ed7b3c369143 mutt/memory.h: typeas(): Add macro
    @@ Commit message
         type is by using it in a _Generic(3) selector, which is required to be
         a type.
     
    +    Below is a complete explanation of how this macro works, since it's
    +    quite non-trivial.
    +
    +    Here's the definition, expanded in several lines:
    +
    +            #define typeas(T)  __typeof__                                 \
    +            (                                                             \
    +                    *(__typeof__(T) *){                                   \
    +                            _Generic(0, T: NULL, default: NULL)           \
    +                    }                                                     \
    +            )
    +
    +    Let's first analyze the inner-most expression; the _Generic(3)
    +    expression:
    +
    +            _Generic(0, T: NULL, default: NULL)
    +
    +    _Generic(3) requires that the things before ':' are either type names or
    +    the 'default' keyword, and requires that 'default' appears at most once.
    +    This is specified in C23 in 6.5.2.1p1:
    +    <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3220.pdf#subsubsection.6.5.2.1>.
    +    It is also specified in C11; I just linked to the most recent standard.
    +
    +    This requirement is used here to make sure that T is a type name, and
    +    not something else such as an expression.
    +
    +    After enforcing those requirements, _Generic(3) evaluates to one of its
    +    branches.  In this case, since both branches are NULL, it doesn't matter
    +    which is taken, and it is evaluated as NULL.  Thus, after the
    +    enforcement of T being a type name, the macro replacement list is
    +    simplified to this:
    +
    +            __typeof__
    +            (
    +                    *(__typeof__(T) *){
    +                            NULL
    +                    }
    +            )
    +
    +    Now, let's focus on the innermost expression, which is the compound
    +    literal:
    +
    +            (__typeof__(T) *){NULL}
    +
    +    This has two parts: the type, within (), and the initializer, within {}.
    +
    +    Compound literals are specified in C23 in 6.5.3.6: <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3220.pdf#subsubsection.6.5.3.6>.
    +    (But they are a C99 feature; I just linked to the most recent standard.)
    +
    +    The initializer is clear: it's a null pointer constant.  Let's focus on
    +    the type:
    +
    +            (__typeof__(T) *)
    +
    +    Since we've already guaranteed (with _Generic(3)) that T is a type name,
    +    we know that __typeof__(T) will be the same as T, so we can simplify a
    +    bit for readability:
    +
    +            (T *)
    +
    +    So, this produces a compound literal which is a pointer of type T*, and
    +    has value NULL (but the value is uninteresting).  The reason why we use
    +    __typeof__(T) instead of T directly is to allow T to be a complex type
    +    such as an array type or a function type.  For example, if T is int[4],
    +    then __typeof__(int[4])* does the right thing, but int[4]* wouldn't
    +    compile.
    +
    +    Now, let's simplify this using T* (but knowing that the real
    +    implementation needs __typeof__) and look again at the entire macro
    +    replacement list:
    +
    +            __typeof__
    +            (
    +                    *(T *){
    +                            NULL
    +                    }
    +            )
    +
    +    The compount literal (which we know to be of type T* and have a null
    +    pointer as value, is dereferenced.  This would normally be bad, because
    +    we can't dereference null pointers, but let's assume it's fine for now.
    +    Once we dereference a pointer of type T*, we get an lvalue of type T,
    +    whatever T is.  Then, __typeof__ takes its type, and returns it;
    +    discarding the value.  __typeof__ makes sure that the null pointer
    +    dereference is fine, since it's not evaluated (unless T is a VLA, in
    +    which case it's theoretically evaluated, but in practice, compilers
    +    don't need to evaluate it, so they shouldn't, and it should still be
    +    fine; but it's one of the reasons this should be part of the compiler,
    +    and I'm trying to add this to ISO C as a keyword, and also in GCC).
    +
         Link: <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3634.txt>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
3:  acb971a257da = 3:  ae8ed607a442 mutt/memory.h: Use typeas() to make these macros more robust
4:  e7c14013ee22 = 4:  d766020cc636 mutt/memory.h: RVALUE(): Add macro for performing lvalue conversion
5:  fe7fca5eddd5 = 5:  27cbe7df7f62 mutt/memory.h: Use compound literals instead of casts
```
</details>

<details>
<summary>v1d</summary>

-  Add comment above typeas().  [@gahr ]

```
$ git range-diff main neomutt/alx/t alx/t 
1:  d34b5828dbd9 = 1:  d34b5828dbd9 mutt/memory.h: MUTT_MEM_REALLOC(): Refactor for readability
2:  ed7b3c369143 ! 2:  96b071be18b5 mutt/memory.h: typeas(): Add macro
    @@ mutt/memory.h
      #endif
      
     +#if !defined(typeas)
    ++/**
    ++ * typeas - type as
    ++ * @param T Type name
    ++ * @retval T Type name
    ++ *
    ++ * typeas(T) is equivalent to typeof(T), except it requires that the
    ++ * parameter T is a type name (typeof() accepts expressions).  For
    ++ * example, typeof(6) is equivalent to typeof(int), but typeas(6)
    ++ * results in a compile-time error.
    ++ */
     +# define typeas(T)  __typeof__(*(__typeof__(T) *){_Generic(0, T: NULL, default: NULL)})
     +#endif
     +
3:  ae8ed607a442 = 3:  e4da2331ba29 mutt/memory.h: Use typeas() to make these macros more robust
4:  d766020cc636 = 4:  036d9f85f89a mutt/memory.h: RVALUE(): Add macro for performing lvalue conversion
5:  27cbe7df7f62 = 5:  25b38163ac82 mutt/memory.h: Use compound literals instead of casts
```
</details>