### PR TITLE
b64_encode_common: Initialise out if inlen is zero

### DIFF
--- a/mutt/base64.c
+++ b/mutt/base64.c
@@ -101,6 +101,12 @@ const int Index64[128] = {
 static size_t b64_encode_common(const char *in, size_t inlen, char *out,
                                 size_t outlen, const char *alpha)
 {
+  if (inlen == 0 && out)
+  {
+    *out = '\0';
+    return 0;
+  }
+
   if (!in || !out)
     return 0;
 


### PR DESCRIPTION
* **What does this PR do?**

At the moment, out is not initialised if in is NULL. This affects the built in GSSAPI authentication as sometimes zero length responses are sent to the server.

This commit makes b64_encode_common initialise out if it is not NULL and inlen is zero even if in is NULL.

* **Screenshots (if relevant)**

* **What are the relevant issue numbers?**
